### PR TITLE
Fix lost spaces when cleaning up dom (BL-16263)

### DIFF
--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -1052,7 +1052,7 @@ namespace Bloom.Book
 
         /// <summary>
         /// Somehow Bloom sometimes gets an extra div in the editable content, which should only contain p elements
-        /// (BL-16065). CkEditor may be implicated. Whe bookdata round-trips them, somehow things were getting
+        /// (BL-16065). CkEditor may be implicated. When bookdata round-trips them, somehow things were getting
         /// messed up so that an extra div containing just a br was visible as an extra line. CoPilot came up
         /// with this patch. It may be doing more than is strictly necessary to prevent BL-16065.
         /// </summary>
@@ -1064,6 +1064,7 @@ namespace Bloom.Book
             }
 
             var doc = SafeXmlDocument.Create();
+            doc.PreserveWhitespace = true;
             doc.LoadXml("<wrapper>" + xml + "</wrapper>");
             var wrapper = doc.DocumentElement;
 

--- a/src/BloomTests/Book/BookDataTests.cs
+++ b/src/BloomTests/Book/BookDataTests.cs
@@ -3309,6 +3309,65 @@ namespace BloomTests.Book
         }
 
         [Test]
+        public void GatherDataItemsFromXElement_BloomEditableAudioSpans_PreservesSpaceBetweenAdjacentSpans()
+        {
+            var dom = new HtmlDom(
+                @"<html ><head></head><body>
+                <div class='bloom-page'>
+                     <div class='bloom-editable bloom-visibility-code-on audio-sentence bloom-postAudioSplit' data-book='coverImageDescription' lang='en' data-audiorecordingmode='TextBox' data-audiorecordingendtimes='6.200 12.080'><p><span class='bloom-highlightSegment'>Gentle waves on a beach.</span> <span class='bloom-highlightSegment'>Large rocks, houses and trees are seen in the distance.</span></p></div>
+                </div>
+                </body></html>",
+                true
+            );
+            var dataSet = new DataSet();
+            var bookData = new BookData(
+                new HtmlDom("<html><body></body></html>"),
+                _collectionSettings,
+                null
+            );
+
+            bookData.GatherDataItemsFromXElement(dataSet, dom.RawDom.DocumentElement);
+
+            var storedForm = dataSet
+                .TextVariables["coverImageDescription"]
+                .TextAlternatives.GetExactAlternative("en");
+            Assert.That(
+                storedForm,
+                Does.Contain(
+                    "</span> <span class=\"bloom-highlightSegment\">Large rocks, houses and trees are seen in the distance."
+                )
+            );
+        }
+
+        [Test]
+        public void SynchronizeDataItemsThroughoutDOM_BloomEditableAudioSpans_PreservesSpaceBetweenAdjacentSpans()
+        {
+            var dom = new HtmlDom(
+                @"<html ><head></head><body>
+                <div id='bloomDataDiv'>
+                     <div data-book='coverImageDescription' lang='en' class='bloom-editable audio-sentence bloom-postAudioSplit' data-audiorecordingmode='TextBox' data-audiorecordingendtimes='6.200 12.080'><p><span class='bloom-highlightSegment'>Gentle waves on a beach.</span> <span class='bloom-highlightSegment'>Large rocks, houses and trees are seen in the distance.</span></p></div>
+                </div>
+                <div class='bloom-page'>
+                     <div findMe='target' class='bloom-editable bloom-visibility-code-on audio-sentence bloom-postAudioSplit' data-book='coverImageDescription' lang='en' data-audiorecordingmode='TextBox' data-audiorecordingendtimes='6.200 12.080'><p/></div>
+                </div>
+                </body></html>",
+                true
+            );
+
+            var data = new BookData(dom, _collectionSettings, null);
+            data.SynchronizeDataItemsThroughoutDOM();
+
+            var target = (SafeXmlElement)
+                dom.SelectSingleNodeHonoringDefaultNS("//*[@findMe='target']");
+            Assert.That(
+                target.InnerXml,
+                Does.Contain(
+                    "</span> <span class=\"bloom-highlightSegment\">Large rocks, houses and trees are seen in the distance."
+                )
+            );
+        }
+
+        [Test]
         public void GatherDataItemsFromXElement_OmitsDataPageNumber()
         {
             var dom = new HtmlDom(


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7888" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7888)
<!-- Reviewable:end -->
