### PR TITLE
Accept 6-digit hex codes, even when transparency OK (BL-16262)

### DIFF
--- a/src/BloomBrowserUI/react_components/color-picking/Colors.stories.tsx
+++ b/src/BloomBrowserUI/react_components/color-picking/Colors.stories.tsx
@@ -624,7 +624,7 @@ export const _HexColorInput = () =>
                 <HexColorInput
                     initial={currentColor}
                     onChangeComplete={(newValue) => {
-                        setCurrentColor(getColorInfoFromString(newValue));
+                        setCurrentColor(newValue);
                     }}
                 />
                 <div

--- a/src/BloomBrowserUI/react_components/color-picking/colorPicker.tsx
+++ b/src/BloomBrowserUI/react_components/color-picking/colorPicker.tsx
@@ -91,8 +91,7 @@ export const ColorPicker: React.FunctionComponent<IColorPickerProps> = (
     props,
 ) => {
     const [eyedropperActive, setEyedropperActive] = useState(false);
-    const [displayOpaqueAsBlankInHex, setDisplayOpaqueAsBlankInHex] =
-        useState(false);
+    const [includeAlphaInHexValue, setIncludeAlphaInHexValue] = useState(true);
     const mountedRef = useRef(true);
     const backdropSelector =
         props.eyedropperBackdropSelector ?? defaultEyedropperBackdropSelector;
@@ -127,9 +126,9 @@ export const ColorPicker: React.FunctionComponent<IColorPickerProps> = (
         options?: { complete?: boolean; fromBlankOpacity?: boolean },
     ) => {
         if (options?.fromBlankOpacity) {
-            setDisplayOpaqueAsBlankInHex(true);
+            setIncludeAlphaInHexValue(false);
         } else {
-            setDisplayOpaqueAsBlankInHex(false);
+            setIncludeAlphaInHexValue(true);
         }
         const clonedColor = cloneColor(swatchColor);
         props.onChange(clonedColor);
@@ -302,7 +301,7 @@ export const ColorPicker: React.FunctionComponent<IColorPickerProps> = (
                     initial={props.currentColor}
                     onChangeComplete={handleHexCodeChange}
                     includeOpacityChannel={!!props.transparency}
-                    displayOpaqueAsBlank={displayOpaqueAsBlankInHex}
+                    includeAlphaInHexValue={includeAlphaInHexValue}
                 />
                 <ColorSwatch
                     colors={props.currentColor.colors}

--- a/src/BloomBrowserUI/react_components/color-picking/colorPicker.tsx
+++ b/src/BloomBrowserUI/react_components/color-picking/colorPicker.tsx
@@ -91,6 +91,8 @@ export const ColorPicker: React.FunctionComponent<IColorPickerProps> = (
     props,
 ) => {
     const [eyedropperActive, setEyedropperActive] = useState(false);
+    const [displayOpaqueAsBlankInHex, setDisplayOpaqueAsBlankInHex] =
+        useState(false);
     const mountedRef = useRef(true);
     const backdropSelector =
         props.eyedropperBackdropSelector ?? defaultEyedropperBackdropSelector;
@@ -122,8 +124,13 @@ export const ColorPicker: React.FunctionComponent<IColorPickerProps> = (
 
     const changeColor = (
         swatchColor: IColorInfo,
-        options?: { complete?: boolean },
+        options?: { complete?: boolean; fromBlankOpacity?: boolean },
     ) => {
+        if (options?.fromBlankOpacity) {
+            setDisplayOpaqueAsBlankInHex(true);
+        } else {
+            setDisplayOpaqueAsBlankInHex(false);
+        }
         const clonedColor = cloneColor(swatchColor);
         props.onChange(clonedColor);
         if (options?.complete) {
@@ -148,20 +155,11 @@ export const ColorPicker: React.FunctionComponent<IColorPickerProps> = (
     };
 
     // Handler for when the user changes the hex code value (including pasting).
-    const handleHexCodeChange = (hexColor: string) => {
-        let colorOnly = hexColor;
-        let newOpacity = props.currentColor.opacity;
-
-        if (props.transparency && /^#[0-9A-Fa-f]{8}$/.test(hexColor)) {
-            colorOnly = hexColor.substring(0, 7);
-            newOpacity = parseInt(hexColor.substring(7, 9), 16) / 255;
-        }
-
-        const newColor = {
-            colors: [colorOnly],
-            opacity: newOpacity,
-        };
-        changeColor(newColor, { complete: true });
+    const handleHexCodeChange = (
+        newColor: IColorInfo,
+        fromBlankOpacity: boolean,
+    ) => {
+        changeColor(newColor, { complete: true, fromBlankOpacity });
     };
 
     const getColorInfoFromColorResult = (
@@ -304,6 +302,7 @@ export const ColorPicker: React.FunctionComponent<IColorPickerProps> = (
                     initial={props.currentColor}
                     onChangeComplete={handleHexCodeChange}
                     includeOpacityChannel={!!props.transparency}
+                    displayOpaqueAsBlank={displayOpaqueAsBlankInHex}
                 />
                 <ColorSwatch
                     colors={props.currentColor.colors}

--- a/src/BloomBrowserUI/react_components/color-picking/hexColorInput.spec.ts
+++ b/src/BloomBrowserUI/react_components/color-picking/hexColorInput.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+    getColorInfoFromHexCodeChange,
+    isCompleteHexColorInput,
+} from "./hexColorInput";
+
+describe("hex color input", () => {
+    it("treats 6-digit hex as complete when opacity is enabled", () => {
+        expect(isCompleteHexColorInput("#123456", true)).toBe(true);
+    });
+
+    it("treats 6-digit hex as fully opaque", () => {
+        expect(getColorInfoFromHexCodeChange("#123456", true)).toEqual({
+            colors: ["#123456"],
+            opacity: 1,
+        });
+    });
+
+    it("preserves explicit alpha from 8-digit hex", () => {
+        expect(getColorInfoFromHexCodeChange("#12345680", true)).toEqual({
+            colors: ["#123456"],
+            opacity: 128 / 255,
+        });
+    });
+
+    it.each(["#123456", "#12345680"])(
+        "treats %s as complete when opacity is enabled",
+        (testHex) => {
+            expect(isCompleteHexColorInput(testHex, true)).toBe(true);
+        },
+    );
+});

--- a/src/BloomBrowserUI/react_components/color-picking/hexColorInput.tsx
+++ b/src/BloomBrowserUI/react_components/color-picking/hexColorInput.tsx
@@ -1,19 +1,20 @@
 import { css } from "@emotion/react";
 import * as React from "react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import tinycolor from "tinycolor2";
 import { IColorInfo } from "./colorSwatch";
 
 interface IHexColorInputProps {
     initial: IColorInfo;
     // Called when the user completes a valid hex color entry.
-    // fromBlankOpacity is true if the entry was a 7-character hex code (implying full opacity).
+    // fromBlankOpacity is true if the entry was a 6-digit hex code (implying full opacity).
     onChangeComplete: (newValue: IColorInfo, fromBlankOpacity: boolean) => void;
     includeOpacityChannel?: boolean;
-    // If true, omit the FF opacity suffix when displaying a fully opaque color.
+    // If true, include the FF opacity suffix when displaying a fully opaque color.
+    // Defaults to true when omitted.
     // The client controls this based on whether the last color change came from
-    // a 7-character hex entry (user typing) or from an external source (swatch, eyedropper, etc.).
-    displayOpaqueAsBlank?: boolean;
+    // a 6-digit hex entry (user typing) or from an external source (swatch, eyedropper, etc.).
+    includeAlphaInHexValue?: boolean;
 }
 
 const hashChar = "#";
@@ -38,7 +39,7 @@ const massageColorInput = (
 const getHexColorValueFromColorInfo = (
     colorInfo: IColorInfo,
     includeOpacityChannel?: boolean,
-    displayOpaqueAsBlank?: boolean,
+    includeAlphaInHexValue?: boolean,
 ): string => {
     // First, our hex value will be empty, if we're dealing with a gradient.
     // The massage method below will add a hash character...
@@ -50,7 +51,8 @@ const getHexColorValueFromColorInfo = (
         return hexColor;
     }
 
-    if (displayOpaqueAsBlank && colorInfo.opacity === 1) {
+    const shouldIncludeAlphaInHexValue = includeAlphaInHexValue ?? true;
+    if (!shouldIncludeAlphaInHexValue && colorInfo.opacity === 1) {
         return hexColor;
     }
 
@@ -89,18 +91,28 @@ export const getColorInfoFromHexCodeChange = (
     };
 };
 
-interface IHexColorInputEditorProps {
-    initialHexValue: string;
-    includeOpacityChannel?: boolean;
-    onChangeComplete: (newValue: IColorInfo, fromBlankOpacity: boolean) => void;
-}
-
-const HexColorInputEditor: React.FunctionComponent<
-    IHexColorInputEditorProps
-> = (props) => {
-    const [currentColor, setCurrentColor] = useState(
-        () => props.initialHexValue,
+export const HexColorInput: React.FunctionComponent<IHexColorInputProps> = (
+    props,
+) => {
+    const inputRef = useRef<HTMLInputElement>(null);
+    const initialHexValue = massageColorInput(
+        getHexColorValueFromColorInfo(
+            props.initial,
+            props.includeOpacityChannel,
+            props.includeAlphaInHexValue,
+        ),
+        props.includeOpacityChannel,
     );
+
+    const [currentColor, setCurrentColor] = useState(() => initialHexValue);
+
+    // Made several attempts to avoid useEffect, but it came back in other forms.
+    // To get rid of it here we can do something like using a key to force a remount,
+    // but then we have to hoist the selection/focus state into the new parent,
+    // and end up needing a much more complex useEffect to restore the selection.
+    useEffect(() => {
+        setCurrentColor(initialHexValue);
+    }, [initialHexValue]);
 
     const handleInputChange: React.ChangeEventHandler<HTMLInputElement> = (
         e,
@@ -111,9 +123,13 @@ const HexColorInputEditor: React.FunctionComponent<
         );
         setCurrentColor(result);
         if (isCompleteHexColorInput(result, props.includeOpacityChannel)) {
-            // fromBlankOpacity is true if a 7-character hex was entered with opacity enabled
+            // fromBlankOpacity is true if a 6-digit hex was entered with opacity enabled
             const fromBlankOpacity =
                 !!props.includeOpacityChannel && result.length === 7;
+            const shouldRestoreFocus =
+                document.activeElement === inputRef.current;
+            const selectionStart = e.target.selectionStart;
+            const selectionEnd = e.target.selectionEnd;
             props.onChangeComplete(
                 getColorInfoFromHexCodeChange(
                     result,
@@ -121,6 +137,28 @@ const HexColorInputEditor: React.FunctionComponent<
                 ),
                 fromBlankOpacity,
             );
+            if (shouldRestoreFocus) {
+                // A valid color update can trigger external focus changes; keep typing seamless.
+                requestAnimationFrame(() => {
+                    const input = inputRef.current;
+                    if (!input) {
+                        return;
+                    }
+
+                    input.focus();
+
+                    const maxIndex = input.value.length;
+                    const restoredStart = Math.min(
+                        selectionStart ?? maxIndex,
+                        maxIndex,
+                    );
+                    const restoredEnd = Math.min(
+                        selectionEnd ?? restoredStart,
+                        maxIndex,
+                    );
+                    input.setSelectionRange(restoredStart, restoredEnd);
+                });
+            }
         }
     };
 
@@ -149,34 +187,10 @@ const HexColorInputEditor: React.FunctionComponent<
                     }
                 `}
                 type="text"
+                ref={inputRef}
                 value={currentColor}
                 onChange={handleInputChange}
             />
         </div>
-    );
-};
-
-// This component wraps the original, renamed HexColorInput so that it can be
-// re-mounted with a new initialHexValue (by key change) whenever the initial
-// color changes from an external source. This lets us avoid a useEffect.
-export const HexColorInput: React.FunctionComponent<IHexColorInputProps> = (
-    props,
-) => {
-    const initialHexValue = massageColorInput(
-        getHexColorValueFromColorInfo(
-            props.initial,
-            props.includeOpacityChannel,
-            props.displayOpaqueAsBlank,
-        ),
-        props.includeOpacityChannel,
-    );
-
-    return (
-        <HexColorInputEditor
-            key={initialHexValue}
-            initialHexValue={initialHexValue}
-            includeOpacityChannel={props.includeOpacityChannel}
-            onChangeComplete={props.onChangeComplete}
-        />
     );
 };

--- a/src/BloomBrowserUI/react_components/color-picking/hexColorInput.tsx
+++ b/src/BloomBrowserUI/react_components/color-picking/hexColorInput.tsx
@@ -1,13 +1,19 @@
 import { css } from "@emotion/react";
 import * as React from "react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import tinycolor from "tinycolor2";
 import { IColorInfo } from "./colorSwatch";
 
 interface IHexColorInputProps {
     initial: IColorInfo;
-    onChangeComplete: (newValue: string) => void;
+    // Called when the user completes a valid hex color entry.
+    // fromBlankOpacity is true if the entry was a 7-character hex code (implying full opacity).
+    onChangeComplete: (newValue: IColorInfo, fromBlankOpacity: boolean) => void;
     includeOpacityChannel?: boolean;
+    // If true, omit the FF opacity suffix when displaying a fully opaque color.
+    // The client controls this based on whether the last color change came from
+    // a 7-character hex entry (user typing) or from an external source (swatch, eyedropper, etc.).
+    displayOpaqueAsBlank?: boolean;
 }
 
 const hashChar = "#";
@@ -32,6 +38,7 @@ const massageColorInput = (
 const getHexColorValueFromColorInfo = (
     colorInfo: IColorInfo,
     includeOpacityChannel?: boolean,
+    displayOpaqueAsBlank?: boolean,
 ): string => {
     // First, our hex value will be empty, if we're dealing with a gradient.
     // The massage method below will add a hash character...
@@ -43,6 +50,10 @@ const getHexColorValueFromColorInfo = (
         return hexColor;
     }
 
+    if (displayOpaqueAsBlank && colorInfo.opacity === 1) {
+        return hexColor;
+    }
+
     const alphaHex = Math.round(colorInfo.opacity * 255)
         .toString(16)
         .padStart(2, "0")
@@ -50,32 +61,46 @@ const getHexColorValueFromColorInfo = (
     return `${hexColor}${alphaHex}`;
 };
 
-export const HexColorInput: React.FunctionComponent<IHexColorInputProps> = (
-    props,
-) => {
-    const getHexValue = React.useCallback(
-        (colorInfo: IColorInfo): string =>
-            massageColorInput(
-                getHexColorValueFromColorInfo(
-                    colorInfo,
-                    props.includeOpacityChannel,
-                ),
-                props.includeOpacityChannel,
-            ),
-        [props.includeOpacityChannel],
+export const isCompleteHexColorInput = (
+    color: string,
+    includeOpacityChannel?: boolean,
+): boolean => {
+    if (!includeOpacityChannel) {
+        return color.length === 7;
+    }
+
+    return color.length === 7 || color.length === 9;
+};
+
+export const getColorInfoFromHexCodeChange = (
+    hexColor: string,
+    includeOpacityChannel?: boolean,
+): IColorInfo => {
+    if (includeOpacityChannel && /^#[0-9A-Fa-f]{8}$/.test(hexColor)) {
+        return {
+            colors: [hexColor.substring(0, 7)],
+            opacity: parseInt(hexColor.substring(7, 9), 16) / 255,
+        };
+    }
+
+    return {
+        colors: [hexColor],
+        opacity: 1,
+    };
+};
+
+interface IHexColorInputEditorProps {
+    initialHexValue: string;
+    includeOpacityChannel?: boolean;
+    onChangeComplete: (newValue: IColorInfo, fromBlankOpacity: boolean) => void;
+}
+
+const HexColorInputEditor: React.FunctionComponent<
+    IHexColorInputEditorProps
+> = (props) => {
+    const [currentColor, setCurrentColor] = useState(
+        () => props.initialHexValue,
     );
-
-    const [currentColor, setCurrentColor] = useState(() =>
-        getHexValue(props.initial),
-    );
-
-    const initialHexValue = getHexValue(props.initial);
-
-    // Keep the displayed hex string in sync when the parent changes the color programmatically
-    // (e.g. swatch click, eyedropper, or external currentColor updates).
-    useEffect(() => {
-        setCurrentColor(initialHexValue);
-    }, [initialHexValue]);
 
     const handleInputChange: React.ChangeEventHandler<HTMLInputElement> = (
         e,
@@ -85,9 +110,17 @@ export const HexColorInput: React.FunctionComponent<IHexColorInputProps> = (
             props.includeOpacityChannel,
         );
         setCurrentColor(result);
-        const completeLength = props.includeOpacityChannel ? 9 : 7;
-        if (result.length === completeLength) {
-            props.onChangeComplete(result);
+        if (isCompleteHexColorInput(result, props.includeOpacityChannel)) {
+            // fromBlankOpacity is true if a 7-character hex was entered with opacity enabled
+            const fromBlankOpacity =
+                !!props.includeOpacityChannel && result.length === 7;
+            props.onChangeComplete(
+                getColorInfoFromHexCodeChange(
+                    result,
+                    props.includeOpacityChannel,
+                ),
+                fromBlankOpacity,
+            );
         }
     };
 
@@ -120,5 +153,30 @@ export const HexColorInput: React.FunctionComponent<IHexColorInputProps> = (
                 onChange={handleInputChange}
             />
         </div>
+    );
+};
+
+// This component wraps the original, renamed HexColorInput so that it can be
+// re-mounted with a new initialHexValue (by key change) whenever the initial
+// color changes from an external source. This lets us avoid a useEffect.
+export const HexColorInput: React.FunctionComponent<IHexColorInputProps> = (
+    props,
+) => {
+    const initialHexValue = massageColorInput(
+        getHexColorValueFromColorInfo(
+            props.initial,
+            props.includeOpacityChannel,
+            props.displayOpaqueAsBlank,
+        ),
+        props.includeOpacityChannel,
+    );
+
+    return (
+        <HexColorInputEditor
+            key={initialHexValue}
+            initialHexValue={initialHexValue}
+            includeOpacityChannel={props.includeOpacityChannel}
+            onChangeComplete={props.onChangeComplete}
+        />
     );
 };


### PR DESCRIPTION
In the process, refactored HexColorInput so that
- updating the text when there is an external color change is handled with a different key producing a remount rather than useEffect
- the API is changed to pass IColorInfo in both directions, not just one, so all the hex knowledge is encapsulated.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7889" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7889)
<!-- Reviewable:end -->
