### PR TITLE
Try to prevent getting stuck in Publish tab (BL-16260)

### DIFF
--- a/src/BloomBrowserUI/utils/WebSocketManager.ts
+++ b/src/BloomBrowserUI/utils/WebSocketManager.ts
@@ -383,6 +383,7 @@ export default class WebSocketManager {
             "collections",
             "bookImage",
             "book", // via useWatchString
+            "workspace", // top-level workspace UI has multiple valid watchers
             "bookTeamCollectionStatus", // via useTColBookStatus
             "bookCollection", // one BookOnBlorgBadge per book subscribes here
             // each book collection subscribes to this

--- a/src/BloomBrowserUI/utils/WebSocketManager.ts
+++ b/src/BloomBrowserUI/utils/WebSocketManager.ts
@@ -277,6 +277,19 @@ export default class WebSocketManager {
             if (!WebSocketManager.clientContextCallbacks[clientContext]) {
                 WebSocketManager.clientContextCallbacks[clientContext] = [];
             }
+
+            // Notify listeners when a socket (re)opens so callers that mirror server state
+            // can re-query APIs and recover from any missed websocket messages.
+            ws.addEventListener("open", () => {
+                const e: IBloomWebSocketEvent = {
+                    clientContext,
+                    id: `websocket/open/${clientContext}`,
+                };
+                WebSocketManager.clientContextCallbacks[clientContext]?.forEach(
+                    (callback) => callback(e),
+                );
+            });
+
             // the following is a refactored holdover from a situation where we were having trouble
             // getting the web ui to properly close its own listeners and socket, so we had to
             // revert to have c# send a message that would close this down. It may or may not be

--- a/src/BloomBrowserUI/utils/bloomApi.ts
+++ b/src/BloomBrowserUI/utils/bloomApi.ts
@@ -323,8 +323,7 @@ export function useWatchApiObject<T>(
 ): T {
     const [val, setVal] = useState<T>(defaultValue);
 
-    useEffect(() => {
-        setVal(defaultValue);
+    const refreshFromApi = React.useCallback(() => {
         get(urlSuffix, (result) => {
             if (typeof result.data === "string") {
                 setVal(JSON.parse(result.data) as T);
@@ -332,12 +331,26 @@ export function useWatchApiObject<T>(
                 setVal(result.data as T);
             }
         });
+    }, [urlSuffix]);
+
+    useEffect(() => {
+        setVal(defaultValue);
+        refreshFromApi();
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [urlSuffix, JSON.stringify(defaultValue)]);
+    }, [refreshFromApi, JSON.stringify(defaultValue)]);
 
     useSubscribeToWebSocketForObject<T>(clientContext, eventId, (message) => {
         setVal(message);
     });
+
+    // If the websocket reconnects, refresh from API in case we missed an event while disconnected.
+    useSubscribeToWebSocketForEvent(
+        clientContext,
+        `websocket/open/${clientContext}`,
+        () => {
+            refreshFromApi();
+        },
+    );
 
     return val;
 }

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -82,21 +82,6 @@ namespace Bloom.Edit
 
         public delegate EditingModel Factory(); //autofac uses this
 
-        /// <summary>
-        /// If this is set, the model may call it (passing false) to prevent switching to and from the Edit tab.
-        /// It should then be called (passing true) when it's OK to switch tabs again.
-        /// We use this so that
-        /// (a) when we are in the process of completing a Save for some command in the edit tab, we can't leave that
-        /// tab (until the save is complete), and
-        /// (b) when are doing the Save that is part of leaving the Edit tab, we can't switch back to Edit tab
-        /// until the save is complete and we're in the expected state for entering the tab.
-        /// Without these restrictions, it is hard to reason about the possible states of the system
-        /// as we execute commands and then rapidly switch tabs.
-        /// Probably only testers will switch tabs so frequently as to run into such problems, and even
-        /// they may not notice the brief disabling of the tabs.
-        /// </summary>
-        public Action<bool> EnableSwitchingTabs;
-
         private EditingStateMachine _stateMachine;
 
         public EditingStateMachine StateMachine => _stateMachine;
@@ -159,7 +144,7 @@ namespace Bloom.Edit
                         _view.OnHideEditTab();
                     }
                 },
-                enableStateTransitions: (enabled) => EnableSwitchingTabs?.Invoke(enabled)
+                enableStateTransitions: (enabled) => _view?.WorkspaceView?.SetTabsEnabled(enabled)
             );
 
             bookSelection.SelectionChanged += OnBookSelectionChanged;

--- a/src/BloomExe/Edit/EditingStateMachine.cs
+++ b/src/BloomExe/Edit/EditingStateMachine.cs
@@ -270,19 +270,27 @@ public class EditingStateMachine
             throw;
         }
 
-        if (_saveActionHandlesSaveBook)
+        try
         {
-            _saveActionHandlesSaveBook = false;
+            if (_saveActionHandlesSaveBook)
+            {
+                _saveActionHandlesSaveBook = false;
+            }
+            else
+            {
+                _saveBook();
+            }
         }
-        else
+        // I'm not sure what should happen if we get an exception in _saveBook,
+        // but we definitely don't want to get stuck in the SavedAndStripped state,
+        // so for now we'll do whatever we were planning to do if it succeeded.
+        finally
         {
-            _saveBook();
+            if (pageId != null)
+                ToNavigating(pageId);
+            else
+                ToNoPage();
         }
-
-        if (pageId != null)
-            ToNavigating(pageId);
-        else
-            ToNoPage();
     }
 
     /// <summary>

--- a/src/BloomExe/Publish/PublishView.cs
+++ b/src/BloomExe/Publish/PublishView.cs
@@ -101,6 +101,9 @@ namespace Bloom.Publish
 
         private void Activate()
         {
+            // Safety net: any Edit-tab save lock must be complete before we reach Publish,
+            // so ensure tab switching is enabled in case the re-enable callback was missed.
+            WorkspaceView?.SetTabsEnabled(true);
             PublishHelper.InPublishTab = true;
             var hostForm = GetHostControlForInvoke() as Form;
             BloomPubMaker.ControlForInvoke = hostForm;

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -151,11 +151,6 @@ namespace Bloom.Workspace
             //
             this._editingView = editingViewFactory();
             this._editingView.WorkspaceView = this;
-            this._editingView.Model.EnableSwitchingTabs = (enabled) =>
-            {
-                _tabsEnabled = enabled;
-                SendTopBarState();
-            };
 
             if (!Program.RunningHarvesterMode)
             {


### PR DESCRIPTION
Hardens useWatchApiObject against an event being broadcast while the socket is reconnecting.
Cleans up some complexity and duplication in disabling during Save().
Hardens re-enabling during Save against an exception in _saveBook.
As a last resort, forces all controls to be enabled when the Publish tab is active.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloomdesktop/pull/7890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7890)
<!-- Reviewable:end -->
