### PR TITLE
On Upload keep cropping structure for really cropped images (BL-16173)

### DIFF
--- a/src/BloomExe/ImageProcessing/ImageUtils.cs
+++ b/src/BloomExe/ImageProcessing/ImageUtils.cs
@@ -2170,7 +2170,8 @@ namespace Bloom.ImageProcessing
             SafeXmlDocument bookDom,
             string imageSourceFolder,
             string imageDestFolder,
-            bool alsoTrimMetadataForUncroppedImages = false
+            bool alsoTrimMetadataForUncroppedImages = false,
+            bool preserveCropStyleForUpload = false
         )
         {
             var images = bookDom.SafeSelectElements("//img").ToList();
@@ -2240,6 +2241,7 @@ namespace Bloom.ImageProcessing
                         cropped,
                         srcUsageCount,
                         replacedOriginals,
+                        preserveCropStyleForUpload,
                         img,
                         src,
                         style,
@@ -2279,6 +2281,7 @@ namespace Bloom.ImageProcessing
             Dictionary<string, string> cropped,
             Dictionary<string, int> srcUsageCount,
             HashSet<string> replacedOriginals,
+            bool preserveCropStyleForUpload,
             SafeXmlElement img,
             string src,
             string style,
@@ -2294,9 +2297,12 @@ namespace Bloom.ImageProcessing
             {
                 // This is a duplicate. We can use the same cropped image file.
                 SetImageSrcAndSyncDataDiv(img, fileName, bloomDataDivEntriesByDataBook);
-                // With that src, it's already cropped, so remove the style to avoid
-                // applying the cropping again to the already-cropped image.
-                img.RemoveAttribute("style");
+                UpdateCropStyleForAlreadyCroppedImage(
+                    img,
+                    imageDestFolder,
+                    fileName,
+                    preserveCropStyleForUpload
+                );
                 return;
             }
 
@@ -2307,6 +2313,7 @@ namespace Bloom.ImageProcessing
                 imageSourceFolder,
                 imageDestFolder,
                 needNewName,
+                preserveCropStyleForUpload,
                 bloomDataDivEntriesByDataBook
             );
 
@@ -2316,6 +2323,39 @@ namespace Bloom.ImageProcessing
                 replacedOriginals.Add(src);
             }
             cropped[key] = croppedFileName;
+        }
+
+        private static void UpdateCropStyleForAlreadyCroppedImage(
+            SafeXmlElement img,
+            string imageDestFolder,
+            string src,
+            bool preserveCropStyleForUpload
+        )
+        {
+            if (!preserveCropStyleForUpload)
+            {
+                // With that src, it's already cropped, so remove the style to avoid
+                // applying the cropping again to the already-cropped image.
+                img.RemoveAttribute("style");
+                return;
+            }
+
+            var cropMetadata = TryGetCropMetadata(img);
+            if (cropMetadata == null)
+            {
+                img.RemoveAttribute("style");
+                return;
+            }
+
+            var decodedSrc = src;
+            var croppedPath = UrlPathString.GetFullyDecodedPath(imageDestFolder, ref decodedSrc);
+            if (!TryGetImageSize(croppedPath, out var croppedImageSize))
+            {
+                img.RemoveAttribute("style");
+                return;
+            }
+
+            UpdateStyleToCoverCanvasElement(img, cropMetadata, croppedImageSize);
         }
 
         private static void DeleteOrphanedImageFiles(
@@ -2478,9 +2518,11 @@ namespace Bloom.ImageProcessing
             string imageSourceFolder,
             string imageDestFolder,
             bool useNewName,
+            bool preserveCropStyleForUpload,
             Dictionary<string, SafeXmlElement> bloomDataDivEntriesByDataBook
         )
         {
+            var cropMetadata = preserveCropStyleForUpload ? TryGetCropMetadata(img) : null;
             var croppedImagePath = MakeCroppedImage(img, imageSourceFolder, imageDestFolder);
             var src = img.GetAttribute("src");
             // a good default if we can't produce a cropped image for any reason.
@@ -2493,6 +2535,7 @@ namespace Bloom.ImageProcessing
             // removing some url encoding to find the actual file). And if we're not
             // using a new name, we want to exactly overwrite the original image file.
             UrlPathString.GetFullyDecodedPath(imageSourceFolder, ref src);
+            var finalCroppedImagePath = string.Empty;
             if (croppedImagePath != null)
             {
                 if (useNewName)
@@ -2507,6 +2550,7 @@ namespace Bloom.ImageProcessing
                     result = Path.GetFileName(croppedImagePath);
                     // Including the current image
                     SetImageSrcAndSyncDataDiv(img, result, bloomDataDivEntriesByDataBook);
+                    finalCroppedImagePath = croppedImagePath;
                 }
                 else
                 {
@@ -2514,10 +2558,124 @@ namespace Bloom.ImageProcessing
                     RobustFile.Move(croppedImagePath, destPath, true);
                     // If it failed, it should have already logged the reason. I think all we can do
                     // is leave the image alone.
+                    finalCroppedImagePath = destPath;
                 }
             }
-            img.RemoveAttribute("style"); // so nothing can possibly think it needs more cropping
+
+            if (
+                preserveCropStyleForUpload
+                && cropMetadata != null
+                && !string.IsNullOrEmpty(finalCroppedImagePath)
+                && TryGetImageSize(finalCroppedImagePath, out var croppedImageSize)
+            )
+            {
+                UpdateStyleToCoverCanvasElement(img, cropMetadata, croppedImageSize);
+            }
+            else
+            {
+                // so nothing can possibly think it needs more cropping
+                img.RemoveAttribute("style");
+            }
+
             return result;
+        }
+
+        // It's tempting to just remove the style, or at least the cropping-related
+        // parts of it, since we've made the image fit almost exactly. And for publishing
+        // (Bloompub, etc) we actually do that, though code elsewhere adds a class that
+        // makes it use object-fit:cover instead of object-fit:contain, which is
+        // important when trying to cover an entire page without a stray pixel.
+        // For upload, where further editing is expected, it is better to keep the
+        // structure of the cropped canvas element, but adjust it so there is no
+        // actual cropping. This also prevents stray lines of uncovered background,
+        // but does not put the book into a special state that might complicate
+        // continued editing.
+        private static void UpdateStyleToCoverCanvasElement(
+            SafeXmlElement img,
+            CropMetadata cropMetadata,
+            Size croppedImageSize
+        )
+        {
+            if (
+                cropMetadata.CanvasElementWidth <= 0
+                || cropMetadata.CanvasElementHeight <= 0
+                || croppedImageSize.Width <= 0
+                || croppedImageSize.Height <= 0
+            )
+            {
+                img.RemoveAttribute("style");
+                return;
+            }
+
+            var coverScale = Math.Max(
+                cropMetadata.CanvasElementWidth / croppedImageSize.Width,
+                cropMetadata.CanvasElementHeight / croppedImageSize.Height
+            );
+            var scaledWidth = croppedImageSize.Width * coverScale;
+            var scaledHeight = croppedImageSize.Height * coverScale;
+
+            var left = (cropMetadata.CanvasElementWidth - scaledWidth) / 2;
+            var top = (cropMetadata.CanvasElementHeight - scaledHeight) / 2;
+
+            // It's particularly important that we keep a width, because that's what
+            // our CSS looks for to suppress the old object-fit:contain rule.
+            var updatedStyle = ReplaceOrAppendPxStyle(
+                img.GetAttribute("style"),
+                "width",
+                scaledWidth
+            );
+            updatedStyle = ReplaceOrAppendPxStyle(updatedStyle, "left", left);
+            updatedStyle = ReplaceOrAppendPxStyle(updatedStyle, "top", top);
+            img.SetAttribute("style", updatedStyle);
+        }
+
+        private static string ReplaceOrAppendPxStyle(
+            string style,
+            string propertyName,
+            double value
+        )
+        {
+            var cleanValue = Math.Abs(value) < 0.0005 ? 0 : value;
+            var valueText = $"{cleanValue.ToString("0.###", CultureInfo.InvariantCulture)}px";
+            if (string.IsNullOrWhiteSpace(style))
+            {
+                return $"{propertyName}: {valueText};";
+            }
+
+            var styleParts = style
+                .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(x => x.Trim())
+                .Where(x => !string.IsNullOrWhiteSpace(x))
+                .ToList();
+
+            var outputParts = new List<string>();
+            var found = false;
+            foreach (var part in styleParts)
+            {
+                var separatorIndex = part.IndexOf(':');
+                if (separatorIndex < 0)
+                {
+                    outputParts.Add(part);
+                    continue;
+                }
+
+                var key = part.Substring(0, separatorIndex).Trim();
+                var currentValue = part.Substring(separatorIndex + 1).Trim();
+                if (key.Equals(propertyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    outputParts.Add($"{propertyName}: {valueText}");
+                    found = true;
+                }
+                else
+                {
+                    outputParts.Add($"{key}: {currentValue}");
+                }
+            }
+
+            if (!found)
+                outputParts.Add($"{propertyName}: {valueText}");
+
+            return string.Join("; ", outputParts) + ";";
         }
 
         private static void SetImageSrcAndSyncDataDiv(

--- a/src/BloomExe/Publish/PublishHelper.cs
+++ b/src/BloomExe/Publish/PublishHelper.cs
@@ -1428,9 +1428,8 @@ namespace Bloom.Publish
         /// represented as a canvas element to our pre-6.2 approach where it was a direct child of the bloom canvas.
         /// The canvas element div is removed, and the img that was in it is moved to an appropriate position
         /// as a direct child of the bloom-canvas.
-        /// We also do this when publishing to BloomLibrary; this saves the harvester needing to worry about
-        /// the background image canvas elements, and also saves our future code having to worry about blorg
-        /// books that have a mixture of old and new background images.
+        /// We don't do this when publishing to BloomLibrary, because really cropping images and then
+        /// switching to content-fit:contain can leave a pixel of the cover visible.
         /// </summary>
         public static void SimplifyBackgroundImages(SafeXmlDocument dom)
         {

--- a/src/BloomExe/WebLibraryIntegration/BookUpload.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookUpload.cs
@@ -545,10 +545,16 @@ namespace Bloom.WebLibraryIntegration
                 controlToInvokeOn
             );
 
-            // Really crop images, which allows us to simplify the representation of background images,
-            // so the new structure with the background canvas elements doesn't get uploaded.
-            // We think it's better if Blorg books don't have this structure until we can migrate all pages
-            // to it.
+            // Really crop images, but leave in place the HTML structures that indicates they are cropped.
+            // Really cropping them will typically reduce the space needed, and may also have value in
+            // protecting privacy in case the cropped parts were not meant to be seen. Earlier verions
+            // removed the HTML cropping structure altogether, which was nice for older Bloom versions
+            // that don't understand it, and could help images automatically adjust to changing page
+            // sizes. But all shipping versions of Bloom now understand cropping, and removing the
+            // cropping structure can cause an imperfect filling of the space, particularly letting
+            // one pixel of a cover show along the edge of an image that should fill it. So we decided
+            // to keep the cropping structure, just adjust it to suit an image that is reduce to as near
+            // the right size as we can get.
             // Since this is a temp directory and a book that's already up-to-date, I think it's safe to
             // just load a DOM from the file, modify it, and write it out again, without all the
             // overhead of creating a book object.

--- a/src/BloomExe/WebLibraryIntegration/BookUpload.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookUpload.cs
@@ -559,9 +559,14 @@ namespace Bloom.WebLibraryIntegration
                 xmlDomFromHtmlFile,
                 stagingDirectory,
                 stagingDirectory,
+                true,
                 true
             );
-            PublishHelper.SimplifyBackgroundImages(xmlDomFromHtmlFile); // after really cropping
+            // Don't do this; even the 'really cropped' images may have a pixel or two of cropping
+            // to make sure they cover their container, which otherwise would not be guaranteed
+            // since 'really crop' has to procuce whole numbers of pixels and object-fit:contain
+            // will try to shrink it so one dimension is perfect and the other possibly too small.
+            //PublishHelper.SimplifyBackgroundImages(xmlDomFromHtmlFile); // after really cropping
 
             XmlHtmlConverter.SaveDOMAsHtml5(xmlDomFromHtmlFile, htmlFile);
         }

--- a/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
+++ b/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
@@ -1440,5 +1440,110 @@ namespace BloomTests.ImageProcessing
                 );
             }
         }
+
+        [Test]
+        public void ReallyCropImages_DefaultMode_RemovesCropStyle()
+        {
+            using (var folder = new TemporaryFolder("DefaultCropStyleRemoval"))
+            {
+                var imagePath = Path.Combine(folder.Path, "cover.png");
+                using (var bitmap = new Bitmap(333, 221))
+                {
+                    bitmap.Save(imagePath, ImageFormat.Png);
+                }
+
+                var dom = new HtmlDom(
+                    @"<html><head></head><body>
+                    <div class=""bloom-page"">
+                        <div class=""marginBox"">
+                            <div class=""bloom-canvas"">"
+                        + MakeImageCanvasElement(
+                            "cropped",
+                            "cover.png",
+                            "height: 99px; left: 0px; top: 0px; width: 100px;",
+                            "width: 230px; left: -55px; top: -35px"
+                        )
+                        + @"</div>
+                        </div>
+                    </div>
+                </body></html>"
+                );
+
+                ImageUtils.ReallyCropImages(dom.RawDom, folder.Path, folder.Path);
+
+                var croppedImg = dom.SelectSingleNode("//img[@id='cropped']");
+                Assert.That(
+                    croppedImg.HasAttribute("style"),
+                    Is.False,
+                    "Default crop mode should remove crop styling"
+                );
+            }
+        }
+
+        [Test]
+        public void ReallyCropImages_UploadMode_KeepsAdjustedCropStyleToFillContainer()
+        {
+            using (var folder = new TemporaryFolder("UploadCropStylePreserved"))
+            {
+                var imagePath = Path.Combine(folder.Path, "cover.png");
+                using (var bitmap = new Bitmap(333, 221))
+                {
+                    bitmap.Save(imagePath, ImageFormat.Png);
+                }
+
+                const double canvasWidth = 100;
+                const double canvasHeight = 99;
+
+                var dom = new HtmlDom(
+                    @"<html><head></head><body>
+                    <div class=""bloom-page"">
+                        <div class=""marginBox"">
+                            <div class=""bloom-canvas"">"
+                        + MakeImageCanvasElement(
+                            "cropped",
+                            "cover.png",
+                            "height: 99px; left: 0px; top: 0px; width: 100px;",
+                            "width: 230px; left: -55px; top: -35px"
+                        )
+                        + @"</div>
+                        </div>
+                    </div>
+                </body></html>"
+                );
+
+                ImageUtils.ReallyCropImages(dom.RawDom, folder.Path, folder.Path, false, true);
+
+                var croppedImg = dom.SelectSingleNode("//img[@id='cropped']");
+                var updatedStyle = croppedImg.GetAttribute("style");
+
+                Assert.That(
+                    string.IsNullOrWhiteSpace(updatedStyle),
+                    Is.False,
+                    "Upload crop mode should preserve style attributes"
+                );
+
+                var styledWidth = ImageUtils.GetNumberFromPx("width", updatedStyle);
+                var styledLeft = ImageUtils.GetNumberFromPx("left", updatedStyle);
+                var styledTop = ImageUtils.GetNumberFromPx("top", updatedStyle);
+
+                Assert.That(styledWidth, Is.GreaterThanOrEqualTo(canvasWidth));
+                Assert.That(styledLeft, Is.LessThanOrEqualTo(0.001));
+                Assert.That(styledTop, Is.LessThanOrEqualTo(0.001));
+
+                var src = croppedImg.GetAttribute("src");
+                var finalImagePath = UrlPathString.GetFullyDecodedPath(folder.Path, ref src);
+                Assert.That(
+                    ImageUtils.TryGetImageSize(finalImagePath, out var finalImageSize),
+                    Is.True
+                );
+
+                var displayedHeight = styledWidth * finalImageSize.Height / finalImageSize.Width;
+                Assert.That(
+                    displayedHeight,
+                    Is.GreaterThanOrEqualTo(canvasHeight - 0.01),
+                    "Adjusted style should ensure the cropped image still fills the canvas height"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7892)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Image cropping during file uploads now offers enhanced control over crop styling behavior with configurable options for different upload workflows.

* **Tests**
  * Added extensive test coverage for image crop style handling to verify correct behavior across different cropping scenarios and upload configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->