### PR TITLE
BL-16306 Prevent duplicate collection save refresh handlers

### DIFF
--- a/src/BloomExe/CollectionTab/CollectionTabView.cs
+++ b/src/BloomExe/CollectionTab/CollectionTabView.cs
@@ -27,6 +27,7 @@ namespace Bloom.CollectionTab
         private bool _isDisposed;
         private bool _bookChangesPending = false; // bookchanged event while tab not visible
         private Book.Book _bookForPendingLabelUpdate = null; // book needing label update when UI ready
+        private Book.Book _bookSubscribedForContentsChanged;
 
         internal WorkspaceView WorkspaceView { get; set; }
 
@@ -93,21 +94,44 @@ namespace Bloom.CollectionTab
 
         private void BookSelectionChanged(Book.Book book)
         {
+            DetachBookContentsChangedHandler();
+
             if (book == null)
                 return;
             if (book.IsSaveable)
                 _model.UpdateThumbnailAsync(book);
-            book.ContentsChanged += (sender, args) =>
+
+            _bookSubscribedForContentsChanged = book;
+            book.ContentsChanged += HandleBookContentsChanged;
+        }
+
+        private void HandleBookContentsChanged(object sender, EventArgs args)
+        {
+            var book = sender as Book.Book;
+            if (book == null)
             {
-                if (_tabSelection.ActiveTab == WorkspaceTab.collection)
-                {
-                    UpdateForBookChanges(book);
-                }
-                else
-                {
-                    _bookChangesPending = true;
-                }
-            };
+                return;
+            }
+
+            if (_tabSelection.ActiveTab == WorkspaceTab.collection)
+            {
+                UpdateForBookChanges(book);
+            }
+            else
+            {
+                _bookChangesPending = true;
+            }
+        }
+
+        private void DetachBookContentsChangedHandler()
+        {
+            if (_bookSubscribedForContentsChanged == null)
+            {
+                return;
+            }
+
+            _bookSubscribedForContentsChanged.ContentsChanged -= HandleBookContentsChanged;
+            _bookSubscribedForContentsChanged = null;
         }
 
         /// <summary>
@@ -364,6 +388,7 @@ namespace Bloom.CollectionTab
                 return;
 
             _isDisposed = true;
+            DetachBookContentsChangedHandler();
             BookCollection.CollectionCreated -= OnBookCollectionCreated;
 
             try


### PR DESCRIPTION
Detach the previous ContentsChanged subscription when the selected book changes and clean it up on dispose.

This keeps the collection tab from accumulating duplicate handlers for the same book, which was causing repeated post-save refresh work and slow saves while the collection tab was active.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7902)
<!-- Reviewable:end -->
