### PR TITLE
BL-16306 Prevent duplicate collection save refresh handlers

### DIFF
--- a/src/BloomExe/CollectionTab/CollectionTabView.cs
+++ b/src/BloomExe/CollectionTab/CollectionTabView.cs
@@ -25,8 +25,17 @@ namespace Bloom.CollectionTab
         private BloomWebSocketServer _webSocketServer;
         private TeamCollectionManager _tcManager;
         private bool _isDisposed;
-        private bool _bookChangesPending = false; // bookchanged event while tab not visible
+
+        // If we get a book changed event while this tab is not visible (we can only get it for the selected book),
+        // this variable keeps track of the book for which we got it, so we can be quite sure to update
+        // our data about that book in various ways when we are the active tab again.
+        private Book.Book _bookForPendingChanges = null;
         private Book.Book _bookForPendingLabelUpdate = null; // book needing label update when UI ready
+
+        // This is normally (via code in BookSelectionChanged) the same as BookSelection.CurrentSelection.
+        // We distinguish it so as to unambiguously identify the (at most) one book which currently
+        // has HandleBookContentsChanged() attached to its BookChanged event. This lets us reliably
+        // remove that handler when the selection changes or this is disposed.
         private Book.Book _bookSubscribedForContentsChanged;
 
         internal WorkspaceView WorkspaceView { get; set; }
@@ -71,8 +80,8 @@ namespace Bloom.CollectionTab
                 if (_tabSelection.ActiveTab == WorkspaceTab.collection)
                 {
                     Logger.WriteEvent("Entered Collections Tab");
-                    if (_bookChangesPending && _bookSelection.CurrentSelection != null)
-                        UpdateForBookChanges(_bookSelection.CurrentSelection);
+                    if (_bookForPendingChanges != null)
+                        UpdateForBookChanges(_bookForPendingChanges);
                 }
             });
             SetTeamCollectionStatus(tcManager);
@@ -119,7 +128,7 @@ namespace Bloom.CollectionTab
             }
             else
             {
-                _bookChangesPending = true;
+                _bookForPendingChanges = book;
             }
         }
 
@@ -184,7 +193,7 @@ namespace Bloom.CollectionTab
 
             // This message causes the preview to update.
             _webSocketServer.SendEvent("bookContent", "reload");
-            _bookChangesPending = false;
+            _bookForPendingChanges = null;
         }
 
         private void OnBookCollectionCreated(object collection, EventArgs args)

--- a/src/BloomExe/CollectionTab/CollectionTabView.cs
+++ b/src/BloomExe/CollectionTab/CollectionTabView.cs
@@ -27,6 +27,7 @@ namespace Bloom.CollectionTab
         private bool _isDisposed;
         private bool _bookChangesPending = false; // bookchanged event while tab not visible
         private Book.Book _bookForPendingLabelUpdate = null; // book needing label update when UI ready
+        private Book.Book _bookSubscribedForContentsChanged;
 
         internal WorkspaceView WorkspaceView { get; set; }
 
@@ -93,21 +94,44 @@ namespace Bloom.CollectionTab
 
         private void BookSelectionChanged(Book.Book book)
         {
+            DetachBookContentsChangedHandler();
+
             if (book == null)
                 return;
             if (book.IsSaveable)
                 _model.UpdateThumbnailAsync(book);
-            book.ContentsChanged += (sender, args) =>
+
+            _bookSubscribedForContentsChanged = book;
+            book.ContentsChanged += HandleBookContentsChanged;
+        }
+
+        private void HandleBookContentsChanged(object sender, EventArgs args)
+        {
+            var book = sender as Book.Book;
+            if (book == null)
             {
-                if (_tabSelection.ActiveTab == WorkspaceTab.collection)
-                {
-                    UpdateForBookChanges(book);
-                }
-                else
-                {
-                    _bookChangesPending = true;
-                }
-            };
+                return;
+            }
+
+            if (_tabSelection.ActiveTab == WorkspaceTab.collection)
+            {
+                UpdateForBookChanges(book);
+            }
+            else
+            {
+                _bookChangesPending = true;
+            }
+        }
+
+        private void DetachBookContentsChangedHandler()
+        {
+            if (_bookSubscribedForContentsChanged == null)
+            {
+                return;
+            }
+
+            _bookSubscribedForContentsChanged.ContentsChanged -= HandleBookContentsChanged;
+            _bookSubscribedForContentsChanged = null;
         }
 
         /// <summary>
@@ -364,6 +388,7 @@ namespace Bloom.CollectionTab
                 return;
 
             _isDisposed = true;
+            DetachBookContentsChangedHandler();
             BookCollection.CollectionCreated -= OnBookCollectionCreated;
 
             try

--- a/src/BloomExe/CollectionTab/CollectionTabView.cs
+++ b/src/BloomExe/CollectionTab/CollectionTabView.cs
@@ -24,6 +24,8 @@ namespace Bloom.CollectionTab
         private BookSelection _bookSelection;
         private BloomWebSocketServer _webSocketServer;
         private TeamCollectionManager _tcManager;
+        private SelectedTabChangedEvent _selectedTabChangedEvent;
+        private LocalizationChangedEvent _localizationChangedEvent;
         private bool _isDisposed;
 
         // If we get a book changed event while this tab is not visible (we can only get it for the selected book),
@@ -42,6 +44,10 @@ namespace Bloom.CollectionTab
 
         public delegate CollectionTabView Factory(); //autofac uses this
 
+        // Event handler delegates stored for unsubscription in Dispose
+        private EventHandler _tcStatusChangedHandler;
+        private EventHandler<BookSelectionChangedEventArgs> _bookSelectionChangedHandler;
+
         public CollectionTabView(
             CollectionModel model,
             SelectedTabChangedEvent selectedTabChangedEvent,
@@ -58,6 +64,8 @@ namespace Bloom.CollectionTab
             _bookSelection = bookSelection;
             _webSocketServer = webSocketServer;
             _tcManager = tcManager;
+            _selectedTabChangedEvent = selectedTabChangedEvent;
+            _localizationChangedEvent = localizationChangedEvent;
 
             // Commented out because of BL-12890, while we think about that.
             //bookRefreshEvent.Subscribe(book => {
@@ -68,24 +76,14 @@ namespace Bloom.CollectionTab
 
             BookCollection.CollectionCreated += OnBookCollectionCreated;
 
-            localizationChangedEvent.Subscribe(unused =>
-            {
-                _webSocketServer.SendEvent("collection", "reload");
-            });
+            _localizationChangedEvent.Subscribe(OnLocalizationChanged);
 
             //TODO splitContainer1.SplitterDistance = _collectionListView.PreferredWidth;
 
-            selectedTabChangedEvent.Subscribe(c =>
-            {
-                if (_tabSelection.ActiveTab == WorkspaceTab.collection)
-                {
-                    Logger.WriteEvent("Entered Collections Tab");
-                    if (_bookForPendingChanges != null)
-                        UpdateForBookChanges(_bookForPendingChanges);
-                }
-            });
+            _selectedTabChangedEvent.Subscribe(OnSelectedTabChanged);
+
             SetTeamCollectionStatus(tcManager);
-            TeamCollectionManager.TeamCollectionStatusChanged += (sender, args) =>
+            _tcStatusChangedHandler = (sender, args) =>
             {
                 if (WorkspaceView != null && !_isDisposed)
                 {
@@ -97,8 +95,26 @@ namespace Bloom.CollectionTab
                     );
                 }
             };
-            bookSelection.SelectionChanged += (sender, e) =>
+            TeamCollectionManager.TeamCollectionStatusChanged += _tcStatusChangedHandler;
+
+            _bookSelectionChangedHandler = (sender, e) =>
                 BookSelectionChanged(bookSelection.CurrentSelection);
+            bookSelection.SelectionChanged += _bookSelectionChangedHandler;
+        }
+
+        private void OnLocalizationChanged(object unused)
+        {
+            _webSocketServer.SendEvent("collection", "reload");
+        }
+
+        private void OnSelectedTabChanged(object obj)
+        {
+            if (_tabSelection.ActiveTab == WorkspaceTab.collection)
+            {
+                Logger.WriteEvent("Entered Collections Tab");
+                if (_bookForPendingChanges != null)
+                    UpdateForBookChanges(_bookForPendingChanges);
+            }
         }
 
         private void BookSelectionChanged(Book.Book book)
@@ -399,6 +415,19 @@ namespace Bloom.CollectionTab
             _isDisposed = true;
             DetachBookContentsChangedHandler();
             BookCollection.CollectionCreated -= OnBookCollectionCreated;
+            _localizationChangedEvent.Unsubscribe(OnLocalizationChanged);
+            _selectedTabChangedEvent.Unsubscribe(OnSelectedTabChanged);
+
+            // Unsubscribe from standard C# events
+            if (_tcStatusChangedHandler != null)
+            {
+                TeamCollectionManager.TeamCollectionStatusChanged -= _tcStatusChangedHandler;
+            }
+
+            if (_bookSelectionChangedHandler != null && _bookSelection != null)
+            {
+                _bookSelection.SelectionChanged -= _bookSelectionChangedHandler;
+            }
 
             try
             {

--- a/src/BloomExe/Event.cs
+++ b/src/BloomExe/Event.cs
@@ -29,17 +29,35 @@ namespace Bloom
         }
 
         private readonly List<Action<TPayload>> _subscribers = new List<Action<TPayload>>();
+        private readonly object _subscriberLock = new object();
 
         public void Subscribe(Action<TPayload> action)
         {
-            if (!_subscribers.Contains(action))
+            lock (_subscriberLock)
             {
-                _subscribers.Add(action);
+                if (!_subscribers.Contains(action))
+                {
+                    _subscribers.Add(action);
+                }
+            }
+        }
+
+        public void Unsubscribe(Action<TPayload> action)
+        {
+            lock (_subscriberLock)
+            {
+                _subscribers.Remove(action);
             }
         }
 
         public virtual void Raise(TPayload descriptor)
         {
+            Action<TPayload>[] subscribers;
+            lock (_subscriberLock)
+            {
+                subscribers = _subscribers.ToArray();
+            }
+
             SIL.Reporting.Logger.WriteMinorEvent("Event: " + _nameForLogging);
             using (
                 PerformanceMeasurement.Global?.MeasureMaybe(
@@ -48,7 +66,7 @@ namespace Bloom
                 )
             )
             {
-                foreach (Action<TPayload> subscriber in _subscribers)
+                foreach (Action<TPayload> subscriber in subscribers)
                 {
                     ((Action<TPayload>)subscriber)(descriptor);
                 }
@@ -57,7 +75,13 @@ namespace Bloom
 
         public bool HasSubscribers
         {
-            get { return _subscribers.Count > 0; }
+            get
+            {
+                lock (_subscriberLock)
+                {
+                    return _subscribers.Count > 0;
+                }
+            }
         }
     }
 

--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -163,6 +163,7 @@ namespace Bloom
                                 typeof(CollectionSettingsApi),
                                 typeof(SubscriptionSettingsEditorApi),
                                 typeof(FeatureStatusApi),
+                                typeof(CollectionTabView),
                                 typeof(CollectionApi),
                                 typeof(RegistrationApi),
                                 typeof(PageControlsApi),

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -1248,7 +1248,7 @@ window.showWorkspaceInitializationFailure = function(message) {
 
         /// <summary>
         /// Changes the active tab in the workspace.
-        /// Todo: we can probably merge the two ChangeTab methods, but I want to be wait for 6.5 to
+        /// Todo: we can probably merge the two ChangeTab methods, but I want to wait for 6.5 to
         /// attempt this, also merging the comments with some care. I'm not sure whether we should keep
         /// the argument as an IBloomTabArea of a WorkspaceTab value. If the latter, _previouslySelectedTabArea
         /// probably wants to change too, and perhaps other things.

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -189,7 +189,7 @@ namespace Bloom.Workspace
             this._publishView = publishViewFactory();
             this._publishView.WorkspaceView = this;
 
-            ApplyTabAreaSelection(_collectionTabView);
+            ChangeTab(_collectionTabView);
 
             SetupZoomModel();
             SendZoomInfo();
@@ -1246,7 +1246,18 @@ window.showWorkspaceInitializationFailure = function(message) {
             return null;
         }
 
-        private void ApplyTabAreaSelection(IBloomTabArea view)
+        /// <summary>
+        /// Changes the active tab in the workspace.
+        /// Todo: we can probably merge the two ChangeTab methods, but I want to be wait for 6.5 to
+        /// attempt this, also merging the comments with some care. I'm not sure whether we should keep
+        /// the argument as an IBloomTabArea of a WorkspaceTab value. If the latter, _previouslySelectedTabArea
+        /// probably wants to change too, and perhaps other things.
+        /// Note that we don't want to make any actual changes of state until the PostponedWork callback runs
+        /// after we raise _selectedTabAboutToChangeEvent. The allows the current tab to shut down cleanly,
+        /// before any changes that might do things like cleaning out its iframe. In particular, we have to wait
+        /// until any changes are saved if we are leaving the edit tab.
+        /// </summary>
+        private void ChangeTab(IBloomTabArea view)
         {
             // Already on the desired tab: nothing to do.  And possible problems if we do do something.
             // See https://issues.bloomlibrary.org/youtrack/issue/BL-8382.
@@ -1255,8 +1266,6 @@ window.showWorkspaceInitializationFailure = function(message) {
 
             var previousTab = GetWorkspaceTab(_previouslySelectedTabArea);
             var currentTab = GetWorkspaceTab(view);
-
-            CurrentTabView = view;
             // Warn the user if we're starting to use too much memory.
             //MemoryManagement.CheckMemory(false, "switched tab in workspace", true);
 
@@ -1277,6 +1286,15 @@ window.showWorkspaceInitializationFailure = function(message) {
                     ToTab = currentTab,
                     PostponedWork = () =>
                     {
+                        CurrentTabView = view;
+
+                        // Mark the tab active only when postponed work actually runs.
+                        // When leaving Edit this is delayed until pending save completes.
+                        if (currentTab.HasValue)
+                        {
+                            _tabSelection.ActiveTab = currentTab.Value;
+                        }
+
                         _selectedTabChangedEvent.Raise(
                             new TabChangedDetails() { FromTab = previousTab, ToTab = currentTab }
                         );
@@ -1291,6 +1309,10 @@ window.showWorkspaceInitializationFailure = function(message) {
                         }
                         SendZoomInfo();
                         SendTopBarState();
+                        if (currentTab == WorkspaceTab.collection)
+                        {
+                            ApplyPostCollectionTabBehavior();
+                        }
                         // TODO-WV2: Can we clear the cache in WV2?  Do we need to?
                     },
                 }
@@ -1343,13 +1365,7 @@ window.showWorkspaceInitializationFailure = function(message) {
         /// <param name="newTab">The tab to activate.</param>
         public void ChangeTab(WorkspaceTab newTab)
         {
-            _tabSelection.ActiveTab = newTab;
-            ApplyTabAreaSelection(GetTabArea(newTab));
-
-            if (newTab == WorkspaceTab.collection)
-            {
-                ApplyPostCollectionTabBehavior();
-            }
+            ChangeTab(GetTabArea(newTab));
         }
 
         // Currently not used, but I'm leaving the method in case we want to put it


### PR DESCRIPTION
A couple of fixes to remove redundant ContentsChanged calls that were slowing down moving back to Collections tab.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7903)
<!-- Reviewable:end -->
