### PR TITLE
Fix transparent processing for cover PNG files (BL-16298)

### DIFF
--- a/src/BloomExe/ImageProcessing/ImageUtils.cs
+++ b/src/BloomExe/ImageProcessing/ImageUtils.cs
@@ -1555,7 +1555,7 @@ namespace Bloom.ImageProcessing
                                 argsBldr.Append(" -background white -extent 0x0 +matte");
                             else if (options.MakeTransparent)
                                 argsBldr.Append(
-                                    " -transparent \"#ffffff\" -transparent \"#fefefe\" -transparent \"#fdfdfd\""
+                                    " -matte -transparent \"#ffffff\" -transparent \"#fefefe\" -transparent \"#fdfdfd\""
                                 );
                             if (options.cropRectangle != Rectangle.Empty)
                             {


### PR DESCRIPTION
The new version of Graphics Magick needed a minor command line tweak.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7904)
<!-- Reviewable:end -->
