### PR TITLE
Remove width limit on Settings button (BL-16307)

### DIFF
--- a/src/BloomBrowserUI/react_components/TopBar/CollectionTopBarControls/CollectionTopBarControls.tsx
+++ b/src/BloomBrowserUI/react_components/TopBar/CollectionTopBarControls/CollectionTopBarControls.tsx
@@ -67,13 +67,11 @@ export const CollectionTopBarControls: React.FunctionComponent = () => {
                     backgroundColor={mainButtonBackground}
                     textColor={mainButtonTextColor}
                     cssOverrides={css`
-                        width: 88px;
                         white-space: normal;
                         line-height: 1.15;
 
                         span {
                             display: inline-block;
-                            max-width: 64px;
                             text-align: center;
                         }
                     `}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7906)
<!-- Reviewable:end -->
