### PR TITLE
Remove wrong-scale dialog and improve legacy dlg code (BL-16269)

### DIFF
--- a/src/BloomExe/Utils/LegacyDpiDialogLauncher.cs
+++ b/src/BloomExe/Utils/LegacyDpiDialogLauncher.cs
@@ -6,7 +6,9 @@ namespace Bloom.Utils
 {
     internal static class LegacyDpiDialogLauncher
     {
-        private static readonly IntPtr DpiAwarenessContextUnaware = new IntPtr(-1);
+        // SYSTEM_AWARE more closely matches Bloom's pre-PerMonitorV2 behavior.
+        // Using UNAWARE can cause apparent double-scaling when the primary monitor is scaled.
+        private static readonly IntPtr LegacyDialogDpiContext = new IntPtr(-2);
 
         [DllImport("user32.dll")]
         private static extern IntPtr SetThreadDpiAwarenessContext(IntPtr dpiContext);
@@ -31,7 +33,7 @@ namespace Bloom.Utils
         /// </summary>
         public static IDisposable EnterLegacyDpiScope()
         {
-            var previousContext = SetThreadDpiAwarenessContext(DpiAwarenessContextUnaware);
+            var previousContext = SetThreadDpiAwarenessContext(LegacyDialogDpiContext);
             return new DpiAwarenessScope(previousContext);
         }
 

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -1367,7 +1367,6 @@ window.showWorkspaceInitializationFailure = function(message) {
         private void WorkspaceView_Load(object sender, EventArgs e)
         {
             _mainBrowser?.SetBuiltInBrowserZoomEnabled(false);
-            CheckDPISettings();
             ShowAutoUpdateDialogIfNeeded();
             ShowForumInvitationDialogIfNeeded();
             // Check whether the last Velopack update attempt actually succeeded. Shows a toast if not.
@@ -1470,29 +1469,6 @@ window.showWorkspaceInitializationFailure = function(message) {
                     waitForMilestone: "collectionButtonsDrawn",
                     maxTickWaitForMilestone: 100
                 );
-            }
-        }
-
-        private void CheckDPISettings()
-        {
-            Graphics g = this.CreateGraphics();
-            try
-            {
-                var dx = g.DpiX;
-                DPIOfThisAccount = dx;
-                var dy = g.DpiY;
-                if (dx != 96 || dy != 96)
-                {
-                    ErrorReport.NotifyUserOfProblem(
-                        new ShowOncePerSessionBasedOnExactMessagePolicy(),
-                        "The \"text size (DPI)\" or \"Screen Magnification\" of the display on this computer is set to a special value, {0}. With that setting, some thing won't look right in Bloom. Possibly books won't lay out correctly. If this is a problem, change the DPI back to 96 (the default on most computers), using the 'Display' Control Panel.",
-                        dx
-                    );
-                }
-            }
-            finally
-            {
-                g.Dispose();
             }
         }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7909)
<!-- Reviewable:end -->
