### PR TITLE
Ensure browser control maintains parent size (BL-16269)

### DIFF
--- a/src/BloomExe/web/ReactControl.cs
+++ b/src/BloomExe/web/ReactControl.cs
@@ -86,6 +86,23 @@ namespace Bloom.web
 
         private Browser _browser;
 
+        private void SyncBrowserBounds()
+        {
+            if (_browser == null || _browser.IsDisposed)
+                return;
+
+            var desiredBounds = ClientRectangle;
+            if (desiredBounds.Width <= 0 || desiredBounds.Height <= 0)
+                return;
+
+            if (_browser.Bounds == desiredBounds)
+                return;
+
+            // The browser may be attached after this control has already been laid out,
+            // so DockStyle.Fill alone is not enough to guarantee it catches up.
+            _browser.Bounds = desiredBounds;
+        }
+
         protected override void OnBackColorChanged(EventArgs e)
         {
             base.OnBackColorChanged(e);
@@ -165,6 +182,7 @@ namespace Bloom.web
                 if (IsDisposed)
                     return;
                 Controls.Add(_browser);
+                SyncBrowserBounds();
 
                 // This allows us to bring up a react control/dialog with focus already set to a specific element.
                 // For example, for BloomMessageBox, we set the Cancel button to have focus so the user
@@ -177,6 +195,12 @@ namespace Bloom.web
                 _browser.ActivateFocussed();
             };
             _browser.NavigateToTempFileThenRemoveIt(tempFile.Path);
+        }
+
+        protected override void OnClientSizeChanged(EventArgs e)
+        {
+            base.OnClientSizeChanged(e);
+            SyncBrowserBounds();
         }
 
         // If given the localization changed event, the control will automatically reload


### PR DESCRIPTION
Fixes issue where scaling could cause browser portion of ReactControl to be drawn too small. (Fallout from prior DPI changes.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7912)
<!-- Reviewable:end -->
