### PR TITLE
Fix text outline applying to new line symbols (BL-16304)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -758,6 +758,12 @@ button.moveButton {
         // I haven't figured out why this is. See some of the later comments in BL-11606.
         overflow: hidden;
         z-index: -1; // go under any text that reach the end of the line (I don't know why, but 0 doesn't work)
+
+        // Canvas text outlines are applied on the editable/container and would otherwise
+        // be inherited by these edit-only paragraph and linebreak markers.
+        // Keep this override in sync with the outline setup in CanvasElementManager.ts.
+        -webkit-text-stroke-width: 0;
+        paint-order: normal;
     }
 
     p::after {

--- a/src/BloomBrowserUI/bookEdit/js/CanvasElementManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/CanvasElementManager.ts
@@ -3261,7 +3261,10 @@ export class CanvasElementManager {
         // (Makes the font look bolder.)
         // So we need to set it only when we are actually applying an outline color.
         // This will also save us data migration if we one day want to give the user control
-        // over the outline width or (much less likely) paint order
+        // over the outline width or (much less likely) paint order.
+        // Keep the paragraph/linebreak marker override in editMode.less in sync with these
+        // inherited outline properties. The edit-only helper glyphs are pseudo-elements and
+        // will pick up changes here unless that LESS rule is updated too.
         const outlineWidthProperty = "-webkit-text-stroke-width";
         const paintOrderProperty = "paint-order";
         const applyOutlineProperties = (target: HTMLElement) => {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7917)
<!-- Reviewable:end -->
