### PR TITLE
Stop distorting eyedropper results with a backdrop (BL-16342)

### DIFF
--- a/src/BloomBrowserUI/react_components/color-picking/colorPickerDialog.tsx
+++ b/src/BloomBrowserUI/react_components/color-picking/colorPickerDialog.tsx
@@ -372,8 +372,8 @@ const ColorPickerDialog: React.FC<IColorPickerDialogProps> = (props) => {
                     css={css`
                         z-index: 60001; // dialogZIndexPlusOne (yuck!)
                         .MuiBackdrop-root {
-                            // We want the overlay barely visible so it doesn't interfere with picking colors.
-                            background-color: rgba(0, 0, 0, 0.05) !important;
+                            // Keep the backdrop transparent so native eyedropper sampling sees the real page color.
+                            background-color: transparent !important;
                         }
                         .MuiDialog-paperScrollPaper {
                             max-height: unset;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7926)
<!-- Reviewable:end -->
