### PR TITLE
Restore toolbox root font size to 11px (BL-16389)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.tsx
@@ -717,6 +717,10 @@ export const ToolboxRoot: React.FunctionComponent = () => {
                 height: 100%;
                 display: flex;
                 flex-direction: column;
+                // This overrides a font-size: x-small that is set on div.toolboxRoot
+                // (it replaces something that we somehow inherited from a jquery stylesheet
+                // in earlier versions of Bloom)
+                font-size: 11px;
             `}
         >
             <ThemeProvider theme={toolboxTheme}>

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.less
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.less
@@ -17,6 +17,10 @@ div.toolboxRoot {
     display: inline-block;
     background-color: @toolboxBackgroundColor;
     color: white;
+    // I think this is obsolete...React code makes the root of the toolbox 11px,
+    // while x-small works out to 10px...but for now I'm keeping it in case it
+    // still controls something we care about. (It was probably obsolete even
+    // under the old jquery toolbox, where some jquery stylesheet make the root 11px).
     font-size: x-small;
     position: fixed;
     top: 25px; // leaves room for pure-drawer control for showing and hiding toolbox


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7936)
<!-- Reviewable:end -->
