### PR TITLE
Fix BL-16416 Delete image option disabled after using "Become Background" (custom cover)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/CanvasElementContextControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/js/CanvasElementContextControls.tsx
@@ -21,6 +21,7 @@ import { showCopyrightAndLicenseDialog } from "../workspaceRoot";
 import {
     doImageCommand,
     getImageUrlFromImageContainer,
+    HandleImageError,
     kImageContainerClass,
     isPlaceHolderImage,
 } from "./bloomImages";
@@ -1715,9 +1716,20 @@ function addVideoMenuItems(
 }
 
 function hasRealImage(img: Element | undefined): boolean {
+    if (!img || isPlaceHolderImage(img.getAttribute("src"))) {
+        return false;
+    }
+    // If the image actually rendered, it is a real image, even if a stale
+    // bloom-imageLoadError class is hanging around. Cover images get a persisted
+    // onerror that sets that class (BookData.cs), and their resource load can fail
+    // spuriously before bootstrap (see BL-14241); nothing clears the class on a
+    // later successful load. naturalWidth is the ground truth: a genuinely broken
+    // image has naturalWidth 0, so this still treats those as not-real. See BL-16416.
+    const htmlImg = img as HTMLImageElement;
+    if (htmlImg.complete && htmlImg.naturalWidth > 0) {
+        return true;
+    }
     return !!(
-        img &&
-        !isPlaceHolderImage(img.getAttribute("src")) &&
         !img.classList.contains("bloom-imageLoadError") &&
         img.parentElement &&
         !img.parentElement.classList.contains("bloom-imageLoadError")
@@ -1928,6 +1940,15 @@ function addImageMenuOptions(
                         );
                     }
 
+                    // Reset any stale load-error state before changing the src, matching
+                    // switchBackgroundToCanvasElement. Otherwise a leftover bloom-imageLoadError
+                    // class (e.g. from the cover image's spurious early-load failure) can make
+                    // the new background image look unreal and disable Delete. See BL-16416.
+                    // hasRealImage() checks the class on both the img and its container, so
+                    // clear both.
+                    bgImg.classList.remove("bloom-imageLoadError");
+                    bgImgContainer?.classList.remove("bloom-imageLoadError");
+                    bgImg.onerror = HandleImageError;
                     // Keep a book-relative path in the attribute. Assigning .src can
                     // expand to an absolute URL, which later file tracking may not resolve.
                     bgImg.setAttribute("src", currentImgSrce);


### PR DESCRIPTION
https://issues.bloomlibrary.org/youtrack/issue/BL-16416

On a custom front cover, after using "Become Background" the resulting
background image is designated the cover image (data-book="coverImage").
Cover images carry a persisted onerror that sets bloom-imageLoadError, and
their resource load can fail spuriously before bootstrap (BL-14241). Nothing
clears that class on a later successful load. BL-16159 made hasRealImage()
return false whenever bloom-imageLoadError is present, so the image looked
"unreal" and the Delete option was disabled even though the image displays
fine. This is cover-specific (interior images have no cover onerror) and
intermittent (the early-load failure is a timing race).

Fix:
- hasRealImage() now treats a non-placeholder image that actually rendered
  (complete && naturalWidth > 0) as real, ignoring a stale
  bloom-imageLoadError class. A genuinely broken image still has
  naturalWidth 0, preserving BL-16159's intent.
- The "Become Background" handler now clears bloom-imageLoadError and rewires
  onerror before changing the background image's src, matching the canonical
  switchBackgroundToCanvasElement path.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7950)
<!-- Reviewable:end -->
