### PR TITLE
More improvements to line art (BL-16336)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -1988,6 +1988,26 @@
         <note>ID: EditTab.Image.Reset</note>
         <note>Removes cropping from image</note>
       </trans-unit>
+      <trans-unit id="EditTab.Image.Background" translate="no">
+        <source xml:lang="en">Background</source>
+        <note>ID: EditTab.Image.Background</note>
+        <note>Submenu for controlling whether the image background is made transparent</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Image.Background.Auto" translate="no">
+        <source xml:lang="en">Auto</source>
+        <note>ID: EditTab.Image.Background.Auto</note>
+        <note>Image background transparency is automatic: transparent when the image looks like line art</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Image.Background.Transparent" translate="no">
+        <source xml:lang="en">Transparent</source>
+        <note>ID: EditTab.Image.Background.Transparent</note>
+        <note>Always make the image background transparent regardless of its content</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Image.Background.Opaque" translate="no">
+        <source xml:lang="en">Opaque</source>
+        <note>ID: EditTab.Image.Background.Opaque</note>
+        <note>Never make the image background transparent</note>
+      </trans-unit>
       <trans-unit id="EditTab.Image.TooLarge" sil:dynamic="true">
         <source xml:lang="en">Bloom ran out of memory loading this image ({0}), which is quite large ({1} by {2} pixels). Click Help for suggestions.</source>
         <note>ID: EditTab.Image.TooLarge</note>

--- a/src/BloomBrowserUI/bookEdit/bookAndPageSettings/PageSettingsConfigrPages.tsx
+++ b/src/BloomBrowserUI/bookEdit/bookAndPageSettings/PageSettingsConfigrPages.tsx
@@ -12,6 +12,7 @@ import {
 import { BloomPalette } from "../../react_components/color-picking/bloomPalette";
 import { useL10n } from "../../react_components/l10nHooks";
 import { getBloomPageElement } from "../../utils/shared";
+import { updateImageTransparencyForPage } from "../js/bloomImages";
 
 export type IPageSettings = {
     page: {
@@ -205,6 +206,10 @@ const setCurrentPageBackgroundColor = (color: string): void => {
     // color override for the same visible surface.
     setOrRemoveCustomProperty(page.style, "--page-background-color", color);
     page.style.removeProperty("--marginBox-background-color");
+
+    // Immediately update img srcs so the browser re-fetches with the correct
+    // transparency setting without waiting for a page save.
+    updateImageTransparencyForPage(page, color);
 };
 
 const getPageNumberColor = (): string => {

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -4,8 +4,11 @@ import $ from "jquery";
 import bloomQtipUtils from "./bloomQtipUtils";
 import {
     cleanupImages,
+    getImageTransparencyMode,
+    getOwningPageBackgroundColor,
     HandleImageError,
     normalizeCoverImageDesignation,
+    setImgTransparentParam,
     SetupMetadataButton,
     SetupResizableElement,
     SetupImagesInContainer,
@@ -457,6 +460,11 @@ export function changeImageInfo(
         );
         (imgOrImageContainer as HTMLImageElement).onerror = HandleImageError;
         (imgOrImageContainer as HTMLImageElement).src = imageInfo.src;
+        const bgColor = getOwningPageBackgroundColor(imgOrImageContainer);
+        setImgTransparentParam(
+            imgOrImageContainer,
+            getImageTransparencyMode(imgOrImageContainer, !!bgColor),
+        );
     }
     // else if it has class bloom-imageContainer or bloom-canvas, we need to set the background-image on the container
     else if (

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -8,7 +8,8 @@ import {
     getOwningPageBackgroundColor,
     HandleImageError,
     normalizeCoverImageDesignation,
-    setImgTransparentParam,
+    buildSrcWithTransparentParam,
+    pageBackgroundNeedsTransparency,
     SetupMetadataButton,
     SetupResizableElement,
     SetupImagesInContainer,
@@ -459,12 +460,13 @@ export function changeImageInfo(
             "bloom-imageLoadError",
         );
         (imgOrImageContainer as HTMLImageElement).onerror = HandleImageError;
-        (imgOrImageContainer as HTMLImageElement).src = imageInfo.src;
         const bgColor = getOwningPageBackgroundColor(imgOrImageContainer);
-        setImgTransparentParam(
+        const mode = getImageTransparencyMode(
             imgOrImageContainer,
-            getImageTransparencyMode(imgOrImageContainer, !!bgColor),
+            pageBackgroundNeedsTransparency(bgColor),
         );
+        (imgOrImageContainer as HTMLImageElement).src =
+            buildSrcWithTransparentParam(imageInfo.src, mode);
     }
     // else if it has class bloom-imageContainer or bloom-canvas, we need to set the background-image on the container
     else if (

--- a/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
@@ -402,13 +402,12 @@ export function getImageTransparencyMode(
 // the background transparent wth a better future algorithm, or if the page background
 // changes. For actual publications (BloomPubs, epubs, videos) we export files with
 // real transparent backgrounds. PDFs, of course, capture what the BloomServer returns.
-export function setImgTransparentParam(
-    img: HTMLElement,
+// Returns `src` with the transparent query parameter set for `mode`, or removed
+// when mode is "none". All other existing query parameters are preserved.
+export function buildSrcWithTransparentParam(
+    src: string,
     mode: TransparencyMode,
-): void {
-    const src = img.getAttribute("src");
-    if (!src) return;
-
+): string {
     const qIndex = src.indexOf("?");
     const path = qIndex < 0 ? src : src.substring(0, qIndex);
     const params =
@@ -423,7 +422,18 @@ export function setImgTransparentParam(
         params.push(`transparent=${mode === "force" ? "force" : "yes"}`);
     }
 
-    const newSrc = params.length > 0 ? `${path}?${params.join("&")}` : path;
+    return params.length > 0 ? `${path}?${params.join("&")}` : path;
+}
+
+// Mark the given img element's src with an appropriate transparent query parameter
+// so BloomServer can apply the correct transparency transform when asked for the image.
+export function setImgTransparentParam(
+    img: HTMLElement,
+    mode: TransparencyMode,
+): void {
+    const src = img.getAttribute("src");
+    if (!src) return;
+    const newSrc = buildSrcWithTransparentParam(src, mode);
     if (newSrc !== src) img.setAttribute("src", newSrc);
 }
 
@@ -435,13 +445,12 @@ export function updateImageTransparencyForPage(
     page: HTMLElement,
     newColor: string,
 ): void {
-    const pageNeedsTransparent = !!newColor;
+    const pageNeedsTransparent = pageBackgroundNeedsTransparency(newColor);
     for (const img of Array.from(page.querySelectorAll("img"))) {
         const imgEl = img as HTMLElement;
-        const classAttr = imgEl.className ?? "";
         if (
-            classAttr.includes("branding") ||
-            classAttr.includes("bloom-qrcode")
+            imgEl.classList.contains("branding") ||
+            imgEl.classList.contains("bloom-qrcode")
         )
             continue;
         setImgTransparentParam(
@@ -475,6 +484,49 @@ function normalizeCssColorToHexOrEmpty(color: string): string {
     return `#${[match[1], match[2], match[3]]
         .map((component) => Number(component).toString(16).padStart(2, "0"))
         .join("")}`.toUpperCase();
+}
+
+// Returns true when `color` represents a near-white value (every channel ≥ 253/255),
+// matching the C# ImageUtils.ShouldMakeTransparentForPageBackground threshold so that
+// white or near-white page backgrounds do not trigger image transparency.
+function isNearWhite(color: string): boolean {
+    const normalized = normalizeCssColorToHexOrEmpty(color);
+    if (!normalized) return false;
+
+    // After normalizeCssColorToHexOrEmpty, rgb/rgba values become uppercase #RRGGBB.
+    const hexMatch = normalized.match(
+        /^#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/,
+    );
+    if (hexMatch) {
+        const r = parseInt(hexMatch[1], 16);
+        const g = parseInt(hexMatch[2], 16);
+        const b = parseInt(hexMatch[3], 16);
+        return r >= 253 && g >= 253 && b >= 253;
+    }
+
+    // Short hex (#FFF → each channel 0xFF = 255). Only #FFF reaches ≥ 253 in this form.
+    const shortHexMatch = normalized.match(
+        /^#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])$/,
+    );
+    if (shortHexMatch) {
+        const r = parseInt(shortHexMatch[1] + shortHexMatch[1], 16);
+        const g = parseInt(shortHexMatch[2] + shortHexMatch[2], 16);
+        const b = parseInt(shortHexMatch[3] + shortHexMatch[3], 16);
+        return r >= 253 && g >= 253 && b >= 253;
+    }
+
+    // "white" is the only CSS named color that passes the ≥ 253 threshold (#FFFFFF).
+    return normalized.toLowerCase() === "white";
+}
+
+// Returns true when `color` is a non-empty, non-transparent, non-near-white CSS color string
+// — i.e., when a page with this background color needs image transparency applied.
+// Matches the behavior of the C# ImageUtils.ShouldMakeTransparentForPageBackground.
+export function pageBackgroundNeedsTransparency(color: string): boolean {
+    if (!color) return false;
+    const normalized = normalizeCssColorToHexOrEmpty(color);
+    if (!normalized) return false; // transparent / zero-alpha / no background
+    return !isNearWhite(normalized);
 }
 
 export function handleMouseEnterBloomCanvas(bloomCanvas: HTMLElement): void {

--- a/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
@@ -340,7 +340,7 @@ export function doImageCommand(
     postJson(endpoint, payload);
 }
 
-function getOwningPageBackgroundColor(element: HTMLElement): string {
+export function getOwningPageBackgroundColor(element: HTMLElement): string {
     const page = element.closest(".bloom-page") as HTMLElement | null;
     if (!page) {
         return "";
@@ -362,6 +362,93 @@ function getOwningPageBackgroundColor(element: HTMLElement): string {
         );
     }
     return result;
+}
+
+// Transparency mode for a single img, mirroring the C# ImageTransparencyMode enum.
+// "none"  = no transparent param (bloom-opaque, or white page)
+// "auto"  = transparent=yes (auto-detect line art)
+// "force" = transparent=force (bloom-transparent: always apply, skip line-art check)
+type TransparencyMode = "none" | "auto" | "force";
+
+// Returns the transparency mode for an img element given whether the owning page
+// has a colored background. bloom-transparent/bloom-opaque are explicit user overrides
+// that take precedence over the page-background gate.
+export function getImageTransparencyMode(
+    img: HTMLElement,
+    pageNeedsTransparent: boolean,
+): TransparencyMode {
+    // bloom-opaque: explicit "never transparent" override.
+    if (img.classList.contains("bloom-opaque")) return "none";
+    // bloom-transparent: explicit "always force transparent" override, even on images
+    // that don't look (at least to our algorithm) like line art.
+    // This can also 'erase' very light-colored parts of an image, even on a white page.
+    if (img.classList.contains("bloom-transparent")) return "force";
+    if (!pageNeedsTransparent) return "none";
+    return "auto";
+}
+
+// Set (or remove) the transparent query param on a single img's src.
+// "none"  → remove any existing transparent param
+// "auto"  → transparent=yes
+// "force" → transparent=force (bypasses line-art detection on the server)
+// We add these params so that when bloom-server is asked for the image, it can apply
+// the appropriate transparency transform. Other information it needs can be obtained
+// from the image itself, but it doesn't have access to the img element whose src caused
+// the retrieval, so it can't check for itself whether the image has bloom-transparent
+// or bloom-opaque classes, or whether the page background is colored.
+// The downside of this approach is that if the raw HTML file in the book folder is
+// simply opened, images will not have transparent backgrounds. We think it is worth
+// the price to have the original image around, and maybe do a better job of making
+// the background transparent wth a better future algorithm, or if the page background
+// changes. For actual publications (BloomPubs, epubs, videos) we export files with
+// real transparent backgrounds. PDFs, of course, capture what the BloomServer returns.
+export function setImgTransparentParam(
+    img: HTMLElement,
+    mode: TransparencyMode,
+): void {
+    const src = img.getAttribute("src");
+    if (!src) return;
+
+    const qIndex = src.indexOf("?");
+    const path = qIndex < 0 ? src : src.substring(0, qIndex);
+    const params =
+        qIndex < 0
+            ? []
+            : src
+                  .substring(qIndex + 1)
+                  .split("&")
+                  .filter((p) => !p.startsWith("transparent="));
+
+    if (mode !== "none") {
+        params.push(`transparent=${mode === "force" ? "force" : "yes"}`);
+    }
+
+    const newSrc = params.length > 0 ? `${path}?${params.join("&")}` : path;
+    if (newSrc !== src) img.setAttribute("src", newSrc);
+}
+
+// Update img src attributes on `page` to add or remove the transparent query
+// parameter. Pass the raw CSS color string just applied (empty when clearing).
+// Call immediately after changing --page-background-color so the browser
+// re-fetches images with the correct transparency setting.
+export function updateImageTransparencyForPage(
+    page: HTMLElement,
+    newColor: string,
+): void {
+    const pageNeedsTransparent = !!newColor;
+    for (const img of Array.from(page.querySelectorAll("img"))) {
+        const imgEl = img as HTMLElement;
+        const classAttr = imgEl.className ?? "";
+        if (
+            classAttr.includes("branding") ||
+            classAttr.includes("bloom-qrcode")
+        )
+            continue;
+        setImgTransparentParam(
+            imgEl,
+            getImageTransparencyMode(imgEl, pageNeedsTransparent),
+        );
+    }
 }
 
 function normalizeCssColorToHexOrEmpty(color: string): string {

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlAvailabilityRules.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlAvailabilityRules.ts
@@ -65,6 +65,10 @@ export const imageAvailabilityRules: AvailabilityRulesMap = {
             );
         },
     },
+    imageBackground: {
+        visible: (ctx) => ctx.hasImage,
+        enabled: (ctx) => ctx.hasRealImage,
+    },
 };
 
 export const videoAvailabilityRules: AvailabilityRulesMap = {

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlRegistry.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlRegistry.ts
@@ -44,10 +44,13 @@ import {
     doImageCommand,
     getImageFromCanvasElement,
     getImageFromContainer,
+    getImageTransparencyMode,
     getImageUrlFromImageContainer,
     HandleImageError,
+    getOwningPageBackgroundColor,
     isPlaceHolderImage,
     kImageContainerClass,
+    setImgTransparentParam,
 } from "../../js/bloomImages";
 import { doVideoCommand } from "../../js/bloomVideo";
 import {
@@ -693,6 +696,84 @@ export const controlRegistry: Record<TopLevelControlId, IControlDefinition> = {
         englishLabel: "Image Fit",
         canvasToolsControl: ImageFillModePanelControl,
     },
+    imageBackground: {
+        kind: "command",
+        id: "imageBackground",
+        l10nId: "EditTab.Image.Background",
+        englishLabel: "Background",
+        action: () => {},
+        menu: {
+            buildMenuItem: (ctx, _runtime) => {
+                const img = getImage(ctx);
+                const isTransparent =
+                    img?.classList.contains("bloom-transparent") ?? false;
+                const isOpaque =
+                    img?.classList.contains("bloom-opaque") ?? false;
+                const isAuto = !isTransparent && !isOpaque;
+
+                // After mutating the img's classes, recompute and apply the transparent param.
+                function applyTransparencyParam() {
+                    if (!img) return;
+                    const bgColor = getOwningPageBackgroundColor(img);
+                    setImgTransparentParam(
+                        img,
+                        getImageTransparencyMode(img, !!bgColor),
+                    );
+                }
+
+                return {
+                    id: "imageBackground",
+                    l10nId: "EditTab.Image.Background",
+                    englishLabel: "Background",
+                    onSelect: () => {},
+                    subMenuItems: [
+                        {
+                            l10nId: "EditTab.Image.Background.Auto",
+                            englishLabel: "Auto",
+                            icon: isAuto
+                                ? React.createElement(CheckIcon, null)
+                                : undefined,
+                            onSelect: () => {
+                                if (!img) return;
+                                img.classList.remove(
+                                    "bloom-transparent",
+                                    "bloom-opaque",
+                                );
+                                applyTransparencyParam();
+                            },
+                        },
+                        {
+                            l10nId: "EditTab.Image.Background.Transparent",
+                            englishLabel: "Transparent",
+                            icon: isTransparent
+                                ? React.createElement(CheckIcon, null)
+                                : undefined,
+                            onSelect: () => {
+                                if (!img) return;
+                                img.classList.add("bloom-transparent");
+                                img.classList.remove("bloom-opaque");
+                                applyTransparencyParam();
+                            },
+                        },
+                        {
+                            l10nId: "EditTab.Image.Background.Opaque",
+                            englishLabel: "Opaque",
+                            icon: isOpaque
+                                ? React.createElement(CheckIcon, null)
+                                : undefined,
+                            onSelect: () => {
+                                if (!img) return;
+                                img.classList.add("bloom-opaque");
+                                img.classList.remove("bloom-transparent");
+                                // bloom-opaque always means "none" regardless of page background.
+                                setImgTransparentParam(img, "none");
+                            },
+                        },
+                    ],
+                };
+            },
+        },
+    },
     chooseVideo: {
         kind: "command",
         id: "chooseVideo",
@@ -1141,6 +1222,7 @@ export const controlSections: Record<SectionId, IControlSection> = {
                 "expandToFillSpace",
                 "becomeBackground",
                 "imageFieldType",
+                "imageBackground",
             ],
         },
     },

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlRegistry.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlRegistry.ts
@@ -50,6 +50,7 @@ import {
     getOwningPageBackgroundColor,
     isPlaceHolderImage,
     kImageContainerClass,
+    pageBackgroundNeedsTransparency,
     setImgTransparentParam,
 } from "../../js/bloomImages";
 import { doVideoCommand } from "../../js/bloomVideo";
@@ -717,7 +718,10 @@ export const controlRegistry: Record<TopLevelControlId, IControlDefinition> = {
                     const bgColor = getOwningPageBackgroundColor(img);
                     setImgTransparentParam(
                         img,
-                        getImageTransparencyMode(img, !!bgColor),
+                        getImageTransparencyMode(
+                            img,
+                            pageBackgroundNeedsTransparency(bgColor),
+                        ),
                     );
                 }
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlTypes.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlTypes.ts
@@ -48,6 +48,7 @@ export type ControlId =
     | "expandToFillSpace"
     | "imageFieldType"
     | "becomeBackground"
+    | "imageBackground"
     | "imageFillMode"
     | "chooseVideo"
     | "recordVideo"

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -3434,43 +3434,8 @@ namespace Bloom.Book
             );
         }
 
-        // returns the active color, be it from Apppearance or the Legacy system
-        public String GetCoverColor()
-        {
-            if (BookInfo.AppearanceSettings.CssThemeName != "legacy-5-6")
-            {
-                var color = BookInfo.AppearanceSettings.GetStringPropertyValueOrDefault(
-                    "cover-background-color",
-                    null
-                );
-                if (color != null)
-                {
-                    return color;
-                }
-            }
-
-            return GetCoverBackgroundColorFromOldInlineStyle(RawDom);
-        }
-
-        internal static String GetCoverBackgroundColorFromOldInlineStyle(SafeXmlDocument dom)
-        {
-            foreach (SafeXmlElement stylesheet in dom.SafeSelectNodes("//style"))
-            {
-                var content = stylesheet.InnerText;
-                // Our XML representation of an HTML DOM doesn't seem to have any object structure we can
-                // work with. The Stylesheet content is just raw CDATA text.
-                // Regex updated to handle comments and lowercase 'div' in the cover color rule.
-                var match = new Regex(
-                    @".*\.bloom-page\.coverColor\s*{.*?background-color:\s*(#[0-9a-fA-F]*|[a-z]*)",
-                    RegexOptions.Singleline
-                ).Match(content);
-                if (match.Success)
-                {
-                    return match.Groups[1].Value;
-                }
-            }
-            return "#FFFFFF";
-        }
+        // returns the active color, be it from Appearance or the Legacy system
+        public String GetCoverColor() => OurHtmlDom.GetCoverColor(BookInfo.AppearanceSettings);
 
         public void SetCoverColor(string color)
         {

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -1995,7 +1995,7 @@ namespace Bloom.Book
 
             // Cover pages: background comes from the CSS rule written into the document's <style>
             // element by SetBackwardsCompatibleCoverBackgroundColor.
-            if ((pageDiv.GetAttribute("class") ?? "").Contains("coverColor"))
+            if (pageDiv.HasClass("coverColor"))
                 return ImageUtils.ShouldMakeTransparentForPageBackground(
                     GetCoverBackgroundColorFromOldInlineStyle(pageDiv.OwnerDocument)
                 );
@@ -2051,17 +2051,17 @@ namespace Bloom.Book
         /// our algorithm to decide whether the image looks like line art.
         /// </summary>
         internal static ImageTransparencyMode GetImageTransparencyMode(
-            string imgClassAttr,
+            SafeXmlElement img,
             bool pageNeedsTransparent
         )
         {
             // bloom-opaque is an explicit user override: never apply transparency.
-            if (imgClassAttr.Contains("bloom-opaque"))
+            if (img.HasClass("bloom-opaque"))
                 return ImageTransparencyMode.None;
             // bloom-transparent is an explicit user override: always force transparency,
             // even for images that don't look (at least to our algorithm) like line art.
             // This can also 'erase' very light-colored parts of an image, even on a white page.
-            if (imgClassAttr.Contains("bloom-transparent"))
+            if (img.HasClass("bloom-transparent"))
                 return ImageTransparencyMode.Force;
             if (!pageNeedsTransparent)
                 return ImageTransparencyMode.None;
@@ -2074,12 +2074,15 @@ namespace Bloom.Book
         /// <c>transparent=yes</c> for auto-detect mode, <c>transparent=force</c> to
         /// bypass the line-art check (bloom-transparent class). Images with bloom-opaque
         /// or on white pages (unless they have bloom-transparent) receive no parameter.
+        /// When <paramref name="suppressBackgroundColors"/> is true every page is treated
+        /// as having a white background, so only bloom-transparent images get a parameter.
         /// Returns a list of modified (element, original-src) pairs so the caller can
         /// restore them with <see cref="RestoreImageSrcs"/>, typically after making
         /// HTML out of the temporarily modified DOM..
         /// </summary>
         internal static List<(SafeXmlElement img, string src)> AddTransparencyParamToImages(
-            HtmlDom dom
+            HtmlDom dom,
+            bool suppressBackgroundColors = false
         )
         {
             var modified = new List<(SafeXmlElement, string)>();
@@ -2090,17 +2093,17 @@ namespace Bloom.Book
                     .Cast<SafeXmlElement>()
             )
             {
-                var pageNeedsTransparent = PageNeedsTransparentImages(pageDiv);
+                var pageNeedsTransparent =
+                    !suppressBackgroundColors && PageNeedsTransparentImages(pageDiv);
                 foreach (
                     SafeXmlElement img in pageDiv
                         .SafeSelectNodes(".//img[@src]")
                         .Cast<SafeXmlElement>()
                 )
                 {
-                    var classAttr = img.GetAttribute("class") ?? "";
-                    if (classAttr.Contains("branding") || classAttr.Contains("bloom-qrcode"))
+                    if (img.HasClass("branding") || img.HasClass("bloom-qrcode"))
                         continue;
-                    var mode = GetImageTransparencyMode(classAttr, pageNeedsTransparent);
+                    var mode = GetImageTransparencyMode(img, pageNeedsTransparent);
                     if (mode == ImageTransparencyMode.None)
                         continue;
                     var src = img.GetAttribute("src");
@@ -2108,12 +2111,7 @@ namespace Bloom.Book
                         continue;
                     modified.Add((img, src));
                     var paramValue = mode == ImageTransparencyMode.Force ? "force" : "yes";
-                    img.SetAttribute(
-                        "src",
-                        src.Contains('?')
-                            ? $"{src}&transparent={paramValue}"
-                            : $"{src}?transparent={paramValue}"
-                    );
+                    img.SetAttribute("src", GetSrcWithTransparencyParam(src, paramValue));
                 }
             }
             return modified;
@@ -2124,6 +2122,30 @@ namespace Bloom.Book
         {
             foreach (var (img, src) in modifications)
                 img.SetAttribute("src", src);
+        }
+
+        /// <summary>
+        /// Returns <paramref name="src"/> with the <c>transparent</c> query parameter set to
+        /// <paramref name="paramValue"/> ("yes" or "force"), replacing any existing value.
+        /// When <paramref name="src"/> has no query string (the common case) this is a simple append.
+        /// </summary>
+        internal static string GetSrcWithTransparencyParam(string src, string paramValue)
+        {
+            var qIndex = src.IndexOf('?');
+            if (qIndex < 0)
+                return $"{src}?transparent={paramValue}";
+
+            // Strip any pre-existing transparent= param, then append the new one.
+            var path = src[..qIndex];
+            var remaining = string.Join(
+                "&",
+                src[(qIndex + 1)..]
+                    .Split('&')
+                    .Where(p => !p.StartsWith("transparent=", StringComparison.OrdinalIgnoreCase))
+            );
+            return remaining.Length > 0
+                ? $"{path}?{remaining}&transparent={paramValue}"
+                : $"{path}?transparent={paramValue}";
         }
 
         /// <summary>

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -11,6 +11,7 @@ using System.Windows.Controls;
 using System.Windows.Markup;
 using System.Xml;
 using Bloom.Api;
+using Bloom.ImageProcessing;
 using Bloom.Publish; // for DynamicJson
 using Bloom.Publish.Epub;
 using Bloom.SafeXml;
@@ -1959,6 +1960,203 @@ namespace Bloom.Book
             }
         }
 
+        /// <summary>
+        /// Returns true if the given bloom-page div has a non-white, non-transparent background
+        /// color, meaning images on this page should have their backgrounds made transparent.
+        /// Considers --page-background-color in the page's inline style (content pages set via
+        /// Page Settings) and the coverColor class (cover pages, reading the cover color from
+        /// the owning document's style element via GetCoverBackgroundColorFromOldInlineStyle).
+        /// This should be consistent with bloomImages.getOwningPageBackgroundColor().
+        /// </summary>
+        public static bool PageNeedsTransparentImages(SafeXmlElement pageDiv)
+        {
+            // Content pages: --page-background-color is written directly into the page div's style.
+            var style = pageDiv.GetAttribute("style");
+            if (!string.IsNullOrEmpty(style))
+            {
+                foreach (
+                    var segment in style.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+                )
+                {
+                    var colonIndex = segment.IndexOf(':');
+                    if (colonIndex <= 0)
+                        continue;
+                    if (
+                        segment
+                            .Substring(0, colonIndex)
+                            .Trim()
+                            .Equals("--page-background-color", StringComparison.OrdinalIgnoreCase)
+                    )
+                        return ImageUtils.ShouldMakeTransparentForPageBackground(
+                            segment.Substring(colonIndex + 1).Trim()
+                        );
+                }
+            }
+
+            // Cover pages: background comes from the CSS rule written into the document's <style>
+            // element by SetBackwardsCompatibleCoverBackgroundColor.
+            if ((pageDiv.GetAttribute("class") ?? "").Contains("coverColor"))
+                return ImageUtils.ShouldMakeTransparentForPageBackground(
+                    GetCoverBackgroundColorFromOldInlineStyle(pageDiv.OwnerDocument)
+                );
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns the active cover background color: first checks AppearanceSettings for
+        /// non-legacy books, then falls back to the CSS rule in the document's style element.
+        /// </summary>
+        public string GetCoverColor(AppearanceSettings settings)
+        {
+            if (settings != null && settings.CssThemeName != "legacy-5-6")
+            {
+                var color = settings.GetStringPropertyValueOrDefault(
+                    "cover-background-color",
+                    null
+                );
+                if (color != null)
+                    return color;
+            }
+            return GetCoverBackgroundColorFromOldInlineStyle(RawDom);
+        }
+
+        /// <summary>
+        /// Reads the cover background color from the CSS rule written into the document's
+        /// &lt;style&gt; element by SetBackwardsCompatibleCoverBackgroundColor.
+        /// Returns "#FFFFFF" if no rule is found.
+        /// </summary>
+        public static string GetCoverBackgroundColorFromOldInlineStyle(SafeXmlDocument dom)
+        {
+            foreach (
+                SafeXmlElement stylesheet in dom.SafeSelectNodes("//style").Cast<SafeXmlElement>()
+            )
+            {
+                var content = stylesheet.InnerText;
+                var match = new Regex(
+                    @".*\.bloom-page\.coverColor\s*{.*?background-color:\s*(#[0-9a-fA-F]*|[a-z]*)",
+                    RegexOptions.Singleline
+                ).Match(content);
+                if (match.Success)
+                    return match.Groups[1].Value;
+            }
+            return "#FFFFFF";
+        }
+
+        /// <summary>
+        /// Returns the transparency mode for a specific image, given its class and whether the page
+        /// needs transparent images (i.e., has a non-white background).
+        /// bloom-opaque and bloom-transparent classes override the page background check, but in the
+        /// absence of those, we use the page background to determine whether we will (later) apply
+        /// our algorithm to decide whether the image looks like line art.
+        /// </summary>
+        internal static ImageTransparencyMode GetImageTransparencyMode(
+            string imgClassAttr,
+            bool pageNeedsTransparent
+        )
+        {
+            // bloom-opaque is an explicit user override: never apply transparency.
+            if (imgClassAttr.Contains("bloom-opaque"))
+                return ImageTransparencyMode.None;
+            // bloom-transparent is an explicit user override: always force transparency,
+            // even for images that don't look (at least to our algorithm) like line art.
+            // This can also 'erase' very light-colored parts of an image, even on a white page.
+            if (imgClassAttr.Contains("bloom-transparent"))
+                return ImageTransparencyMode.Force;
+            if (!pageNeedsTransparent)
+                return ImageTransparencyMode.None;
+            return ImageTransparencyMode.Auto;
+        }
+
+        /// <summary>
+        /// For each image that needs transparent rendering, append the appropriate
+        /// <c>transparent</c> query parameter to the img src:
+        /// <c>transparent=yes</c> for auto-detect mode, <c>transparent=force</c> to
+        /// bypass the line-art check (bloom-transparent class). Images with bloom-opaque
+        /// or on white pages (unless they have bloom-transparent) receive no parameter.
+        /// Returns a list of modified (element, original-src) pairs so the caller can
+        /// restore them with <see cref="RestoreImageSrcs"/>, typically after making
+        /// HTML out of the temporarily modified DOM..
+        /// </summary>
+        internal static List<(SafeXmlElement img, string src)> AddTransparencyParamToImages(
+            HtmlDom dom
+        )
+        {
+            var modified = new List<(SafeXmlElement, string)>();
+            foreach (
+                SafeXmlElement pageDiv in dom.SafeSelectNodes(
+                        "//div[contains(@class,'bloom-page')]"
+                    )
+                    .Cast<SafeXmlElement>()
+            )
+            {
+                var pageNeedsTransparent = PageNeedsTransparentImages(pageDiv);
+                foreach (
+                    SafeXmlElement img in pageDiv
+                        .SafeSelectNodes(".//img[@src]")
+                        .Cast<SafeXmlElement>()
+                )
+                {
+                    var classAttr = img.GetAttribute("class") ?? "";
+                    if (classAttr.Contains("branding") || classAttr.Contains("bloom-qrcode"))
+                        continue;
+                    var mode = GetImageTransparencyMode(classAttr, pageNeedsTransparent);
+                    if (mode == ImageTransparencyMode.None)
+                        continue;
+                    var src = img.GetAttribute("src");
+                    if (string.IsNullOrEmpty(src))
+                        continue;
+                    modified.Add((img, src));
+                    var paramValue = mode == ImageTransparencyMode.Force ? "force" : "yes";
+                    img.SetAttribute(
+                        "src",
+                        src.Contains('?')
+                            ? $"{src}&transparent={paramValue}"
+                            : $"{src}?transparent={paramValue}"
+                    );
+                }
+            }
+            return modified;
+        }
+
+        /// <summary>Restore image srcs saved by <see cref="AddTransparencyParamToImages"/>.</summary>
+        internal static void RestoreImageSrcs(List<(SafeXmlElement img, string src)> modifications)
+        {
+            foreach (var (img, src) in modifications)
+                img.SetAttribute("src", src);
+        }
+
+        /// <summary>
+        /// Remove any <c>transparent=yes</c> or <c>transparent=force</c> query parameter
+        /// from img srcs in <paramref name="pageDiv"/>. Call this when page content is
+        /// received back from the browser before saving it permanently to the book DOM.
+        /// </summary>
+        internal static void RemoveTransparencyParamFromImages(SafeXmlElement pageDiv)
+        {
+            foreach (
+                SafeXmlElement img in pageDiv.SafeSelectNodes(".//img[@src]").Cast<SafeXmlElement>()
+            )
+            {
+                var src = img.GetAttribute("src");
+                if (src == null || !src.Contains("transparent="))
+                    continue;
+
+                var qIndex = src.IndexOf('?');
+                if (qIndex < 0)
+                    continue; // no query string; nothing to remove
+                var path = src[..qIndex];
+                var remaining = string.Join(
+                    "&",
+                    src[(qIndex + 1)..]
+                        .Split('&')
+                        .Where(p =>
+                            !p.StartsWith("transparent=", StringComparison.OrdinalIgnoreCase)
+                        )
+                );
+                img.SetAttribute("src", remaining.Length > 0 ? path + "?" + remaining : path);
+            }
+        }
+
         private static void RemoveStyleProperties(
             SafeXmlElement element,
             params string[] propertyNames
@@ -2016,6 +2214,7 @@ namespace Bloom.Book
                 node.ParentNode.RemoveChild(node);
             RemoveTemplateEditingMarkup(edittedPageDiv);
             RemoveCkEditorMarkup(edittedPageDiv);
+            RemoveTransparencyParamFromImages(edittedPageDiv);
 
             destinationPageDiv.InnerXml = edittedPageDiv.InnerXml;
 

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -1143,7 +1143,16 @@ namespace Bloom.Edit
 
         public static string GetEditPageIframeContents(Book.Book book, IPage page)
         {
-            return GetEditPageIframeDom(book, page).getHtmlStringDisplayOnly();
+            var dom = GetEditPageIframeDom(book, page);
+            var transparencyModifications = HtmlDom.AddTransparencyParamToImages(dom);
+            try
+            {
+                return dom.getHtmlStringDisplayOnly();
+            }
+            finally
+            {
+                HtmlDom.RestoreImageSrcs(transparencyModifications);
+            }
         }
 
         public static HtmlDom GetEditPageIframeDom(Book.Book book, IPage page)

--- a/src/BloomExe/Edit/PageEditingModel.cs
+++ b/src/BloomExe/Edit/PageEditingModel.cs
@@ -40,8 +40,7 @@ namespace Bloom.Edit
             var imageFileName = ImageUtils.ProcessAndSaveImageIntoFolder(
                 imageInfo,
                 bookFolderPath,
-                isSameFile,
-                pageBackgroundColor
+                isSameFile
             );
             try
             {

--- a/src/BloomExe/ImageProcessing/ImageUtils.cs
+++ b/src/BloomExe/ImageProcessing/ImageUtils.cs
@@ -35,6 +35,7 @@ namespace Bloom.ImageProcessing
     /// <summary>
     /// Controls whether (and how) a background-transparency pass is applied to an image.
     /// </summary>
+    /// <notes> Should be kept in sync with the definition of TransparencyMode in bloomImages.ts. </notes>
     public enum ImageTransparencyMode
     {
         /// <summary>Do not apply transparency (bloom-opaque class, or white/no page background).</summary>
@@ -754,7 +755,7 @@ namespace Bloom.ImageProcessing
                 // In that case, we don't need to save it again.
                 if (!reusingSameFilename)
                 {
-                    // Resize if the image would be more than 300dpi on an A4 page.
+                    // Resize if the image is larger than our limit.
                     var importSize = GetDesiredImageSize(
                         imageInfo.Image.Width,
                         imageInfo.Image.Height
@@ -867,7 +868,8 @@ namespace Bloom.ImageProcessing
             string destDir,
             ImageTransparencyMode transparencyMode = ImageTransparencyMode.None,
             int maxShortSide = 0,
-            int maxLongSide = 0
+            int maxLongSide = 0,
+            bool transparencyOnly = false
         )
         {
             try
@@ -882,8 +884,10 @@ namespace Bloom.ImageProcessing
                             maxLongSide
                         )
                         : GetDesiredImageSize(imageInfo.Image.Width, imageInfo.Image.Height);
+                // When transparencyOnly, we must not resize — we only want to apply transparency.
                 var needsResize =
-                    size.Width < imageInfo.Image.Width || size.Height < imageInfo.Image.Height;
+                    !transparencyOnly
+                    && (size.Width < imageInfo.Image.Width || size.Height < imageInfo.Image.Height);
                 var isJpeg = AppearsToBeJpeg(imageInfo);
                 var isPng = AppearsToBePng(imageInfo);
                 var isWebFormat = isJpeg || isPng;
@@ -891,10 +895,18 @@ namespace Bloom.ImageProcessing
                     transparencyMode == ImageTransparencyMode.Force
                     || transparencyMode == ImageTransparencyMode.Auto
                         && ShouldMakeBackgroundTransparent(imageInfo);
-                // Would a PNG→JPEG size-saving conversion be worth trying? Since JPEG can't do transparency,
-                // we only want to consider this if we don't need transparency and the image doesn't already
-                // have transparency.
-                var tryJpegConversion = !shouldMakeTransparent && !HasTransparency(imageInfo.Image);
+                // Would a PNG→JPEG size-saving conversion be worth trying? Skip when transparencyOnly
+                // because we're here only to apply transparency, not to optimize format.
+                var tryJpegConversion =
+                    !transparencyOnly
+                    && !shouldMakeTransparent
+                    && !HasTransparency(imageInfo.Image);
+
+                // When transparencyOnly, skip all processing for images that don't need transparency.
+                // The null return causes GetPathToAdjustedImage to cache this as a no-op, so
+                // subsequent requests for the same image return immediately without reloading it.
+                if (transparencyOnly && !shouldMakeTransparent)
+                    return null;
 
                 // If only a JPEG conversion is being considered (no resize, already web format,
                 // no transparency), attempt it and bail out either way — no point copying a file

--- a/src/BloomExe/ImageProcessing/ImageUtils.cs
+++ b/src/BloomExe/ImageProcessing/ImageUtils.cs
@@ -32,6 +32,21 @@ using TempFile = SIL.IO.TempFile;
 
 namespace Bloom.ImageProcessing
 {
+    /// <summary>
+    /// Controls whether (and how) a background-transparency pass is applied to an image.
+    /// </summary>
+    public enum ImageTransparencyMode
+    {
+        /// <summary>Do not apply transparency (bloom-opaque class, or white/no page background).</summary>
+        None,
+
+        /// <summary>Apply transparency only when the image is detected as line art (transparent=yes).</summary>
+        Auto,
+
+        /// <summary>Always apply transparency, bypassing the line-art check (transparent=force).</summary>
+        Force,
+    }
+
     static class ImageUtils
     {
         public const int MaxLength = 3840; // equals Ultra HD ("4K") long dimension (max width for landscape, height for portrait)
@@ -80,16 +95,10 @@ namespace Bloom.ImageProcessing
         }
 
         // Tolerances used by the quantize-based line-art palette check.
-        // To be unambiguously a line-art background, a color must have a perceptual brightness
+        // To be a line-art background, a color must have a perceptual brightness
         // of at least LineArtBackgroundMinBrightness and a chroma (max-min channel) of at
         // most LineArtBackgroundMaxChroma.
-        // If its brightness is below LineArtBackgroundMinBrightness or its chroma is
-        // above LineArtBackgroundMaxChroma, but its brightness is above LineArtBackgroundBorderlineBrightness,
-        // the color is considered borderline: it counts as a background if all other colors are compatible
-        // with its hue.
-        // Otherwise the color is not considered a line-art background at all.
         private const double LineArtBackgroundMinBrightness = 235.0;
-        private const double LineArtBackgroundBorderlineBrightness = 220.0;
         private const int LineArtBackgroundMaxChroma = 6;
 
         // An "ink" palette entry whose chroma (max-min channel) is at or below this counts as
@@ -168,17 +177,13 @@ namespace Bloom.ImageProcessing
                 if (!seen.Add(key))
                     continue;
                 totalDistinct++;
-                bool borderline;
-                if (IsLineArtBackground(c, out borderline))
+                if (IsLineArtBackground(c))
                 {
                     whiteFound = true;
                 }
                 else
                 {
                     inks.Add(c);
-                    // borderline colors are close enough to count as a background if they have a
-                    // similar hue to other colors. We check this by leaving them in inks.
-                    whiteFound |= borderline;
                 }
             }
             if (!whiteFound || totalDistinct < 2)
@@ -270,13 +275,9 @@ namespace Bloom.ImageProcessing
 
         /// <summary>
         /// Returns true if the color is bright enough (and free of significant hue)
-        /// to be considered unambiguously a line art background.
-        /// If it is not quite that light, or has perceptible hue, but is light enough
-        /// to consider a background IFF the hue is acceptable, we return false but
-        /// set borderline to true.
-        /// If both results are false, the color is definitely not line art background.
+        /// to be considered a line art background.
         /// </summary>
-        private static bool IsLineArtBackground(Color c, out bool borderline)
+        private static bool IsLineArtBackground(Color c)
         {
             // Perceptual brightness formula: 0.299*R + 0.587*G + 0.114*B
             // Threshold: all channels 235 => brightness = 0.299*235 + 0.587*235 + 0.114*235 = 235
@@ -284,9 +285,6 @@ namespace Bloom.ImageProcessing
             double brightness = 0.299 * c.R + 0.587 * c.G + 0.114 * c.B;
             int max = Math.Max(c.R, Math.Max(c.G, c.B));
             int min = Math.Min(c.R, Math.Min(c.G, c.B));
-            // deliberately ignore hue for borderline; we'll check later that any hue it has
-            // is compatible with other colors.
-            borderline = brightness >= LineArtBackgroundBorderlineBrightness;
             return brightness >= LineArtBackgroundMinBrightness
                 && (max - min) <= LineArtBackgroundMaxChroma;
         }
@@ -686,10 +684,11 @@ namespace Bloom.ImageProcessing
         }
 
         /// <summary>
-        /// Ensure the image does not exceed the maximum size we've set with MaxLength and MaxBreadth.
-        /// Ensure that non-jpeg files have an opaque background.
-        /// Make the image a png if it's not a jpeg.  Make large png images into jpeg images to save space.
-        /// Save the processed image in the book's folder.
+        /// Save a copy of the image into the book's folder with minimal processing.
+        /// Non-web formats (BMP, TIFF, etc.) are converted to PNG so browsers can display them;
+        /// very high-resolution images are downscaled..
+        /// All other processing (more resizing, format optimization, transparency) is deferred to
+        /// display time via <see cref="AdjustImageForDisplay"/>.
         ///
         /// If the image has a filename, that name is used in creating any new files.
         /// WARNING: imageInfo.Image could be replaced (causing the original to be disposed)
@@ -698,14 +697,11 @@ namespace Bloom.ImageProcessing
         public static string ProcessAndSaveImageIntoFolder(
             PalasoImage imageInfo,
             string bookFolderPath,
-            bool isSameFile,
-            string pageBackgroundColor = null
+            bool isSameFile
         )
         {
-            //LogMemoryUsage();
-
             // As of BL-15441, we aren't using real placeHolder image files anymore. But if one is there,
-            // don't go through all the processing and saving machinations for it.
+            // don't go through all the saving machinations for it.
             if (
                 !string.IsNullOrEmpty(imageInfo.OriginalFilePath)
                 && IsPlaceholderImageFilename(imageInfo.OriginalFilePath)
@@ -714,59 +710,15 @@ namespace Bloom.ImageProcessing
                 return Path.GetFileName(imageInfo.OriginalFilePath);
             }
             if (!Directory.Exists(bookFolderPath))
-                throw new DirectoryNotFoundException(bookFolderPath + " does not exist"); // may as well check this early
+                throw new DirectoryNotFoundException(bookFolderPath + " does not exist");
             bool isEncodedAsJpeg = false;
             try
             {
-                var originalCurrentPath = imageInfo.GetCurrentFilePath();
-                var imageRemade = false;
-                var size = GetDesiredImageSize(imageInfo.Image.Width, imageInfo.Image.Height);
-
-                if (
-                    size.Width < imageInfo.Image.Width
-                    || size.Height < imageInfo.Image.Height
-                    || !(AppearsToBeJpeg(imageInfo) || AppearsToBePng(imageInfo))
-                )
-                {
-                    // Either need to shrink the image since it's larger than our maximum allowed size,
-                    // or need to convert from a BMP or TIFF file to a PNG file (or both).
-                    // NB: the original imageInfo.Image is disposed of in the setter below.
-                    // As of now (9/2016) this is safe because there are no other references to it higher in the stack.
-                    var img = TryResizeImageWithGraphicsMagick(imageInfo, size);
-                    if (img != null)
-                    {
-                        imageInfo.Image = img;
-                        imageRemade = true;
-                    }
-                }
-                var needToStripMetadata = imageInfo.Metadata.ExceptionCaughtWhileLoading != null;
-
                 isEncodedAsJpeg = AppearsToBeJpeg(imageInfo);
+                var isPng = AppearsToBePng(imageInfo);
+                var isWebFormat = isEncodedAsJpeg || isPng;
+                // Non-web formats get saved as PNG so browsers can display them
                 var saveAsJpeg = isEncodedAsJpeg;
-
-                string jpegFilePath = Path.Combine(
-                    bookFolderPath,
-                    GetFileNameToUseForSavingImage(bookFolderPath, imageInfo, true)
-                );
-                // Compute once; the result drives both the JPEG→PNG conversion below and the
-                // PNG→JPEG guard in convertedToJpeg. Running GraphicsMagick twice would be wasteful.
-                var isLineArt = ShouldMakeBackgroundTransparent(imageInfo);
-                var shouldMakeTransparentForPageBackground =
-                    isLineArt && ShouldMakeTransparentForPageBackground(pageBackgroundColor);
-                // Convert JPEG line art to PNG on insert: JPEGs can't carry transparency, so a
-                // line-art JPEG would never get its background made transparent when shown on a
-                // colored page background. Saving as PNG fixes that at the cost of slightly larger
-                // files, which is worth it for images that we want to make transparent (BL-16336).
-                if (saveAsJpeg && shouldMakeTransparentForPageBackground)
-                    saveAsJpeg = false;
-                // Don't convert line-art PNGs to JPEG: JPEG is only right for photographic content.
-                var convertedToJpeg =
-                    !saveAsJpeg
-                    && !HasTransparency(imageInfo.Image)
-                    && !isLineArt
-                    && TryChangeFormatToJpegIfHelpful(imageInfo, jpegFilePath);
-                if (convertedToJpeg)
-                    return Path.GetFileName(jpegFilePath);
 
                 string imageFileName;
                 if (isSameFile)
@@ -787,14 +739,8 @@ namespace Bloom.ImageProcessing
                         imageInfo,
                         saveAsJpeg
                     );
+
                 var sourcePath = imageInfo.GetCurrentFilePath();
-                if (imageRemade & sourcePath == originalCurrentPath)
-                {
-                    // We don't want to copy the original file if we have remade the image.  (BL-15708)
-                    // If graphicsmagick succeeds, it produces a temp file with a random name and changes
-                    // the current path setting.
-                    sourcePath = null;
-                }
                 var destinationPath = Path.Combine(bookFolderPath, imageFileName);
                 var reusingSameFilename =
                     isSameFile
@@ -802,34 +748,58 @@ namespace Bloom.ImageProcessing
                         imageFileName,
                         StringComparison.InvariantCultureIgnoreCase
                     );
-                var sourceEncodingMatchesDestination = isEncodedAsJpeg == saveAsJpeg;
-                if (needToStripMetadata)
-                {
-                    if (!TryStripMetadataWithGraphicsMagick(imageInfo, sourcePath, destinationPath))
-                        imageInfo.Image.Save(
-                            destinationPath,
-                            saveAsJpeg ? ImageFormat.Jpeg : ImageFormat.Png
-                        );
-                }
+                var needToStripMetadata = imageInfo.Metadata.ExceptionCaughtWhileLoading != null;
+
                 // I _think_ isSameFile is true only when we copy an image and paste it back in the same place.
-                // In that case, we don't need to save it again. I checked that when we
-                // use the old cropping tool to create a different image, it doesn't take this path.
-                // As far as I can tell isSameFile is only true if we are copying the file on top of
-                // itself, and that can't ever be useful.
-                else if (!reusingSameFilename)
+                // In that case, we don't need to save it again.
+                if (!reusingSameFilename)
                 {
-                    // Pasting an image can result in sourcePath being null.
-                    // So can graphicsmagick failures where we had to remake the image. (BL-15708)
-                    if (sourcePath == null || !sourceEncodingMatchesDestination)
+                    // Resize if the image would be more than 300dpi on an A4 page.
+                    var importSize = GetDesiredImageSize(
+                        imageInfo.Image.Width,
+                        imageInfo.Image.Height
+                    );
+                    if (
+                        importSize.Width < imageInfo.Image.Width
+                        || importSize.Height < imageInfo.Image.Height
+                    )
+                    {
+                        var resized = TryResizeImageWithGraphicsMagick(imageInfo, importSize);
+                        if (resized != null)
+                        {
+                            imageInfo.Image = resized;
+                            sourcePath = imageInfo.GetCurrentFilePath();
+                        }
+                    }
+
+                    if (needToStripMetadata)
+                    {
+                        if (
+                            !TryStripMetadataWithGraphicsMagick(
+                                imageInfo,
+                                sourcePath,
+                                destinationPath
+                            )
+                        )
+                            imageInfo.Image.Save(
+                                destinationPath,
+                                saveAsJpeg ? ImageFormat.Jpeg : ImageFormat.Png
+                            );
+                    }
+                    else if (sourcePath != null && isWebFormat)
+                    {
+                        // Copy the original file unchanged to preserve full quality
+                        RobustFile.Copy(sourcePath, destinationPath);
+                    }
+                    else
+                    {
+                        // Clipboard paste (no source file) or non-web format: save from image data
                         imageInfo.Image.Save(
                             destinationPath,
                             saveAsJpeg ? ImageFormat.Jpeg : ImageFormat.Png
                         );
-                    else
-                        RobustFile.Copy(sourcePath, destinationPath);
+                    }
                 }
-                if (shouldMakeTransparentForPageBackground)
-                    MakeSavedImageBackgroundTransparent(destinationPath);
                 if (_createdTempImageFile != null)
                 {
                     if (RobustFile.Exists(_createdTempImageFile))
@@ -842,23 +812,17 @@ namespace Bloom.ImageProcessing
             {
                 throw; //these are informative on their own
             }
-            /* No. OutOfMemory is almost meaningless when it comes to image errors. Better not to confuse people
-         * catch (OutOfMemoryException error)
-        {
-            //Enhance: it would be great if we could bring up that problem dialog ourselves, and offer this picture as an attachment
-            throw new ApplicationException("Bloom ran out of memory while trying to import the picture. We suggest that you quit Bloom, run it again, and then try importing this picture again. If that fails, please go to the Help menu and choose 'Report a Problem'", error);
-        }*/
             catch (Exception error)
             {
                 if (
-                    !String.IsNullOrEmpty(imageInfo.FileName)
+                    !string.IsNullOrEmpty(imageInfo.FileName)
                     && RobustFile.Exists(imageInfo.OriginalFilePath)
                 )
                 {
                     var megs = new FileInfo(imageInfo.OriginalFilePath).Length / (1024 * 1000);
                     if (megs > 2)
                     {
-                        var msg = String.Format(
+                        var msg = string.Format(
                             "Bloom was not able to prepare that image for including in the book. \r\nThis is a rather large image to be adding to a book --{0} Megs--.",
                             megs
                         );
@@ -877,6 +841,112 @@ namespace Bloom.ImageProcessing
                         + imageInfo.FileName,
                     error
                 );
+            }
+        }
+
+        /// <summary>
+        /// Create a display-ready processed version of an image in <paramref name="destDir"/>:
+        /// resize if too large, convert format if beneficial (JPEG→PNG for transparent line art,
+        /// PNG→JPEG for photographic content), and optionally make backgrounds transparent.
+        /// This contains the processing that was formerly done at import time by
+        /// <see cref="ProcessAndSaveImageIntoFolder"/>; it is now applied at display time so that
+        /// the book folder always stores something as close as we think reasonable to the original/unmodified file.
+        /// </summary>
+        /// <param name="sourcePath">Path to the image file in the book folder.</param>
+        /// <param name="destDir">Directory in which to write the processed copy.</param>
+        /// <param name="transparencyMode">
+        /// Controls whether to make the background transparent. If <see cref="ImageTransparencyMode.Auto"/>,
+        /// the decision is made here based on an attempt to judge whether the image content looks like line art.
+        /// </param>
+        /// <returns>
+        /// Path of the processed image inside <paramref name="destDir"/>, or <c>null</c> if the
+        /// original can be served as-is or if processing failed.
+        /// </returns>
+        public static string AdjustImageForDisplay(
+            string sourcePath,
+            string destDir,
+            ImageTransparencyMode transparencyMode = ImageTransparencyMode.None,
+            int maxShortSide = 0,
+            int maxLongSide = 0
+        )
+        {
+            try
+            {
+                using var imageInfo = PalasoImage.FromFileRobustly(sourcePath);
+                var size =
+                    maxShortSide > 0 && maxLongSide > 0
+                        ? GetDesiredImageSize(
+                            imageInfo.Image.Width,
+                            imageInfo.Image.Height,
+                            maxShortSide,
+                            maxLongSide
+                        )
+                        : GetDesiredImageSize(imageInfo.Image.Width, imageInfo.Image.Height);
+                var needsResize =
+                    size.Width < imageInfo.Image.Width || size.Height < imageInfo.Image.Height;
+                var isJpeg = AppearsToBeJpeg(imageInfo);
+                var isPng = AppearsToBePng(imageInfo);
+                var isWebFormat = isJpeg || isPng;
+                var shouldMakeTransparent =
+                    transparencyMode == ImageTransparencyMode.Force
+                    || transparencyMode == ImageTransparencyMode.Auto
+                        && ShouldMakeBackgroundTransparent(imageInfo);
+                // Would a PNG→JPEG size-saving conversion be worth trying? Since JPEG can't do transparency,
+                // we only want to consider this if we don't need transparency and the image doesn't already
+                // have transparency.
+                var tryJpegConversion = !shouldMakeTransparent && !HasTransparency(imageInfo.Image);
+
+                // If only a JPEG conversion is being considered (no resize, already web format,
+                // no transparency), attempt it and bail out either way — no point copying a file
+                // that is already optimal.
+                if (!needsResize && isWebFormat && !shouldMakeTransparent && tryJpegConversion)
+                {
+                    if (!Directory.Exists(destDir))
+                        Directory.CreateDirectory(destDir);
+                    var jpegOnlyPath = Path.Combine(destDir, Path.GetRandomFileName() + ".jpg");
+                    return TryChangeFormatToJpegIfHelpful(imageInfo, jpegOnlyPath)
+                        ? jpegOnlyPath
+                        : null;
+                }
+
+                // If nothing needs changing, serve the original.
+                if (!needsResize && isWebFormat && !shouldMakeTransparent)
+                    return null;
+
+                // Resize if needed, or convert from non-web format (BMP, TIFF, …)
+                if (needsResize || !isWebFormat)
+                {
+                    var resized = TryResizeImageWithGraphicsMagick(imageInfo, size);
+                    if (resized != null)
+                        imageInfo.Image = resized;
+                }
+
+                // JPEG cannot carry transparency; switch to PNG for transparent line art
+                var saveAsJpeg = isJpeg && !shouldMakeTransparent;
+
+                if (!Directory.Exists(destDir))
+                    Directory.CreateDirectory(destDir);
+
+                // Try PNG→JPEG for photographic content that doesn't need transparency
+                if (tryJpegConversion)
+                {
+                    var jpegPath = Path.Combine(destDir, Path.GetRandomFileName() + ".jpg");
+                    if (TryChangeFormatToJpegIfHelpful(imageInfo, jpegPath))
+                        return jpegPath;
+                }
+
+                var ext = saveAsJpeg ? ".jpg" : ".png";
+                var destPath = Path.Combine(destDir, Path.GetRandomFileName() + ext);
+                imageInfo.Image.Save(destPath, saveAsJpeg ? ImageFormat.Jpeg : ImageFormat.Png);
+
+                if (shouldMakeTransparent)
+                    ApplyBloomTransparencyToFile(destPath);
+
+                return destPath;
+            }
+            catch (Exception)
+            {
+                return null;
             }
         }
 
@@ -910,7 +980,6 @@ namespace Bloom.ImageProcessing
                 {
                     Size = new Size(0, 0),
                     MakeOpaque = false,
-                    MakeTransparent = false,
                     JpegQuality = 0,
                     ProfilesToStrip = profiles,
                 };
@@ -1460,7 +1529,6 @@ namespace Bloom.ImageProcessing
                 {
                     Size = size,
                     MakeOpaque = makeOpaque,
-                    MakeTransparent = makeTransparent,
                     JpegQuality = 0,
                     ProfilesToStrip = null,
                 };
@@ -1468,6 +1536,8 @@ namespace Bloom.ImageProcessing
                 if (result.ExitCode == 0)
                 {
                     RobustFile.Copy(tempCopy, path, true);
+                    if (makeTransparent)
+                        ApplyBloomTransparencyToFile(path);
                     // Copy metadata from older file to the new one.  GraphicsMagick does a poor job on metadata.
                     var newMeta = RobustFileIO.CreateTaglibFile(path);
                     CopyTags(oldMetaData, newMeta);
@@ -1690,9 +1760,14 @@ namespace Bloom.ImageProcessing
             {
                 var sourcePath = imageInfo.GetCurrentFilePath();
                 var isJpegImage = AppearsToBeJpeg(imageInfo);
+                // Track whether we created sourcePath ourselves so we know it's safe to delete.
+                // Pre-existing book images (including those in export staging folders under GetTempPath)
+                // must never be deleted here.
+                var weCreatedSourceFile = false;
                 if (String.IsNullOrEmpty(sourcePath) || !RobustFile.Exists(sourcePath))
                 {
                     sourcePath = CreateSourceFileForImage(imageInfo, isJpegImage);
+                    weCreatedSourceFile = true;
                 }
                 var destPath = TempFileUtils.GetTempFilepathWithExtension(
                     isJpegImage ? ".jpg" : ".png"
@@ -1703,7 +1778,6 @@ namespace Bloom.ImageProcessing
                     {
                         Size = size,
                         MakeOpaque = makeOpaque,
-                        MakeTransparent = false,
                         JpegQuality = 0,
                         ProfilesToStrip = null,
                     };
@@ -1735,11 +1809,10 @@ namespace Bloom.ImageProcessing
                     // Ignore any errors deleting temp files.  If we leak, we leak...
                     try
                     {
-                        // don't need this any longer if it's a temp file and not used for the current image
-                        if (
-                            sourcePath.StartsWith(Path.GetTempPath())
-                            && sourcePath != imageInfo.GetCurrentFilePath()
-                        )
+                        // Only delete sourcePath if WE created it via CreateSourceFileForImage.
+                        // Pre-existing book images must not be deleted even if they live under
+                        // GetTempPath() (export staging folders live there too).
+                        if (weCreatedSourceFile && sourcePath != imageInfo.GetCurrentFilePath())
                             RobustFile.Delete(sourcePath);
                     }
                     catch (Exception e)
@@ -1810,7 +1883,6 @@ namespace Bloom.ImageProcessing
         {
             internal Size Size; // if (0,0), don't resize
             internal bool MakeOpaque;
-            internal bool MakeTransparent;
             internal int JpegQuality; // 0 means use input jpeg's quality
             internal string ProfilesToStrip; // null means don't strip any profiles
             internal Rectangle cropRectangle;
@@ -1872,7 +1944,6 @@ namespace Bloom.ImageProcessing
             {
                 Size = new Size(0, 0), // preserve current size (no scaling)
                 MakeOpaque = false,
-                MakeTransparent = false,
                 JpegQuality = 0, // same as input
                 ProfilesToStrip = null,
                 cropRectangle = cropRectangle,
@@ -1893,11 +1964,6 @@ namespace Bloom.ImageProcessing
             GraphicsMagickOptions options
         )
         {
-            Debug.Assert(
-                !(options.MakeOpaque && options.MakeTransparent),
-                "makeOpaque and makeTransparent cannot both be true."
-            );
-
             return WithSafeFilePath(
                 sourcePath,
                 safeSourcePath =>
@@ -1910,12 +1976,6 @@ namespace Bloom.ImageProcessing
                             argsBldr.AppendFormat("convert \"{0}\"", safeSourcePath);
                             if (options.MakeOpaque)
                                 argsBldr.Append(" -background white -extent 0x0 +matte");
-                            else if (options.MakeTransparent)
-                            {
-                                // We intentionally do not rely on GraphicsMagick's -transparent options.
-                                // After the conversion we apply Bloom's RemoveWhiteBackground semantics
-                                // so anti-aliased edges get proper alpha instead of white fringes.
-                            }
                             if (options.cropRectangle != Rectangle.Empty)
                             {
                                 argsBldr.AppendFormat(
@@ -1977,9 +2037,6 @@ namespace Bloom.ImageProcessing
                                 new NullProgress()
                             );
 
-                            if (result.ExitCode == 0 && options.MakeTransparent)
-                                ApplyBloomTransparencyToGraphicsMagickOutput(safeDestPath);
-
                             if (result.ExitCode == 0 && destPath != safeDestPath)
                                 RobustFile.Copy(safeDestPath, destPath, true);
                             return result;
@@ -1990,7 +2047,7 @@ namespace Bloom.ImageProcessing
             );
         }
 
-        private static void ApplyBloomTransparencyToGraphicsMagickOutput(string imagePath)
+        private static void ApplyBloomTransparencyToFile(string imagePath)
         {
             if (!imagePath.EndsWith(".png", StringComparison.InvariantCultureIgnoreCase))
                 return;
@@ -2077,7 +2134,6 @@ namespace Bloom.ImageProcessing
                     {
                         Size = new Size(0, 0), // preserve current size (no scaling)
                         MakeOpaque = false,
-                        MakeTransparent = false,
                         JpegQuality = 92, // High quality (but not extreme)
                         ProfilesToStrip = null,
                     };
@@ -3307,20 +3363,24 @@ namespace Bloom.ImageProcessing
             {
                 if (ShouldMakeBackgroundTransparent(imageInfo))
                 {
-                    var options = new GraphicsMagickOptions
-                    {
-                        Size = new Size(0, 0),
-                        MakeOpaque = false,
-                        MakeTransparent = true,
-                        cropRectangle = Rectangle.Empty,
-                        JpegQuality = 0, // ignored for PNG output, which transparency requires
-                        ProfilesToStrip = null,
-                    };
-                    var result = RunGraphicsMagick(sourcePath, destinationPath, options);
-                    return result.ExitCode == 0;
+                    RobustFile.Copy(sourcePath, destinationPath, true);
+                    ApplyBloomTransparencyToFile(destinationPath);
+                    return true;
                 }
             }
             return false;
+        }
+
+        /// <summary>
+        /// Like <see cref="MakeTransparentBackgroundIfNeeded"/> but always applies the
+        /// transparency algorithm, bypassing the line-art detection check.
+        /// Used when an image has the <c>bloom-transparent</c> class (<c>transparent=force</c>).
+        /// </summary>
+        internal static bool MakeTransparentBackground(string sourcePath, string destinationPath)
+        {
+            RobustFile.Copy(sourcePath, destinationPath, true);
+            ApplyBloomTransparencyToFile(destinationPath);
+            return true;
         }
     }
 }

--- a/src/BloomExe/ImageProcessing/RuntimeImageProcessor.cs
+++ b/src/BloomExe/ImageProcessing/RuntimeImageProcessor.cs
@@ -103,7 +103,8 @@ namespace Bloom.ImageProcessing
         public string GetPathToAdjustedImage(
             string originalPath,
             bool getThumbnail = false,
-            ImageTransparencyMode transparencyMode = ImageTransparencyMode.None
+            ImageTransparencyMode transparencyMode = ImageTransparencyMode.None,
+            bool transparencyOnly = false
         )
         {
             //don't mess with Bloom UI images
@@ -111,6 +112,8 @@ namespace Bloom.ImageProcessing
                 return originalPath;
 
             // Each combination of processing flags needs its own cache entry.
+            // transparencyOnly (Auto mode that skips resize/JPEG-conversion) gets its own prefix
+            // so it doesn't collide with normal Auto entries that may have cached a JPEG conversion.
             var cacheFileName = originalPath;
             if (getThumbnail && transparencyMode == ImageTransparencyMode.Force)
                 cacheFileName = "force_thumbnail_" + cacheFileName;
@@ -120,6 +123,8 @@ namespace Bloom.ImageProcessing
                 cacheFileName = "thumbnail_" + cacheFileName;
             else if (transparencyMode == ImageTransparencyMode.Force)
                 cacheFileName = "force_" + cacheFileName;
+            else if (transparencyMode == ImageTransparencyMode.Auto && transparencyOnly)
+                cacheFileName = "transparent_orig_" + cacheFileName;
             else if (transparencyMode == ImageTransparencyMode.Auto)
                 cacheFileName = "transparent_" + cacheFileName;
 
@@ -200,7 +205,8 @@ namespace Bloom.ImageProcessing
                     processedPath = ImageUtils.AdjustImageForDisplay(
                         originalPath,
                         _cacheFolder,
-                        transparencyMode
+                        transparencyMode,
+                        transparencyOnly: transparencyOnly
                     );
                 }
 
@@ -544,19 +550,25 @@ namespace Bloom.ImageProcessing
             // t0: pixels at/above this brightness become fully transparent.
             // t1: pixels at/below this brightness stay fully opaque.
             // Values between t1..t0 get linearly ramped alpha.
-            // The ramp is guaranteed at least kMinRampWidth units wide so that near-background
-            // pixels get a smooth gradient rather than a hard aliased edge.
+            //
+            // For a white background (detected ~255) t0=220, t1=180, giving the standard 40-unit ramp.
+            // For darker backgrounds t0 is pulled down to match, and t1 follows to keep the ramp
+            // kMinRampWidth wide — but t1 is never allowed below kMinOpaqueBrightnessThreshold so
+            // that dark content pixels stay fully opaque even on dark backgrounds.  This may produce
+            // a narrower ramp than kMinRampWidth on very dark images, which is the right trade-off.
+            // On extremely dark images, we may not make anything transparent.
             const double kTransparentBrightnessThreshold = 220.0;
             const double kOpaqueBrightnessThreshold = 180.0;
             const double kMinRampWidth = 40.0;
+            const double kMinOpaqueBrightnessThreshold = 60.0;
             var detectedBackgroundBrightness = 0.299 * maxR + 0.587 * maxG + 0.114 * maxB;
             var transparentBrightnessThreshold = Math.Min(
                 kTransparentBrightnessThreshold,
                 detectedBackgroundBrightness
             );
-            var opaqueBrightnessThreshold = Math.Min(
-                kOpaqueBrightnessThreshold,
-                transparentBrightnessThreshold - kMinRampWidth
+            var opaqueBrightnessThreshold = Math.Max(
+                kMinOpaqueBrightnessThreshold,
+                Math.Min(kOpaqueBrightnessThreshold, transparentBrightnessThreshold - kMinRampWidth)
             );
             var phase2Elapsed = totalStopwatch.Elapsed;
             Debug.WriteLine(

--- a/src/BloomExe/ImageProcessing/RuntimeImageProcessor.cs
+++ b/src/BloomExe/ImageProcessing/RuntimeImageProcessor.cs
@@ -37,14 +37,23 @@ namespace Bloom.ImageProcessing
             _bookRenamedEvent = bookRenamedEvent;
             _originalPathToProcessedVersionPath = new ConcurrentDictionary<string, string>();
             _imageFilesToReturnUnprocessed = new ConcurrentDictionary<string, bool>();
-            _cacheFolder = Path.Combine(Path.GetTempPath(), "Bloom");
+            // Use a dedicated subfolder so we can safely delete the whole folder on cleanup.
+            _cacheFolder = Path.Combine(Path.GetTempPath(), "Bloom", "ImageCache");
             _bookRenamedEvent.Subscribe(OnBookRenamed);
         }
 
         private void OnBookRenamed(KeyValuePair<string, string> fromPathAndToPath)
         {
-            //Note, we don't pay attention to what the change was, we just purge the whole cache
+            // Don't pay attention to what the change was; just purge the whole cache.
+            ClearAll();
+        }
 
+        /// <summary>
+        /// Clear all cached image data and delete the cached files. Call when switching books
+        /// or renaming a book so the next requests use fresh processing.
+        /// </summary>
+        public void ClearAll()
+        {
             TryToDeleteCachedImages();
             _originalPathToProcessedVersionPath = new ConcurrentDictionary<string, string>();
             _imageFilesToReturnUnprocessed = new ConcurrentDictionary<string, bool>();
@@ -58,13 +67,16 @@ namespace Bloom.ImageProcessing
             TryToDeleteCachedImages();
             _originalPathToProcessedVersionPath = null;
 
-            //NB: this turns out to be dangerous. Without it, we still delete all we can, leave some files around
-            //each time, and then deleting them on the next run
-            //			_cacheFolder.Dispose();
+            // Try to delete the entire cache folder (catches files from previous sessions
+            // that weren't tracked in _originalPathToProcessedVersionPath).
+            // This might be redundant. Bloom seems to normally delete the whole %temp%/Bloom folder on exit.
+            if (Directory.Exists(_cacheFolder))
+                RobustFileIO.TryDeleteDirectory(_cacheFolder, recursive: true);
 
             GC.SuppressFinalize(this);
         }
 
+        // This might be redundant. Bloom seems to normally delete the whole %temp%/Bloom folder on exit.
         private void TryToDeleteCachedImages()
         {
             lock (this)
@@ -91,19 +103,25 @@ namespace Bloom.ImageProcessing
         public string GetPathToAdjustedImage(
             string originalPath,
             bool getThumbnail = false,
-            bool isForCover = false
+            ImageTransparencyMode transparencyMode = ImageTransparencyMode.None
         )
         {
             //don't mess with Bloom UI images
             if (new[] { "/img/", "placeHolder", "Button" }.Any(s => originalPath.Contains(s)))
                 return originalPath;
 
+            // Each combination of processing flags needs its own cache entry.
             var cacheFileName = originalPath;
-
-            if (getThumbnail)
-            {
+            if (getThumbnail && transparencyMode == ImageTransparencyMode.Force)
+                cacheFileName = "force_thumbnail_" + cacheFileName;
+            else if (getThumbnail && transparencyMode == ImageTransparencyMode.Auto)
+                cacheFileName = "transparent_thumbnail_" + cacheFileName;
+            else if (getThumbnail)
                 cacheFileName = "thumbnail_" + cacheFileName;
-            }
+            else if (transparencyMode == ImageTransparencyMode.Force)
+                cacheFileName = "force_" + cacheFileName;
+            else if (transparencyMode == ImageTransparencyMode.Auto)
+                cacheFileName = "transparent_" + cacheFileName;
 
             // check if this image is in the do-not-process list
             bool test;
@@ -135,42 +153,66 @@ namespace Bloom.ImageProcessing
                     _originalPathToProcessedVersionPath.TryRemove(cacheFileName, out valueRemoved);
                 }
 
-                // there is not a cached version, try to make one
-                var pathToProcessedImage = Path.Combine(
-                    _cacheFolder,
-                    Path.GetRandomFileName() + Path.GetExtension(originalPath)
-                );
-
-                if (!Directory.Exists(Path.GetDirectoryName(pathToProcessedImage)))
-                    Directory.CreateDirectory(Path.GetDirectoryName(pathToProcessedImage));
-
-                // BL-1112: images not loading in page thumbnails
-                var success = true;
-                var wantOriginal = !getThumbnail && !isForCover;
+                // No cached version — try to make one.
+                string processedPath;
                 if (getThumbnail)
                 {
+                    // BL-1112: images not loading in page thumbnails
                     // The HTML div that contains the thumbnails is 80 pixels wide, so make the thumbnails 80 pixels wide
-                    success = GenerateThumbnail(originalPath, pathToProcessedImage, 80);
+                    var pathToProcessedImage = Path.Combine(
+                        _cacheFolder,
+                        Path.GetRandomFileName() + Path.GetExtension(originalPath)
+                    );
+                    if (!Directory.Exists(Path.GetDirectoryName(pathToProcessedImage)))
+                        Directory.CreateDirectory(Path.GetDirectoryName(pathToProcessedImage));
+                    if (!GenerateThumbnail(originalPath, pathToProcessedImage, 80))
+                    {
+                        processedPath = null;
+                    }
+                    else
+                    {
+                        if (
+                            transparencyMode != ImageTransparencyMode.None
+                            && ImageUtils.IsPngFile(pathToProcessedImage)
+                        )
+                        {
+                            // Apply transparency to the PNG thumbnail in-place.
+                            // Force: always apply; Auto: apply only if line art.
+                            using var tempFile = TempFile.WithExtension(".png");
+                            var applied =
+                                transparencyMode == ImageTransparencyMode.Force
+                                    ? ImageUtils.MakeTransparentBackground(
+                                        pathToProcessedImage,
+                                        tempFile.Path
+                                    )
+                                    : ImageUtils.MakeTransparentBackgroundIfNeeded(
+                                        pathToProcessedImage,
+                                        tempFile.Path
+                                    );
+                            if (applied)
+                                RobustFile.Copy(tempFile.Path, pathToProcessedImage, true);
+                        }
+                        processedPath = pathToProcessedImage;
+                    }
                 }
-                else if (isForCover)
+                else
                 {
-                    success = MakePngBackgroundTransparentIfDesirable(
+                    processedPath = ImageUtils.AdjustImageForDisplay(
                         originalPath,
-                        pathToProcessedImage
+                        _cacheFolder,
+                        transparencyMode
                     );
                 }
 
-                if (wantOriginal || !success)
+                if (processedPath == null)
                 {
-                    // add this image to the do-not-process list so we don't waste time doing this again
-                    if (!success)
-                        _imageFilesToReturnUnprocessed.TryAdd(cacheFileName, true);
+                    _imageFilesToReturnUnprocessed.TryAdd(cacheFileName, true);
                     return originalPath;
                 }
 
-                _originalPathToProcessedVersionPath.TryAdd(cacheFileName, pathToProcessedImage); //remember it so we can reuse if they show it again, and later delete
+                _originalPathToProcessedVersionPath.TryAdd(cacheFileName, processedPath); //remember it so we can reuse if they show it again, and later delete
 
-                return pathToProcessedImage;
+                return processedPath;
             }
         }
 
@@ -405,12 +447,9 @@ namespace Bloom.ImageProcessing
                 revisedBitmap.Palette = GivePaletteTransparentBackground(revisedBitmap);
                 return revisedBitmap;
             }
-            // impose a maximum size (BL-2871: "Opposites" had ~6k x 6k and caused ArgumentException)
-            var destinationWidth = Math.Min(1000, originalImage.Image.Width);
-            var destinationHeight = (int)(
-                (float)originalImage.Image.Height
-                * ((float)destinationWidth / (float)originalImage.Image.Width)
-            );
+            // Keep full resolution for alpha extraction so line-art edges are not softened by pre-scaling.
+            var destinationWidth = originalImage.Image.Width;
+            var destinationHeight = originalImage.Image.Height;
             using (
                 var scaledSource = new Bitmap(
                     destinationWidth,
@@ -421,7 +460,28 @@ namespace Bloom.ImageProcessing
             using (var g = Graphics.FromImage(scaledSource))
             {
                 g.DrawImage(originalImage.Image, 0, 0, destinationWidth, destinationHeight);
-                return RemoveWhiteBackground(scaledSource);
+                var transparentImage = RemoveWhiteBackground(scaledSource);
+
+                // Keep the old maximum-size behavior (BL-2871), but scale after alpha extraction.
+                var scaledWidth = Math.Min(1000, transparentImage.Width);
+                if (scaledWidth >= transparentImage.Width)
+                    return transparentImage;
+
+                var scaledHeight = (int)(
+                    (float)transparentImage.Height
+                    * ((float)scaledWidth / (float)transparentImage.Width)
+                );
+                var scaledTransparentImage = new Bitmap(
+                    scaledWidth,
+                    scaledHeight,
+                    PixelFormat.Format32bppArgb
+                );
+                using (var gScaled = Graphics.FromImage(scaledTransparentImage))
+                {
+                    gScaled.DrawImage(transparentImage, 0, 0, scaledWidth, scaledHeight);
+                }
+                transparentImage.Dispose();
+                return scaledTransparentImage;
             }
         }
 
@@ -450,6 +510,7 @@ namespace Bloom.ImageProcessing
             var pixels = new byte[stride * height];
             Marshal.Copy(srcData.Scan0, pixels, 0, pixels.Length);
             source.UnlockBits(srcData);
+            var totalStopwatch = Stopwatch.StartNew();
 
             // 1. Find the lightest color in the image (max R+G+B sum)
             int maxR = 0,
@@ -474,25 +535,35 @@ namespace Bloom.ImageProcessing
                     }
                 }
             }
+            var phase1Elapsed = totalStopwatch.Elapsed;
+            Debug.WriteLine(
+                $"RuntimeImageProcessor.RemoveWhiteBackground {width}x{height} phase1={phase1Elapsed.TotalMilliseconds:0.###}ms"
+            );
 
-            // 2. Compute the largest channel deficit from the lightest color (for normalization)
-            // This maps the palest color to alpha=0 while keeping strong saturated colors opaque.
-            int maxDeficit = 1; // avoid divide by zero
-            for (int y = 0; y < height; y++)
-            {
-                for (int x = 0; x < width; x++)
-                {
-                    int idx = y * stride + x * 4;
-                    int b = pixels[idx];
-                    int g = pixels[idx + 1];
-                    int r = pixels[idx + 2];
-                    int deficit = Math.Max(maxR - r, Math.Max(maxG - g, maxB - b));
-                    if (deficit > maxDeficit)
-                        maxDeficit = deficit;
-                }
-            }
+            // 2. Build brightness thresholds for a transparency ramp.
+            // t0: pixels at/above this brightness become fully transparent.
+            // t1: pixels at/below this brightness stay fully opaque.
+            // Values between t1..t0 get linearly ramped alpha.
+            // The ramp is guaranteed at least kMinRampWidth units wide so that near-background
+            // pixels get a smooth gradient rather than a hard aliased edge.
+            const double kTransparentBrightnessThreshold = 220.0;
+            const double kOpaqueBrightnessThreshold = 180.0;
+            const double kMinRampWidth = 40.0;
+            var detectedBackgroundBrightness = 0.299 * maxR + 0.587 * maxG + 0.114 * maxB;
+            var transparentBrightnessThreshold = Math.Min(
+                kTransparentBrightnessThreshold,
+                detectedBackgroundBrightness
+            );
+            var opaqueBrightnessThreshold = Math.Min(
+                kOpaqueBrightnessThreshold,
+                transparentBrightnessThreshold - kMinRampWidth
+            );
+            var phase2Elapsed = totalStopwatch.Elapsed;
+            Debug.WriteLine(
+                $"RuntimeImageProcessor.RemoveWhiteBackground {width}x{height} phase2={(phase2Elapsed - phase1Elapsed).TotalMilliseconds:0.###}ms bg={detectedBackgroundBrightness:0.###} t0={transparentBrightnessThreshold:0.###} t1={opaqueBrightnessThreshold:0.###}"
+            );
 
-            // 3. For each pixel, set alpha based on distance from the lightest color.
+            // 3. For each pixel, set alpha from perceptual brightness using t0/t1 ramp.
             // Keep this pass after the two read-only analysis passes above: we mutate pixels in place.
             for (int y = 0; y < height; y++)
             {
@@ -503,16 +574,37 @@ namespace Bloom.ImageProcessing
                     int g = pixels[idx + 1];
                     int r = pixels[idx + 2];
                     // pixels[idx + 3] is source alpha, always 255 for opaque input.
-                    // Use the strongest per-channel deficit from the background candidate.
-                    int deficit = Math.Max(maxR - r, Math.Max(maxG - g, maxB - b));
-                    // alpha = 0 for lightest color, 255 for largest deficit from it
-                    byte newAlpha = (byte)(255.0 * deficit / maxDeficit);
+                    var brightness = 0.299 * r + 0.587 * g + 0.114 * b;
+                    byte newAlpha;
+                    if (brightness >= transparentBrightnessThreshold)
+                    {
+                        newAlpha = 0;
+                    }
+                    else if (brightness <= opaqueBrightnessThreshold)
+                    {
+                        newAlpha = 255;
+                    }
+                    else
+                    {
+                        newAlpha = (byte)(
+                            255.0
+                            * (transparentBrightnessThreshold - brightness)
+                            / (transparentBrightnessThreshold - opaqueBrightnessThreshold)
+                        );
+                    }
                     pixels[idx + 3] = newAlpha;
                     // Keep RGB as-is to preserve color intensity (e.g. pure red stays red).
                 }
             }
+            var phase3Elapsed = totalStopwatch.Elapsed;
+            Debug.WriteLine(
+                $"RuntimeImageProcessor.RemoveWhiteBackground {width}x{height} phase3={(phase3Elapsed - phase2Elapsed).TotalMilliseconds:0.###}ms"
+            );
             Marshal.Copy(pixels, 0, dstData.Scan0, pixels.Length);
             result.UnlockBits(dstData);
+            Debug.WriteLine(
+                $"RuntimeImageProcessor.RemoveWhiteBackground {width}x{height} total={totalStopwatch.Elapsed.TotalMilliseconds:0.###}ms"
+            );
             return result;
         }
 

--- a/src/BloomExe/Publish/BloomPub/BloomPubMaker.cs
+++ b/src/BloomExe/Publish/BloomPub/BloomPubMaker.cs
@@ -215,113 +215,230 @@ namespace Bloom.Publish.BloomPub
             SafeXmlDocument dom
         )
         {
-            List<string> imagesToPreserveResolution;
-            List<string> coverImages;
+            var imagesToPreserveResolution = FindImagesToPreserveResolution(dom);
 
             var fullScreenAttr = dom.GetElementsByTagName("body")
                 .Cast<SafeXmlElement>()
                 .First()
                 .GetAttribute("data-bffullscreenpicture");
-            if (
+            // Motion books in landscape mode produce an all-black background; making images
+            // transparent on a black background makes line art invisible (BL-6564).
+            var fullScreenBlack =
                 fullScreenAttr != null
-                && fullScreenAttr.IndexOf("bloomReader", StringComparison.InvariantCulture) >= 0
+                && fullScreenAttr.IndexOf("bloomReader", StringComparison.InvariantCulture) >= 0;
+
+            // ImagePublishSettings.MaxWidth/MaxHeight are in landscape orientation (width > height),
+            // but GetDesiredImageSize expects portrait orientation, so pass Height as maxShortSide.
+            var maxShortSide = (int)imagePublishSettings.MaxHeight;
+            var maxLongSide = (int)imagePublishSettings.MaxWidth;
+
+            // Cache: (lowercaseFilename, transparencyMode) → new filename, or null if unchanged.
+            var processedImages = new Dictionary<(string, ImageTransparencyMode), string>();
+
+            // Tracks format changes (e.g. "photo.jpg" → "photo.png") so a second element
+            // referencing the same original file can locate the renamed file on disk.
+            var renamedFiles = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            // Files on disk that are still referenced unchanged by an already-processed element.
+            // A later format-change (e.g. jpg → png) must not delete a claimed file, because
+            // the earlier element's style/src still points to it.
+            var claimedFilenames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            using (var tempDir = new TemporaryFolder("BloomPubImageAdjust"))
+            {
+                foreach (
+                    SafeXmlElement pageDiv in dom.SafeSelectNodes(
+                            "//div[contains(@class,'bloom-page')]"
+                        )
+                        .Cast<SafeXmlElement>()
+                )
+                {
+                    var pageNeedsTransparent =
+                        !fullScreenBlack && HtmlDom.PageNeedsTransparentImages(pageDiv);
+
+                    // Background-image style divs: ConvertImagesToBackground already ran and
+                    // copied bloom-transparent/bloom-opaque from the deleted img to the div.
+                    foreach (
+                        var div in pageDiv
+                            .SafeSelectNodes(
+                                ".//div[contains(@class,'bloom-background-image-in-style-attr')]"
+                            )
+                            .Cast<SafeXmlElement>()
+                    )
+                    {
+                        var style = div.GetAttribute("style") ?? "";
+                        if (!style.Contains("background-image:url"))
+                            continue;
+                        var filename = ExtractFilenameFromBackgroundImageStyleUrl(style);
+                        if (
+                            string.IsNullOrEmpty(filename)
+                            || imagesToPreserveResolution.Contains(filename)
+                        )
+                            continue;
+
+                        var transparencyMode = GetElementTransparencyMode(
+                            div.GetAttribute("class") ?? "",
+                            pageNeedsTransparent,
+                            fullScreenBlack
+                        );
+                        var newFilename = ProcessImageFile(
+                            filename,
+                            transparencyMode,
+                            modifiedBookFolderPath,
+                            tempDir.FolderPath,
+                            maxShortSide,
+                            maxLongSide,
+                            processedImages,
+                            renamedFiles,
+                            claimedFilenames
+                        );
+                        if (newFilename != null)
+                        {
+                            var oldEncoded = System.Web.HttpUtility.UrlPathEncode(filename);
+                            var newEncoded = System.Web.HttpUtility.UrlPathEncode(newFilename);
+                            div.SetAttribute(
+                                "style",
+                                style.Replace(oldEncoded, newEncoded).Replace(filename, newFilename)
+                            );
+                        }
+                    }
+
+                    // After ConvertImagesToBackground, all content images (inside
+                    // bloom-imageContainer / bloom-canvas) are already background-image divs
+                    // handled by the loop above. Any remaining img elements (branding, qrcode)
+                    // don't need transparency and are small enough not to require resizing here.
+                }
+            }
+        }
+
+        /// <summary>
+        /// Determine what transparency processing an image element needs, based on its CSS
+        /// classes and whether its page has a colored background.
+        /// </summary>
+        private static ImageTransparencyMode GetElementTransparencyMode(
+            string classAttr,
+            bool pageNeedsTransparent,
+            bool fullScreenBlack
+        )
+        {
+            // Motion-book all-black backdrop: transparency makes images invisible.
+            if (fullScreenBlack)
+                return ImageTransparencyMode.None;
+            // bloom-opaque: explicit user override "never make transparent".
+            if (classAttr.Contains("bloom-opaque"))
+                return ImageTransparencyMode.None;
+            // bloom-transparent: explicit user override "always force transparent".
+            if (classAttr.Contains("bloom-transparent"))
+                return ImageTransparencyMode.Force;
+            if (!pageNeedsTransparent)
+                return ImageTransparencyMode.None;
+            return ImageTransparencyMode.Auto;
+        }
+
+        /// <summary>
+        /// Compress/resize a single image file, applying transparency if needed. Returns the
+        /// new filename when the file format changed (e.g. jpg → png), or null when the filename
+        /// is unchanged. Results are cached by (filename, mode) so the same (file, processing)
+        /// pair is only handled once. If the file was already renamed by an earlier call with a
+        /// different mode, <paramref name="renamedFiles"/> is consulted to locate it on disk.
+        /// </summary>
+        private static string ProcessImageFile(
+            string filename,
+            ImageTransparencyMode mode,
+            string bookFolderPath,
+            string tempFolderPath,
+            int maxShortSide,
+            int maxLongSide,
+            Dictionary<(string, ImageTransparencyMode), string> processedImages,
+            Dictionary<string, string> renamedFiles,
+            HashSet<string> claimedFilenames
+        )
+        {
+            var cacheKey = (filename.ToLowerInvariant(), mode);
+            if (processedImages.TryGetValue(cacheKey, out var cached))
+                return cached;
+
+            // A previous call may have renamed this file (different mode, same image).
+            var currentFilename = renamedFiles.TryGetValue(filename, out var renamed)
+                ? renamed
+                : filename;
+            var filePath = Path.Combine(bookFolderPath, currentFilename);
+            if (
+                !RobustFile.Exists(filePath)
+                || !BookCompressor.CompressableImageFileExtensions.Contains(
+                    Path.GetExtension(filePath).ToLowerInvariant()
+                )
             )
             {
-                // This feature (currently used for motion books in landscape mode) triggers an all-black background,
-                // due to a rule in bookFeatures.less.
-                // Making white pixels transparent on an all-black background makes line-art disappear,
-                // which is bad (BL-6564), so just make an empty list in this case.
-                coverImages = new List<string>();
+                // Propagate an earlier rename even if we can't process the file.
+                var fallback = string.Equals(
+                    currentFilename,
+                    filename,
+                    StringComparison.OrdinalIgnoreCase
+                )
+                    ? null
+                    : currentFilename;
+                processedImages[cacheKey] = fallback;
+                return fallback;
+            }
+
+            var adjustedPath = ImageUtils.AdjustImageForDisplay(
+                filePath,
+                tempFolderPath,
+                mode,
+                maxShortSide,
+                maxLongSide
+            );
+
+            string result;
+            if (adjustedPath == null)
+            {
+                // No size/transparency change needed; the file stays at currentFilename.
+                claimedFilenames.Add(currentFilename);
+                result = string.Equals(
+                    currentFilename,
+                    filename,
+                    StringComparison.OrdinalIgnoreCase
+                )
+                    ? null
+                    : currentFilename;
             }
             else
             {
-                coverImages = FindCoverImages(dom);
-            }
-            imagesToPreserveResolution = FindImagesToPreserveResolution(dom);
-
-            foreach (var filePath in Directory.GetFiles(modifiedBookFolderPath))
-            {
-                if (
-                    BookCompressor.CompressableImageFileExtensions.Contains(
-                        Path.GetExtension(filePath).ToLowerInvariant()
+                var adjustedExt = Path.GetExtension(adjustedPath).ToLowerInvariant();
+                var currentExt = Path.GetExtension(currentFilename).ToLowerInvariant();
+                if (adjustedExt == currentExt)
+                {
+                    // Same extension: overwrite in place; file stays at currentFilename.
+                    RobustFile.Copy(adjustedPath, filePath, overwrite: true);
+                    claimedFilenames.Add(currentFilename);
+                    result = string.Equals(
+                        currentFilename,
+                        filename,
+                        StringComparison.OrdinalIgnoreCase
                     )
-                )
-                {
-                    var fileName = Path.GetFileName(filePath);
-                    if (imagesToPreserveResolution.Contains(fileName))
-                        continue; // don't compress these
-                    // Cover images should be transparent if possible.  Others don't need to be.
-                    var forUseOnColoredBackground = coverImages.Contains(fileName);
-                    GetNewImageIfNeeded(filePath, imagePublishSettings, forUseOnColoredBackground);
-                }
-            }
-        }
-
-        private static void GetNewImageIfNeeded(
-            string filePath,
-            ImagePublishSettings imagePublishSettings,
-            bool forUseOnColoredBackground
-        )
-        {
-            using (var tagFile = RobustFileIO.CreateTaglibFile(filePath))
-            {
-                var currentWidth = tagFile.Properties.PhotoWidth;
-                var currentHeight = tagFile.Properties.PhotoHeight;
-                // We want to make sure that the image is not larger than the maximum width or height.
-                // We don't know whether the image is portrait or landscape, so we have to check both
-                // orientations.  The publish settings are known to be in landscape orientation, and
-                // the image has to fit into those bounds, but we don't care whether the actual display
-                // is portrait or landscape.
-                if (
-                    imagePublishSettings.MaxWidth >= currentWidth
-                        && imagePublishSettings.MaxHeight >= currentHeight
-                    || imagePublishSettings.MaxWidth >= currentHeight
-                        && imagePublishSettings.MaxHeight >= currentWidth
-                )
-                {
-                    if (!forUseOnColoredBackground)
-                        return; // current file is okay as is: small enough and no need to make transparent.
-                }
-            }
-            BookCompressor.CopyResizedImageFile(
-                filePath,
-                filePath,
-                imagePublishSettings,
-                forUseOnColoredBackground
-            );
-        }
-
-        private const string kBackgroundImage = "background-image:url('"; // must match format string in HtmlDom.SetImageElementUrl()
-
-        private static List<string> FindCoverImages(SafeXmlDocument xmlDom)
-        {
-            var transparentImageFiles = new List<string>();
-            foreach (
-                var div in xmlDom
-                    .SafeSelectNodes(
-                        "//div[contains(concat(' ',@class,' '),' coverColor ')]//div[contains(@class,'bloom-background-image-in-style-attr')]"
-                    )
-                    .Cast<SafeXmlElement>()
-            )
-            {
-                var style = div.GetAttribute("style");
-                if (!String.IsNullOrEmpty(style) && style.Contains("background-image:url"))
-                {
-                    // extract filename from the background-image style
-                    transparentImageFiles.Add(ExtractFilenameFromBackgroundImageStyleUrl(style));
+                        ? null
+                        : currentFilename;
                 }
                 else
                 {
-                    // extract filename from child img element
-                    var img = div.SelectSingleNode("//img[@src]");
-                    if (img != null)
-                        transparentImageFiles.Add(
-                            System.Web.HttpUtility.UrlDecode(img.GetAttribute("src"))
-                        );
+                    // Format changed (e.g. jpg → png): create new file. Only delete the old
+                    // file if no earlier element still references it at its current name.
+                    var newFilename =
+                        Path.GetFileNameWithoutExtension(currentFilename) + adjustedExt;
+                    RobustFile.Copy(adjustedPath, Path.Combine(bookFolderPath, newFilename));
+                    if (!claimedFilenames.Contains(currentFilename))
+                        RobustFile.Delete(filePath);
+                    renamedFiles[filename] = newFilename;
+                    result = newFilename;
                 }
             }
-            return transparentImageFiles;
+
+            processedImages[cacheKey] = result;
+            return result;
         }
+
+        private const string kBackgroundImage = "background-image:url('"; // must match format string in HtmlDom.SetImageElementUrl()
 
         private static List<string> FindImagesToPreserveResolution(SafeXmlDocument dom)
         {
@@ -918,14 +1035,21 @@ namespace Bloom.Publish.BloomPub
                         imgContainer.SetAttribute(attr.Name, attr.Value);
                 }
 
+                var imgClass = img.GetAttribute("class") ?? "";
                 var classesToAdd = " bloom-background-image-in-style-attr";
+                // Preserve the user's explicit transparency overrides so FindImagesNeedingTransparency
+                // can still read them after the img element is deleted below.
+                if (imgClass.Contains("bloom-transparent"))
+                    classesToAdd += " bloom-transparent";
+                else if (imgClass.Contains("bloom-opaque"))
+                    classesToAdd += " bloom-opaque";
                 // This is a nasty special case; see BL-11712. This class causes images to grow to
                 // cover the container, so when we convert to a background image, somehow we need to
                 // do the same thing. If we have other similar classes we will have to do it again,
                 // and again have two equivalent rules. Maybe we can eventually get rid of converting
                 // to background image? Why did we want to, anyway?? Maybe we can copy all classes from
                 // the img? But we'd still need duplicate rules.
-                if ((img.GetAttribute("class") ?? "").Contains("bloom-imageObjectFit-cover"))
+                if (imgClass.Contains("bloom-imageObjectFit-cover"))
                     classesToAdd += " bloom-imageObjectFit-cover";
                 else
                 {

--- a/src/BloomExe/Publish/BloomPub/BloomPubMaker.cs
+++ b/src/BloomExe/Publish/BloomPub/BloomPubMaker.cs
@@ -235,13 +235,14 @@ namespace Bloom.Publish.BloomPub
             // Cache: (lowercaseFilename, transparencyMode) → new filename, or null if unchanged.
             var processedImages = new Dictionary<(string, ImageTransparencyMode), string>();
 
-            // Tracks format changes (e.g. "photo.jpg" → "photo.png") so a second element
-            // referencing the same original file can locate the renamed file on disk.
-            var renamedFiles = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            // Original files that have been format-converted (e.g. "photo.jpg" when it became
+            // "photo_t.png"). Deletion is deferred until after all elements are processed so
+            // that a second element with a different mode can still read the original.
+            var pendingDeletions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             // Files on disk that are still referenced unchanged by an already-processed element.
-            // A later format-change (e.g. jpg → png) must not delete a claimed file, because
-            // the earlier element's style/src still points to it.
+            // A deferred deletion must not remove a claimed file, because the earlier element's
+            // style/src still points to it.
             var claimedFilenames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             using (var tempDir = new TemporaryFolder("BloomPubImageAdjust"))
@@ -277,7 +278,7 @@ namespace Bloom.Publish.BloomPub
                             continue;
 
                         var transparencyMode = GetElementTransparencyMode(
-                            div.GetAttribute("class") ?? "",
+                            div,
                             pageNeedsTransparent,
                             fullScreenBlack
                         );
@@ -289,7 +290,7 @@ namespace Bloom.Publish.BloomPub
                             maxShortSide,
                             maxLongSide,
                             processedImages,
-                            renamedFiles,
+                            pendingDeletions,
                             claimedFilenames
                         );
                         if (newFilename != null)
@@ -308,6 +309,19 @@ namespace Bloom.Publish.BloomPub
                     // handled by the loop above. Any remaining img elements (branding, qrcode)
                     // don't need transparency and are small enough not to require resizing here.
                 }
+
+                // Delete original files that were format-converted by some mode and are no
+                // longer referenced directly. Deletion is deferred to here so that a second
+                // element using a different mode can still read the original during processing.
+                foreach (var fileToDelete in pendingDeletions)
+                {
+                    if (!claimedFilenames.Contains(fileToDelete))
+                    {
+                        var pathToDelete = Path.Combine(modifiedBookFolderPath, fileToDelete);
+                        if (RobustFile.Exists(pathToDelete))
+                            RobustFile.Delete(pathToDelete);
+                    }
+                }
             }
         }
 
@@ -316,7 +330,7 @@ namespace Bloom.Publish.BloomPub
         /// classes and whether its page has a colored background.
         /// </summary>
         private static ImageTransparencyMode GetElementTransparencyMode(
-            string classAttr,
+            SafeXmlElement element,
             bool pageNeedsTransparent,
             bool fullScreenBlack
         )
@@ -325,10 +339,10 @@ namespace Bloom.Publish.BloomPub
             if (fullScreenBlack)
                 return ImageTransparencyMode.None;
             // bloom-opaque: explicit user override "never make transparent".
-            if (classAttr.Contains("bloom-opaque"))
+            if (element.HasClass("bloom-opaque"))
                 return ImageTransparencyMode.None;
             // bloom-transparent: explicit user override "always force transparent".
-            if (classAttr.Contains("bloom-transparent"))
+            if (element.HasClass("bloom-transparent"))
                 return ImageTransparencyMode.Force;
             if (!pageNeedsTransparent)
                 return ImageTransparencyMode.None;
@@ -339,8 +353,12 @@ namespace Bloom.Publish.BloomPub
         /// Compress/resize a single image file, applying transparency if needed. Returns the
         /// new filename when the file format changed (e.g. jpg → png), or null when the filename
         /// is unchanged. Results are cached by (filename, mode) so the same (file, processing)
-        /// pair is only handled once. If the file was already renamed by an earlier call with a
-        /// different mode, <paramref name="renamedFiles"/> is consulted to locate it on disk.
+        /// pair is only handled once. Each (filename, mode) pair always processes from the
+        /// original source file, so different modes never interfere with each other. When a
+        /// format change occurs (e.g. jpg → png), a mode-specific suffix is added to avoid
+        /// filename collisions between modes, and the original is added to
+        /// <paramref name="pendingDeletions"/> rather than deleted immediately (so that a
+        /// subsequent element with a different mode can still read the original).
         /// </summary>
         private static string ProcessImageFile(
             string filename,
@@ -350,7 +368,7 @@ namespace Bloom.Publish.BloomPub
             int maxShortSide,
             int maxLongSide,
             Dictionary<(string, ImageTransparencyMode), string> processedImages,
-            Dictionary<string, string> renamedFiles,
+            HashSet<string> pendingDeletions,
             HashSet<string> claimedFilenames
         )
         {
@@ -358,11 +376,10 @@ namespace Bloom.Publish.BloomPub
             if (processedImages.TryGetValue(cacheKey, out var cached))
                 return cached;
 
-            // A previous call may have renamed this file (different mode, same image).
-            var currentFilename = renamedFiles.TryGetValue(filename, out var renamed)
-                ? renamed
-                : filename;
-            var filePath = Path.Combine(bookFolderPath, currentFilename);
+            // Each (filename, mode) pair always works from the original source file.
+            // Different modes never follow each other's renames, so there is no cross-mode
+            // interference.
+            var filePath = Path.Combine(bookFolderPath, filename);
             if (
                 !RobustFile.Exists(filePath)
                 || !BookCompressor.CompressableImageFileExtensions.Contains(
@@ -370,16 +387,8 @@ namespace Bloom.Publish.BloomPub
                 )
             )
             {
-                // Propagate an earlier rename even if we can't process the file.
-                var fallback = string.Equals(
-                    currentFilename,
-                    filename,
-                    StringComparison.OrdinalIgnoreCase
-                )
-                    ? null
-                    : currentFilename;
-                processedImages[cacheKey] = fallback;
-                return fallback;
+                processedImages[cacheKey] = null;
+                return null;
             }
 
             var adjustedPath = ImageUtils.AdjustImageForDisplay(
@@ -393,45 +402,31 @@ namespace Bloom.Publish.BloomPub
             string result;
             if (adjustedPath == null)
             {
-                // No size/transparency change needed; the file stays at currentFilename.
-                claimedFilenames.Add(currentFilename);
-                result = string.Equals(
-                    currentFilename,
-                    filename,
-                    StringComparison.OrdinalIgnoreCase
-                )
-                    ? null
-                    : currentFilename;
+                // No size/transparency change needed; the original file is used as-is.
+                claimedFilenames.Add(filename);
+                result = null;
             }
             else
             {
                 var adjustedExt = Path.GetExtension(adjustedPath).ToLowerInvariant();
-                var currentExt = Path.GetExtension(currentFilename).ToLowerInvariant();
-                if (adjustedExt == currentExt)
+
+                // Whether the extension changed or not, always write to a new mode-specific
+                // file and defer deletion of the original. This prevents the same-extension
+                // case (e.g. PNG made transparent, or JPEG resized) from overwriting the
+                // original before a later (filename, differentMode) pair has processed it.
+                var modeSuffix = mode switch
                 {
-                    // Same extension: overwrite in place; file stays at currentFilename.
-                    RobustFile.Copy(adjustedPath, filePath, overwrite: true);
-                    claimedFilenames.Add(currentFilename);
-                    result = string.Equals(
-                        currentFilename,
-                        filename,
-                        StringComparison.OrdinalIgnoreCase
-                    )
-                        ? null
-                        : currentFilename;
-                }
-                else
-                {
-                    // Format changed (e.g. jpg → png): create new file. Only delete the old
-                    // file if no earlier element still references it at its current name.
-                    var newFilename =
-                        Path.GetFileNameWithoutExtension(currentFilename) + adjustedExt;
-                    RobustFile.Copy(adjustedPath, Path.Combine(bookFolderPath, newFilename));
-                    if (!claimedFilenames.Contains(currentFilename))
-                        RobustFile.Delete(filePath);
-                    renamedFiles[filename] = newFilename;
-                    result = newFilename;
-                }
+                    ImageTransparencyMode.Force => "_tf",
+                    ImageTransparencyMode.Auto => "_t",
+                    _ => "_r", // None mode: resize / format-conversion only
+                };
+                var newFilename =
+                    Path.GetFileNameWithoutExtension(filename) + modeSuffix + adjustedExt;
+                RobustFile.Copy(adjustedPath, Path.Combine(bookFolderPath, newFilename));
+                // Defer deletion: a later element with a different mode may still need
+                // the original. The actual delete happens after all elements are processed.
+                pendingDeletions.Add(filename);
+                result = newFilename;
             }
 
             processedImages[cacheKey] = result;
@@ -1018,9 +1013,10 @@ namespace Bloom.Publish.BloomPub
                     .ToArray()
             )
             {
-                var img = imgContainer.ChildNodes.FirstOrDefault(n =>
-                    n is SafeXmlElement && n.Name == "img"
-                );
+                var img =
+                    imgContainer.ChildNodes.FirstOrDefault(n =>
+                        n is SafeXmlElement && n.Name == "img"
+                    ) as SafeXmlElement;
                 if (img == null || string.IsNullOrEmpty(img.GetAttribute("src")))
                     continue;
                 // The filename should be already urlencoded since src is a url.
@@ -1035,13 +1031,12 @@ namespace Bloom.Publish.BloomPub
                         imgContainer.SetAttribute(attr.Name, attr.Value);
                 }
 
-                var imgClass = img.GetAttribute("class") ?? "";
                 var classesToAdd = " bloom-background-image-in-style-attr";
                 // Preserve the user's explicit transparency overrides so FindImagesNeedingTransparency
                 // can still read them after the img element is deleted below.
-                if (imgClass.Contains("bloom-transparent"))
+                if (img.HasClass("bloom-transparent"))
                     classesToAdd += " bloom-transparent";
-                else if (imgClass.Contains("bloom-opaque"))
+                else if (img.HasClass("bloom-opaque"))
                     classesToAdd += " bloom-opaque";
                 // This is a nasty special case; see BL-11712. This class causes images to grow to
                 // cover the container, so when we convert to a background image, somehow we need to
@@ -1049,7 +1044,7 @@ namespace Bloom.Publish.BloomPub
                 // and again have two equivalent rules. Maybe we can eventually get rid of converting
                 // to background image? Why did we want to, anyway?? Maybe we can copy all classes from
                 // the img? But we'd still need duplicate rules.
-                if (imgClass.Contains("bloom-imageObjectFit-cover"))
+                if (img.HasClass("bloom-imageObjectFit-cover"))
                     classesToAdd += " bloom-imageObjectFit-cover";
                 else
                 {

--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -2211,9 +2211,8 @@ namespace Bloom.Publish.Epub
                         )
                         .Cast<SafeXmlElement>()
                         .LastOrDefault(); // last ancestor = nearest page div
-                    var imgClassAttr = img.GetAttribute("class") ?? "";
                     var transparencyMode = HtmlDom.GetImageTransparencyMode(
-                        imgClassAttr,
+                        img,
                         owningPage != null && HtmlDom.PageNeedsTransparentImages(owningPage)
                     );
                     var dstPath = CopyFileToEpub(
@@ -3413,10 +3412,15 @@ namespace Bloom.Publish.Epub
                 limitImageDimensions,
                 transparencyMode
             );
-            // CopyFile may have changed the extension (e.g. PNG photo → JPEG).
+            // CopyFile may have changed the path (e.g. PNG photo → JPEG, or collision rename).
+            // Reconstruct fileName by stripping the subfolder-aware content prefix so the
+            // manifest entry and the actual file on disk always agree.
             if (!actualDstPath.Equals(dstPath, StringComparison.OrdinalIgnoreCase))
             {
-                fileName = Path.ChangeExtension(fileName, Path.GetExtension(actualDstPath));
+                var contentPrefix = string.IsNullOrEmpty(subfolder)
+                    ? _contentFolder
+                    : Path.Combine(_contentFolder, subfolder);
+                fileName = actualDstPath[(contentPrefix.Length + 1)..].Replace('\\', '/');
                 dstPath = actualDstPath;
             }
             _manifestItems.Add(SubfolderAdjustedName(subfolder, fileName));
@@ -3522,7 +3526,18 @@ namespace Bloom.Publish.Epub
                     var adjustedExt = Path.GetExtension(adjustedPath).ToLowerInvariant();
                     var dstExt = Path.GetExtension(dstPath).ToLowerInvariant();
                     if (adjustedExt != dstExt)
-                        dstPath = Path.ChangeExtension(dstPath, adjustedExt);
+                    {
+                        // Re-check for collisions with the new extension — the earlier collision
+                        // loop only ran against the original extension.
+                        var basePath = Path.ChangeExtension(dstPath, adjustedExt);
+                        dstPath = basePath;
+                        var baseNoExt = Path.Combine(
+                            Path.GetDirectoryName(basePath),
+                            Path.GetFileNameWithoutExtension(basePath)
+                        );
+                        for (int fix = 1; RobustFile.Exists(dstPath); fix++)
+                            dstPath = baseNoExt + fix + adjustedExt;
+                    }
                     RobustFile.Copy(adjustedPath, dstPath);
                     return dstPath;
                 }

--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -127,8 +127,8 @@ namespace Bloom.Publish.Epub
         private Dictionary<string, string> _mapItemToId = new Dictionary<string, string>();
 
         // Keep track of the files we already copied to the ePUB, so we don't copy them again to a new name.
-        private Dictionary<string, string> _mapSrcPathToDestFileName =
-            new Dictionary<string, string>();
+        private Dictionary<(string, ImageTransparencyMode), string> _mapSrcPathToDestFileName =
+            new Dictionary<(string, ImageTransparencyMode), string>();
 
         // All the things (files) we need to list in the manifest
         private List<string> _manifestItems;
@@ -538,7 +538,13 @@ namespace Bloom.Publish.Epub
             // Cover image file and therefore thumbnail file may be non-existent simply because no cover image was chosen/it was still the placeHolder, not a problem
             if (thumbnailFileExists)
             {
-                CopyFileToEpub(epubThumbnailImagePath, true, true, kImagesFolder, imageSettings);
+                CopyFileToEpub(
+                    epubThumbnailImagePath,
+                    limitImageDimensions: true,
+                    transparencyMode: ImageTransparencyMode.Auto,
+                    subfolder: kImagesFolder,
+                    imageSettings: imageSettings
+                );
             }
             var warnings = EmbedFonts(progress); // must call after copying stylesheets
             if (warnings.Any())
@@ -2195,20 +2201,25 @@ namespace Bloom.Publish.Epub
                     continue; // REVIEW: should we remove the element since the image source is empty?
                 if (srcPath == String.Empty)
                 {
-                    img.ParentNode.RemoveChild(img); // the image source file can't be found.
+                    img.ParentNode.RemoveChild(img);
+                    continue;
                 }
                 else
                 {
-                    var isCoverImage =
-                        img.SafeSelectNodes(
-                                "ancestor::div[contains(concat(' ',@class,' '),' coverColor ')]"
-                            )
-                            .Cast<SafeXmlElement>()
-                            .Count() != 0;
+                    var owningPage = img.SafeSelectNodes(
+                            "ancestor::div[contains(@class,'bloom-page')]"
+                        )
+                        .Cast<SafeXmlElement>()
+                        .LastOrDefault(); // last ancestor = nearest page div
+                    var imgClassAttr = img.GetAttribute("class") ?? "";
+                    var transparencyMode = HtmlDom.GetImageTransparencyMode(
+                        imgClassAttr,
+                        owningPage != null && HtmlDom.PageNeedsTransparentImages(owningPage)
+                    );
                     var dstPath = CopyFileToEpub(
                         srcPath,
                         limitImageDimensions: true,
-                        forUseOnColoredBackground: isCoverImage,
+                        transparencyMode: transparencyMode,
                         subfolder: kImagesFolder,
                         imageSettings: imageSettings
                     );
@@ -3358,14 +3369,16 @@ namespace Bloom.Publish.Epub
         private string CopyFileToEpub(
             string srcPath,
             bool limitImageDimensions = false,
-            bool forUseOnColoredBackground = false,
+            ImageTransparencyMode transparencyMode = ImageTransparencyMode.None,
             string subfolder = "",
             ImagePublishSettings imageSettings = null
         )
         {
             string existingFile;
-            if (_mapSrcPathToDestFileName.TryGetValue(srcPath, out existingFile))
-                return existingFile; // File already present, must be used more than once.
+            if (
+                _mapSrcPathToDestFileName.TryGetValue((srcPath, transparencyMode), out existingFile)
+            )
+                return existingFile; // Same file + same transparency already processed.
             var fileName = GetAdjustedFilename(srcPath, Storage.FolderPath);
             // If the fileName starts with a folder inside the Bloom book that maps onto
             // a folder in the epub, remove that folder from the fileName since the proper
@@ -3393,15 +3406,21 @@ namespace Bloom.Publish.Epub
             Directory.CreateDirectory(Path.GetDirectoryName(dstPath));
             if (imageSettings == null)
                 imageSettings = new ImagePublishSettings();
-            CopyFile(
+            var actualDstPath = CopyFile(
                 srcPath,
                 dstPath,
                 imageSettings,
                 limitImageDimensions,
-                forUseOnColoredBackground
+                transparencyMode
             );
+            // CopyFile may have changed the extension (e.g. PNG photo → JPEG).
+            if (!actualDstPath.Equals(dstPath, StringComparison.OrdinalIgnoreCase))
+            {
+                fileName = Path.ChangeExtension(fileName, Path.GetExtension(actualDstPath));
+                dstPath = actualDstPath;
+            }
             _manifestItems.Add(SubfolderAdjustedName(subfolder, fileName));
-            _mapSrcPathToDestFileName[srcPath] = dstPath;
+            _mapSrcPathToDestFileName[(srcPath, transparencyMode)] = dstPath;
             return dstPath;
         }
 
@@ -3469,13 +3488,15 @@ namespace Bloom.Publish.Epub
 
         /// <summary>
         /// This supports testing without actually copying files.
+        /// Returns the actual destination path used, which may have a different extension than
+        /// <paramref name="dstPath"/> if image format conversion occurred.
         /// </summary>
-        internal virtual void CopyFile(
+        internal virtual string CopyFile(
             string srcPath,
             string dstPath,
             ImagePublishSettings imagePublishSettings,
             bool limitImageDimensions = false,
-            bool forUseOnColoredBackground = false
+            ImageTransparencyMode transparencyMode = ImageTransparencyMode.None
         )
         {
             if (
@@ -3485,13 +3506,29 @@ namespace Bloom.Publish.Epub
                 )
             )
             {
-                BookCompressor.CopyResizedImageFile(
+                // ImagePublishSettings.MaxWidth/MaxHeight are in landscape orientation; pass Height
+                // as maxShortSide to match what GetDesiredImageSize expects.
+                using var tempDir = new TemporaryFolder("EpubImageAdjust");
+                var adjustedPath = ImageUtils.AdjustImageForDisplay(
                     srcPath,
-                    dstPath,
-                    imagePublishSettings,
-                    forUseOnColoredBackground
+                    tempDir.FolderPath,
+                    transparencyMode,
+                    (int)imagePublishSettings.MaxHeight,
+                    (int)imagePublishSettings.MaxWidth
                 );
-                return;
+                if (adjustedPath != null)
+                {
+                    // Format may have changed (e.g. PNG photo → JPEG); update dstPath accordingly.
+                    var adjustedExt = Path.GetExtension(adjustedPath).ToLowerInvariant();
+                    var dstExt = Path.GetExtension(dstPath).ToLowerInvariant();
+                    if (adjustedExt != dstExt)
+                        dstPath = Path.ChangeExtension(dstPath, adjustedExt);
+                    RobustFile.Copy(adjustedPath, dstPath);
+                    return dstPath;
+                }
+                // AdjustImageForDisplay returned null: no processing needed, just copy.
+                RobustFile.Copy(srcPath, dstPath);
+                return dstPath;
             }
             if (dstPath.Contains(kCssFolder) && dstPath.EndsWith(".css"))
             {
@@ -3504,9 +3541,10 @@ namespace Bloom.Publish.Epub
                     RegexOptions.CultureInvariant | RegexOptions.IgnoreCase
                 );
                 RobustFile.WriteAllText(dstPath, outputText);
-                return;
+                return dstPath;
             }
             RobustFile.Copy(srcPath, dstPath);
+            return dstPath;
         }
 
         // The validator is (probably excessively) upset about IDs that start with numbers.

--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -442,7 +442,8 @@ namespace Bloom.Publish
 
             return BloomServer.MakeInMemoryHtmlFileInBookFolder(
                 dom,
-                source: InMemoryHtmlFileSource.Pub
+                source: InMemoryHtmlFileSource.Pub,
+                suppressBackgroundColors: !_currentlyLoadedBook.UserPrefs.IncludeBackgroundColors
             );
         }
 

--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -424,7 +424,7 @@ namespace Bloom.Publish
             PageLayout.UpdatePageSplitMode(dom.RawDom);
 
             XmlHtmlConverter.MakeXmlishTagsSafeForInterpretationAsHtml(dom.RawDom);
-            dom.UseOriginalImages = true; // don't want low-res images or transparency in PDF.
+            dom.UseOriginalImages = true; // don't want low-res images in PDF.
             var pages = dom.SafeSelectNodes("//div[contains(@class,'bloom-page')]")
                 .Cast<SafeXmlElement>()
                 .ToList();
@@ -440,38 +440,10 @@ namespace Bloom.Publish
             // use the body element instead.
             dom.Body.AddClass("drag-activity-play");
 
-            MarkCoverImageForTransparency(dom);
-
             return BloomServer.MakeInMemoryHtmlFileInBookFolder(
                 dom,
                 source: InMemoryHtmlFileSource.Pub
             );
-        }
-
-        private void MarkCoverImageForTransparency(HtmlDom dom)
-        {
-            // If the user doesn't want to include background colors on the pages, then there's
-            // no need to make black and white pictures transparent.
-            if (_currentlyLoadedBook?.UserPrefs.IncludeBackgroundColors != true)
-                return;
-            var coverImgNodes = dom.SafeSelectNodes(
-                "//div[contains(@class,'bloom-page') and contains(@class,'coverColor')]//img[@src]"
-            );
-            foreach (var img in coverImgNodes)
-            {
-                var classAttr = img.GetAttribute("class");
-                if (classAttr.Contains("branding") || classAttr.Contains("bloom-qrcode"))
-                    continue;
-                var src = img.GetAttribute("src");
-                if (!string.IsNullOrEmpty(src))
-                {
-                    if (src.Contains("?"))
-                        src = src + "&transparent=yes";
-                    else
-                        src = src + "?transparent=yes";
-                    img.SetAttribute("src", src);
-                }
-            }
         }
 
         private void AddStylesheetClasses(SafeXmlDocument dom)

--- a/src/BloomExe/RobustFileIO.cs
+++ b/src/BloomExe/RobustFileIO.cs
@@ -54,5 +54,22 @@ namespace Bloom
         {
             return RetryUtility.Retry(() => TagLib.File.Create(path));
         }
+
+        /// <summary>
+        /// Attempts to delete a directory once. Returns false if an exception prevents deletion,
+        /// rather than retrying or throwing — suitable for best-effort cleanup during shutdown.
+        /// </summary>
+        public static bool TryDeleteDirectory(string path, bool recursive = false)
+        {
+            try
+            {
+                Directory.Delete(path, recursive);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
     }
 }

--- a/src/BloomExe/RobustFileIO.cs
+++ b/src/BloomExe/RobustFileIO.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using Bloom.ImageProcessing;
 using SIL.Code;
@@ -66,8 +67,9 @@ namespace Bloom
                 Directory.Delete(path, recursive);
                 return true;
             }
-            catch
+            catch (Exception ex)
             {
+                Bloom.Utils.MiscUtils.SuppressUnusedExceptionVarWarning(ex);
                 return false;
             }
         }

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -200,6 +200,7 @@ namespace Bloom.Api
             _useCache = Settings.Default.ImageHandler != "off";
             ApiHandler = new BloomApiHandler(bookSelection);
             _theOneInstance = this;
+            _bookSelection.SelectionChanged += (_, _) => _cache?.ClearAll();
         }
 
 #if DEBUG
@@ -446,7 +447,16 @@ namespace Bloom.Api
                 ReplaceAnyVideoElementsWithPlaceholder(dom);
             }
             dom.Title = InMemoryHtmlFile.GetTitleForProcessExplorer(source) + " (InMemoryHtmlFile)"; // makes this show up in Windows Process Explorer WebView2 listing
-            var html5String = dom.getHtmlStringDisplayOnly();
+            var transparencyModifications = HtmlDom.AddTransparencyParamToImages(dom);
+            string html5String;
+            try
+            {
+                html5String = dom.getHtmlStringDisplayOnly();
+            }
+            finally
+            {
+                HtmlDom.RestoreImageSrcs(transparencyModifications);
+            }
             lock (_theOneInstance._queue)
             {
                 foreach (var item in _theOneInstance._idleTasks)
@@ -625,9 +635,19 @@ namespace Bloom.Api
                 if (localPath == "book-preview/index.htm")
                 {
                     request.ResponseContentType = "text/html";
-                    var html = CurrentBook
-                        .GetPreviewHtmlFileForWholeBook()
-                        .getHtmlStringDisplayOnly();
+                    var previewDom = CurrentBook.GetPreviewHtmlFileForWholeBook();
+                    var transparencyModifications = HtmlDom.AddTransparencyParamToImages(
+                        previewDom
+                    );
+                    string html;
+                    try
+                    {
+                        html = previewDom.getHtmlStringDisplayOnly();
+                    }
+                    finally
+                    {
+                        HtmlDom.RestoreImageSrcs(transparencyModifications);
+                    }
                     request.WriteCompleteOutput(html);
                     return true;
                 }
@@ -1041,28 +1061,23 @@ namespace Bloom.Api
                 //          want them. Running them through _cache.GetPathToAdjustedImage() is not necessary, and in PNG files
                 //          it converts all white areas to transparent. This is resulting in icons which only contain white
                 //          (because they are rendered on a dark background) becoming completely invisible.
-                // But things in the book folder should possibly be processed. The code below will still investigate
-                // whether it is really necessary; currently we're not resizing images except for thumbnails,
-                // and otherwise, only the cover image needs adjusting (to possibly provide a transparent background).
+                // Things in the book folder are processed on demand: resized, format-converted, and optionally
+                // made transparent, with results cached by GetPathToAdjustedImage / AdjustImageForDisplay.
                 processImage = sourceDir == CurrentBook?.FolderPath;
             }
 
             var originalImageFile = imageFile;
             // Currently _useCache is always true. It appears likely that the intent
             // is not so much about caching, but whether we want image processing.
-            // If we go back to allowing this to be turned off, we may need to make
-            // use of a check like CurrentBook?.ImageFileIsForBookCover() to make sure
-            // it is not disabled there, where it is important for transparency as
-            // well as performance.
             if (processImage && _useCache)
             {
-                // thumbnail requests have the thumbnail parameter set in the query string
                 var thumb = info.GetQueryParameters()["thumbnail"] != null;
-                var isForCover = CurrentBook?.ImageFileIsForBookCover(imageFile) ?? false;
-                if (thumb || isForCover)
-                {
-                    imageFile = _cache.GetPathToAdjustedImage(imageFile, thumb, isForCover);
-                }
+                var transparentParam = info.GetQueryParameters()["transparent"];
+                var transparencyMode =
+                    transparentParam == "force" ? ImageTransparencyMode.Force
+                    : transparentParam == "yes" ? ImageTransparencyMode.Auto
+                    : ImageTransparencyMode.None;
+                imageFile = _cache.GetPathToAdjustedImage(imageFile, thumb, transparencyMode);
 
                 if (String.IsNullOrEmpty(imageFile))
                     return false;

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -200,7 +200,8 @@ namespace Bloom.Api
             _useCache = Settings.Default.ImageHandler != "off";
             ApiHandler = new BloomApiHandler(bookSelection);
             _theOneInstance = this;
-            _bookSelection.SelectionChanged += (_, _) => _cache?.ClearAll();
+            if (_bookSelection != null) // maybe null in some tests?
+                _bookSelection.SelectionChanged += (_, _) => _cache?.ClearAll();
         }
 
 #if DEBUG
@@ -388,7 +389,8 @@ namespace Bloom.Api
             HtmlDom dom,
             bool isCurrentPageContent = false,
             bool setAsCurrentPageForDebugging = false,
-            InMemoryHtmlFileSource source = InMemoryHtmlFileSource.Normal
+            InMemoryHtmlFileSource source = InMemoryHtmlFileSource.Normal,
+            bool suppressBackgroundColors = false
         )
         {
             var simulatedPageFileName = Path.ChangeExtension(
@@ -447,7 +449,10 @@ namespace Bloom.Api
                 ReplaceAnyVideoElementsWithPlaceholder(dom);
             }
             dom.Title = InMemoryHtmlFile.GetTitleForProcessExplorer(source) + " (InMemoryHtmlFile)"; // makes this show up in Windows Process Explorer WebView2 listing
-            var transparencyModifications = HtmlDom.AddTransparencyParamToImages(dom);
+            var transparencyModifications = HtmlDom.AddTransparencyParamToImages(
+                dom,
+                suppressBackgroundColors
+            );
             string html5String;
             try
             {
@@ -944,7 +949,6 @@ namespace Bloom.Api
 
             if (imageFile.StartsWith(OriginalImageMarker + "/"))
             {
-                processImage = false;
                 imageFile = imageFile.Substring((OriginalImageMarker + "/").Length);
 
                 if (!RobustFileExistsWithCaseCheck(imageFile))
@@ -955,28 +959,47 @@ namespace Bloom.Api
                     return false;
                 }
 
-                if (
-                    CurrentBook?.UserPrefs.IncludeBackgroundColors == true
-                    && info.GetQueryParameters()["transparent"] == "yes"
-                )
+                var transparentParam = info.GetQueryParameters()["transparent"];
+
+                // bloom-transparent (transparent=force) must always be honored, even when
+                // serving original images for PDF. Use the cache so format conversion
+                // (e.g. jpg → png) is handled correctly.
+                if (transparentParam == "force" && _useCache)
                 {
-                    if (ImageUtils.IsPngFile(imageFile))
+                    var forcedFile = _cache.GetPathToAdjustedImage(
+                        imageFile,
+                        false,
+                        ImageTransparencyMode.Force
+                    );
+                    if (!string.IsNullOrEmpty(forcedFile))
                     {
-                        using (var tempFile = TempFile.WithExtension(".png"))
-                        {
-                            if (
-                                ImageUtils.MakeTransparentBackgroundIfNeeded(
-                                    imageFile,
-                                    tempFile.Path
-                                )
-                            )
-                            {
-                                info.ReplyWithImage(tempFile.Path);
-                                return true;
-                            }
-                        }
+                        info.ReplyWithImage(forcedFile, imageFile);
+                        return true;
                     }
                 }
+
+                if (
+                    CurrentBook?.UserPrefs.IncludeBackgroundColors == true
+                    && transparentParam == "yes"
+                    && _useCache
+                )
+                {
+                    // Use transparencyOnly so AdjustImageForDisplay skips resize and JPEG
+                    // conversion and returns null (→ cached as a no-op) when the image isn't
+                    // line art, avoiding an expensive reload on every subsequent request.
+                    var autoFile = _cache.GetPathToAdjustedImage(
+                        imageFile,
+                        false,
+                        ImageTransparencyMode.Auto,
+                        transparencyOnly: true
+                    );
+                    // autoFile == imageFile means the cache confirmed this image is not line art;
+                    // either way we reply with whatever the cache decided is correct.
+                    info.ReplyWithImage(autoFile, imageFile);
+                    return true;
+                }
+                // IncludeBackgroundColors is off, or no transparent param — serve the original
+                // without any processing.
                 info.ReplyWithImage(imageFile);
                 return true;
             }

--- a/src/BloomExe/web/PageListApi.cs
+++ b/src/BloomExe/web/PageListApi.cs
@@ -341,22 +341,16 @@ namespace Bloom.web
                     .Cast<SafeXmlElement>()
             )
             {
-                var classAttr = img.GetAttribute("class") ?? "";
-                if (classAttr.Contains("branding") || classAttr.Contains("bloom-qrcode"))
+                if (img.HasClass("branding") || img.HasClass("bloom-qrcode"))
                     continue;
-                var mode = HtmlDom.GetImageTransparencyMode(classAttr, pageNeedsTransparent);
+                var mode = HtmlDom.GetImageTransparencyMode(img, pageNeedsTransparent);
                 if (mode == ImageTransparencyMode.None)
                     continue;
                 var src = img.GetAttribute("src");
                 if (!string.IsNullOrEmpty(src))
                 {
                     var paramValue = mode == ImageTransparencyMode.Force ? "force" : "yes";
-                    img.SetAttribute(
-                        "src",
-                        src.Contains('?')
-                            ? $"{src}&transparent={paramValue}"
-                            : $"{src}?transparent={paramValue}"
-                    );
+                    img.SetAttribute("src", HtmlDom.GetSrcWithTransparencyParam(src, paramValue));
                 }
             }
             // For WebView2, this prevents any interaction with elements in the page thumbnail.

--- a/src/BloomExe/web/PageListApi.cs
+++ b/src/BloomExe/web/PageListApi.cs
@@ -9,6 +9,7 @@ using Bloom.Api;
 using Bloom.Book;
 using Bloom.CollectionTab;
 using Bloom.Edit;
+using Bloom.ImageProcessing;
 using Bloom.SafeXml;
 using Bloom.Utils;
 using SIL.Reporting;
@@ -333,6 +334,31 @@ namespace Bloom.web
             }
 
             MarkImageNodesForThumbnail(pageElement);
+            var pageNeedsTransparent = HtmlDom.PageNeedsTransparentImages(pageElement);
+            foreach (
+                SafeXmlElement img in pageElement
+                    .SafeSelectNodes(".//img[@src]")
+                    .Cast<SafeXmlElement>()
+            )
+            {
+                var classAttr = img.GetAttribute("class") ?? "";
+                if (classAttr.Contains("branding") || classAttr.Contains("bloom-qrcode"))
+                    continue;
+                var mode = HtmlDom.GetImageTransparencyMode(classAttr, pageNeedsTransparent);
+                if (mode == ImageTransparencyMode.None)
+                    continue;
+                var src = img.GetAttribute("src");
+                if (!string.IsNullOrEmpty(src))
+                {
+                    var paramValue = mode == ImageTransparencyMode.Force ? "force" : "yes";
+                    img.SetAttribute(
+                        "src",
+                        src.Contains('?')
+                            ? $"{src}&transparent={paramValue}"
+                            : $"{src}?transparent={paramValue}"
+                    );
+                }
+            }
             // For WebView2, this prevents any interaction with elements in the page thumbnail.
             // We put an overlay over it to try to prevent such interaction, but this is more
             // reliable. Nothing in the page will ever get focus, be tabbed to, be read by

--- a/src/BloomExe/web/controllers/PublishApi.cs
+++ b/src/BloomExe/web/controllers/PublishApi.cs
@@ -721,6 +721,7 @@ namespace Bloom.web.controllers
                 settings.ImagePublishSettings,
                 modifiedBook.RawDom
             );
+            modifiedBook.Save(true);
             progress.Message(
                 "Common.Done",
                 "Shown in a list of messages when Bloom has completed a task.",

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -2187,7 +2187,7 @@ namespace BloomTests.Book
             document.LoadXml(xml);
 
             // SUT
-            var result = Bloom.Book.Book.GetCoverBackgroundColorFromOldInlineStyle(document);
+            var result = HtmlDom.GetCoverBackgroundColorFromOldInlineStyle(document);
 
             Assert.AreEqual("#abcdef", result);
         }
@@ -2200,7 +2200,7 @@ namespace BloomTests.Book
             document.LoadXml(xml);
 
             // SUT
-            var result = Bloom.Book.Book.GetCoverBackgroundColorFromOldInlineStyle(document);
+            var result = HtmlDom.GetCoverBackgroundColorFromOldInlineStyle(document);
 
             // should look like a hex color
             Assert.IsTrue(result.StartsWith("#"));
@@ -2225,7 +2225,7 @@ namespace BloomTests.Book
             document.LoadXml(xml);
 
             // SUT
-            var result = Bloom.Book.Book.GetCoverBackgroundColorFromOldInlineStyle(document);
+            var result = HtmlDom.GetCoverBackgroundColorFromOldInlineStyle(document);
 
             Assert.AreEqual("black", result);
         }
@@ -2249,7 +2249,7 @@ namespace BloomTests.Book
             document.LoadXml(xml);
 
             // SUT
-            var result = Bloom.Book.Book.GetCoverBackgroundColorFromOldInlineStyle(document);
+            var result = HtmlDom.GetCoverBackgroundColorFromOldInlineStyle(document);
 
             Assert.AreEqual("#ffd4d4", result);
         }

--- a/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
+++ b/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
@@ -64,9 +64,27 @@ namespace BloomTests.ImageProcessing
         }
 
         [Test]
-        public void ProcessAndSaveImageIntoFolder_PhotoButPNGFile_SavesAsJpeg()
+        public void ProcessAndSaveImageIntoFolder_PhotoButPNGFile_SavesAsPng()
         {
-            ProcessAndSaveImageIntoFolder_AndTestResults("man.png", ImageFormat.Jpeg);
+            // Import no longer converts formats; PNG is preserved as-is.
+            ProcessAndSaveImageIntoFolder_AndTestResults("man.png", ImageFormat.Png);
+        }
+
+        [Test]
+        public void AdjustImageForDisplay_PhotoButPNGFile_ConvertsToJpeg()
+        {
+            var inputPath = SIL.IO.FileLocationUtilities.GetFileDistributedWithApplication(
+                _pathToTestImages,
+                "man.png"
+            );
+            using (var destFolder = new TemporaryFolder("AdjustImageForDisplay_PhotoPng"))
+            {
+                var result = ImageUtils.AdjustImageForDisplay(inputPath, destFolder.Path);
+                Assert.IsNotNull(result, "Expected a processed version to be created");
+                Assert.AreEqual(".jpg", Path.GetExtension(result));
+                using (var img = Image.FromFile(result))
+                    Assert.AreEqual(ImageFormat.Jpeg, img.RawFormat);
+            }
         }
 
         [Test]
@@ -171,10 +189,10 @@ namespace BloomTests.ImageProcessing
         }
 
         [Test]
-        public void ProcessAndSaveImageIntoFolder_LineArtOnColoredPage_MakesSavedPngTransparent()
+        public void AdjustImageForDisplay_LineArtPngWithTransparent_MakesBackgroundTransparent()
         {
-            using (var sourceFolder = new TemporaryFolder("LineArtOnColoredPage_Source"))
-            using (var destinationFolder = new TemporaryFolder("LineArtOnColoredPage_Dest"))
+            using (var sourceFolder = new TemporaryFolder("AdjustImageForDisplay_LineArt_Source"))
+            using (var destFolder = new TemporaryFolder("AdjustImageForDisplay_LineArt_Dest"))
             {
                 var sourcePath = sourceFolder.Combine("line-art.png");
                 using (var bitmap = new Bitmap(40, 40))
@@ -186,32 +204,31 @@ namespace BloomTests.ImageProcessing
                     bitmap.Save(sourcePath, ImageFormat.Png);
                 }
 
-                using (var image = PalasoImage.FromFileRobustly(sourcePath))
-                {
-                    var fileName = ImageUtils.ProcessAndSaveImageIntoFolder(
-                        image,
-                        destinationFolder.Path,
-                        false,
-                        "#2E2E2E"
-                    );
+                var result = ImageUtils.AdjustImageForDisplay(
+                    sourcePath,
+                    destFolder.Path,
+                    transparencyMode: ImageTransparencyMode.Auto
+                );
 
-                    Assert.AreEqual(".png", Path.GetExtension(fileName));
-                    var outputPath = destinationFolder.Combine(fileName);
-                    using (var result = (Bitmap)Image.FromFile(outputPath))
-                    {
-                        Assert.That(result.GetPixel(0, 0).A, Is.EqualTo(0));
-                        Assert.That(result.GetPixel(20, 20).A, Is.EqualTo(255));
-                    }
+                Assert.IsNotNull(result);
+                Assert.AreEqual(".png", Path.GetExtension(result));
+                using (var resultBitmap = (Bitmap)Image.FromFile(result))
+                {
+                    Assert.That(resultBitmap.GetPixel(0, 0).A, Is.EqualTo(0));
+                    Assert.That(resultBitmap.GetPixel(20, 20).A, Is.EqualTo(255));
                 }
             }
         }
 
         [Test]
-        public void ProcessAndSaveImageIntoFolder_LineArtJpegSameFileOnColoredPage_UsesPngFilenameAndData()
+        public void AdjustImageForDisplay_LineArtJpegWithTransparent_ConvertsToPngAndMakesTransparent()
         {
-            using (var folder = new TemporaryFolder("LineArtJpegSameFile"))
+            using (
+                var sourceFolder = new TemporaryFolder("AdjustImageForDisplay_LineArtJpeg_Source")
+            )
+            using (var destFolder = new TemporaryFolder("AdjustImageForDisplay_LineArtJpeg_Dest"))
             {
-                var sourcePath = folder.Combine("line-art.jpg");
+                var sourcePath = sourceFolder.Combine("line-art.jpg");
                 using (var bitmap = new Bitmap(40, 40))
                 using (var graphics = Graphics.FromImage(bitmap))
                 using (var pen = new Pen(Color.Black, 3))
@@ -221,23 +238,19 @@ namespace BloomTests.ImageProcessing
                     bitmap.Save(sourcePath, ImageFormat.Jpeg);
                 }
 
-                using (var image = PalasoImage.FromFileRobustly(sourcePath))
-                {
-                    var fileName = ImageUtils.ProcessAndSaveImageIntoFolder(
-                        image,
-                        folder.Path,
-                        true,
-                        "#2E2E2E"
-                    );
+                var result = ImageUtils.AdjustImageForDisplay(
+                    sourcePath,
+                    destFolder.Path,
+                    transparencyMode: ImageTransparencyMode.Auto
+                );
 
-                    Assert.AreEqual(".png", Path.GetExtension(fileName));
-                    var outputPath = folder.Combine(fileName);
-                    using (var result = (Bitmap)Image.FromFile(outputPath))
-                    {
-                        Assert.AreEqual(ImageFormat.Png, result.RawFormat);
-                        Assert.That(result.GetPixel(0, 0).A, Is.EqualTo(0));
-                        Assert.That(result.GetPixel(20, 20).A, Is.EqualTo(255));
-                    }
+                Assert.IsNotNull(result);
+                Assert.AreEqual(".png", Path.GetExtension(result));
+                using (var resultBitmap = (Bitmap)Image.FromFile(result))
+                {
+                    Assert.AreEqual(ImageFormat.Png, resultBitmap.RawFormat);
+                    Assert.That(resultBitmap.GetPixel(0, 0).A, Is.EqualTo(0));
+                    Assert.That(resultBitmap.GetPixel(20, 20).A, Is.EqualTo(255));
                 }
             }
         }

--- a/src/BloomTests/Publish/Epub/ExportEpubTests.cs
+++ b/src/BloomTests/Publish/Epub/ExportEpubTests.cs
@@ -9,6 +9,7 @@ using System.Xml.Linq;
 using Bloom;
 using Bloom.Book;
 using Bloom.FontProcessing;
+using Bloom.ImageProcessing;
 using Bloom.Publish;
 using Bloom.Publish.Epub;
 using Bloom.SafeXml;
@@ -2990,25 +2991,25 @@ namespace BloomTests.Publish.Epub
             Book = book;
         }
 
-        internal override void CopyFile(
+        internal override string CopyFile(
             string srcPath,
             string dstPath,
             ImagePublishSettings imagePublishSettings,
             bool reduceImageIfPossible = false,
-            bool makeTransparentifAppropriate = false
+            ImageTransparencyMode transparencyMode = ImageTransparencyMode.None
         )
         {
             if (srcPath.Contains("notareallocation"))
             {
                 File.WriteAllText(dstPath, "This is a test fake");
-                return;
+                return dstPath;
             }
-            base.CopyFile(
+            return base.CopyFile(
                 srcPath,
                 dstPath,
                 imagePublishSettings,
                 reduceImageIfPossible,
-                makeTransparentifAppropriate
+                transparencyMode
             );
         }
     }


### PR DESCRIPTION
Do alpha channel before scaling image

Clean up doing transparency

no longer a responsibility of RunGraphicksMagic, since we no longer use its algorithm. Cuts out a good bit of complexity and file copying.

Refactoring in prep for further changes

Basics of keeping original images

Use new algorithms in publishing

Add the Background menu option

Cleanup

Reinstate some resize on import

Merge branch 'Version6.4'

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7951)
<!-- Reviewable:end -->


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/7951)
