### PR TITLE
Make page thumbnail list update incrementally when adding pages (BL-16418)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.tsx
+++ b/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.tsx
@@ -533,10 +533,12 @@ const PageList: React.FunctionComponent<{ initialPageLayout: string }> = (
 
     // All the code in this useEffect is one-time initialization.
     useEffect(() => {
-        let localizedNotification = "";
+        // English fallback shown in the "saving" toast until the localized text arrives.
+        // The websocket listener must be registered immediately (see below), so it cannot
+        // wait for localization; in the worst case an early save shows this fallback.
+        let localizedNotification = "Saving...";
 
-        // This function will be hooked up (after we set localizedNotification properly)
-        // to be called when C# sends messages through the web socket.
+        // This function will be called when C# sends messages through the web socket.
         // We need a named function because it looks cleaner.
         webSocketListenerFunction = (event) => {
             switch (event.id) {
@@ -581,17 +583,36 @@ const PageList: React.FunctionComponent<{ initialPageLayout: string }> = (
                     // below that uses resetValue for something we don't care about.
                     setResetValue((oldResetValue) => oldResetValue + 1);
                     break;
+                case `websocket/open/${kWebsocketContext}`:
+                    // The socket just (re)opened. Any messages C# sent while we had no
+                    // connection (e.g. while this iframe was loading, or after a network
+                    // hiccup before the 2-second reconnect loop restored the socket) were
+                    // lost; the server does not queue them. Re-fetch the page list so we
+                    // are sure to be in sync. This bump also drives the very first load:
+                    // the effect below skips its initial run (reloadValue === 0) and waits
+                    // for this, so we fetch the page list exactly once, when the socket is
+                    // ready, instead of fetching immediately and then again on open.
+                    setReloadValue((oldReloadValue) => oldReloadValue + 1);
+                    break;
             }
         };
+
+        // Register the listener right away. This used to happen only inside the .done()
+        // of the localization request below, which widened the window during load in which
+        // messages from C# (e.g. pageListNeedsRefresh after adding a page) were silently
+        // dropped. Registering now shrinks that window but does not eliminate it: anything
+        // C# sends before the socket finishes opening is still lost (the server does not
+        // queue messages). The websocket/open handler above is what actually closes the
+        // remaining gap, by re-fetching the page list once the socket is connected.
+        WebSocketManager.addListener(
+            kWebsocketContext,
+            webSocketListenerFunction,
+        );
 
         theOneLocalizationManager
             .asyncGetText("EditTab.SavingNotification", "Saving...", "")
             .done((savingNotification) => {
                 localizedNotification = savingNotification;
-                WebSocketManager.addListener(
-                    kWebsocketContext,
-                    webSocketListenerFunction,
-                );
             });
         theOneLocalizationManager
             .asyncGetText("EditTab.PageList.Heading", "Pages", "")
@@ -601,12 +622,19 @@ const PageList: React.FunctionComponent<{ initialPageLayout: string }> = (
             });
     }, []);
 
-    // Initially we have an empty page list. Then we run this once and get a list
-    // of pages that have the right ID and caption (and the right number of pages)
-    // but the content is empty. The individual thumbnail objects do their own API
-    // calls to fill in the page content. Then this runs again when the sequence
-    // of pages changes (e.g., adding a page or re-ordering them).
+    // We get a list of pages that have the right ID and caption (and the right number
+    // of pages) but the content is empty. The individual thumbnail objects do their own
+    // API calls to fill in the page content. This runs again when the sequence of pages
+    // changes (e.g., adding a page or re-ordering them).
     useEffect(() => {
+        // Skip the initial run (reloadValue === 0). The websocket/open handler above bumps
+        // reloadValue to 1 as soon as the socket connects, which re-runs this effect.
+        // Fetching here on mount too would just be a wasted duplicate that the open handler
+        // always repeats. Waiting for the open bump also means the socket is listening
+        // before we fetch, so we cannot miss a refresh notification sent right after.
+        if (reloadValue === 0) {
+            return;
+        }
         get("pageList/pages", (response) => {
             // We're using a double approach here. The WebThumbnailList actually gets
             // notified a few times of the initial selected page. Each time, it sends

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -733,8 +733,18 @@ namespace Bloom.Book
             // Remember, Linux filenames are case sensitive!
             stylesheetsToIgnore.Add("basePage"); // will work for basePage.css, basePage-legacy-5-6.css, etc.
             stylesheetsToIgnore.Add("editMode.css");
+            // Like editMode.css, editPaneGlobal.css is an edit-time stylesheet, and
+            // RemoveModeStyleSheets strips it whenever a book is saved. If we treat it as a
+            // template stylesheet, AddStylesheetFromAnotherBook re-adds it on every page
+            // inserted from a template that links it (e.g. Basic Book), and so reports the
+            // book's stylesheet collection as changed on every insert, forcing a needless
+            // full reload of the page thumbnail list each time.
+            stylesheetsToIgnore.Add("editPaneGlobal.css");
             stylesheetsToIgnore.Add("previewMode.css");
             stylesheetsToIgnore.Add("XMatter");
+            // origami.css is one of BookStorage.CssFilesThatAreAlwaysWanted: storage links it
+            // into every stored book itself, so a template never needs to contribute it.
+            stylesheetsToIgnore.Add("origami.css");
             stylesheetsToIgnore.AddRange(BookStorage.CssFilesThatAreDynamicallyUpdated);
 
             foreach (var link in _dom.SafeSelectNodes("//link[@rel='stylesheet']"))

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -619,9 +619,26 @@ namespace Bloom.Edit
                         page as Page,
                         e.NumberToAdd
                     );
-                    _view.Browser.RunJavascriptAsync(
-                        "document.getElementById('pageList').contentWindow.location.reload(true);"
-                    );
+                    // We deliberately do NOT force the page-list iframe to reload here.
+                    // InsertPageAfter raises pageListChangedEvent (deferred until idle), which
+                    // leads to UpdatePageList(); that either sends pageListNeedsRefresh over the
+                    // websocket (a cheap, incremental update in the React page list) or, if the
+                    // new page brought new stylesheets, regenerates the page-list document and
+                    // navigates the iframe to it. We used to also do a hard location.reload of
+                    // the iframe here, but that repainted the entire thumbnail list on every
+                    // insert and raced with those deferred notifications: a websocket message
+                    // arriving while the iframe was mid-reload was silently dropped, leaving the
+                    // list permanently stale.
+                    //
+                    // The stylesheet-change path still navigates the iframe, which does repaint
+                    // the whole list and does have a brief window during load where websocket
+                    // messages are ignored. The difference is that this navigation is no longer a
+                    // blind reload racing a separate notification: it is triggered by the deferred
+                    // event itself and loads a freshly regenerated document that already contains
+                    // the new page (and its stylesheet), so it is correct on its own. And when the
+                    // reloaded iframe's socket opens, the React code re-fetches the page list (see
+                    // the websocket/open handler in pageThumbnailList.tsx), recovering anything
+                    // missed during the load. So no stale-list race remains.
                     //_view.UpdatePageList(false);  InsertPageAfter calls this via pageListChangedEvent.  See BL-3632 for trouble this causes.
                     //_pageSelection.SelectPage(newPage);
                     if (e.FromTemplate)

--- a/src/BloomExe/Edit/PageThumbnailList.cs
+++ b/src/BloomExe/Edit/PageThumbnailList.cs
@@ -189,6 +189,15 @@ namespace Bloom.Edit
             pageListDom = Model.CurrentBook.GetHtmlDomForPageList(pageListDom);
 
             _baseForRelativePaths = pageListDom.BaseForRelativePaths;
+
+            // Notify the browser side on this full-rebuild path too. Historically only the
+            // early-abort branch above sent this message, so a caller that reached this branch
+            // without also navigating the iframe to a regenerated document (e.g.
+            // UpdatePageList(false) after the Book object had been replaced) never triggered
+            // any repaint at all. When the caller *does* navigate the iframe
+            // (UpdatePageList(true)), this message is redundant but harmless: at worst the old
+            // document refreshes its list just before being replaced.
+            WebSocketServer.SendString("pageThumbnailList", "pageListNeedsRefresh", "");
             return result.ToList();
         }
 


### PR DESCRIPTION
Adding any page from the Add Page dialog repainted the entire page
thumbnail list, and occasionally the list never updated at all until
something else forced a refresh. Several causes, all addressed here:

- OnInsertPage did a hard location.reload of the page-list iframe on
  every insert. This rebooted the whole React list and raced with the
  deferred pageListChangedEvent notifications; a websocket message
  arriving mid-reload was silently dropped, leaving the list stale.
  Removed; the refresh now flows solely through UpdatePageList.

- GetTemplateStyleSheets treated editPaneGlobal.css as a template
  stylesheet. Since RemoveModeStyleSheets strips that link on every
  save, AddStylesheetFromAnotherBook re-added it on every insert from
  a template that links it (e.g. Basic Book), so stylesChanged was
  perpetually true and every insert took the full page-list document
  swap instead of the cheap websocket refresh. It is now ignored,
  along with origami.css, which storage manages independently.

- The full-rebuild branch of UpdateItemsInternal sent no websocket
  notification, so a caller that reached it without also navigating
  the iframe never triggered any repaint. It now always sends
  pageListNeedsRefresh.

- The page list registered its websocket listener only after an async
  localization call resolved, leaving a load-time window in which
  messages from C# were lost; WebSocketManager does not queue them.
  The listener is now registered immediately, and the list re-fetches
  whenever its socket (re)opens so any message missed while
  disconnected self-heals.

Adding a page whose stylesheets are already in the book now updates
just the affected thumbnails; the full document swap remains only for
inserts that genuinely bring new stylesheets.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7952)
<!-- Reviewable:end -->
