### PR TITLE
Fix change field handling of narration (BL-16368)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementDuplication.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementDuplication.ts
@@ -319,6 +319,9 @@ export class CanvasElementDuplication {
         });
     }
 
+    // Copy everything we need to so that the copy will have the same narration audio as the source,
+    // but with independent ids and files so that if the copy narration is changed, it won't affect the source
+    // (or vice versa). (We also avoid duplicate IDs, which is incorrect in HTML and can cause problems).
     public copyAnySoundFileAndAttributesForEditable(
         sourceElement: HTMLElement,
         copiedElement: HTMLElement,

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementDuplication.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementDuplication.ts
@@ -291,7 +291,35 @@ export class CanvasElementDuplication {
         );
     }
 
-    private copyAnySoundFileAndAttributesForEditable(
+    // Copies audio-sentence ids and files in an editable, giving each a new independent id
+    // so that changing the field type doesn't share recordings with the data-book source.
+    public makeEditableAudioIndependent(editable: HTMLElement): void {
+        if (!editable) {
+            return;
+        }
+
+        const audioElements: Element[] = [];
+        if (
+            editable.classList.contains("audio-sentence") &&
+            editable.getAttribute("id")
+        ) {
+            audioElements.push(editable);
+        }
+
+        audioElements.push(
+            ...Array.from(editable.querySelectorAll(".audio-sentence[id]")),
+        );
+
+        audioElements.forEach((audioElement) => {
+            const oldId = audioElement.getAttribute("id");
+            if (!oldId) {
+                return;
+            }
+            this.copySoundFileAndAttributes(audioElement, oldId, audioElement);
+        });
+    }
+
+    public copyAnySoundFileAndAttributesForEditable(
         sourceElement: HTMLElement,
         copiedElement: HTMLElement,
     ): void {

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementManager.ts
@@ -2737,6 +2737,10 @@ export class CanvasElementManager {
         );
     }
 
+    public makeEditableAudioIndependent(editable: HTMLElement): void {
+        this.duplication.makeEditableAudioIndependent(editable);
+    }
+
     public startDraggingSplitter() {
         this.editingSuspension.startDraggingSplitter();
     }

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlTextMenuItems.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlTextMenuItems.ts
@@ -6,6 +6,7 @@
 import * as React from "react";
 import { default as CheckIcon } from "@mui/icons-material/Check";
 import { get, postThatMightNavigate } from "../../../utils/bloomApi";
+import { wrapWithRequestPageContentDelay } from "../../js/bloomEditing";
 import { getCanvasElementManager } from "./canvasElementPageBridge";
 import { IControlContext, IControlMenuCommandRow } from "./canvasControlTypes";
 
@@ -384,46 +385,58 @@ export function makeFieldTypeMenuItem(
                     return;
                 }
 
-                translationGroup.classList.add(...fieldType.classes);
-                editables.forEach((editable) => {
-                    editable.classList.add(...fieldType.editableClasses);
-                    editable.removeAttribute("data-derived");
-                    editable.setAttribute("data-book", fieldType.dataBook);
-                    if (
-                        editable.classList.contains(
-                            "bloom-visibility-code-on",
-                        ) &&
-                        fieldType.dataBook
-                    ) {
-                        get(
-                            `editView/getDataBookValue?lang=${editable.getAttribute("lang")}&dataBook=${fieldType.dataBook}`,
-                            (result) => {
-                                const response = result.data;
-                                const content = response.content;
-                                const temp = document.createElement("div");
-                                temp.innerHTML = content || "";
-                                const keptExistingContent =
-                                    temp.textContent.trim() === "";
-                                if (!keptExistingContent) {
-                                    editable.innerHTML = content;
-                                    applyEditableAudioIdentityFromDataBookValue(
-                                        editable,
-                                        response,
-                                    );
-                                }
-                                if (fieldTypeChanged && keptExistingContent) {
-                                    getCanvasElementManager()?.makeEditableAudioIndependent(
-                                        editable,
-                                    );
-                                }
-                            },
-                        );
-                    } else if (fieldTypeChanged) {
-                        getCanvasElementManager()?.makeEditableAudioIndependent(
-                            editable,
-                        );
+                // Wrap to prevent saving an incompletely modified page
+                // while the async getDataBookValue request is in flight.
+                void wrapWithRequestPageContentDelay(async () => {
+                    translationGroup.classList.add(...fieldType.classes);
+                    for (const editable of editables) {
+                        editable.classList.add(...fieldType.editableClasses);
+                        editable.removeAttribute("data-derived");
+                        editable.setAttribute("data-book", fieldType.dataBook);
+                        if (
+                            editable.classList.contains(
+                                "bloom-visibility-code-on",
+                            ) &&
+                            fieldType.dataBook
+                        ) {
+                            await new Promise<void>((resolve) => {
+                                get(
+                                    `editView/getDataBookValue?lang=${editable.getAttribute("lang")}&dataBook=${fieldType.dataBook}`,
+                                    (result) => {
+                                        const response = result.data;
+                                        const content = response.content;
+                                        const temp =
+                                            document.createElement("div");
+                                        temp.innerHTML = content || "";
+                                        const keptExistingContent =
+                                            temp.textContent.trim() === "";
+                                        if (!keptExistingContent) {
+                                            editable.innerHTML = content;
+                                            applyEditableAudioIdentityFromDataBookValue(
+                                                editable,
+                                                response,
+                                            );
+                                        }
+                                        if (
+                                            fieldTypeChanged &&
+                                            keptExistingContent
+                                        ) {
+                                            getCanvasElementManager()?.makeEditableAudioIndependent(
+                                                editable,
+                                            );
+                                        }
+                                        resolve();
+                                    },
+                                    () => resolve(),
+                                );
+                            });
+                        } else if (fieldTypeChanged) {
+                            getCanvasElementManager()?.makeEditableAudioIndependent(
+                                editable,
+                            );
+                        }
                     }
-                });
+                }, "setCanvasFieldType");
             },
         });
     });

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlTextMenuItems.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlTextMenuItems.ts
@@ -5,7 +5,7 @@
 
 import * as React from "react";
 import { default as CheckIcon } from "@mui/icons-material/Check";
-import { getString, postThatMightNavigate } from "../../../utils/bloomApi";
+import { get, postThatMightNavigate } from "../../../utils/bloomApi";
 import { getCanvasElementManager } from "./canvasElementPageBridge";
 import { IControlContext, IControlMenuCommandRow } from "./canvasControlTypes";
 
@@ -138,6 +138,53 @@ function clearFieldTypeClasses(translationGroup: HTMLElement): void {
             );
         });
     });
+}
+
+function applyEditableAudioIdentityFromDataBookValue(
+    editable: HTMLElement,
+    dataBookValue: {
+        id?: string;
+        dataAudioRecordingMode?: string;
+        dataDuration?: string;
+        dataAudioRecordingEndTimes?: string;
+        recordingMd5?: string;
+        hasAudioSentenceClass?: boolean;
+        hasBloomPostAudioSplitClass?: boolean;
+    },
+) {
+    const syncAttribute = (attributeName: string, value?: string) => {
+        if (value) {
+            editable.setAttribute(attributeName, value);
+        } else {
+            editable.removeAttribute(attributeName);
+        }
+    };
+
+    if (dataBookValue.id) {
+        editable.setAttribute("id", dataBookValue.id);
+    }
+
+    syncAttribute(
+        "data-audiorecordingmode",
+        dataBookValue.dataAudioRecordingMode,
+    );
+    syncAttribute("data-duration", dataBookValue.dataDuration);
+    syncAttribute(
+        "data-audiorecordingendtimes",
+        dataBookValue.dataAudioRecordingEndTimes,
+    );
+    syncAttribute("recordingmd5", dataBookValue.recordingMd5);
+
+    if (dataBookValue.hasAudioSentenceClass) {
+        editable.classList.add("audio-sentence");
+    } else {
+        editable.classList.remove("audio-sentence");
+    }
+    if (dataBookValue.hasBloomPostAudioSplitClass) {
+        editable.classList.add("bloom-postAudioSplit");
+    } else {
+        editable.classList.remove("bloom-postAudioSplit");
+    }
 }
 
 export function makeLanguageMenuItem(
@@ -283,6 +330,9 @@ export function makeFieldTypeMenuItem(
                     translationGroup.getElementsByClassName("bloom-editable"),
                 ).forEach((editable) => {
                     const htmlEditable = editable as HTMLElement;
+                    getCanvasElementManager()?.makeEditableAudioIndependent(
+                        htmlEditable,
+                    );
                     htmlEditable.removeAttribute("data-book");
                     htmlEditable.removeAttribute("data-derived");
                 });
@@ -302,6 +352,7 @@ export function makeFieldTypeMenuItem(
                 if (!translationGroup) {
                     return;
                 }
+                const fieldTypeChanged = activeType !== fieldType.dataBook;
                 clearFieldTypeClasses(translationGroup);
                 const editables = Array.from(
                     translationGroup.getElementsByClassName("bloom-editable"),
@@ -344,15 +395,32 @@ export function makeFieldTypeMenuItem(
                         ) &&
                         fieldType.dataBook
                     ) {
-                        getString(
+                        get(
                             `editView/getDataBookValue?lang=${editable.getAttribute("lang")}&dataBook=${fieldType.dataBook}`,
-                            (content) => {
+                            (result) => {
+                                const response = result.data;
+                                const content = response.content;
                                 const temp = document.createElement("div");
                                 temp.innerHTML = content || "";
-                                if (temp.textContent.trim() !== "") {
+                                const keptExistingContent =
+                                    temp.textContent.trim() === "";
+                                if (!keptExistingContent) {
                                     editable.innerHTML = content;
+                                    applyEditableAudioIdentityFromDataBookValue(
+                                        editable,
+                                        response,
+                                    );
+                                }
+                                if (fieldTypeChanged && keptExistingContent) {
+                                    getCanvasElementManager()?.makeEditableAudioIndependent(
+                                        editable,
+                                    );
                                 }
                             },
+                        );
+                    } else if (fieldTypeChanged) {
+                        getCanvasElementManager()?.makeEditableAudioIndependent(
+                            editable,
                         );
                     }
                 });

--- a/src/BloomExe/web/controllers/EditingViewApi.cs
+++ b/src/BloomExe/web/controllers/EditingViewApi.cs
@@ -158,7 +158,31 @@ namespace Bloom.web.controllers
             var dataBook = request.RequiredParam("dataBook");
             var multiText = View.Model.CurrentBook.BookData.GetMultiTextVariableOrEmpty(dataBook);
             var value = multiText.GetExactAlternative(lang) ?? "";
-            request.ReplyWithText(value);
+            var matchingDataDivElement =
+                View.Model.CurrentBook.RawDom.SelectSingleNode(
+                    $"//div[@id='bloomDataDiv']/div[@data-book='{dataBook}' and @lang='{lang}']"
+                ) as SafeXmlElement;
+
+            request.ReplyWithJson(
+                new
+                {
+                    content = value,
+                    id = matchingDataDivElement?.GetAttribute("id"),
+                    dataAudioRecordingMode = matchingDataDivElement?.GetAttribute(
+                        "data-audiorecordingmode"
+                    ),
+                    dataDuration = matchingDataDivElement?.GetAttribute("data-duration"),
+                    dataAudioRecordingEndTimes = matchingDataDivElement?.GetAttribute(
+                        "data-audiorecordingendtimes"
+                    ),
+                    recordingMd5 = matchingDataDivElement?.GetAttribute("recordingmd5"),
+                    hasAudioSentenceClass = matchingDataDivElement?.HasClass("audio-sentence")
+                        ?? false,
+                    hasBloomPostAudioSplitClass = matchingDataDivElement?.HasClass(
+                        "bloom-postAudioSplit"
+                    ) ?? false,
+                }
+            );
         }
 
         /// <summary>


### PR DESCRIPTION
- changing to None, or something that doesn't have text already: keeps the current text and any recording, but recording get a new ID and is no longer locked (or duplicated)
- changing to something that has a value: also gets any existing recording.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7953)
<!-- Reviewable:end -->
