### PR TITLE
Makes long-running Apps tool APIs run properly in background (BL-16350)

### DIFF
--- a/src/BloomBrowserUI/publish/Apps/AppPublisherScreen.tsx
+++ b/src/BloomBrowserUI/publish/Apps/AppPublisherScreen.tsx
@@ -460,11 +460,7 @@ const AppPublisherScreenContents: React.FunctionComponent<{
                         <Step expanded={true} completed={false}>
                             <StepLabel>
                                 <AppActionButton
-                                    enabled={
-                                        prepareIsReady &&
-                                        buildIsNeeded &&
-                                        canRunBuild
-                                    }
+                                    enabled={prepareIsReady && canRunBuild}
                                     l10nKey="PublishTab.Apps.Build"
                                     onClick={() =>
                                         screenState.runAction("build")

--- a/src/BloomBrowserUI/publish/Apps/appBuilderShared.ts
+++ b/src/BloomBrowserUI/publish/Apps/appBuilderShared.ts
@@ -34,6 +34,12 @@ export interface IAppBuilderStatus {
     rabRoot?: string;
     trackedBookTitles?: string[];
     trackedBooks: IAppBuilderTrackedBook[];
+    /** The action currently running on the server, or undefined if idle. */
+    activeAction?: AppBuilderAction;
+    /** Last progress stage reported by the server (e.g. "building-android-app"). */
+    activeActionProgressStage?: string;
+    /** Last progress percent (0–100) reported by the server. */
+    activeActionProgressPercent?: number;
 }
 
 export type AppBuilderPrepareStepId =
@@ -74,6 +80,12 @@ export interface IAppBuilderStatusApi {
     apkSizeBytes?: number;
     rabRoot?: string;
     trackedBookTitles?: string[];
+    activeAction?: string;
+    activeActionProgressStage?: string;
+    activeActionProgressPercent?: number;
+    ActiveAction?: string;
+    ActiveActionProgressStage?: string;
+    ActiveActionProgressPercent?: number;
     RabInstalled?: boolean;
     ProjectExists?: boolean;
     ApkExists?: boolean;
@@ -128,6 +140,10 @@ export interface IProgressStageLabels {
 }
 
 export const kAppBuilderWebSocketContext = "publish-rab";
+
+/// Websocket event id sent by the C# side when a prepare/build/install completes.
+/// The message payload is "{action}:success" or "{action}:failure".
+export const kAppBuilderActionCompleteEventId = "actionComplete";
 
 export type AppBuilderAction = "prepare" | "build" | "install";
 
@@ -209,6 +225,16 @@ export function normalizeStatus(
         getDefaultPrepareSteps()
     ).map(normalizePrepareStepStatus);
 
+    const rawActiveAction =
+        status?.activeAction ?? status?.ActiveAction ?? undefined;
+    const rawProgressStage =
+        status?.activeActionProgressStage ??
+        status?.ActiveActionProgressStage ??
+        undefined;
+    const rawProgressPercent =
+        status?.activeActionProgressPercent ??
+        status?.ActiveActionProgressPercent ??
+        undefined;
     return {
         rabInstalled: status?.rabInstalled ?? status?.RabInstalled ?? false,
         projectExists: status?.projectExists ?? status?.ProjectExists ?? false,
@@ -230,6 +256,9 @@ export function normalizeStatus(
         trackedBooks: (status?.trackedBooks ?? status?.TrackedBooks ?? []).map(
             normalizeTrackedBook,
         ),
+        activeAction: rawActiveAction as AppBuilderAction | undefined,
+        activeActionProgressStage: rawProgressStage,
+        activeActionProgressPercent: rawProgressPercent,
     };
 }
 

--- a/src/BloomBrowserUI/publish/Apps/useAppBuilderPublisherScreen.ts
+++ b/src/BloomBrowserUI/publish/Apps/useAppBuilderPublisherScreen.ts
@@ -1,5 +1,11 @@
 import * as React from "react";
-import { get, getWithPromise, postData, postJson } from "../../utils/bloomApi";
+import {
+    get,
+    getWithPromise,
+    post,
+    postData,
+    postJson,
+} from "../../utils/bloomApi";
 import {
     IBloomWebSocketProgressEvent,
     useSubscribeToWebSocketForEvent,
@@ -16,6 +22,7 @@ import {
     IAppBuilderStatusApi,
     IAppBuilderSizeEstimatesApi,
     kAppBuilderWebSocketContext,
+    kAppBuilderActionCompleteEventId,
     normalizeSizeEstimates,
     normalizeStatus,
     AppBuilderAction,
@@ -158,6 +165,34 @@ export function useAppBuilderPublisherScreen(
                 statusRetryTimeoutRef.current = undefined;
             }
             setStatus(nextStatus);
+            // If the backend reports an action is running but we have no local busyAction
+            // (e.g. after a remount mid-build), restore the action and its last-known progress
+            // so the indicator appears immediately without waiting for a websocket event.
+            if (nextStatus.activeAction) {
+                const isRestoringFromBlank = !busyActionRef.current;
+                setBusyAction(
+                    (current) =>
+                        current ??
+                        (nextStatus.activeAction as AppBuilderAction),
+                );
+                if (isRestoringFromBlank) {
+                    if (nextStatus.activeActionProgressStage) {
+                        setProgressStageCode(
+                            nextStatus.activeActionProgressStage,
+                        );
+                    }
+                    setProgressPercent(
+                        nextStatus.activeActionProgressPercent ?? 0,
+                    );
+                }
+            } else if (busyActionRef.current) {
+                // Server is idle but client still thinks an action is running —
+                // recover by clearing the stale busy state (e.g. after a remount
+                // that missed the actionComplete websocket event).
+                setBusyAction(undefined);
+                setProgressPercent(0);
+                setProgressStageCode(undefined);
+            }
 
             if (initializeSettingsAfterPrepare && nextStatus.appDefPath) {
                 const initializedSettings = await initializeAppBuilderSettings(
@@ -198,18 +233,77 @@ export function useAppBuilderPublisherScreen(
         }
     }
 
-    // This effect is warranted because tab activation is an external UI lifecycle boundary,
-    // and we need to reset the ephemeral BloomPUB cache plus re-read the RAB project whenever the Apps screen becomes active.
+    // Track busyAction in a ref so async callbacks can read the latest value
+    // without closing over a stale render's state.
+    const busyActionRef = React.useRef(busyAction);
+    busyActionRef.current = busyAction;
+
+    // This effect is warranted because tab activation is an external UI lifecycle boundary.
+    // We fetch status first so any active build, its current stage, and its progress are
+    // shown immediately — without waiting for the next websocket event — and so we know
+    // whether it's safe to reset the ephemeral BloomPUB cache.
     React.useEffect(() => {
         if (!isActive) {
             return;
         }
 
-        void postData("publish/rab/reset-bloompub-cache", {}).then(() => {
+        void (async () => {
+            // Snapshot the current server state right away.
+            let activeActionFromServer: AppBuilderAction | undefined;
+            try {
+                const nextStatus = await fetchStatusAsync();
+                if (!isMountedRef.current) {
+                    return;
+                }
+                setStatus(nextStatus);
+                activeActionFromServer = nextStatus.activeAction;
+                if (activeActionFromServer) {
+                    // Only restore server-side progress when we weren't already tracking
+                    // the action locally — if busyAction is already set, live websocket
+                    // events have fresher values than the status snapshot might.
+                    const wasAlreadyTracking = !!busyActionRef.current;
+                    setBusyAction(
+                        (current) => current ?? activeActionFromServer!,
+                    );
+                    if (!wasAlreadyTracking) {
+                        if (nextStatus.activeActionProgressStage) {
+                            setProgressStageCode(
+                                nextStatus.activeActionProgressStage,
+                            );
+                        }
+                        setProgressPercent(
+                            nextStatus.activeActionProgressPercent ?? 0,
+                        );
+                    }
+                }
+                void refreshSettings(nextStatus.appDefPath);
+            } catch {
+                // Status fetch failed; fall through to the cache-reset path which
+                // will call refreshStatus() for its own retry handling.
+            }
+
+            if (!isMountedRef.current) {
+                return;
+            }
+            refreshSizeEstimates();
+
+            if (activeActionFromServer) {
+                // A background action is running — skip the cache reset to avoid
+                // deleting BloomPUBs the build is actively using.
+                return;
+            }
+
+            // No active action: clear the stale per-session BloomPUB cache, then
+            // do a full status refresh to pick up any changes since the last visit.
+            await postData("publish/rab/reset-bloompub-cache", {});
+            if (!isMountedRef.current) {
+                return;
+            }
             void refreshStatus();
             refreshSizeEstimates();
-        });
-        // refreshStatus and refreshSizeEstimates are intentionally omitted so this only reruns when the tab activation boundary changes.
+        })();
+        // fetchStatusAsync, refreshSettings, refreshSizeEstimates, and refreshStatus
+        // are intentionally omitted — this only reruns at the tab-activation boundary.
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isActive]);
 
@@ -265,22 +359,28 @@ export function useAppBuilderPublisherScreen(
             return;
         }
 
+        // We know the action is done — clear busy state immediately rather than
+        // delegating to refreshStatus's recovery else-branch (which is for remounts
+        // that missed the completion event).
+        setBusyAction(undefined);
         setProgressPercent(0);
         setProgressStageCode(undefined);
         if (action === "prepare" || action === "build") {
             setPendingBuildNeeded(false);
             refreshSizeEstimates();
         }
+        // Fetch updated server state: APK path, project existence, build signature,
+        // and (for prepare) initialize settings from the new appDef.
         await refreshStatus(initializeSettingsAfterPrepare);
-        if (!isMountedRef.current) {
-            return;
-        }
-
-        setBusyAction(undefined);
     }
 
     function runAction(action: AppBuilderAction): void {
         if (action === "build" && !hasRequiredBuildSettings(settings)) {
+            return;
+        }
+        // UI guards (canRunBuild, canRunPrepare …) should prevent this, but bail out
+        // here before touching any shared state as a safety net.
+        if (busyAction) {
             return;
         }
 
@@ -298,17 +398,47 @@ export function useAppBuilderPublisherScreen(
                     : undefined,
         );
         setBusyAction(action);
-        postData(
-            `publish/rab/${action}`,
-            {},
-            () => {
-                void handleActionCompleted(action, action === "prepare");
-            },
-            () => {
-                void handleActionCompleted(action, false);
-            },
-        );
+        // The endpoint returns immediately; actual completion arrives via the
+        // "actionComplete" websocket event handled by the subscription below.
+        // Pass a failure callback so that a server-side rejection (e.g. another action
+        // already running) doesn't leave busyAction permanently set.
+        post(`publish/rab/${action}`, undefined, () => {
+            // Don't think this can ever happen, since the only immediate failure mode is
+            // if we try to start an action while another is running, and the UI should
+            // prevent that. If it does, clear everything so at least the user can try again.
+            setBusyAction(undefined);
+            setProgressPercent(0);
+            setProgressStageCode(undefined);
+        });
     }
+
+    // Listen for background-task completion from the server.
+    // useWebSocketListener keeps the callback reference current on every render
+    // so handleActionCompleted always has a fresh closure.
+    useSubscribeToWebSocketForStringMessage(
+        kAppBuilderWebSocketContext,
+        kAppBuilderActionCompleteEventId,
+        (result) => {
+            const separatorIndex = result.indexOf(":");
+            if (separatorIndex < 0) {
+                return;
+            }
+            const completedAction = result.substring(
+                0,
+                separatorIndex,
+            ) as AppBuilderAction;
+            // guard against possibility of receiving a completion event that is stale somehow.
+            if (completedAction !== busyActionRef.current) {
+                return;
+            }
+            const succeeded =
+                result.substring(separatorIndex + 1) === "success";
+            void handleActionCompleted(
+                completedAction,
+                completedAction === "prepare" && succeeded,
+            );
+        },
+    );
 
     function showApkInExplorerInShell(): void {
         if (!status.apkPath) {

--- a/src/BloomBrowserUI/react_components/requiresSubscription.tsx
+++ b/src/BloomBrowserUI/react_components/requiresSubscription.tsx
@@ -165,7 +165,7 @@ export const RequiresSubscriptionOverlayWrapper: React.FunctionComponent<{
             >
                 {props.children}
             </div>
-            {featureStatus?.enabled || (
+            {featureStatus === undefined || featureStatus.enabled || (
                 <div
                     css={css`
                         position: absolute;

--- a/src/BloomExe/Publish/Rab/RabProjectModels.cs
+++ b/src/BloomExe/Publish/Rab/RabProjectModels.cs
@@ -28,6 +28,26 @@ namespace Bloom.Publish.Rab
         public RabTrackedBookInfo[] TrackedBooks { get; set; } = Array.Empty<RabTrackedBookInfo>();
         public RabPrepareStepStatus[] PrepareSteps { get; set; } =
             Array.Empty<RabPrepareStepStatus>();
+
+        /// <summary>
+        /// The action currently running ("prepare", "build", or "install"), or null if idle.
+        /// Lets the UI restore its busy indicator when switching back to the Apps tab mid-action.
+        /// </summary>
+        public string ActiveAction { get; set; }
+
+        /// <summary>
+        /// The most-recently reported progress stage code for the active action (e.g.
+        /// "building-android-app"), or null when idle.  Sent with the status so the UI can
+        /// show the correct stage label immediately on tab re-activation, without waiting for
+        /// the next websocket progress event.
+        /// </summary>
+        public string ActiveActionProgressStage { get; set; }
+
+        /// <summary>
+        /// The most-recently reported progress percentage (0–100) for the active action, or
+        /// 0 when idle.  Paired with <see cref="ActiveActionProgressStage"/> for the same reason.
+        /// </summary>
+        public int ActiveActionProgressPercent { get; set; }
     }
 
     /// <summary>

--- a/src/BloomExe/Publish/Rab/RabProjectService.cs
+++ b/src/BloomExe/Publish/Rab/RabProjectService.cs
@@ -12,6 +12,7 @@ using System.Net.Http;
 using System.Security;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Bloom.Api;
@@ -80,10 +81,10 @@ namespace Bloom.Publish.Rab
         private readonly CollectionSettings _collectionSettings;
         private readonly BloomWebSocketServer _webSocketServer;
         private readonly IWebSocketProgress _progress;
-        private string _activeProgressAction;
+        private volatile string _activeProgressAction;
         private int _lastBuildProgressPercent;
-        private string _lastLoggedProgressStage;
-        private int? _lastLoggedProgressPercent;
+        private volatile string _lastLoggedProgressStage;
+        private volatile int _lastLoggedProgressPercent = -1;
 
         public RabProjectService(
             CollectionModel collectionModel,
@@ -365,6 +366,9 @@ namespace Bloom.Publish.Rab
                     )
                 );
 
+            // read this once early in the method to avoid returning inconsistent progress info if
+            // another thread changes it.
+            var activeAction = _activeProgressAction;
             var status = new RabProjectStatus()
             {
                 RabInstalled = rabInstalled,
@@ -379,6 +383,12 @@ namespace Bloom.Publish.Rab
                 TrackedBooks = trackedBooks,
                 TrackedBookTitles = trackedBooks.Select(book => book.Title).ToArray(),
                 PrepareSteps = prepareSteps,
+                ActiveAction = activeAction,
+                ActiveActionProgressStage = activeAction != null ? _lastLoggedProgressStage : null,
+                ActiveActionProgressPercent =
+                    activeAction != null
+                        ? (_lastLoggedProgressPercent < 0 ? 0 : _lastLoggedProgressPercent)
+                        : 0,
             };
 
             if (status.ProjectExists)
@@ -433,6 +443,52 @@ namespace Bloom.Publish.Rab
         }
 
         /// <summary>
+        /// True while a prepare/build/install action is running on a background thread.
+        /// </summary>
+        internal bool IsActionInProgress => _activeProgressAction != null;
+
+        /// <summary>
+        /// Atomically claims the action slot, setting <see cref="_activeProgressAction"/> to
+        /// <paramref name="action"/>. Returns true if this call won the slot, false if another
+        /// action is already running.
+        /// </summary>
+        internal bool TryBeginAction(string action)
+        {
+            if (Interlocked.CompareExchange(ref _activeProgressAction, action, null) != null)
+                return false;
+            // Reset stale progress from the previous action so a status poll that lands
+            // before the first ReportProgressStage call doesn't serve stale values.
+            _lastLoggedProgressStage = null;
+            _lastLoggedProgressPercent = -1;
+            return true;
+        }
+
+        /// <summary>
+        /// Releases the action slot. Called by <see cref="RabPublishApi"/> just before
+        /// <see cref="SendActionCompleteEvent"/> so the slot remains claimed until the
+        /// action is complete. (We clear it before actually sending the notification
+        /// so that the notification handlers correctly see that no task is running).
+        /// </summary>
+        internal void ClearAction()
+        {
+            _activeProgressAction = null;
+        }
+
+        /// <summary>
+        /// Sends an "actionComplete" websocket event so the Apps screen knows when a background
+        /// prepare/build/install has finished.  Called by RabPublishApi after ReportFailure (if
+        /// any) so the error message is logged before the UI tears down the progress subscriber.
+        /// </summary>
+        internal void SendActionCompleteEvent(string action, bool succeeded)
+        {
+            _webSocketServer.SendString(
+                kWebSocketContext,
+                RabPublishApi.kWebSocketEventId_ActionComplete,
+                $"{action}:{(succeeded ? "success" : "failure")}"
+            );
+        }
+
+        /// <summary>
         /// Reports an App Builder failure to Bloom's log and the progress channel used by the Apps screen.
         /// </summary>
         public void ReportFailure(string action, Exception error)
@@ -449,106 +505,92 @@ namespace Bloom.Publish.Rab
         private void Prepare()
         {
             var paths = GetPaths();
-            _activeProgressAction = "prepare";
-            try
+            ReportProgressStage("checking-installer", 0);
+            if (!EnsureRabInstalledForPrepare())
+                return;
+
+            // Prepare makes the on-disk RAB workspace match Bloom's current settings and tracked-book list,
+            // creating the project only on the first run and refreshing inputs after that.
+            EnsureWorkspaceFolders(paths);
+            EnsureRabBuildPrerequisites(paths);
+
+            ReportProgressStage("preparing-workspace", 0);
+            _progress.MessageWithoutLocalizing(
+                "Preparing the Reading App Builder workspace...",
+                ProgressKind.Heading
+            );
+
+            ReportProgressStage("exporting-bloompubs", 10);
+            var trackedBooks = ExportPrepareBooks(paths);
+            var effectiveSettings = GetEffectiveAppSettings(paths);
+            var supportFiles = EnsureProjectSupportFiles(paths);
+            var existingProjectPath = FindAppDefPath(paths);
+            RabPrepareState state;
+            var createdNewProject = string.IsNullOrEmpty(existingProjectPath);
+
+            if (createdNewProject)
             {
-                ReportProgressStage("checking-installer", 0);
-                if (!EnsureRabInstalledForPrepare())
-                    return;
+                ReportProgressStage("generating-signing-key", 55);
+                _progress.MessageWithoutLocalizing("Preparing Bloom's Android signing key...");
+                state = CreatePrepareState(EnsureBloomOwnedSigningState(paths));
 
-                // Prepare makes the on-disk RAB workspace match Bloom's current settings and tracked-book list,
-                // creating the project only on the first run and refreshing inputs after that.
-                EnsureWorkspaceFolders(paths);
-                EnsureRabBuildPrerequisites(paths);
-
-                ReportProgressStage("preparing-workspace", 0);
+                ReportProgressStage("creating-project", 70);
                 _progress.MessageWithoutLocalizing(
-                    "Preparing the Reading App Builder workspace...",
-                    ProgressKind.Heading
+                    "Creating the initial Reading App Builder project..."
+                );
+                RunRabCommand(
+                    BuildRabArgsForNewProject(
+                        paths,
+                        effectiveSettings,
+                        trackedBooks,
+                        state,
+                        supportFiles
+                    ),
+                    paths.RabRoot
                 );
 
-                ReportProgressStage("exporting-bloompubs", 10);
-                var trackedBooks = ExportPrepareBooks(paths);
-                var effectiveSettings = GetEffectiveAppSettings(paths);
-                var supportFiles = EnsureProjectSupportFiles(paths);
-                var existingProjectPath = FindAppDefPath(paths);
-                RabPrepareState state;
-                var createdNewProject = string.IsNullOrEmpty(existingProjectPath);
-
-                if (createdNewProject)
-                {
-                    ReportProgressStage("generating-signing-key", 55);
-                    _progress.MessageWithoutLocalizing("Preparing Bloom's Android signing key...");
-                    state = CreatePrepareState(EnsureBloomOwnedSigningState(paths));
-
-                    ReportProgressStage("creating-project", 70);
-                    _progress.MessageWithoutLocalizing(
-                        "Creating the initial Reading App Builder project..."
+                existingProjectPath = FindAppDefPath(paths);
+                if (string.IsNullOrEmpty(existingProjectPath))
+                    throw new ApplicationException(
+                        "Reading App Builder finished, but Bloom could not find the generated .appDef file."
                     );
-                    RunRabCommand(
-                        BuildRabArgsForNewProject(
-                            paths,
-                            effectiveSettings,
-                            trackedBooks,
-                            state,
-                            supportFiles
-                        ),
-                        paths.RabRoot
-                    );
-
-                    existingProjectPath = FindAppDefPath(paths);
-                    if (string.IsNullOrEmpty(existingProjectPath))
-                        throw new ApplicationException(
-                            "Reading App Builder finished, but Bloom could not find the generated .appDef file."
-                        );
-                }
-                else
-                {
-                    ReportProgressStage("updating-project", 70);
-                    _progress.MessageWithoutLocalizing(
-                        "The Reading App Builder project already exists. Refreshing BloomPUB inputs instead."
-                    );
-                    state = EnsureStateHasProjectAndSigningInfo(
-                        paths,
-                        LoadState(paths) ?? new RabPrepareState(),
-                        existingProjectPath
-                    );
-                    state = ApplyBloomOwnedSigningState(state, EnsureBloomOwnedSigningState(paths));
-                }
-
-                state = EnsureStateHasProjectAndSigningInfo(paths, state, existingProjectPath);
-                EnsureKeystore(state.KeystorePath, state.KeystorePassword);
-                state.Books = trackedBooks;
-
-                if (!createdNewProject)
-                {
-                    PrepareProjectForTrackedBookImport(existingProjectPath, trackedBooks);
-                    ReportProgressStage("updating-project", 85);
-                    RunRabCommand(
-                        BuildRabArgsForProjectUpdate(
-                            paths,
-                            state,
-                            trackedBooks,
-                            supportFiles,
-                            false
-                        ),
-                        paths.RabRoot
-                    );
-                }
-
-                ReconcileProjectWithImportedBooks(existingProjectPath, trackedBooks);
-                SynchronizeProjectFonts(existingProjectPath, trackedBooks);
-                ReportProgressStage("updating-project", 85);
-                SaveState(paths, state);
-
-                ReportProgressStage("complete", 100);
-                _progress.MessageWithoutLocalizing("Prepare complete.", ProgressKind.Heading);
-                _progress.MessageWithoutLocalizing($"Project file: {existingProjectPath}");
             }
-            finally
+            else
             {
-                _activeProgressAction = null;
+                ReportProgressStage("updating-project", 70);
+                _progress.MessageWithoutLocalizing(
+                    "The Reading App Builder project already exists. Refreshing BloomPUB inputs instead."
+                );
+                state = EnsureStateHasProjectAndSigningInfo(
+                    paths,
+                    LoadState(paths) ?? new RabPrepareState(),
+                    existingProjectPath
+                );
+                state = ApplyBloomOwnedSigningState(state, EnsureBloomOwnedSigningState(paths));
             }
+
+            state = EnsureStateHasProjectAndSigningInfo(paths, state, existingProjectPath);
+            EnsureKeystore(state.KeystorePath, state.KeystorePassword);
+            state.Books = trackedBooks;
+
+            if (!createdNewProject)
+            {
+                PrepareProjectForTrackedBookImport(existingProjectPath, trackedBooks);
+                ReportProgressStage("updating-project", 85);
+                RunRabCommand(
+                    BuildRabArgsForProjectUpdate(paths, state, trackedBooks, supportFiles, false),
+                    paths.RabRoot
+                );
+            }
+
+            ReconcileProjectWithImportedBooks(existingProjectPath, trackedBooks);
+            SynchronizeProjectFonts(existingProjectPath, trackedBooks);
+            ReportProgressStage("updating-project", 85);
+            SaveState(paths, state);
+
+            ReportProgressStage("complete", 100);
+            _progress.MessageWithoutLocalizing("Prepare complete.", ProgressKind.Heading);
+            _progress.MessageWithoutLocalizing($"Project file: {existingProjectPath}");
         }
 
         private bool EnsureRabInstalledForPrepare()
@@ -653,183 +695,158 @@ namespace Bloom.Publish.Rab
             // Build reuses BloomPUBs created during the current Apps-screen session and regenerates only missing ones.
             var paths = GetPaths();
             EnsureWorkspaceFolders(paths);
-            _activeProgressAction = "build";
             _lastBuildProgressPercent = 0;
-            try
+            ReportProgressStage("preparing-build", 0);
+            var state = LoadStateOrThrow(paths);
+            EnsureKeystore(state.KeystorePath, state.KeystorePassword);
+            EnsureRabBuildPrerequisites(paths);
+            ReportProgressStage("exporting-bloompubs", 10);
+            var trackedBooks = ExportTrackedBooks(paths, state);
+            var supportFiles = EnsureProjectSupportFiles(paths);
+
+            ReportProgressStage("updating-project", 35);
+            _progress.MessageWithoutLocalizing(
+                "Updating the Reading App Builder project with fresh BloomPUB files..."
+            );
+            PrepareProjectForTrackedBookImport(state.AppDefPath, trackedBooks);
+            RunRabCommand(
+                BuildRabArgsForProjectUpdate(paths, state, trackedBooks, supportFiles, false),
+                paths.RabRoot
+            );
+            ReconcileProjectWithImportedBooks(state.AppDefPath, trackedBooks);
+            SynchronizeProjectFonts(state.AppDefPath, trackedBooks);
+            state.Books = trackedBooks;
+            SaveState(paths, state);
+
+            ReportProgressStage("building-android-app", 45);
+            _progress.MessageWithoutLocalizing(
+                "Building the Android app with Reading App Builder...",
+                ProgressKind.Heading
+            );
+            Directory.CreateDirectory(paths.SafeApkRoot);
+            RunRabCommand(
+                BuildRabArgsForProjectUpdate(
+                    paths,
+                    state,
+                    Array.Empty<RabBookPublishInfo>(),
+                    supportFiles,
+                    true
+                ),
+                paths.RabRoot
+            );
+
+            ReportProgressStage("finalizing-apk", 98);
+
+            var apkPath = FindLatestApkPath(paths);
+            if (string.IsNullOrEmpty(apkPath))
             {
-                ReportProgressStage("preparing-build", 0);
-                var state = LoadStateOrThrow(paths);
-                EnsureKeystore(state.KeystorePath, state.KeystorePassword);
-                EnsureRabBuildPrerequisites(paths);
-                ReportProgressStage("exporting-bloompubs", 10);
-                var trackedBooks = ExportTrackedBooks(paths, state);
-                var supportFiles = EnsureProjectSupportFiles(paths);
-
-                ReportProgressStage("updating-project", 35);
-                _progress.MessageWithoutLocalizing(
-                    "Updating the Reading App Builder project with fresh BloomPUB files..."
-                );
-                PrepareProjectForTrackedBookImport(state.AppDefPath, trackedBooks);
-                RunRabCommand(
-                    BuildRabArgsForProjectUpdate(paths, state, trackedBooks, supportFiles, false),
-                    paths.RabRoot
-                );
-                ReconcileProjectWithImportedBooks(state.AppDefPath, trackedBooks);
-                SynchronizeProjectFonts(state.AppDefPath, trackedBooks);
-                state.Books = trackedBooks;
-                SaveState(paths, state);
-
-                ReportProgressStage("building-android-app", 45);
-                _progress.MessageWithoutLocalizing(
-                    "Building the Android app with Reading App Builder...",
-                    ProgressKind.Heading
-                );
-                Directory.CreateDirectory(paths.SafeApkRoot);
-                RunRabCommand(
-                    BuildRabArgsForProjectUpdate(
-                        paths,
-                        state,
-                        Array.Empty<RabBookPublishInfo>(),
-                        supportFiles,
-                        true
-                    ),
-                    paths.RabRoot
-                );
-
-                ReportProgressStage("finalizing-apk", 98);
-
-                var apkPath = FindLatestApkPath(paths);
-                if (string.IsNullOrEmpty(apkPath))
+                var searchRoots = new[]
                 {
-                    var searchRoots = new[]
-                    {
-                        paths.ApkRoot,
-                        paths.SafeApkRoot,
-                        paths.BuildRoot,
-                        paths.RabRoot,
-                    }
-                        .Where(Directory.Exists)
-                        .Distinct(StringComparer.OrdinalIgnoreCase)
-                        .ToArray();
-                    var apkCandidates = searchRoots
-                        .SelectMany(root =>
-                            Directory.GetFiles(root, "*.apk", SearchOption.AllDirectories)
-                        )
-                        .Distinct(StringComparer.OrdinalIgnoreCase)
-                        .ToArray();
-
-                    throw new ApplicationException(
-                        "Reading App Builder finished without producing an APK in the collection's Bloom App Data folder. "
-                            + $"Searched roots: {string.Join(", ", searchRoots)}. "
-                            + $"APK candidates found: {string.Join(", ", apkCandidates)}"
-                    );
+                    paths.ApkRoot,
+                    paths.SafeApkRoot,
+                    paths.BuildRoot,
+                    paths.RabRoot,
                 }
+                    .Where(Directory.Exists)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+                var apkCandidates = searchRoots
+                    .SelectMany(root =>
+                        Directory.GetFiles(root, "*.apk", SearchOption.AllDirectories)
+                    )
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
 
-                ReportProgressStage("complete", 100);
-                _progress.MessageWithoutLocalizing("Build complete.", ProgressKind.Heading);
-                _progress.MessageWithoutLocalizing($"APK: {apkPath}");
-
-                state.LastBuiltInputSignature = ComputeBuildInputSignature(
-                    GetEffectiveAppSettings(paths),
-                    trackedBooks
+                throw new ApplicationException(
+                    "Reading App Builder finished without producing an APK in the collection's Bloom App Data folder. "
+                        + $"Searched roots: {string.Join(", ", searchRoots)}. "
+                        + $"APK candidates found: {string.Join(", ", apkCandidates)}"
                 );
-                state.LastBuiltApkPath = apkPath;
-                SaveState(paths, state);
             }
-            finally
-            {
-                _activeProgressAction = null;
-            }
+
+            ReportProgressStage("complete", 100);
+            _progress.MessageWithoutLocalizing("Build complete.", ProgressKind.Heading);
+            _progress.MessageWithoutLocalizing($"APK: {apkPath}");
+
+            state.LastBuiltInputSignature = ComputeBuildInputSignature(
+                GetEffectiveAppSettings(paths),
+                trackedBooks
+            );
+            state.LastBuiltApkPath = apkPath;
+            SaveState(paths, state);
         }
 
         private void Install()
         {
             // Install re-reads package/app metadata from the project so launching uses the same identity that was built.
             var paths = GetPaths();
-            _activeProgressAction = "install";
-            try
+            var apkPath = FindLatestApkPath(paths);
+            if (string.IsNullOrEmpty(apkPath))
+                throw new ApplicationException(
+                    "Build the app before trying to install it on a phone."
+                );
+
+            var adbPath = FindAdbPath();
+            if (string.IsNullOrEmpty(adbPath))
+                throw new ApplicationException(
+                    "Bloom could not find adb. Install Android platform-tools or make adb available on PATH."
+                );
+
+            var project = LoadProjectOrNull(paths);
+            var packageName = project?.PackageName;
+            if (string.IsNullOrWhiteSpace(packageName))
+                packageName = GetPackageName();
+
+            var appName = project?.AppName;
+            if (string.IsNullOrWhiteSpace(appName))
+                appName = GetAppName();
+
+            ReportProgressStage("checking-device", 0);
+            _progress.MessageWithoutLocalizing("Checking for a connected Android device...");
+            var device = GetSingleConnectedDevice(adbPath);
+
+            ReportProgressStage("installing-on-phone", 45);
+            _progress.MessageWithoutLocalizing(
+                $"Installing {Path.GetFileName(apkPath)} on {device.DisplayName}...",
+                ProgressKind.Heading
+            );
+            var installResult = InstallApkOnDevice(adbPath, device.Serial, apkPath, paths.RabRoot);
+            if (installResult.ExitCode != 0)
             {
-                var apkPath = FindLatestApkPath(paths);
-                if (string.IsNullOrEmpty(apkPath))
-                    throw new ApplicationException(
-                        "Build the app before trying to install it on a phone."
-                    );
-
-                var adbPath = FindAdbPath();
-                if (string.IsNullOrEmpty(adbPath))
-                    throw new ApplicationException(
-                        "Bloom could not find adb. Install Android platform-tools or make adb available on PATH."
-                    );
-
-                var project = LoadProjectOrNull(paths);
-                var packageName = project?.PackageName;
-                if (string.IsNullOrWhiteSpace(packageName))
-                    packageName = GetPackageName();
-
-                var appName = project?.AppName;
-                if (string.IsNullOrWhiteSpace(appName))
-                    appName = GetAppName();
-
-                ReportProgressStage("checking-device", 0);
-                _progress.MessageWithoutLocalizing("Checking for a connected Android device...");
-                var device = GetSingleConnectedDevice(adbPath);
-
-                ReportProgressStage("installing-on-phone", 45);
-                _progress.MessageWithoutLocalizing(
-                    $"Installing {Path.GetFileName(apkPath)} on {device.DisplayName}...",
-                    ProgressKind.Heading
-                );
-                var installResult = InstallApkOnDevice(
-                    adbPath,
-                    device.Serial,
-                    apkPath,
-                    paths.RabRoot
-                );
-                if (installResult.ExitCode != 0)
+                if (IsUpdateIncompatibleInstallFailure(installResult.Output))
                 {
-                    if (IsUpdateIncompatibleInstallFailure(installResult.Output))
-                    {
-                        _progress.MessageWithoutLocalizing(
-                            $"A different signed copy of {appName} is already installed on {device.DisplayName}. Removing it and retrying...",
-                            ProgressKind.Warning
-                        );
-                        UninstallAppFromDevice(adbPath, device.Serial, packageName, paths.RabRoot);
-                        installResult = InstallApkOnDevice(
-                            adbPath,
-                            device.Serial,
-                            apkPath,
-                            paths.RabRoot
-                        );
-                    }
-
-                    if (installResult.ExitCode != 0)
-                    {
-                        throw new ApplicationException(
-                            $"{Path.GetFileName(adbPath)} exited with code {installResult.ExitCode}."
-                        );
-                    }
+                    _progress.MessageWithoutLocalizing(
+                        $"A different signed copy of {appName} is already installed on {device.DisplayName}. Removing it and retrying...",
+                        ProgressKind.Warning
+                    );
+                    UninstallAppFromDevice(adbPath, device.Serial, packageName, paths.RabRoot);
+                    installResult = InstallApkOnDevice(
+                        adbPath,
+                        device.Serial,
+                        apkPath,
+                        paths.RabRoot
+                    );
                 }
 
-                ReportProgressStage("launching-on-phone", 85);
-                _progress.MessageWithoutLocalizing(
-                    $"Launching {appName} on {device.DisplayName}...",
-                    ProgressKind.Heading
-                );
-                RunProcess(
-                    adbPath,
-                    BuildLaunchAppArguments(device.Serial, packageName),
-                    paths.RabRoot
-                );
-                ReportProgressStage("complete", 100);
-                _progress.MessageWithoutLocalizing(
-                    $"Install complete. Opened {appName} on {device.DisplayName}.",
-                    ProgressKind.Heading
-                );
+                if (installResult.ExitCode != 0)
+                {
+                    throw new ApplicationException(
+                        $"{Path.GetFileName(adbPath)} exited with code {installResult.ExitCode}."
+                    );
+                }
             }
-            finally
-            {
-                _activeProgressAction = null;
-            }
+
+            ReportProgressStage("launching-on-phone", 85);
+            _progress.MessageWithoutLocalizing(
+                $"Launching {appName} on {device.DisplayName}...",
+                ProgressKind.Heading
+            );
+            RunProcess(adbPath, BuildLaunchAppArguments(device.Serial, packageName), paths.RabRoot);
+            ReportProgressStage("complete", 100);
+            _progress.MessageWithoutLocalizing(
+                $"Install complete. Opened {appName} on {device.DisplayName}.",
+                ProgressKind.Heading
+            );
         }
 
         internal virtual RabWorkspacePaths GetPaths()

--- a/src/BloomExe/Publish/Rab/RabPublishApi.cs
+++ b/src/BloomExe/Publish/Rab/RabPublishApi.cs
@@ -12,6 +12,13 @@ namespace Bloom.Publish.Rab
         private const string kApiUrlPart = "publish/rab/";
         public const string kWebSocketContext = "publish-rab";
 
+        /// <summary>
+        /// WebSocket event id sent when a prepare/build/install action finishes.
+        /// The message payload is "{action}:success" or "{action}:failure"
+        /// (e.g. "build:success").
+        /// </summary>
+        public const string kWebSocketEventId_ActionComplete = "actionComplete";
+
         private readonly RabProjectService _rabProjectService;
 
         public RabPublishApi(RabProjectService rabProjectService)
@@ -25,10 +32,14 @@ namespace Bloom.Publish.Rab
         public void RegisterWithApiHandler(BloomApiHandler apiHandler)
         {
             // Keep the API layer thin: deserialize/route here and let RabProjectService own the workflow rules.
+
+            // Status and size reads don't need the sync lock — they're pure reads that can run
+            // concurrently with a background build without corrupting shared state.
             apiHandler.RegisterEndpointHandler(
                 kApiUrlPart + "status",
                 request => request.ReplyWithJson(_rabProjectService.GetStatus()),
-                true
+                false,
+                requiresSync: false
             );
             apiHandler.RegisterEndpointHandler(
                 kApiUrlPart + "settings",
@@ -75,7 +86,8 @@ namespace Bloom.Publish.Rab
             apiHandler.RegisterEndpointHandler(
                 kApiUrlPart + "size-estimates",
                 request => request.ReplyWithJson(_rabProjectService.GetSizeEstimates()),
-                true
+                false,
+                requiresSync: false
             );
             apiHandler.RegisterEndpointHandler(
                 kApiUrlPart + "reset-bloompub-cache",
@@ -95,54 +107,122 @@ namespace Bloom.Publish.Rab
                 },
                 true
             );
-            apiHandler.RegisterAsyncEndpointHandler(
+
+            // The three long-running actions (prepare, build, install) fire a background task and
+            // return immediately so the sync lock is not held for their entire duration.
+            // Progress updates arrive via the "publish-rab" websocket channel as before.
+            // Completion is signalled via the "actionComplete" websocket event.
+            apiHandler.RegisterEndpointHandler(
                 kApiUrlPart + "prepare",
-                async request =>
-                    await RunRabOperationAsync(
-                        request,
-                        () => _rabProjectService.PrepareAsync(),
-                        "Prepare"
-                    ),
-                true
+                request =>
+                {
+                    if (!_rabProjectService.TryBeginAction("prepare"))
+                    {
+                        request.Failed("A prepare/build/install action is already running.");
+                        return;
+                    }
+                    _ = Task.Run(async () =>
+                    {
+                        var succeeded = false;
+                        try
+                        {
+                            try
+                            {
+                                await _rabProjectService.PrepareAsync();
+                                succeeded = true;
+                            }
+                            catch (Exception error)
+                            {
+                                // ReportFailure logs to the progress channel first so the error
+                                // message lands in the ActionLogAccordion before the UI tears
+                                // down the subscription in response to "actionComplete".
+                                _rabProjectService.ReportFailure("Prepare", error);
+                            }
+                        }
+                        finally
+                        {
+                            // ClearAction before SendActionCompleteEvent so the slot stays claimed
+                            // until the client is notified, preventing a status-poll in the gap
+                            // from incorrectly clearing the client's busyAction via recovery logic.
+                            _rabProjectService.ClearAction();
+                            _rabProjectService.SendActionCompleteEvent("prepare", succeeded);
+                        }
+                    });
+                    request.PostSucceeded();
+                },
+                false,
+                requiresSync: false
             );
-            apiHandler.RegisterAsyncEndpointHandler(
+            apiHandler.RegisterEndpointHandler(
                 kApiUrlPart + "build",
-                async request =>
-                    await RunRabOperationAsync(
-                        request,
-                        () => _rabProjectService.BuildAsync(),
-                        "Build"
-                    ),
-                true
+                request =>
+                {
+                    if (!_rabProjectService.TryBeginAction("build"))
+                    {
+                        request.Failed("A prepare/build/install action is already running.");
+                        return;
+                    }
+                    _ = Task.Run(async () =>
+                    {
+                        var succeeded = false;
+                        try
+                        {
+                            try
+                            {
+                                await _rabProjectService.BuildAsync();
+                                succeeded = true;
+                            }
+                            catch (Exception error)
+                            {
+                                _rabProjectService.ReportFailure("Build", error);
+                            }
+                        }
+                        finally
+                        {
+                            _rabProjectService.ClearAction();
+                            _rabProjectService.SendActionCompleteEvent("build", succeeded);
+                        }
+                    });
+                    request.PostSucceeded();
+                },
+                false,
+                requiresSync: false
             );
-            apiHandler.RegisterAsyncEndpointHandler(
+            apiHandler.RegisterEndpointHandler(
                 kApiUrlPart + "install",
-                async request =>
-                    await RunRabOperationAsync(
-                        request,
-                        () => _rabProjectService.InstallAsync(),
-                        "Try on phone"
-                    ),
-                true
+                request =>
+                {
+                    if (!_rabProjectService.TryBeginAction("install"))
+                    {
+                        request.Failed("A prepare/build/install action is already running.");
+                        return;
+                    }
+                    _ = Task.Run(async () =>
+                    {
+                        var succeeded = false;
+                        try
+                        {
+                            try
+                            {
+                                await _rabProjectService.InstallAsync();
+                                succeeded = true;
+                            }
+                            catch (Exception error)
+                            {
+                                _rabProjectService.ReportFailure("Try on phone", error);
+                            }
+                        }
+                        finally
+                        {
+                            _rabProjectService.ClearAction();
+                            _rabProjectService.SendActionCompleteEvent("install", succeeded);
+                        }
+                    });
+                    request.PostSucceeded();
+                },
+                false,
+                requiresSync: false
             );
-        }
-
-        private async Task RunRabOperationAsync(
-            ApiRequest request,
-            Func<Task> operation,
-            string actionName
-        )
-        {
-            try
-            {
-                await operation();
-            }
-            catch (Exception error)
-            {
-                _rabProjectService.ReportFailure(actionName, error);
-            }
-
-            request.PostSucceeded();
         }
     }
 }

--- a/src/BloomExe/web/controllers/FeatureStatusApi.cs
+++ b/src/BloomExe/web/controllers/FeatureStatusApi.cs
@@ -52,7 +52,8 @@ namespace Bloom.web.controllers
                         );
                     }
                 },
-                false
+                false,
+                requiresSync: false
             );
         }
     }


### PR DESCRIPTION
Several Apps tool APIs, especially Build, were made to kick off a background task and then return; task completion signaled by websocket.
Enhanced so if you return to the tool and build is still running, it gets back into a state indicating the progress of the build.
Also, Build is now more appropriately enabled; you don't have to do Customize first if all the required settings are already known.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7961)
<!-- Reviewable:end -->


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/7961)
