### PR TITLE
Add PR Review Tracker caller workflow

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,19 @@
+# Caller for the shared "PR Review Tracker" automation.
+#
+# The actual logic lives once, centrally, in the org repo:
+#   BloomBooks/.github/.github/workflows/pr-review-tracker.yml
+# This file just forwards this repo's pull_request events to it. Copy this same
+# ~12-line caller into any repo whose PRs should appear on the board.
+#
+# Requires the org-level secret PROJECT_TOKEN to be shared with this repo
+# (secrets: inherit passes it through to the reusable workflow).
+name: PR Review Tracker
+
+on:
+    pull_request:
+        types: [opened, reopened, synchronize]
+
+jobs:
+    track:
+        uses: BloomBooks/.github/.github/workflows/pr-review-tracker.yml@main
+        secrets: inherit

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -5,8 +5,8 @@
 # This file just forwards this repo's pull_request events to it. Copy this same
 # ~12-line caller into any repo whose PRs should appear on the board.
 #
-# Requires the org-level secret PROJECT_TOKEN to be shared with this repo
-# (secrets: inherit passes it through to the reusable workflow).
+# Requires the org-level secret PROJECT_TOKEN to be shared with this repo; we
+# pass only that one secret through to the reusable workflow (not every secret).
 name: PR Review Tracker
 
 on:
@@ -15,5 +15,11 @@ on:
 
 jobs:
     track:
+        # PRs from forks don't receive repository secrets, so PROJECT_TOKEN would
+        # be empty and the run would fail. BloomDesktop is public and gets fork
+        # PRs; board automation only needs to cover same-repo PRs, so skip forks.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: BloomBooks/.github/.github/workflows/pr-review-tracker.yml@main
-        secrets: inherit
+        # Pass only PROJECT_TOKEN, not `secrets: inherit`, to limit blast radius.
+        secrets:
+            PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -5,8 +5,8 @@
 # This file just forwards this repo's pull_request events to it. Copy this same
 # ~12-line caller into any repo whose PRs should appear on the board.
 #
-# Requires the org-level secret PROJECT_TOKEN to be shared with this repo; we
-# pass only that one secret through to the reusable workflow (not every secret).
+# Requires the org-level secret PR_REVIEW_TRACKER_PROJECT_TOKEN to be shared with
+# this repo; we pass only that one secret through (not every secret).
 name: PR Review Tracker
 
 on:
@@ -15,11 +15,11 @@ on:
 
 jobs:
     track:
-        # PRs from forks don't receive repository secrets, so PROJECT_TOKEN would
-        # be empty and the run would fail. BloomDesktop is public and gets fork
-        # PRs; board automation only needs to cover same-repo PRs, so skip forks.
+        # PRs from forks don't receive repository secrets, so the token would be
+        # empty and the run would fail. BloomDesktop is public and gets fork PRs;
+        # board automation only needs to cover same-repo PRs, so skip forks.
         if: github.event.pull_request.head.repo.full_name == github.repository
         uses: BloomBooks/.github/.github/workflows/pr-review-tracker.yml@main
-        # Pass only PROJECT_TOKEN, not `secrets: inherit`, to limit blast radius.
+        # Pass only this one secret, not `secrets: inherit`, to limit blast radius.
         secrets:
-            PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+            PR_REVIEW_TRACKER_PROJECT_TOKEN: ${{ secrets.PR_REVIEW_TRACKER_PROJECT_TOKEN }}


### PR DESCRIPTION
Opts BloomDesktop into the BloomBooks **PR Review Tracker** org project ([#2](https://github.com/orgs/BloomBooks/projects/2)).

This thin caller forwards `pull_request` events (`opened`/`reopened`/`synchronize`) to the shared reusable workflow in [`BloomBooks/.github`](https://github.com/BloomBooks/.github/pull/1). That workflow adds the PR to the board and sets its Status to *Waiting for AI-Review* — including moving the card **back** to *Waiting* whenever a new commit is pushed.

**Depends on:**
- BloomBooks/.github#1 (the reusable workflow) being merged.
- The org-level `PROJECT_TOKEN` secret being shared with this repo (already configured).

To onboard another repo later: copy this same file into it and add it to the `PROJECT_TOKEN` secret's repository list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7966)
<!-- Reviewable:end -->
