### PR TITLE
Fix BL-16446: Could not make PalasoImage when opening copyright dialog for image with query string in src

### DIFF
--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -552,6 +552,14 @@ namespace Bloom.Edit
                 );
             }
 
+            // The fileName comes straight from the html src attribute, so it may carry a query
+            // string (e.g. "image1.png?transparent=yes") and/or still be URL-encoded. Reduce it
+            // to the actual file name on disk before we try to load the image; otherwise
+            // PalasoImage fails to find the file and we wrongly report it as corrupt. (BL-16446)
+            // CreateFromUnencodedString only decodes if the string still looks encoded (the
+            // server already decodes query parameters once), and PathOnly drops the query string.
+            fileName = UrlPathString.CreateFromUnencodedString(fileName).PathOnly.NotEncoded;
+
             // keep a reference to the fileName rather the image to avoid dispose issues
             _fileNameOfImageBeingModified = fileName;
 


### PR DESCRIPTION
Fixes [BL-16446](https://issues.bloomlibrary.org/youtrack/issue/BL-16446).

## Problem

Clicking the credits/copyright button on an image could fail with a misleading error:

> The image file image.jpg is corrupt and needs to be replaced. (Could not make PalasoImage from ...\image1.png because Could not find file '...\image1.png'.)

The image's html `src` is passed to the backend verbatim as `imageUrl`. Bloom appends a query string to some image srcs (e.g. `image1.png?transparent=yes` for images with transparency), and filenames containing spaces are URL-encoded (e.g. `The%20Moon_Cover.jpg`). `EditingView.PrepareToEditImageMetadata` built the path with `Path.Combine` **without stripping the query string or decoding**, so `PalasoImage.FromFileRobustly` couldn't find the file and reported it as corrupt.

## Fix

Normalize the incoming `src` to the actual on-disk file name before loading:

```csharp
fileName = UrlPathString.CreateFromUnencodedString(fileName).PathOnly.NotEncoded;
```

- `PathOnly` drops the `?query` (same `.PathOnly.NotEncoded` normalization `ImageApi` already uses).
- `CreateFromUnencodedString` decodes only if the string still looks encoded — the server already decodes query params once, so this avoids a double-decode.
- The cleaned name is stored in `_fileNameOfImageBeingModified`, so a subsequent metadata **save** targets the right file too.

## Testing

No automated tests run (this path is exercised only through the UI-heavy `EditingView`); the `UrlPathString` normalization itself is covered by existing `UrlPathStringTests`. Verified against the reported book that the live cover `src` was `image1.png?transparent=yes`, that `image1.png` is a valid file, and that stripping the query lets the dialog open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/7979)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7979)
<!-- Reviewable:end -->
