### PR TITLE
Fix go.sh leaking orphaned Node watcher processes on Windows

### DIFF
--- a/src/BloomBrowserUI/scripts/dev.mjs
+++ b/src/BloomBrowserUI/scripts/dev.mjs
@@ -1,5 +1,5 @@
 /* eslint-env node */
-/* global console, process */
+/* global clearTimeout, console, process, setTimeout */
 import { spawn } from "child_process";
 import path from "node:path";
 import * as fs from "node:fs";
@@ -9,6 +9,7 @@ import { glob } from "glob";
 import { compilePugFiles } from "./compilePug.mjs";
 import { copyStaticFile } from "./copyStaticFile.mjs";
 import { copyContentFile } from "../../content/scripts/copyContentFile.mjs";
+import { killProcessTree } from "./processTree.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -435,24 +436,38 @@ async function startWatchers() {
     );
 }
 
-function cleanup(exitCode = 0) {
+// Force-kill every watcher subtree, then exit. We must kill whole trees (not
+// just the direct children) because on Windows a plain kill leaves each
+// watcher's own command children (notably `onchange -k`) running, and those
+// orphans accumulate across runs. We await the kills so they actually complete
+// before we exit; a watchdog guarantees we still exit even if a kill hangs.
+async function cleanup(exitCode = 0) {
     if (isShuttingDown) {
         return;
     }
     isShuttingDown = true;
     console.log("\nShutting down...");
-    for (const proc of processes) {
-        proc.kill();
-    }
     const normalizedExitCode =
         typeof exitCode === "number" && Number.isFinite(exitCode)
             ? exitCode
             : 0;
+
+    // Never let a stuck kill keep us alive indefinitely.
+    const watchdog = setTimeout(() => process.exit(normalizedExitCode), 5000);
+    watchdog.unref();
+
+    await Promise.all(
+        processes.map((proc) =>
+            proc.pid ? killProcessTree(proc.pid) : Promise.resolve(),
+        ),
+    );
+
+    clearTimeout(watchdog);
     process.exit(normalizedExitCode);
 }
 
-process.on("SIGINT", () => cleanup(0));
-process.on("SIGTERM", () => cleanup(0));
+process.on("SIGINT", () => void cleanup(0));
+process.on("SIGTERM", () => void cleanup(0));
 
 async function main() {
     if (!fs.existsSync(process.execPath)) {

--- a/src/BloomBrowserUI/scripts/dev.mjs
+++ b/src/BloomBrowserUI/scripts/dev.mjs
@@ -125,7 +125,7 @@ function spawnProcess(command, args, options = {}) {
         }
         console.error(`Process failed to start: ${command}`);
         console.error(err);
-        cleanup(1);
+        void cleanup(1);
     });
 
     proc.on("close", (code, signal) => {
@@ -135,13 +135,13 @@ function spawnProcess(command, args, options = {}) {
 
         if (signal) {
             console.error(`Process exited due to signal ${signal}: ${command}`);
-            cleanup(1);
+            void cleanup(1);
             return;
         }
 
         if (code !== 0) {
             console.error(`Process exited with code ${code}: ${command}`);
-            cleanup(code ?? 1);
+            void cleanup(code ?? 1);
         }
     });
 
@@ -193,7 +193,7 @@ function startVite(port) {
                 return;
             }
             console.error("Vite failed to start:", err);
-            cleanup(1);
+            void cleanup(1);
         });
 
         vite.on("close", (code) => {
@@ -204,12 +204,12 @@ function startVite(port) {
                 console.error(
                     `Vite exited before becoming ready (code ${code}).`,
                 );
-                cleanup(1);
+                void cleanup(1);
                 return;
             }
 
             console.error(`Vite exited unexpectedly (code ${code}).`);
-            cleanup(code ?? 1);
+            void cleanup(code ?? 1);
         });
     });
 }
@@ -490,5 +490,5 @@ async function main() {
 
 main().catch((err) => {
     console.error("Dev script failed:", err);
-    cleanup(1);
+    void cleanup(1);
 });

--- a/src/BloomBrowserUI/scripts/go.mjs
+++ b/src/BloomBrowserUI/scripts/go.mjs
@@ -4,6 +4,10 @@ import { spawn } from "node:child_process";
 import net from "node:net";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+    killProcessTree,
+    sweepStaleWorktreeNodeProcesses,
+} from "./processTree.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -259,6 +263,16 @@ const waitForViteClient = async (port, timeoutMs) => {
     return false;
 };
 
+// Terminate a spawned child AND all of its descendants.
+//
+// On Windows we do NOT rely on SIGINT propagation: terminating a Node child does
+// not terminate its descendants, so the dev.mjs subtree (Vite + ~7 watchers and
+// their own command children) would orphan if we merely signaled dev.mjs and
+// then trusted it to reap them before exiting. Instead we `taskkill /t /f` the
+// whole subtree directly, which is the only reliable way to leave zero orphans.
+//
+// On POSIX we keep the graceful SIGINT-then-force path so dotnet/Bloom can shut
+// down cleanly; terminals already propagate Ctrl-C to the process group there.
 const terminateChild = (child) =>
     new Promise((resolve) => {
         if (!child || child.exitCode !== null || child.signalCode) {
@@ -283,6 +297,14 @@ const terminateChild = (child) =>
 
         child.once("exit", finish);
 
+        if (process.platform === "win32") {
+            // Kill the entire subtree by pid; the "exit" event resolves us, and
+            // the watchdog covers the case where it never arrives.
+            void killProcessTree(child.pid);
+            forceTimer = setTimeout(finish, gracefulShutdownMs);
+            return;
+        }
+
         try {
             child.kill("SIGINT");
         } catch {
@@ -295,27 +317,7 @@ const terminateChild = (child) =>
                 return;
             }
 
-            if (process.platform === "win32") {
-                const killer = spawn(
-                    "taskkill",
-                    ["/pid", String(child.pid), "/t", "/f"],
-                    {
-                        stdio: "ignore",
-                        shell: false,
-                    },
-                );
-
-                killer.on("exit", finish);
-                killer.on("error", finish);
-                return;
-            }
-
-            try {
-                child.kill("SIGTERM");
-            } catch (error) {
-                void error;
-            }
-
+            void killProcessTree(child.pid, "SIGTERM");
             setTimeout(finish, 250);
         }, gracefulShutdownMs);
     });
@@ -560,6 +562,20 @@ const startBloomExe = (vitePort) => {
 };
 
 const main = async () => {
+    // Defensive sweep: a prior launcher that was hard-killed (terminal closed,
+    // SIGKILL, timeout) cannot run its shutdown handlers, so its Vite + watcher
+    // node processes orphan. Reap any such leftovers from THIS worktree before we
+    // start, so a previous leak can't starve the machine and wreck this run. We
+    // match on this worktree's repo-root path (which appears in the command lines
+    // of dev.mjs, watchBloomExe.mjs, and the Vite/onchange bins) and exclude our
+    // own pid. Killing a tree root takes its relative-path descendants
+    // (watchLess, onchange's command children) with it.
+    await sweepStaleWorktreeNodeProcesses({
+        commandLineMarker: repoRoot,
+        excludePids: [process.pid],
+        log: (message) => console.log(`[go] ${message}`),
+    });
+
     console.log(
         "[go] Launching Vite first and waiting for it to go quiet before starting Bloom.",
     );

--- a/src/BloomBrowserUI/scripts/processTree.mjs
+++ b/src/BloomBrowserUI/scripts/processTree.mjs
@@ -1,0 +1,148 @@
+/* eslint-env node */
+/* global process */
+import { spawn } from "node:child_process";
+
+const isWindows = process.platform === "win32";
+
+/**
+ * Force-kill a process and ALL of its descendants.
+ *
+ * This exists because the dev launcher spawns a deep tree (dev.mjs -> Vite plus
+ * ~7 watcher processes -> onchange's own command children). On Windows a plain
+ * SIGTERM/SIGINT to a Node child does NOT reach that child's descendants, so the
+ * watcher grandchildren orphan and accumulate across runs. `taskkill /t` walks
+ * and kills the whole tree, which is the only reliable way to avoid the leak.
+ *
+ * On POSIX we keep the historical best-effort behavior (signal the process
+ * directly); terminals already propagate Ctrl-C to the foreground process group,
+ * and we avoid the larger behavioral change of detached process groups on a
+ * platform the bug does not affect.
+ *
+ * @param {number} pid - Process id to kill (together with its descendants on Windows).
+ * @param {string} [signal] - POSIX signal to send; ignored on Windows. Defaults to SIGTERM.
+ * @returns {Promise<void>} Resolves once the kill attempt has completed.
+ */
+export const killProcessTree = (pid, signal = "SIGTERM") =>
+    new Promise((resolve) => {
+        if (!Number.isInteger(pid) || pid <= 0) {
+            resolve();
+            return;
+        }
+
+        if (isWindows) {
+            const killer = spawn(
+                "taskkill",
+                ["/pid", String(pid), "/t", "/f"],
+                {
+                    stdio: "ignore",
+                    shell: false,
+                },
+            );
+            killer.on("exit", () => resolve());
+            killer.on("error", () => resolve());
+            return;
+        }
+
+        try {
+            process.kill(pid, signal);
+        } catch {
+            // The process may already be gone; nothing more to do.
+        }
+        resolve();
+    });
+
+/**
+ * Quote a string as a single PowerShell single-quoted literal (doubling any
+ * embedded single quotes), so an arbitrary worktree path can be embedded safely.
+ *
+ * @param {string} value - The raw string to quote.
+ * @returns {string} A PowerShell-safe single-quoted literal.
+ */
+const toPowerShellLiteral = (value) => `'${value.replace(/'/g, "''")}'`;
+
+/**
+ * Find the process ids of stale `node.exe` processes whose command line contains
+ * the given marker (typically this worktree's BloomBrowserUI path), excluding the
+ * supplied pids (e.g. our own process). Windows only; returns an empty array on
+ * other platforms because the orphaning bug this guards against is Windows-specific.
+ *
+ * @param {string} commandLineMarker - Substring that identifies this worktree's processes.
+ * @param {number[]} [excludePids] - Process ids to exclude from the result.
+ * @returns {Promise<number[]>} The matching, non-excluded process ids.
+ */
+export const findStaleWorktreeNodeProcesses = (
+    commandLineMarker,
+    excludePids = [],
+) =>
+    new Promise((resolve) => {
+        if (!isWindows || !commandLineMarker) {
+            resolve([]);
+            return;
+        }
+
+        const excluded = new Set(excludePids.filter(Number.isInteger));
+        const markerLiteral = toPowerShellLiteral(commandLineMarker);
+        // List node.exe processes whose command line mentions this worktree and
+        // print just their pids, one per line.
+        const script = [
+            `$marker = ${markerLiteral};`,
+            "Get-CimInstance Win32_Process -Filter \"Name='node.exe'\"",
+            "| Where-Object { $_.CommandLine -and $_.CommandLine.Contains($marker) }",
+            "| ForEach-Object { $_.ProcessId }",
+        ].join(" ");
+
+        const probe = spawn(
+            "powershell.exe",
+            ["-NoProfile", "-NonInteractive", "-Command", script],
+            { stdio: ["ignore", "pipe", "ignore"], shell: false },
+        );
+
+        let output = "";
+        probe.stdout.on("data", (chunk) => {
+            output += chunk.toString();
+        });
+
+        probe.on("error", () => resolve([]));
+        probe.on("exit", () => {
+            const pids = output
+                .split(/\r?\n/)
+                .map((line) => Number.parseInt(line.trim(), 10))
+                .filter((pid) => Number.isInteger(pid) && pid > 0)
+                .filter((pid) => !excluded.has(pid));
+            resolve([...new Set(pids)]);
+        });
+    });
+
+/**
+ * Detect and force-kill stale dev-server `node.exe` processes left over from a
+ * previous run of THIS worktree (e.g. after the launcher was hard-killed and its
+ * signal handlers never ran). This keeps a prior leak from silently starving the
+ * machine and wrecking the next `go.sh`. Windows only; a no-op elsewhere.
+ *
+ * @param {object} params
+ * @param {string} params.commandLineMarker - Substring identifying this worktree's processes.
+ * @param {number[]} [params.excludePids] - Process ids to leave alone (e.g. our own).
+ * @param {(message: string) => void} [params.log] - Logger for what was swept.
+ * @returns {Promise<number>} The number of stale processes that were killed.
+ */
+export const sweepStaleWorktreeNodeProcesses = async (params) => {
+    if (!isWindows) {
+        return 0;
+    }
+
+    const stalePids = await findStaleWorktreeNodeProcesses(
+        params.commandLineMarker,
+        params.excludePids,
+    );
+
+    if (stalePids.length === 0) {
+        return 0;
+    }
+
+    params.log?.(
+        `Found ${stalePids.length} stale dev-server node process(es) from a previous run of this worktree (pids: ${stalePids.join(", ")}). Cleaning them up before starting.`,
+    );
+
+    await Promise.all(stalePids.map((pid) => killProcessTree(pid)));
+    return stalePids.length;
+};

--- a/src/BloomBrowserUI/scripts/processTree.mjs
+++ b/src/BloomBrowserUI/scripts/processTree.mjs
@@ -61,14 +61,22 @@ export const killProcessTree = (pid, signal = "SIGTERM") =>
 const toPowerShellLiteral = (value) => `'${value.replace(/'/g, "''")}'`;
 
 /**
- * Find the process ids of stale `node.exe` processes whose command line contains
- * the given marker (typically this worktree's BloomBrowserUI path), excluding the
- * supplied pids (e.g. our own process). Windows only; returns an empty array on
+ * Find the process ids of stale, ORPHANED `node.exe` processes whose command line
+ * contains the given marker (typically this worktree's repo-root path), excluding
+ * the supplied pids (e.g. our own process). Windows only; returns an empty array on
  * other platforms because the orphaning bug this guards against is Windows-specific.
+ *
+ * "Orphaned" means the process's parent is no longer running -- exactly the state a
+ * dev-server tree is left in after the launcher is hard-killed without running its
+ * shutdown handlers. Requiring a dead parent is what keeps the sweep from killing a
+ * legitimate concurrent run from the same worktree (e.g. another terminal's
+ * `yarn dev` or tests), whose processes still have a living parent. We only need to
+ * find the orphaned tree roots; their still-parented descendants (Vite, onchange's
+ * command children) are taken down when the root's tree is killed.
  *
  * @param {string} commandLineMarker - Substring that identifies this worktree's processes.
  * @param {number[]} [excludePids] - Process ids to exclude from the result.
- * @returns {Promise<number[]>} The matching, non-excluded process ids.
+ * @returns {Promise<number[]>} The matching, orphaned, non-excluded process ids.
  */
 export const findStaleWorktreeNodeProcesses = (
     commandLineMarker,
@@ -82,12 +90,17 @@ export const findStaleWorktreeNodeProcesses = (
 
         const excluded = new Set(excludePids.filter(Number.isInteger));
         const markerLiteral = toPowerShellLiteral(commandLineMarker);
-        // List node.exe processes whose command line mentions this worktree and
-        // print just their pids, one per line.
+        // List node.exe processes whose command line mentions this worktree AND
+        // whose parent process is no longer alive (true orphans), printing just
+        // their pids, one per line. We build a lookup of every live pid so the
+        // parent-alive test is a cheap hash check.
         const script = [
             `$marker = ${markerLiteral};`,
-            "Get-CimInstance Win32_Process -Filter \"Name='node.exe'\"",
-            "| Where-Object { $_.CommandLine -and $_.CommandLine.Contains($marker) }",
+            "$all = Get-CimInstance Win32_Process;",
+            "$alive = @{};",
+            "foreach ($p in $all) { $alive[[int]$p.ProcessId] = $true }",
+            "$all",
+            "| Where-Object { $_.Name -eq 'node.exe' -and $_.CommandLine -and $_.CommandLine.Contains($marker) -and -not $alive.ContainsKey([int]$_.ParentProcessId) }",
             "| ForEach-Object { $_.ProcessId }",
         ].join(" ");
 
@@ -140,7 +153,7 @@ export const sweepStaleWorktreeNodeProcesses = async (params) => {
     }
 
     params.log?.(
-        `Found ${stalePids.length} stale dev-server node process(es) from a previous run of this worktree (pids: ${stalePids.join(", ")}). Cleaning them up before starting.`,
+        `Found ${stalePids.length} orphaned dev-server node process(es) from a hard-killed previous run of this worktree (pids: ${stalePids.join(", ")}). Cleaning them up before starting.`,
     );
 
     await Promise.all(stalePids.map((pid) => killProcessTree(pid)));


### PR DESCRIPTION
## Problem

`go.sh` leaks orphaned `node.exe` watcher processes on Windows. Every time the launcher's process tree is torn down (Ctrl-C, the launcher being killed, `go.mjs`'s shutdown path, or a hard kill), the Vite + watcher **grandchildren orphan instead of dying** and accumulate across runs. Once the machine is resource-starved, a freshly launched Vite binds its port but never returns an HTTP response, so `go.mjs`'s health check times out and the launcher aborts with `Vite on port NNNNN never became reachable at /@vite/client` — making `go.sh` look broken when the real issue is leftover zombies.

## Root cause

On Windows, `child.kill("SIGINT")` from a parent Node process does **not** deliver a real SIGINT — Node force-terminates the target via `TerminateProcess` without running its handlers and without touching its descendants. So `go.mjs`'s `terminateChild` killed `dev.mjs`, saw the `exit` event fire immediately, cancelled its `taskkill /t /f` fallback timer, and considered shutdown done — leaving the whole `dev.mjs → Vite + ~7 onchange/LESS watchers (+ their own command children)` subtree orphaned. A hard kill of `go.mjs` reaped nothing at all.

## Changes

- **New `src/BloomBrowserUI/scripts/processTree.mjs`**
  - `killProcessTree(pid)` — `taskkill /pid <pid> /t /f` on Windows (kills the entire subtree); best-effort signal on POSIX.
  - `sweepStaleWorktreeNodeProcesses(...)` — finds `node.exe` whose command line contains this worktree's repo-root path (via `Get-CimInstance Win32_Process`), excludes our own pid, and tree-kills them.
- **`go.mjs`**
  - `terminateChild` now tree-kills the child subtree directly via `taskkill /t /f` on Windows instead of trusting SIGINT propagation. POSIX keeps the graceful SIGINT-then-force path so `dotnet`/Bloom shut down cleanly.
  - `main()` runs a **defensive startup sweep** so leftovers from a hard-killed prior run (whose handlers never ran) are reaped before launching — keyed on the repo-root path that appears in `dev.mjs`, `watchBloomExe.mjs`, and the Vite/onchange bins. Killing a tree root takes its relative-path descendants (`watchLess`, onchange's command children) with it.
- **`dev.mjs`**
  - `cleanup()` is now async, tree-kills every tracked child, and awaits the kills before `process.exit()`, with a 5s watchdog so a stuck kill can't hang shutdown. This covers the standalone `yarn dev` Ctrl-C path.

## Verification

Tested against **real** dev-server trees spawned exactly the way `go.mjs` spawns them (no heavyweight Bloom/`dotnet` build needed):

| Scenario | Tree size | Orphans left |
|---|---|---|
| Graceful teardown (`killProcessTree` of dev pid — what `terminateChild` now does) | 14 | **0** ✅ |
| Startup sweep (live tree left running, then swept) | 9 | **0** ✅ |
| Negative control — old `dev.kill("SIGINT")` path | 9 | **4** ❌ (bug reproduced) |

Final worktree orphan count after testing: **0**.

## Notes

- A native Windows **Job Object** (`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`) would give true zero-transient-orphan guarantees even on `SIGKILL` of the launcher, but it requires a native addon and this project is yarn-only with no native build deps. The startup sweep makes hard-kill leaks self-healing instead — they can't accumulate or wreck the next run.
- The project's lint script only covers `*.ts{,x}`, so these `.mjs` files aren't linted in CI; they were checked with eslint directly and are clean (two remaining warnings are pre-existing on an untouched line of `dev.mjs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/7980)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7980)
<!-- Reviewable:end -->
