### PR TITLE
BL-16449 Reuse copyright/license metadata + "Add this info to all images" in C&L dialog

### DIFF
--- a/DistFiles/localization/en/BloomMediumPriority.xlf
+++ b/DistFiles/localization/en/BloomMediumPriority.xlf
@@ -19,20 +19,20 @@
         <note>ID: CopyrightAndLicense.FromThisBook</note>
         <note>Label shown on the reuse option that offers the book's own copyright and license (in place of an illustrator/photographer name).</note>
       </trans-unit>
-      <trans-unit id="CopyrightAndLicense.Gathering" translate="no">
+      <trans-unit id="Common.Gathering" translate="no">
         <source xml:lang="en">Gathering…</source>
-        <note>ID: CopyrightAndLicense.Gathering</note>
-        <note>Shown while Bloom is scanning the book's images to find reusable copyright/license metadata.</note>
+        <note>ID: Common.Gathering</note>
+        <note>Shown while Bloom is collecting items.</note>
       </trans-unit>
       <trans-unit id="CopyrightAndLicense.CopyToAllImages" translate="no">
         <source xml:lang="en">Add this info to all images in this book</source>
         <note>ID: CopyrightAndLicense.CopyToAllImages</note>
         <note>Button that applies the current image's copyright and license to every other image in the book.</note>
       </trans-unit>
-      <trans-unit id="CopyrightAndLicense.Working" translate="no">
+      <trans-unit id="Common.Working" translate="no">
         <source xml:lang="en">Working…</source>
-        <note>ID: CopyrightAndLicense.Working</note>
-        <note>Shown next to a spinner while Bloom applies the copyright and license to all images in the book.</note>
+        <note>ID: Common.Working</note>
+        <note>Shown next to a spinner while an operation is in progress.</note>
       </trans-unit>
       <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.AppBuilder" translate="no">
         <source xml:lang="en">App Builder</source>

--- a/DistFiles/localization/en/BloomMediumPriority.xlf
+++ b/DistFiles/localization/en/BloomMediumPriority.xlf
@@ -9,6 +9,31 @@
         <source xml:lang="en">Available with your Bloom Subscription</source>
         <note>ID: AvailableWithSubscription</note>
       </trans-unit>
+      <trans-unit id="CopyrightAndLicense.ReuseMetadataShortcutLabel" translate="no">
+        <source xml:lang="en">Shortcuts:</source>
+        <note>ID: CopyrightAndLicense.ReuseMetadataShortcutLabel</note>
+        <note>Header above a list of metadata the user can reuse from other images in the book or books in the collection.</note>
+      </trans-unit>
+      <trans-unit id="CopyrightAndLicense.FromThisBook" translate="no">
+        <source xml:lang="en">Copyright and license from this book</source>
+        <note>ID: CopyrightAndLicense.FromThisBook</note>
+        <note>Label shown on the reuse option that offers the book's own copyright and license (in place of an illustrator/photographer name).</note>
+      </trans-unit>
+      <trans-unit id="CopyrightAndLicense.Gathering" translate="no">
+        <source xml:lang="en">Gathering…</source>
+        <note>ID: CopyrightAndLicense.Gathering</note>
+        <note>Shown while Bloom is scanning the book's images to find reusable copyright/license metadata.</note>
+      </trans-unit>
+      <trans-unit id="CopyrightAndLicense.CopyToAllImages" translate="no">
+        <source xml:lang="en">Add this info to all images in this book</source>
+        <note>ID: CopyrightAndLicense.CopyToAllImages</note>
+        <note>Button that applies the current image's copyright and license to every other image in the book.</note>
+      </trans-unit>
+      <trans-unit id="CopyrightAndLicense.Working" translate="no">
+        <source xml:lang="en">Working…</source>
+        <note>ID: CopyrightAndLicense.Working</note>
+        <note>Shown next to a spinner while Bloom applies the copyright and license to all images in the book.</note>
+      </trans-unit>
       <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.AppBuilder" translate="no">
         <source xml:lang="en">App Builder</source>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.AppBuilder</note>

--- a/src/BloomBrowserUI/bookEdit/copyrightAndLicense/CopyrightAndLicenseDialog.tsx
+++ b/src/BloomBrowserUI/bookEdit/copyrightAndLicense/CopyrightAndLicenseDialog.tsx
@@ -105,6 +105,10 @@ export const CopyrightAndLicenseDialog: React.FunctionComponent<{
         setCopyrightInfo(data.copyrightInfo);
         setLicenseInfo(data.licenseInfo);
         setAppliedVersion((v) => v + 1);
+        // Picking a shortcut changes the fields just like a manual edit, so any prior "pushed to
+        // all images" confirmation is now stale: re-offer the button (but leave an in-flight
+        // push's spinner alone).
+        markEditedSincePush();
     }
 
     // Header for the image reuse chooser.

--- a/src/BloomBrowserUI/bookEdit/copyrightAndLicense/CopyrightAndLicenseDialog.tsx
+++ b/src/BloomBrowserUI/bookEdit/copyrightAndLicense/CopyrightAndLicenseDialog.tsx
@@ -244,6 +244,10 @@ export const CopyrightAndLicenseDialog: React.FunctionComponent<{
                             }
                             onChange={(newLicenseInfo: ILicenseInfo) => {
                                 setLicenseInfo(newLicenseInfo);
+                                // Like the other edit handlers, a license change via the badge
+                                // means the fields no longer match a completed push-to-all, so
+                                // clear any stale "Done" indicator.
+                                markEditedSincePush();
                             }}
                             disabled={useOriginalCopyrightAndLicense}
                         />

--- a/src/BloomBrowserUI/bookEdit/copyrightAndLicense/CopyrightAndLicenseDialog.tsx
+++ b/src/BloomBrowserUI/bookEdit/copyrightAndLicense/CopyrightAndLicenseDialog.tsx
@@ -5,16 +5,20 @@ import { useState } from "react";
 import { renderRootSync } from "../../utils/reactRender";
 import { Tab, TabList, TabPanel } from "react-tabs";
 import "react-tabs/style/react-tabs.less";
+import { CircularProgress } from "@mui/material";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 
 import { WireUpForWinforms } from "../../utils/WireUpWinform";
 import { get, postBoolean, postData } from "../../utils/bloomApi";
-import { kBloomBlue } from "../../bloomMaterialUITheme";
+import { useSubscribeToWebSocketForEvent } from "../../utils/WebSocketManager";
+import { kBloomBlue, kMutedTextGray } from "../../bloomMaterialUITheme";
 import {
     BloomDialog,
     DialogBottomButtons,
     DialogTitle,
     DialogMiddle,
 } from "../../react_components/BloomDialog/BloomDialog";
+import BloomButton from "../../react_components/bloomButton";
 import {
     IBloomDialogEnvironmentParams,
     useSetupBloomDialog,
@@ -29,6 +33,7 @@ import { useL10n } from "../../react_components/l10nHooks";
 import { CopyrightPanel, ICopyrightInfo } from "./CopyrightPanel";
 import { ILicenseInfo, LicensePanel } from "./LicensePanel";
 import { LicenseBadge } from "./LicenseBadge";
+import { MetadataChooser } from "./MetadataChooser";
 import BloomMessageBoxSupport from "../../utils/bloomMessageBoxSupport";
 
 export interface ICopyrightAndLicenseData {
@@ -85,6 +90,37 @@ export const CopyrightAndLicenseDialog: React.FunctionComponent<{
     const [isCopyrightValid, setIsCopyrightValid] = useState(false);
     const [isLicenseValid, setIsLicenseValid] = useState(true);
 
+    // The single condition that gates saving. The OK button is enabled only when this is true;
+    // the "Add to all images" and "copy" buttons are hidden entirely when it is false (rather
+    // than shown disabled). Anything keyed to "can we save?" should use this, not the OK button.
+    const canSave = isCopyrightValid && isLicenseValid;
+
+    // The CopyrightPanel and LicensePanel seed their internal state from props only at mount.
+    // To refill their fields when the user picks a metadata package, we update the data state
+    // here and bump this version, which is used as the panels' `key` to force a remount.
+    const [appliedVersion, setAppliedVersion] = useState(0);
+
+    function applyMetadataPackage(data: ICopyrightAndLicenseData) {
+        setCopyrightInfo(data.copyrightInfo);
+        setLicenseInfo(data.licenseInfo);
+        setAppliedVersion((v) => v + 1);
+    }
+
+    // Header for the image reuse chooser.
+    const ReuseMetadataShortcutLabelHeader = useL10n(
+        "Shortcuts:",
+        "CopyrightAndLicense.ReuseMetadataShortcutLabel",
+    );
+
+    // Tracks the "Add this info to all images" operation. It can take a while on a book with
+    // many images, so instead of closing the dialog (and leaving the UI seemingly frozen) we
+    // stay open and show progress: a spinner while working, then a "done" confirmation.
+    const [pushState, setPushState] = useState<"idle" | "working" | "done">(
+        "idle",
+    );
+    const pushWorkingLabel = useL10n("Working…", "CopyrightAndLicense.Working");
+    const pushDoneLabel = useL10n("Done", "Common.Done");
+
     function onCopyrightChange(
         copyrightInfo: ICopyrightInfo,
         useOriginalCopyrightAndLicense: boolean,
@@ -93,28 +129,56 @@ export const CopyrightAndLicenseDialog: React.FunctionComponent<{
         setCopyrightInfo(copyrightInfo);
         setUseOriginalCopyrightAndLicense(useOriginalCopyrightAndLicense);
         setIsCopyrightValid(isValid);
+        // Editing makes a prior "pushed to all images" confirmation stale; offer the button again.
+        setPushState("idle");
     }
 
     function onLicenseChange(licenseInfo: ILicenseInfo, isValid: boolean) {
         setLicenseInfo(licenseInfo);
         setIsLicenseValid(isValid);
+        setPushState("idle");
     }
 
-    function handleOk() {
+    // The current dialog values, in the shape the backend expects.
+    function gatherData(): ICopyrightAndLicenseData {
         const derivativeInfo: IDerivativeInfo = {
             isBookDerivative:
                 !!props.data.derivativeInfo &&
                 props.data.derivativeInfo.isBookDerivative,
             useOriginalCopyright: useOriginalCopyrightAndLicense,
         };
-        const data: ICopyrightAndLicenseData = {
+        return {
             copyrightInfo,
             licenseInfo,
             derivativeInfo,
         };
-        postData(getApiUrlSuffix(props.isForBook), data);
+    }
+
+    function handleOk() {
+        // Save just the current image/book and close.
+        postData(getApiUrlSuffix(props.isForBook), gatherData());
         closeDialog();
     }
+
+    // Push the current metadata to every other image in the book. This can be slow, so we keep
+    // the dialog open and show a "Working…" spinner. We do NOT switch to "done" when the POST
+    // resolves — that happens as soon as the save is *initiated*, before the copy actually runs.
+    // Instead the backend sends a websocket event (see useSubscribeToWebSocketForEvent below)
+    // when the copy has finished, and that flips us to "done".
+    function handlePushToAllImages() {
+        setPushState("working");
+        postData(
+            getApiUrlSuffix(props.isForBook) + "?applyToAllImages=true",
+            gatherData(),
+        );
+    }
+
+    // The backend fires this when a "Add to all images" operation has actually finished.
+    useSubscribeToWebSocketForEvent(
+        "copyrightAndLicense",
+        "pushedToAllImages",
+        () => setPushState("done"),
+    );
 
     return (
         <BloomDialog {...propsForBloomDialog}>
@@ -186,27 +250,142 @@ export const CopyrightAndLicenseDialog: React.FunctionComponent<{
                     </TabList>
                     <TabPanel>
                         {copyrightInfo && (
-                            <CopyrightPanel
-                                isForBook={props.isForBook}
-                                derivativeInfo={props.data.derivativeInfo}
-                                copyrightInfo={copyrightInfo}
-                                onChange={(
-                                    copyrightInfo,
-                                    useOriginalCopyrightAndLicense,
-                                    isValid,
-                                ) =>
-                                    onCopyrightChange(
+                            <div
+                                css={css`
+                                    display: flex;
+                                    flex-direction: column;
+                                    // Fill the tab so the chooser can hug the bottom (it uses
+                                    // margin-top: auto) while the copyright fields stay at top.
+                                    height: 100%;
+                                    box-sizing: border-box;
+                                `}
+                            >
+                                <CopyrightPanel
+                                    key={appliedVersion}
+                                    isForBook={props.isForBook}
+                                    derivativeInfo={props.data.derivativeInfo}
+                                    copyrightInfo={copyrightInfo}
+                                    onChange={(
                                         copyrightInfo,
                                         useOriginalCopyrightAndLicense,
                                         isValid,
+                                    ) =>
+                                        onCopyrightChange(
+                                            copyrightInfo,
+                                            useOriginalCopyrightAndLicense,
+                                            isValid,
+                                        )
+                                    }
+                                />
+                                {
+                                    // The image-only "Add to all images" button, sitting just
+                                    // below the copyright fields. Shown only for images, and only
+                                    // when the metadata can be saved (or a push is in progress/done).
+                                    !props.isForBook &&
+                                        (canSave || pushState !== "idle") && (
+                                            <div
+                                                css={css`
+                                                    display: flex;
+                                                    align-items: center;
+                                                    // Right-align the button/progress.
+                                                    justify-content: flex-end;
+                                                    min-height: 36px;
+                                                `}
+                                            >
+                                                {pushState === "idle" && (
+                                                    <BloomButton
+                                                        l10nKey="CopyrightAndLicense.CopyToAllImages"
+                                                        hasText={true}
+                                                        enabled={true}
+                                                        variant="outlined"
+                                                        css={css`
+                                                            // Outlined button.
+                                                            text-transform: none;
+                                                        `}
+                                                        onClick={
+                                                            handlePushToAllImages
+                                                        }
+                                                    >
+                                                        Add this info to all
+                                                        images in this book
+                                                    </BloomButton>
+                                                )}
+                                                {pushState === "working" && (
+                                                    <div
+                                                        css={css`
+                                                            display: flex;
+                                                            align-items: center;
+                                                            gap: 8px;
+                                                            color: ${kMutedTextGray};
+                                                        `}
+                                                    >
+                                                        <CircularProgress
+                                                            size={16}
+                                                        />
+                                                        {pushWorkingLabel}
+                                                    </div>
+                                                )}
+                                                {pushState === "done" && (
+                                                    <div
+                                                        css={css`
+                                                            display: flex;
+                                                            align-items: center;
+                                                            gap: 6px;
+                                                        `}
+                                                    >
+                                                        <CheckCircleIcon
+                                                            fontSize="small"
+                                                            css={css`
+                                                                color: #4caf50;
+                                                            `}
+                                                        />
+                                                        {pushDoneLabel}
+                                                    </div>
+                                                )}
+                                            </div>
+                                        )
+                                }
+                                {
+                                    // A bottom-hugging group: the reuse chooser, shown only when
+                                    // editing an image (not for the book's own copyright/license).
+                                    // It is a sibling of (not keyed like) CopyrightPanel, so
+                                    // applying a package remounts the panel to refill its fields
+                                    // without resetting the chooser. (copyrightInfo is already
+                                    // guaranteed truthy by the enclosing block.)
+                                    !props.isForBook && licenseInfo && (
+                                        <div
+                                            css={css`
+                                                margin-top: auto;
+                                                display: flex;
+                                                flex-direction: column;
+                                            `}
+                                        >
+                                            <MetadataChooser
+                                                currentData={{
+                                                    copyrightInfo,
+                                                    licenseInfo,
+                                                }}
+                                                onChoose={applyMetadataPackage}
+                                                headerText={
+                                                    ReuseMetadataShortcutLabelHeader
+                                                }
+                                                listEndpoint="copyrightAndLicense/imageFileNamesInBook"
+                                                getItemEndpoint={(file) =>
+                                                    "copyrightAndLicense/imageMetadataForFile?fileName=" +
+                                                    encodeURIComponent(file)
+                                                }
+                                                alsoOfferBookMetadata={true}
+                                            />
+                                        </div>
                                     )
                                 }
-                            />
+                            </div>
                         )}
                     </TabPanel>
                     <TabPanel>
                         {licenseInfo && (
                             <LicensePanel
+                                key={appliedVersion}
                                 isForBook={props.isForBook}
                                 licenseInfo={licenseInfo}
                                 derivativeInfo={props.data.derivativeInfo}
@@ -222,7 +401,7 @@ export const CopyrightAndLicenseDialog: React.FunctionComponent<{
                 <DialogOkButton
                     onClick={handleOk}
                     default={true}
-                    enabled={isCopyrightValid && isLicenseValid}
+                    enabled={canSave}
                 />
                 <DialogCancelButton onClick_DEPRECATED={closeDialog} />
             </DialogBottomButtons>

--- a/src/BloomBrowserUI/bookEdit/copyrightAndLicense/CopyrightAndLicenseDialog.tsx
+++ b/src/BloomBrowserUI/bookEdit/copyrightAndLicense/CopyrightAndLicenseDialog.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
 
 import * as React from "react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { renderRootSync } from "../../utils/reactRender";
 import { Tab, TabList, TabPanel } from "react-tabs";
 import "react-tabs/style/react-tabs.less";
@@ -34,6 +34,7 @@ import { CopyrightPanel, ICopyrightInfo } from "./CopyrightPanel";
 import { ILicenseInfo, LicensePanel } from "./LicensePanel";
 import { LicenseBadge } from "./LicenseBadge";
 import { MetadataChooser } from "./MetadataChooser";
+import { computePackageKey } from "./metadataReuseUtils";
 import BloomMessageBoxSupport from "../../utils/bloomMessageBoxSupport";
 
 export interface ICopyrightAndLicenseData {
@@ -121,9 +122,16 @@ export const CopyrightAndLicenseDialog: React.FunctionComponent<{
     const pushWorkingLabel = useL10n("Working…", "Common.Working");
     const pushDoneLabel = useL10n("Done", "Common.Done");
 
+    // The package key of the values submitted by the most recent "Add to all images" push, so
+    // that when the completion event arrives we can tell whether the user has edited since. (null
+    // means no push has been initiated.)
+    const pushedKeyRef = useRef<string | null>(null);
+
     // Editing makes a prior "pushed to all images" confirmation stale, so offer the button
     // again. But if a push is still running ("working"), leave the spinner alone: resetting to
     // "idle" mid-operation would hide the spinner and re-enable the button for redundant clicks.
+    // (The completion handler below still notices that the values changed and avoids a stale
+    // "done".)
     function markEditedSincePush() {
         setPushState((prev) => (prev === "working" ? prev : "idle"));
     }
@@ -173,6 +181,10 @@ export const CopyrightAndLicenseDialog: React.FunctionComponent<{
     // when the copy has finished, and that flips us to "done".
     function handlePushToAllImages() {
         setPushState("working");
+        // Remember exactly which values we are pushing, so the completion handler can tell whether
+        // the user has edited since (in which case the values that finished copying are stale and
+        // we must not show "done" for the current, un-pushed values).
+        pushedKeyRef.current = computePackageKey(gatherData());
         postData(
             getApiUrlSuffix(props.isForBook) + "?applyToAllImages=true",
             gatherData(),
@@ -184,11 +196,19 @@ export const CopyrightAndLicenseDialog: React.FunctionComponent<{
         );
     }
 
-    // The backend fires this when a "Add to all images" operation has actually finished.
+    // The backend fires this when a "Add to all images" operation has actually finished. Only
+    // show "done" if the dialog's current values still match what we pushed; if the user edited
+    // while the push was in flight, those edits were not copied, so we drop back to "idle" and
+    // offer the button again rather than claiming the new values are done.
     useSubscribeToWebSocketForEvent(
         "copyrightAndLicense",
         "pushedToAllImages",
-        () => setPushState("done"),
+        () =>
+            setPushState(
+                computePackageKey(gatherData()) === pushedKeyRef.current
+                    ? "done"
+                    : "idle",
+            ),
     );
 
     return (

--- a/src/BloomBrowserUI/bookEdit/copyrightAndLicense/CopyrightAndLicenseDialog.tsx
+++ b/src/BloomBrowserUI/bookEdit/copyrightAndLicense/CopyrightAndLicenseDialog.tsx
@@ -170,6 +170,11 @@ export const CopyrightAndLicenseDialog: React.FunctionComponent<{
         postData(
             getApiUrlSuffix(props.isForBook) + "?applyToAllImages=true",
             gatherData(),
+            undefined,
+            // If the POST itself fails before reaching the server, no "pushedToAllImages"
+            // websocket event will ever arrive, so reset to "idle" rather than leaving the
+            // spinner running forever.
+            () => setPushState("idle"),
         );
     }
 

--- a/src/BloomBrowserUI/bookEdit/copyrightAndLicense/CopyrightAndLicenseDialog.tsx
+++ b/src/BloomBrowserUI/bookEdit/copyrightAndLicense/CopyrightAndLicenseDialog.tsx
@@ -118,7 +118,7 @@ export const CopyrightAndLicenseDialog: React.FunctionComponent<{
     const [pushState, setPushState] = useState<"idle" | "working" | "done">(
         "idle",
     );
-    const pushWorkingLabel = useL10n("Working…", "CopyrightAndLicense.Working");
+    const pushWorkingLabel = useL10n("Working…", "Common.Working");
     const pushDoneLabel = useL10n("Done", "Common.Done");
 
     function onCopyrightChange(
@@ -401,7 +401,10 @@ export const CopyrightAndLicenseDialog: React.FunctionComponent<{
                 <DialogOkButton
                     onClick={handleOk}
                     default={true}
-                    enabled={canSave}
+                    // Disable OK while a push is in flight, so the user can't fire a
+                    // redundant save and unmount the dialog before the "pushedToAllImages"
+                    // websocket event arrives (which would set state on an unmounted component).
+                    enabled={canSave && pushState !== "working"}
                 />
                 <DialogCancelButton onClick_DEPRECATED={closeDialog} />
             </DialogBottomButtons>

--- a/src/BloomBrowserUI/bookEdit/copyrightAndLicense/CopyrightAndLicenseDialog.tsx
+++ b/src/BloomBrowserUI/bookEdit/copyrightAndLicense/CopyrightAndLicenseDialog.tsx
@@ -444,9 +444,10 @@ function showCopyrightAndLicenseDialog(
     show();
 }
 
-// Either the `get` call will show info to the user
-// (e.g. read-only info if he can't modify the image or a message stating images cannot be changed unless unlocked)
-// or we will display the dialog.
+// The `get` call either returns the image's copyright/license data (so we display the dialog),
+// returns nothing (e.g. the image file wasn't found, so there is nothing to show), or fails with
+// a message we surface to the user (e.g. the image is embedded data rather than a file, so its
+// information can't be edited).
 export function showCopyrightAndLicenseInfoOrDialog(imageUrl?: string) {
     const isForBook: boolean = !imageUrl;
     get(

--- a/src/BloomBrowserUI/bookEdit/copyrightAndLicense/CopyrightAndLicenseDialog.tsx
+++ b/src/BloomBrowserUI/bookEdit/copyrightAndLicense/CopyrightAndLicenseDialog.tsx
@@ -121,6 +121,13 @@ export const CopyrightAndLicenseDialog: React.FunctionComponent<{
     const pushWorkingLabel = useL10n("Working…", "Common.Working");
     const pushDoneLabel = useL10n("Done", "Common.Done");
 
+    // Editing makes a prior "pushed to all images" confirmation stale, so offer the button
+    // again. But if a push is still running ("working"), leave the spinner alone: resetting to
+    // "idle" mid-operation would hide the spinner and re-enable the button for redundant clicks.
+    function markEditedSincePush() {
+        setPushState((prev) => (prev === "working" ? prev : "idle"));
+    }
+
     function onCopyrightChange(
         copyrightInfo: ICopyrightInfo,
         useOriginalCopyrightAndLicense: boolean,
@@ -129,14 +136,13 @@ export const CopyrightAndLicenseDialog: React.FunctionComponent<{
         setCopyrightInfo(copyrightInfo);
         setUseOriginalCopyrightAndLicense(useOriginalCopyrightAndLicense);
         setIsCopyrightValid(isValid);
-        // Editing makes a prior "pushed to all images" confirmation stale; offer the button again.
-        setPushState("idle");
+        markEditedSincePush();
     }
 
     function onLicenseChange(licenseInfo: ILicenseInfo, isValid: boolean) {
         setLicenseInfo(licenseInfo);
         setIsLicenseValid(isValid);
-        setPushState("idle");
+        markEditedSincePush();
     }
 
     // The current dialog values, in the shape the backend expects.

--- a/src/BloomBrowserUI/bookEdit/copyrightAndLicense/MetadataChooser.tsx
+++ b/src/BloomBrowserUI/bookEdit/copyrightAndLicense/MetadataChooser.tsx
@@ -15,17 +15,18 @@ import { useL10n } from "../../react_components/l10nHooks";
 import { ICopyrightAndLicenseData } from "./CopyrightAndLicenseDialog";
 import { computePackageKey, getLicenseShorthand } from "./metadataReuseUtils";
 
-// One distinct copyright/license/illustrator combination found among the book's images,
-// along with a precomputed human-readable summary for display.
+// One distinct copyright/license/illustrator combination found among the book's images. We
+// store only raw data here; the human-readable summary (which depends on localized labels) is
+// computed at render time, where the labels are always current. (useL10n returns the English
+// fallback synchronously and the localized string only on a later render, so a summary baked in
+// during the once-on-mount gather effect would be stuck in English.)
 interface IMetadataPackage {
     key: string;
     data: ICopyrightAndLicenseData;
-    summary: string;
     illustrator: string;
-    // When set, this label replaces the illustrator/photographer line. Used for the book's own
-    // copyright/license, which has no illustrator and is labeled "Copyright and license from this
-    // book" instead.
-    secondaryLabel?: string;
+    // True for the book's own copyright/license, which has no illustrator and is labeled
+    // "Copyright and license from this book" in place of the illustrator/photographer line.
+    isFromThisBook?: boolean;
 }
 
 // Shown at the bottom of the Copyright and License dialog. It gathers candidate metadata
@@ -78,8 +79,9 @@ export const MetadataChooser: React.FunctionComponent<{
         setListMaxHeight(Math.ceil(thirdBottom - firstTop));
     }, [packages.length]);
 
-    // Labels needed to build summaries. Hooks must be called unconditionally up front,
-    // so we capture them here rather than inside the gathering loop.
+    // Localized labels for the rows. These are read at render time (below), NOT inside the
+    // gather effect: useL10n delivers the localized value asynchronously, but the effect runs
+    // only once on mount, so anything it captured would be stuck on the English fallback.
     const allRightsReservedLabel = useL10n(
         "All Rights Reserved",
         "License.AllRightsReserved",
@@ -105,18 +107,13 @@ export const MetadataChooser: React.FunctionComponent<{
         const seen = new Set<string>();
 
         // De-duplicate and append one candidate (ignoring ones too sparse to be worth offering).
-        // secondaryLabel, when given, replaces the illustrator line (used for the book's own data).
+        // isFromThisBook marks the book's own copyright/license (labeled specially at render).
         function addData(
             data: ICopyrightAndLicenseData | undefined,
-            secondaryLabel?: string,
+            isFromThisBook?: boolean,
         ) {
             if (!data) return;
-            const pkg = makePackage(
-                data,
-                allRightsReservedLabel,
-                customLabel,
-                secondaryLabel,
-            );
+            const pkg = makePackage(data, isFromThisBook);
             if (!pkg) return; // not enough metadata to be worth offering
             if (seen.has(pkg.key)) return;
             seen.add(pkg.key);
@@ -142,7 +139,7 @@ export const MetadataChooser: React.FunctionComponent<{
                                 },
                                 licenseInfo: bookData.licenseInfo,
                             },
-                            fromThisBookLabel,
+                            true, // isFromThisBook
                         );
                     }
                 } catch (error) {
@@ -185,7 +182,8 @@ export const MetadataChooser: React.FunctionComponent<{
         return () => {
             cancelled.current = true;
         };
-        // We intentionally run this once on mount; the props/labels are stable for the dialog's life.
+        // We intentionally run this once on mount; the props are stable for the dialog's life.
+        // (Localized labels are deliberately NOT used here — see the labels comment above.)
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
@@ -267,6 +265,13 @@ export const MetadataChooser: React.FunctionComponent<{
             >
                 {orderedPackages.map((pkg) => {
                     const isChosen = pkg.key === currentKey;
+                    // Computed here (not when gathering) so the labels are always the current,
+                    // localized ones rather than the English fallbacks present at mount.
+                    const summary = getSummary(
+                        pkg.data,
+                        allRightsReservedLabel,
+                        customLabel,
+                    );
                     return (
                         <div
                             key={pkg.key}
@@ -311,15 +316,15 @@ export const MetadataChooser: React.FunctionComponent<{
                                     flex-direction: column;
                                 `}
                             >
-                                <div>{pkg.summary}</div>
-                                {pkg.secondaryLabel ? (
+                                <div>{summary}</div>
+                                {pkg.isFromThisBook ? (
                                     <div
                                         css={css`
                                             font-size: 0.8em;
                                             color: ${kMutedTextGray};
                                         `}
                                     >
-                                        {pkg.secondaryLabel}
+                                        {fromThisBookLabel}
                                     </div>
                                 ) : (
                                     pkg.illustrator && (
@@ -343,23 +348,30 @@ export const MetadataChooser: React.FunctionComponent<{
     );
 };
 
-// Builds a display package from raw metadata, or returns undefined if there's not enough
-// information (no copyright holder and no illustrator) to be worth offering.
+// Builds a package from raw metadata, or returns undefined if there's not enough information
+// (no copyright holder and no illustrator) to be worth offering. No localized labels here: the
+// display summary is built at render time by getSummary so it tracks the current language.
 function makePackage(
     data: ICopyrightAndLicenseData,
-    allRightsReservedLabel: string,
-    customLabel: string,
-    secondaryLabel?: string,
+    isFromThisBook?: boolean,
 ): IMetadataPackage | undefined {
     const holder = (data.copyrightInfo.copyrightHolder || "").trim();
-    const year = (data.copyrightInfo.copyrightYear || "").trim();
     const illustrator = (data.copyrightInfo.imageCreator || "").trim();
     if (!holder && !illustrator) return undefined;
 
-    const key = computePackageKey(data);
+    return { key: computePackageKey(data), data, illustrator, isFromThisBook };
+}
 
-    // The row shows copyright + license on the first line and the illustrator separately,
-    // so the summary here intentionally omits the creator.
+// Builds the first row of a package: copyright (© year holder) and the license shorthand,
+// joined by a middot. The illustrator is shown separately, so it's intentionally omitted here.
+// Takes the localized labels as arguments so it can be called at render time with current values.
+function getSummary(
+    data: ICopyrightAndLicenseData,
+    allRightsReservedLabel: string,
+    customLabel: string,
+): string {
+    const holder = (data.copyrightInfo.copyrightHolder || "").trim();
+    const year = (data.copyrightInfo.copyrightYear || "").trim();
     const license = getLicenseShorthand(
         data.licenseInfo,
         allRightsReservedLabel,
@@ -367,7 +379,5 @@ function makePackage(
     );
     let copyright = "";
     if (holder) copyright = year ? `© ${year} ${holder}` : `© ${holder}`;
-    const summary = [copyright, license].filter((s) => !!s).join(" · ");
-
-    return { key, data, summary, illustrator, secondaryLabel };
+    return [copyright, license].filter((s) => !!s).join(" · ");
 }

--- a/src/BloomBrowserUI/bookEdit/copyrightAndLicense/MetadataChooser.tsx
+++ b/src/BloomBrowserUI/bookEdit/copyrightAndLicense/MetadataChooser.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
 
 import * as React from "react";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import CheckIcon from "@mui/icons-material/Check";
 
 import { getAsync } from "../../utils/bloomApi";
@@ -12,6 +12,7 @@ import {
     kMutedTextGray,
 } from "../../bloomMaterialUITheme";
 import { useL10n } from "../../react_components/l10nHooks";
+import { useMountEffect } from "../../utils/useMountEffect";
 import { ICopyrightAndLicenseData } from "./CopyrightAndLicenseDialog";
 import { computePackageKey, getLicenseShorthand } from "./metadataReuseUtils";
 
@@ -102,7 +103,7 @@ export const MetadataChooser: React.FunctionComponent<{
     );
     const gatheringLabel = useL10n("Gathering…", "Common.Gathering");
 
-    useEffect(() => {
+    useMountEffect(() => {
         // Set when the dialog unmounts so the scan stops instead of running on against a
         // collection/book that may have hundreds of items.
         const cancelled = { current: false };
@@ -186,8 +187,7 @@ export const MetadataChooser: React.FunctionComponent<{
         };
         // We intentionally run this once on mount; the props are stable for the dialog's life.
         // (Localized labels are deliberately NOT used here — see the labels comment above.)
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    });
 
     function handleChoose(pkg: IMetadataPackage) {
         // Filling the dialog's fields updates currentData, which makes this package's

--- a/src/BloomBrowserUI/bookEdit/copyrightAndLicense/MetadataChooser.tsx
+++ b/src/BloomBrowserUI/bookEdit/copyrightAndLicense/MetadataChooser.tsx
@@ -60,9 +60,10 @@ export const MetadataChooser: React.FunctionComponent<{
     const initialKeyRef = useRef(currentKey);
 
     // We never cap the list when there are three or fewer options (so three choices never
-    // scroll). With four or more, we measure the first three rows and cap to exactly that
-    // height, so the fourth option starts the scrollbar. Measuring (rather than a fixed pixel
-    // height) keeps this correct across fonts and translations, where row heights vary.
+    // scroll). With four or more, we measure three full rows plus half of the fourth and cap to
+    // that height, so a peek of the fourth option makes it obvious the list scrolls. Measuring
+    // (rather than a fixed pixel height) keeps this correct across fonts and translations, where
+    // row heights vary.
     const listRef = useRef<HTMLDivElement>(null);
     const [listMaxHeight, setListMaxHeight] = useState<number | undefined>(
         undefined,
@@ -75,8 +76,12 @@ export const MetadataChooser: React.FunctionComponent<{
         }
         const rows = list.children;
         const firstTop = rows[0].getBoundingClientRect().top;
-        const thirdBottom = rows[2].getBoundingClientRect().bottom;
-        setListMaxHeight(Math.ceil(thirdBottom - firstTop));
+        const fourthRect = rows[3].getBoundingClientRect();
+        // Bottom of the third row is the top of the fourth; add half the fourth row's height so
+        // half of it peeks below the cutoff.
+        setListMaxHeight(
+            Math.ceil(fourthRect.top + fourthRect.height / 2 - firstTop),
+        );
     }, [packages.length]);
 
     // Localized labels for the rows. These are read at render time (below), NOT inside the
@@ -254,9 +259,9 @@ export const MetadataChooser: React.FunctionComponent<{
                     display: flex;
                     flex-direction: column;
                     gap: 4px;
-                    // Height is capped to three rows (see listMaxHeight) only when there are more
-                    // than three options, so three choices never scroll and a fourth starts the
-                    // scrollbar.
+                    // Height is capped to three and a half rows (see listMaxHeight) only when
+                    // there are more than three options, so three choices never scroll and a
+                    // fourth peeks in to show the list scrolls.
                     overflow-y: auto;
                 `}
             >

--- a/src/BloomBrowserUI/bookEdit/copyrightAndLicense/MetadataChooser.tsx
+++ b/src/BloomBrowserUI/bookEdit/copyrightAndLicense/MetadataChooser.tsx
@@ -95,10 +95,7 @@ export const MetadataChooser: React.FunctionComponent<{
         "Copyright and license from this book",
         "CopyrightAndLicense.FromThisBook",
     );
-    const gatheringLabel = useL10n(
-        "Gathering…",
-        "CopyrightAndLicense.Gathering",
-    );
+    const gatheringLabel = useL10n("Gathering…", "Common.Gathering");
 
     useEffect(() => {
         // Set when the dialog unmounts so the scan stops instead of running on against a

--- a/src/BloomBrowserUI/bookEdit/copyrightAndLicense/MetadataChooser.tsx
+++ b/src/BloomBrowserUI/bookEdit/copyrightAndLicense/MetadataChooser.tsx
@@ -1,0 +1,373 @@
+import { css } from "@emotion/react";
+
+import * as React from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import CheckIcon from "@mui/icons-material/Check";
+
+import { getAsync } from "../../utils/bloomApi";
+import {
+    kBloomBlue,
+    kBloomBlue50Transparent,
+    kBloomBuff,
+    kMutedTextGray,
+} from "../../bloomMaterialUITheme";
+import { useL10n } from "../../react_components/l10nHooks";
+import { ICopyrightAndLicenseData } from "./CopyrightAndLicenseDialog";
+import { computePackageKey, getLicenseShorthand } from "./metadataReuseUtils";
+
+// One distinct copyright/license/illustrator combination found among the book's images,
+// along with a precomputed human-readable summary for display.
+interface IMetadataPackage {
+    key: string;
+    data: ICopyrightAndLicenseData;
+    summary: string;
+    illustrator: string;
+    // When set, this label replaces the illustrator/photographer line. Used for the book's own
+    // copyright/license, which has no illustrator and is labeled "Copyright and license from this
+    // book" instead.
+    secondaryLabel?: string;
+}
+
+// Shown at the bottom of the Copyright and License dialog. It gathers candidate metadata
+// (progressively, one request at a time) from some source — the other images in this book, or
+// the other books in this collection — and offers the distinct results so the user can reuse
+// one with a single click instead of retyping. This is an experiment: we deliberately do no
+// caching, and the scan stops if the dialog closes.
+export const MetadataChooser: React.FunctionComponent<{
+    // The dialog's current copyright/license values. A package is shown as "chosen"
+    // (check mark) when it matches these, so the current metadata is checked when the dialog
+    // opens and the check mark follows whatever the user picks.
+    currentData: ICopyrightAndLicenseData;
+    onChoose: (data: ICopyrightAndLicenseData) => void;
+    // The header shown above the list (already localized by the caller).
+    headerText: string;
+    // Endpoint returning a string[] of item ids to gather (image file names, or book folders).
+    listEndpoint: string;
+    // Given an item id, the endpoint that returns that item's ICopyrightAndLicenseData.
+    getItemEndpoint: (id: string) => string;
+    // When true (editing an image), also offer the book's own copyright/license — minus the
+    // illustrator/photographer — since images usually share the book's copyright and license.
+    alsoOfferBookMetadata?: boolean;
+}> = (props) => {
+    const [packages, setPackages] = useState<IMetadataPackage[]>([]);
+    const [isGathering, setIsGathering] = useState(true);
+    const currentKey = computePackageKey(props.currentData);
+
+    // The package matching the item's existing metadata (the one shown checked when the dialog
+    // opens) is pinned to the top of the list. We freeze the open-time key in a ref so the list
+    // does not reshuffle as the user clicks different options afterward.
+    const initialKeyRef = useRef(currentKey);
+
+    // We never cap the list when there are three or fewer options (so three choices never
+    // scroll). With four or more, we measure the first three rows and cap to exactly that
+    // height, so the fourth option starts the scrollbar. Measuring (rather than a fixed pixel
+    // height) keeps this correct across fonts and translations, where row heights vary.
+    const listRef = useRef<HTMLDivElement>(null);
+    const [listMaxHeight, setListMaxHeight] = useState<number | undefined>(
+        undefined,
+    );
+    useLayoutEffect(() => {
+        const list = listRef.current;
+        if (!list || packages.length <= 3) {
+            setListMaxHeight(undefined);
+            return;
+        }
+        const rows = list.children;
+        const firstTop = rows[0].getBoundingClientRect().top;
+        const thirdBottom = rows[2].getBoundingClientRect().bottom;
+        setListMaxHeight(Math.ceil(thirdBottom - firstTop));
+    }, [packages.length]);
+
+    // Labels needed to build summaries. Hooks must be called unconditionally up front,
+    // so we capture them here rather than inside the gathering loop.
+    const allRightsReservedLabel = useL10n(
+        "All Rights Reserved",
+        "License.AllRightsReserved",
+    );
+    const customLabel = useL10n("Custom", "License.Custom");
+    const illustratorLabel = useL10n(
+        "Illustrator/Photographer",
+        "Copyright.IllustratorOrPhotographer",
+    );
+    const fromThisBookLabel = useL10n(
+        "Copyright and license from this book",
+        "CopyrightAndLicense.FromThisBook",
+    );
+    const gatheringLabel = useL10n(
+        "Gathering…",
+        "CopyrightAndLicense.Gathering",
+    );
+
+    useEffect(() => {
+        // Set when the dialog unmounts so the scan stops instead of running on against a
+        // collection/book that may have hundreds of items.
+        const cancelled = { current: false };
+        const seen = new Set<string>();
+
+        // De-duplicate and append one candidate (ignoring ones too sparse to be worth offering).
+        // secondaryLabel, when given, replaces the illustrator line (used for the book's own data).
+        function addData(
+            data: ICopyrightAndLicenseData | undefined,
+            secondaryLabel?: string,
+        ) {
+            if (!data) return;
+            const pkg = makePackage(
+                data,
+                allRightsReservedLabel,
+                customLabel,
+                secondaryLabel,
+            );
+            if (!pkg) return; // not enough metadata to be worth offering
+            if (seen.has(pkg.key)) return;
+            seen.add(pkg.key);
+            setPackages((previous) => [...previous, pkg]);
+        }
+
+        async function gather() {
+            // Offer the book's own copyright/license first (when editing an image), minus the
+            // illustrator/photographer.
+            if (props.alsoOfferBookMetadata) {
+                try {
+                    const bookResponse = await getAsync(
+                        "copyrightAndLicense/bookCopyrightAndLicense",
+                    );
+                    if (!cancelled.current && bookResponse.data) {
+                        const bookData =
+                            bookResponse.data as ICopyrightAndLicenseData;
+                        addData(
+                            {
+                                copyrightInfo: {
+                                    ...bookData.copyrightInfo,
+                                    imageCreator: "",
+                                },
+                                licenseInfo: bookData.licenseInfo,
+                            },
+                            fromThisBookLabel,
+                        );
+                    }
+                } catch (error) {
+                    console.warn(
+                        "MetadataChooser: could not read the book's metadata",
+                        error,
+                    );
+                }
+            }
+            if (cancelled.current) return;
+
+            const namesResponse = await getAsync(props.listEndpoint);
+            const ids: string[] = namesResponse.data || [];
+            for (const id of ids) {
+                if (cancelled.current) return;
+
+                let data: ICopyrightAndLicenseData | undefined;
+                try {
+                    const response = await getAsync(props.getItemEndpoint(id));
+                    // The endpoint replies with an empty string for a missing/unreadable item.
+                    if (response.data) data = response.data;
+                } catch (error) {
+                    // Never let a single bad item abort (or error out of) gathering: just skip
+                    // it. The backend already turns read failures into an empty reply; this also
+                    // covers an unexpected network/parse failure.
+                    console.warn(
+                        `MetadataChooser: skipping "${id}" (could not read its metadata)`,
+                        error,
+                    );
+                }
+                if (cancelled.current) return;
+                addData(data);
+            }
+        }
+
+        gather().finally(() => {
+            if (!cancelled.current) setIsGathering(false);
+        });
+
+        return () => {
+            cancelled.current = true;
+        };
+        // We intentionally run this once on mount; the props/labels are stable for the dialog's life.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    function handleChoose(pkg: IMetadataPackage) {
+        // Filling the dialog's fields updates currentData, which makes this package's
+        // key match currentKey, so the check mark moves here automatically.
+        props.onChoose(pkg.data);
+    }
+
+    // If we finished scanning the book and found no other image with reusable copyright/
+    // license metadata, show no chooser UI at all (no header, no separator line).
+    if (!isGathering && packages.length === 0) return null;
+
+    // While still scanning and nothing has turned up yet, show only a minimal progress hint.
+    // We hold off on the header and separator line until there is something to offer, so that
+    // if the scan ends up empty nothing flashes into view and back out.
+    if (packages.length === 0) {
+        return (
+            <div
+                css={css`
+                    margin-top: 10px;
+                    font-style: italic;
+                    color: ${kMutedTextGray};
+                `}
+            >
+                {gatheringLabel}
+            </div>
+        );
+    }
+
+    // Pin the open-time match (see initialKeyRef) to the top, keeping discovery order otherwise.
+    // The match may be appended at any point during the asynchronous scan, so we reorder here at
+    // render time rather than when building the list.
+    const orderedPackages = (() => {
+        const index = packages.findIndex(
+            (pkg) => pkg.key === initialKeyRef.current,
+        );
+        if (index <= 0) return packages;
+        const reordered = [...packages];
+        const [match] = reordered.splice(index, 1);
+        return [match, ...reordered];
+    })();
+
+    return (
+        <div
+            css={css`
+                // The enclosing group hugs the bottom of the dialog page; sit just below the
+                // "copy to all" button.
+                display: flex;
+                flex-direction: column;
+                align-self: stretch;
+            `}
+        >
+            <div
+                css={css`
+                    font-size: 0.8em;
+                    color: ${kMutedTextGray};
+                    margin-bottom: 5px;
+                `}
+            >
+                {props.headerText}
+            </div>
+            <div
+                ref={listRef}
+                style={
+                    listMaxHeight === undefined
+                        ? undefined
+                        : { maxHeight: `${listMaxHeight}px` }
+                }
+                css={css`
+                    display: flex;
+                    flex-direction: column;
+                    gap: 4px;
+                    // Height is capped to three rows (see listMaxHeight) only when there are more
+                    // than three options, so three choices never scroll and a fourth starts the
+                    // scrollbar.
+                    overflow-y: auto;
+                `}
+            >
+                {orderedPackages.map((pkg) => {
+                    const isChosen = pkg.key === currentKey;
+                    return (
+                        <div
+                            key={pkg.key}
+                            onClick={() => handleChoose(pkg)}
+                            css={css`
+                                display: flex;
+                                align-items: center;
+                                cursor: pointer;
+                                padding: 6px 8px;
+                                border-radius: 4px;
+                                // Each option looks like a clickable card: a visible border and
+                                // background that lifts on hover, and a bloom-blue highlight when
+                                // it is the chosen one.
+                                border: 1px solid
+                                    ${isChosen ? kBloomBlue : kBloomBuff};
+                                background-color: ${isChosen
+                                    ? kBloomBlue50Transparent
+                                    : "white"};
+                                transition:
+                                    background-color 0.1s,
+                                    border-color 0.1s;
+                                &:hover {
+                                    border-color: ${kBloomBlue};
+                                    background-color: ${isChosen
+                                        ? kBloomBlue50Transparent
+                                        : "rgba(29, 148, 164, 0.08)"};
+                                }
+                            `}
+                        >
+                            <CheckIcon
+                                css={css`
+                                    color: ${kBloomBlue};
+                                    margin-right: 6px;
+                                    visibility: ${isChosen
+                                        ? "visible"
+                                        : "hidden"};
+                                `}
+                            />
+                            <div
+                                css={css`
+                                    display: flex;
+                                    flex-direction: column;
+                                `}
+                            >
+                                <div>{pkg.summary}</div>
+                                {pkg.secondaryLabel ? (
+                                    <div
+                                        css={css`
+                                            font-size: 0.8em;
+                                            color: ${kMutedTextGray};
+                                        `}
+                                    >
+                                        {pkg.secondaryLabel}
+                                    </div>
+                                ) : (
+                                    pkg.illustrator && (
+                                        <div
+                                            css={css`
+                                                font-size: 0.8em;
+                                                color: ${kMutedTextGray};
+                                            `}
+                                        >
+                                            {illustratorLabel}:{" "}
+                                            {pkg.illustrator}
+                                        </div>
+                                    )
+                                )}
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+};
+
+// Builds a display package from raw metadata, or returns undefined if there's not enough
+// information (no copyright holder and no illustrator) to be worth offering.
+function makePackage(
+    data: ICopyrightAndLicenseData,
+    allRightsReservedLabel: string,
+    customLabel: string,
+    secondaryLabel?: string,
+): IMetadataPackage | undefined {
+    const holder = (data.copyrightInfo.copyrightHolder || "").trim();
+    const year = (data.copyrightInfo.copyrightYear || "").trim();
+    const illustrator = (data.copyrightInfo.imageCreator || "").trim();
+    if (!holder && !illustrator) return undefined;
+
+    const key = computePackageKey(data);
+
+    // The row shows copyright + license on the first line and the illustrator separately,
+    // so the summary here intentionally omits the creator.
+    const license = getLicenseShorthand(
+        data.licenseInfo,
+        allRightsReservedLabel,
+        customLabel,
+    );
+    let copyright = "";
+    if (holder) copyright = year ? `© ${year} ${holder}` : `© ${holder}`;
+    const summary = [copyright, license].filter((s) => !!s).join(" · ");
+
+    return { key, data, summary, illustrator, secondaryLabel };
+}

--- a/src/BloomBrowserUI/bookEdit/copyrightAndLicense/metadataReuseUtils.ts
+++ b/src/BloomBrowserUI/bookEdit/copyrightAndLicense/metadataReuseUtils.ts
@@ -1,0 +1,62 @@
+// Shared helpers for reusing copyright/license/creator metadata: building a stable identity
+// for a metadata set and a short license shorthand. Kept separate from the React components so
+// the MetadataChooser can use them.
+import { ICopyrightAndLicenseData } from "./CopyrightAndLicenseDialog";
+import { ILicenseInfo, LicenseType } from "./LicensePanel";
+
+// A stable identity for a copyright/license combination, used to de-duplicate offered
+// packages and to tell which one matches the dialog's current values. Two metadata sets with
+// the same key are considered the same.
+export function computePackageKey(data: ICopyrightAndLicenseData): string {
+    const cc = data.licenseInfo.creativeCommonsInfo;
+    return JSON.stringify({
+        illustrator: (data.copyrightInfo.imageCreator || "").trim(),
+        year: (data.copyrightInfo.copyrightYear || "").trim(),
+        holder: (data.copyrightInfo.copyrightHolder || "").trim(),
+        licenseType: data.licenseInfo.licenseType,
+        rightsStatement: (data.licenseInfo.rightsStatement || "").trim(),
+        allowCommercial: cc?.allowCommercial,
+        allowDerivatives: cc?.allowDerivatives,
+        intergovernmentalVersion: cc?.intergovernmentalVersion,
+    });
+}
+
+// A plain (non-hook) version of useGetLicenseShorthand from LicenseBadge.tsx, so callers can
+// compute a shorthand without violating the rules of hooks. The labels for the non-CC cases
+// must be passed in (the caller gets them from useL10n).
+export function getLicenseShorthand(
+    licenseInfo: ILicenseInfo,
+    allRightsReservedLabel: string,
+    customLabel: string,
+): string {
+    switch (licenseInfo.licenseType) {
+        case LicenseType.CreativeCommons:
+        case LicenseType.PublicDomain:
+            return getCcToken(licenseInfo).toUpperCase();
+        case LicenseType.Contact:
+            return allRightsReservedLabel;
+        case LicenseType.Custom:
+            return customLabel;
+        default:
+            return "";
+    }
+}
+
+function getCcToken(licenseInfo: ILicenseInfo): string {
+    if (licenseInfo.licenseType === LicenseType.PublicDomain) return "cc0";
+
+    let token = "cc-by-";
+    if (licenseInfo.creativeCommonsInfo.allowCommercial === "no")
+        token += "nc-";
+    switch (licenseInfo.creativeCommonsInfo.allowDerivatives) {
+        case "no":
+            token += "nd";
+            break;
+        case "sharealike":
+            token += "sa";
+            break;
+        case "yes":
+            break;
+    }
+    return token.replace(/-\s*$/, "");
+}

--- a/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
@@ -22,7 +22,6 @@ import { farthest } from "../../utils/elementUtils";
 import { EditableDivUtils } from "./editableDivUtils";
 import { playingBloomGame } from "../toolbox/games/DragActivityTabControl";
 import { kPlaybackOrderContainerClass } from "../toolbox/talkingBook/audioRecording";
-import { showCopyrightAndLicenseDialog } from "../workspaceRoot";
 import { getWorkspaceBundleExports } from "./workspaceFrames";
 import {
     changeImage,
@@ -1155,7 +1154,11 @@ export function SetupMetadataButton(parent: HTMLElement) {
         button.addEventListener("click", () => {
             // Don't do this before it gets clicked; might not be correct at the time we set up the handler.
             const url = img.getAttribute("src");
-            showCopyrightAndLicenseDialog(url ?? "");
+            // Launch via the workspace (top window) bundle, not this page iframe, so that saving
+            // the metadata — which reloads the page iframe — doesn't tear the dialog down.
+            getWorkspaceBundleExports().showCopyrightAndLicenseDialog(
+                url ?? "",
+            );
         });
         theOneLocalizationManager
             .asyncGetText(titleId, title, "tooltip text")

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlRegistry.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlRegistry.ts
@@ -39,7 +39,7 @@ import { default as CopyrightIcon } from "@mui/icons-material/Copyright";
 import { default as DeleteIcon } from "@mui/icons-material/DeleteOutline";
 import { default as SearchIcon } from "@mui/icons-material/Search";
 import { default as VolumeUpIcon } from "@mui/icons-material/VolumeUp";
-import { showCopyrightAndLicenseDialog } from "../../workspaceRoot";
+import { getWorkspaceBundleExports } from "../../js/workspaceFrames";
 import {
     doImageCommand,
     getImageFromCanvasElement,
@@ -481,7 +481,9 @@ export const controlRegistry: Record<TopLevelControlId, IControlDefinition> = {
             }
 
             runtime.closeMenu(true);
-            showCopyrightAndLicenseDialog(
+            // Launch via the workspace (top window) bundle, not this page iframe, so that saving
+            // the metadata — which reloads the page iframe — doesn't tear the dialog down.
+            getWorkspaceBundleExports().showCopyrightAndLicenseDialog(
                 getImageUrlFromImageContainer(imageContainer),
             );
         },

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -1806,6 +1806,29 @@ namespace Bloom.Edit
         }
 #endif
 
+        // Client context and event id used to tell the open Copyright & License dialog that an
+        // "Add this info to all images" operation has finished. These must match the constants
+        // used by the React dialog (CopyrightAndLicenseDialog.tsx).
+        public const string kCopyrightWebSocketContext = "copyrightAndLicense";
+        public const string kCopyrightWebSocketEventId_PushedToAllImages = "pushedToAllImages";
+
+        /// <summary>
+        /// Tell the (still-open) Copyright &amp; License dialog that an "Add this info to all
+        /// images" request has finished, so it can replace its "Working…" spinner with a "done"
+        /// confirmation. The image-metadata POST handler calls this for every such request,
+        /// whether or not the copy actually ran (e.g. the save failed or the image is not a
+        /// normal image), so the dialog never waits forever. We can't signal completion from the
+        /// POST response itself, which returns as soon as the save is initiated, well before the
+        /// asynchronous post-save action runs.
+        /// </summary>
+        public void NotifyCopyrightPushedToAllImages()
+        {
+            _webSocketServer.SendEvent(
+                kCopyrightWebSocketContext,
+                kCopyrightWebSocketEventId_PushedToAllImages
+            );
+        }
+
         public void CopyImageMetadataToWholeBook(Metadata metadata)
         {
             using (var dlg = new ProgressDialogForeground()) //REVIEW: this foreground dialog has known problems in other contexts... it was used here because of its ability to handle exceptions well. TODO: make the background one handle exceptions well

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -608,25 +608,6 @@ namespace Bloom.Edit
             }
         }
 
-        public bool AskUserIfCopyImageMetadataToAllImages()
-        {
-            var answer = MessageBox.Show(
-                LocalizationManager.GetString(
-                    "EditTab.CopyImageIPMetadataQuestion",
-                    "Copy this information to all other images in this book?",
-                    "get this after you edit the metadata of an image"
-                ),
-                LocalizationManager.GetString(
-                    "EditTab.TitleOfCopyIPToWholeBooksDialog",
-                    "Image Intellectual Property Information"
-                ),
-                MessageBoxButtons.YesNo,
-                MessageBoxIcon.Question,
-                MessageBoxDefaultButton.Button2
-            );
-            return answer == DialogResult.Yes;
-        }
-
         public void CopyImageMetadataToAllImages(Metadata metadata)
         {
             {

--- a/src/BloomExe/web/controllers/CopyrightAndLicenseApi.cs
+++ b/src/BloomExe/web/controllers/CopyrightAndLicenseApi.cs
@@ -67,6 +67,9 @@ namespace Bloom.web.controllers
         private void HandleImageMetadataForFile(ApiRequest request)
         {
             var fileName = request.RequiredParam("fileName");
+            // We don't guard fileName against path traversal here. This is a local-only API and we
+            // control both ends, so we don't care about the case where something asks to look at an
+            // image outside of the book folder.
             var path = Model.CurrentBook.FolderPath.CombineForPath(fileName);
             if (!RobustFile.Exists(path))
             {
@@ -192,6 +195,13 @@ namespace Bloom.web.controllers
                         // have not yet committed to a new image, we don't want to save the page
                         // and save the metadata to the current image file, if any.
                         View.ApplyImageMetadataToImageToolbox(metadata);
+                        // The "Add this info to all images" button is also visible in this
+                        // toolbox-launched case. We can't copy to the book's images here (we
+                        // have not committed to an image and deliberately don't save the page),
+                        // but we must still clear the dialog's "Working…" spinner so it doesn't
+                        // hang forever.
+                        if (applyToAllImages)
+                            View.Model.NotifyCopyrightPushedToAllImages();
                         request.PostSucceeded();
                         break;
                     }

--- a/src/BloomExe/web/controllers/CopyrightAndLicenseApi.cs
+++ b/src/BloomExe/web/controllers/CopyrightAndLicenseApi.cs
@@ -5,6 +5,7 @@ using Bloom.Api;
 using Bloom.Book;
 using Bloom.Edit;
 using SIL.Core.ClearShare;
+using SIL.Extensions;
 using SIL.IO;
 using SIL.Reporting;
 using SIL.Windows.Forms.ClearShare;
@@ -34,6 +35,58 @@ namespace Bloom.web.controllers
                 HandleImageCopyrightAndLicense,
                 true
             );
+            // The next two endpoints support the "reuse metadata from another image" chooser.
+            // They are read-only and are driven one image at a time from the front-end so that
+            // gathering can be progressive and can stop when the dialog is closed.
+            apiHandler.RegisterEndpointHandler(
+                "copyrightAndLicense/imageFileNamesInBook",
+                HandleImageFileNamesInBook,
+                false
+            );
+            apiHandler.RegisterEndpointHandler(
+                "copyrightAndLicense/imageMetadataForFile",
+                HandleImageMetadataForFile,
+                false
+            );
+        }
+
+        // Returns the file names of the "real" images in the current book (excluding license,
+        // branding, and placeholder images). The metadata chooser fetches each one's metadata
+        // separately so it can show results as they arrive.
+        private void HandleImageFileNamesInBook(ApiRequest request)
+        {
+            var domBody = Model.CurrentBook.RawDom.DocumentElement.SelectSingleNode("//body");
+            var langs = Model.CurrentBook.GetLanguagePrioritiesForLocalizedTextOnPage();
+            var names = ImageApi.GetCreditableImageFileNamesInBook(domBody, langs);
+            request.ReplyWithJson(names);
+        }
+
+        // Returns the copyright/license metadata for a single image file (by file name) in the
+        // same JSON shape that the dialog's image GET uses. Read-only: unlike
+        // HandleImageCopyrightAndLicense, this does not prepare the image for editing.
+        private void HandleImageMetadataForFile(ApiRequest request)
+        {
+            var fileName = request.RequiredParam("fileName");
+            var path = Model.CurrentBook.FolderPath.CombineForPath(fileName);
+            if (!RobustFile.Exists(path))
+            {
+                request.ReplyWithJson(String.Empty);
+                return;
+            }
+            try
+            {
+                var metadata = RobustFileIO.MetadataFromFile(path);
+                request.ReplyWithJson(GetJsonFromMetadata(metadata, forBook: false));
+            }
+            catch (Exception e)
+            {
+                // A corrupt or unreadable image must not break gathering. Log it and reply with
+                // empty so the chooser simply skips this image instead of surfacing an error.
+                Logger.WriteEvent(
+                    $"MetadataChooser: could not read metadata for image '{fileName}': {e.Message}"
+                );
+                request.ReplyWithJson(String.Empty);
+            }
         }
 
         private void HandleGetCCImage(ApiRequest request)
@@ -128,31 +181,68 @@ namespace Bloom.web.controllers
                     break;
                 case HttpMethods.Post:
                     metadata = GetMetadataFromJson(request, forBook: false);
+                    // The dialog's "Copy to all other images in the book" button sets this.
+                    // (We no longer pop up a question asking whether to copy to all images.)
+                    bool applyToAllImages = request.GetParamOrNull("applyToAllImages") == "true";
+                    if (View.MetadataEditIsFromImageToolbox)
+                    {
+                        // Invoke the palaso image toolbox's save callback directly so that the
+                        // toolbox UI immediately shows the new copyright/license information.
+                        // However, since we launched this dialog from the image chooser, and
+                        // have not yet committed to a new image, we don't want to save the page
+                        // and save the metadata to the current image file, if any.
+                        View.ApplyImageMetadataToImageToolbox(metadata);
+                        request.PostSucceeded();
+                        break;
+                    }
+
                     View.Model.SaveThen(
                         () =>
                         { // Saved DOM must be up to date with possibly new imageUrl
-                            bool wasNormalSuccessfulSave = View.SaveImageMetadata(metadata);
-                            bool isNormalImageType =
-                                View.FileNameOfImageBeingModified != null
-                                && ImageUpdater.IsNormalImagePath(
-                                    View.FileNameOfImageBeingModified
-                                );
-                            bool shouldAskUserIfCopyMetadataToAllImages =
-                                wasNormalSuccessfulSave && isNormalImageType;
-                            bool copyMetadataToAllImages = shouldAskUserIfCopyMetadataToAllImages
-                                ? View.AskUserIfCopyImageMetadataToAllImages()
-                                : false;
-                            if (copyMetadataToAllImages)
+                            try
                             {
-                                View.CopyImageMetadataToAllImages(metadata);
+                                bool wasNormalSuccessfulSave = View.SaveImageMetadata(metadata);
+                                // The filename can be null if coming in from the libpalaso toolbox callback,
+                                // in which case wasNormalSuccessfulSave will be false anyway.
+                                bool isNormalImageType =
+                                    View.FileNameOfImageBeingModified != null
+                                    && ImageUpdater.IsNormalImagePath(
+                                        View.FileNameOfImageBeingModified
+                                    );
+                                if (
+                                    applyToAllImages
+                                    && wasNormalSuccessfulSave
+                                    && isNormalImageType
+                                )
+                                {
+                                    // Copies the metadata to every image (runs synchronously).
+                                    View.CopyImageMetadataToAllImages(metadata);
+                                }
+                                else if (wasNormalSuccessfulSave)
+                                {
+                                    View.UpdateMetadataForCurrentImage(); // Need to get things up to date on the current page.
+                                }
                             }
-                            else if (wasNormalSuccessfulSave)
+                            finally
                             {
-                                View.UpdateMetadataForCurrentImage(); // Need to get things up to date on the current page.
+                                // Always tell the (still-open) dialog that the "Add this info to
+                                // all images" request has finished, so it can replace its
+                                // "Working…" spinner with a "done" confirmation. We must do this
+                                // even when the copy didn't actually run (save failed, non-normal
+                                // image, or an error above) so the spinner never hangs forever.
+                                if (applyToAllImages)
+                                    View.Model.NotifyCopyrightPushedToAllImages();
                             }
                             return View.Model.CurrentPage.Id;
                         },
-                        () => { } // wrong state, do nothing
+                        () =>
+                        {
+                            // We weren't in a state to save, so nothing happened; still clear the
+                            // dialog's "Working…" spinner if it is waiting on an "Add this info to
+                            // all images" request.
+                            if (applyToAllImages)
+                                View.Model.NotifyCopyrightPushedToAllImages();
+                        }
                     );
 
                     request.PostSucceeded();

--- a/src/BloomExe/web/controllers/ImageApi.cs
+++ b/src/BloomExe/web/controllers/ImageApi.cs
@@ -23,16 +23,18 @@ namespace Bloom.web.controllers
     public class ImageApi
     {
         private readonly BookSelection _bookSelection;
-        private readonly string[] _doNotPasteArray;
+        private readonly string[] _nonCreditableImages;
 
         public ImageApi(BookSelection bookSelection)
         {
             _bookSelection = bookSelection;
             // The following is a list of image files that we don't want to generate image credits for.
             // It includes CC license image, placeholder and branding images.
-            _doNotPasteArray = GetImageFilesToNotCreditFor().ToArray();
-            for (int i = 0; i < _doNotPasteArray.Length; ++i)
-                _doNotPasteArray[i] = BookStorage.GetNormalizedPathForOS(_doNotPasteArray[i]);
+            _nonCreditableImages = GetImageFilesToNotCreditFor().ToArray();
+            for (int i = 0; i < _nonCreditableImages.Length; ++i)
+                _nonCreditableImages[i] = BookStorage.GetNormalizedPathForOS(
+                    _nonCreditableImages[i]
+                );
         }
 
         private static IEnumerable<string> GetImageFilesToNotCreditFor()
@@ -86,7 +88,7 @@ namespace Bloom.web.controllers
             var result = new Dictionary<string, List<string>>();
             result.AddRange(
                 GetWhichImagesAreUsedOnWhichPages(domBody, langs)
-                    .Where(kvp => !DoNotPasteCreditsImages(kvp.Key))
+                    .Where(kvp => !IsNonCreditableImage(kvp.Key))
             );
             return result;
         }
@@ -328,16 +330,16 @@ namespace Bloom.web.controllers
         }
 
         /// <summary>
-        /// Determine whether or not a particular image should have its credits pasted.
+        /// Determine whether or not a particular image is one we never generate credits for.
         /// </summary>
         /// <param name="name"></param>
         /// <returns></returns>
-        private bool DoNotPasteCreditsImages(string name)
+        private bool IsNonCreditableImage(string name)
         {
-            // returns 'true' if 'name' is among the list of ones we don't want to paste image credits for
+            // returns 'true' if 'name' is among the list of ones we don't want to generate image credits for
             // includes CC license image, placeholder and branding images
             var normalName = BookStorage.GetNormalizedPathForOS(name);
-            return _doNotPasteArray.Contains(normalName)
+            return _nonCreditableImages.Contains(normalName)
                 || name.ToLowerInvariant().StartsWith("placeholder");
         }
 

--- a/src/BloomExe/web/controllers/ImageApi.cs
+++ b/src/BloomExe/web/controllers/ImageApi.cs
@@ -91,6 +91,29 @@ namespace Bloom.web.controllers
             return result;
         }
 
+        /// <summary>
+        /// Returns the file names of the "real" images used in the book (in order of first
+        /// occurrence), excluding the license, branding, and placeholder images that we never
+        /// want to attribute credits to. This is a static counterpart to
+        /// GetFilteredImageNameToPagesDictionary so that other controllers (e.g. the copyright
+        /// and license dialog's metadata chooser) can get the list without an ImageApi instance.
+        /// </summary>
+        public static List<string> GetCreditableImageFileNamesInBook(
+            SafeXmlNode domBody,
+            IEnumerable<string> langs
+        )
+        {
+            var doNotPaste = new HashSet<string>(
+                GetImageFilesToNotPasteCreditsFor().Select(BookStorage.GetNormalizedPathForOS)
+            );
+            return GetWhichImagesAreUsedOnWhichPages(domBody, langs)
+                .Keys.Where(name =>
+                    !doNotPaste.Contains(BookStorage.GetNormalizedPathForOS(name))
+                    && !name.ToLowerInvariant().StartsWith("placeholder")
+                )
+                .ToList();
+        }
+
         private void HandleCopyImageCreditsForWholeBook(ApiRequest request)
         {
             // This method is called on a fileserver thread. To minimize the chance that the current selection somehow

--- a/src/BloomExe/web/controllers/ImageApi.cs
+++ b/src/BloomExe/web/controllers/ImageApi.cs
@@ -28,14 +28,14 @@ namespace Bloom.web.controllers
         public ImageApi(BookSelection bookSelection)
         {
             _bookSelection = bookSelection;
-            // The following is a list of image files that we don't want to paste image credits for.
+            // The following is a list of image files that we don't want to generate image credits for.
             // It includes CC license image, placeholder and branding images.
-            _doNotPasteArray = GetImageFilesToNotPasteCreditsFor().ToArray();
+            _doNotPasteArray = GetImageFilesToNotCreditFor().ToArray();
             for (int i = 0; i < _doNotPasteArray.Length; ++i)
                 _doNotPasteArray[i] = BookStorage.GetNormalizedPathForOS(_doNotPasteArray[i]);
         }
 
-        private static IEnumerable<string> GetImageFilesToNotPasteCreditsFor()
+        private static IEnumerable<string> GetImageFilesToNotCreditFor()
         {
             // Handles all except placeholder images. They can show up with digits after them, so we do them differently.
             var imageFiles = new HashSet<string> { "license.png" };
@@ -103,12 +103,12 @@ namespace Bloom.web.controllers
             IEnumerable<string> langs
         )
         {
-            var doNotPaste = new HashSet<string>(
-                GetImageFilesToNotPasteCreditsFor().Select(BookStorage.GetNormalizedPathForOS)
+            var nonCreditableImages = new HashSet<string>(
+                GetImageFilesToNotCreditFor().Select(BookStorage.GetNormalizedPathForOS)
             );
             return GetWhichImagesAreUsedOnWhichPages(domBody, langs)
                 .Keys.Where(name =>
-                    !doNotPaste.Contains(BookStorage.GetNormalizedPathForOS(name))
+                    !nonCreditableImages.Contains(BookStorage.GetNormalizedPathForOS(name))
                     && !name.ToLowerInvariant().StartsWith("placeholder")
                 )
                 .ToList();

--- a/src/BloomTests/web/controllers/ImageApiTests.cs
+++ b/src/BloomTests/web/controllers/ImageApiTests.cs
@@ -390,6 +390,89 @@ namespace BloomTests.web.controllers
         }
 
         [Test]
+        public void GetCreditableImageFileNamesInBook_FiltersAndOrders()
+        {
+            const string xhtml =
+                @"
+<body>
+	<div class='bloom-page bloom-frontMatter cover' data-page-number=''>
+		<div data-after-content='' class='pageLabel' lang='en'>
+			Front Cover
+		</div >
+		<div class='marginBox'>
+			<div class='bloom-canvas bloom-background-image-in-style-attr' style='background-image:url(""AOR_aa013m.png"")'/>
+		</div>
+	</div>
+	<div class='bloom-page bloom-frontMatter' data-page-number=''>
+		<div data-after-content='' class='pageLabel' lang='en'>
+			Credits Page
+		</div >
+		<div class='marginBox'>
+			<div class='bloom-metaData licenseAndCopyrightBlock' lang='en'>
+				<div class='licenseBlock'>
+					<img class='licenseImage' src='license.png'/>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class='bloom-page numberedPage' lang='' data-page-number='1'>
+		<div class='marginBox'>
+			<div class='bloom-canvas'>
+				<img data-license='cc-by' src='The%20Moon%20and%20The%20Cap_Page%20041.jpg'/>
+			</div>
+			<div class='bloom-canvas'>
+				<img src='placeHolder.png'/>
+			</div>
+		</div>
+	</div>
+	<div class='bloom-page numberedPage' lang='' data-page-number='2'>
+		<div class='marginBox'>
+			<div class='bloom-canvas'>
+				<img data-license='cc-by-nd' src='AOR_EAG00864.png'/>
+			</div>
+			<!-- repeat of an earlier image should not appear twice -->
+			<div class='bloom-canvas'>
+				<img data-license='cc-by' src='The%20Moon%20and%20The%20Cap_Page%20041.jpg'/>
+			</div>
+		</div>
+	</div>
+</body>";
+
+            var dom = SafeXmlDocument.Create();
+            dom.LoadXml(xhtml);
+            // Sanity check: the raw (unfiltered) list still includes the images we expect to be filtered.
+            var unfiltered = ImageApi.GetWhichImagesAreUsedOnWhichPages(
+                dom.SelectSingleNode("//body"),
+                new[] { "en" }
+            );
+            Assert.IsTrue(
+                unfiltered.ContainsKey("license.png"),
+                "Setup check: license.png should be in the unfiltered list"
+            );
+            Assert.IsTrue(
+                unfiltered.ContainsKey("placeHolder.png"),
+                "Setup check: placeHolder.png should be in the unfiltered list"
+            );
+
+            var names = ImageApi.GetCreditableImageFileNamesInBook(
+                dom.SelectSingleNode("//body"),
+                new[] { "en" }
+            );
+
+            Assert.AreEqual(
+                new List<string>
+                {
+                    "AOR_aa013m.png",
+                    "The Moon and The Cap_Page 041.jpg",
+                    "AOR_EAG00864.png",
+                },
+                names,
+                "Should return creditable images once each, in order of first occurrence, "
+                    + "with license and placeholder images filtered out"
+            );
+        }
+
+        [Test]
         public void CollectFormattedCredits_SingleCredit_Works()
         {
             _creditsToFormat.Add("my credit", new List<string> { "Front Cover", "2" });


### PR DESCRIPTION
## What this does
Adds tools to the Copyright & License dialog for reusing metadata from other images (pull), and causing all other images to get the same metadata as the current image (push).

<img width="311" height=auto alt="image" src="https://github.com/user-attachments/assets/8e6b85d1-851a-411a-8dee-e738734e714f" />

- **Adds Metadata "Shortcuts" chooser** — gathers copyright/license metadata from the other images in the book (plus the book's own copyright/license) so the user can apply an existing set with one click instead of retyping. Gathering is progressive (one image at a time) and stops when the dialog closes. The set matching the image's current metadata is shown checked and pinned to the top of the list.
- **"Add this info to all images in this book" button** — replaces the old WinForms yes/no "copy to all images?" MessageBox. The dialog stays open and shows a *Working…* spinner, then a *Done* confirmation driven by a websocket event when the copy actually finishes.
- **Launch the dialog via the workspace (top window) bundle** rather than the page iframe, so saving the metadata (which reloads the page iframe) no longer tears the dialog down.

The reuse chooser is offered **only when editing image metadata**, not for the book's own copyright/license.

## Backend

New read-only endpoints to list the book's creditable image file names and to read a single image's metadata, plus a static `ImageApi.GetCreditableImageFileNamesInBook` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/7983)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7983)
<!-- Reviewable:end -->
