### PR TITLE
Optimize page thumbnail loading  (BL-16336)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -2008,24 +2008,24 @@
         <note>ID: EditTab.Image.Reset</note>
         <note>Removes cropping from image</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.Background" translate="no">
-        <source xml:lang="en">Background</source>
-        <note>ID: EditTab.Image.Background</note>
+      <trans-unit id="EditTab.Image.Transparency" translate="no">
+        <source xml:lang="en">Transparency</source>
+        <note>ID: EditTab.Image.Transparency</note>
         <note>Submenu for controlling whether the image background is made transparent</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.Background.Auto" translate="no">
+      <trans-unit id="EditTab.Image.Transparency.Auto" translate="no">
         <source xml:lang="en">Auto</source>
-        <note>ID: EditTab.Image.Background.Auto</note>
+        <note>ID: EditTab.Image.Transparency.Auto</note>
         <note>Image background transparency is automatic: transparent when the image looks like line art</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.Background.Transparent" translate="no">
+      <trans-unit id="EditTab.Image.Transparency.Transparent" translate="no">
         <source xml:lang="en">Transparent</source>
-        <note>ID: EditTab.Image.Background.Transparent</note>
+        <note>ID: EditTab.Image.Transparency.Transparent</note>
         <note>Always make the image background transparent regardless of its content</note>
       </trans-unit>
-      <trans-unit id="EditTab.Image.Background.Opaque" translate="no">
+      <trans-unit id="EditTab.Image.Transparency.Opaque" translate="no">
         <source xml:lang="en">Opaque</source>
-        <note>ID: EditTab.Image.Background.Opaque</note>
+        <note>ID: EditTab.Image.Transparency.Opaque</note>
         <note>Never make the image background transparent</note>
       </trans-unit>
       <trans-unit id="EditTab.Image.TooLarge" sil:dynamic="true">

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlRegistry.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlRegistry.ts
@@ -700,8 +700,8 @@ export const controlRegistry: Record<TopLevelControlId, IControlDefinition> = {
     imageBackground: {
         kind: "command",
         id: "imageBackground",
-        l10nId: "EditTab.Image.Background",
-        englishLabel: "Background",
+        l10nId: "EditTab.Image.Transparency",
+        englishLabel: "Transparency",
         action: () => {},
         menu: {
             buildMenuItem: (ctx, _runtime) => {
@@ -727,12 +727,12 @@ export const controlRegistry: Record<TopLevelControlId, IControlDefinition> = {
 
                 return {
                     id: "imageBackground",
-                    l10nId: "EditTab.Image.Background",
-                    englishLabel: "Background",
+                    l10nId: "EditTab.Image.Transparency",
+                    englishLabel: "Transparency",
                     onSelect: () => {},
                     subMenuItems: [
                         {
-                            l10nId: "EditTab.Image.Background.Auto",
+                            l10nId: "EditTab.Image.Transparency.Auto",
                             englishLabel: "Auto",
                             icon: isAuto
                                 ? React.createElement(CheckIcon, null)
@@ -747,7 +747,7 @@ export const controlRegistry: Record<TopLevelControlId, IControlDefinition> = {
                             },
                         },
                         {
-                            l10nId: "EditTab.Image.Background.Transparent",
+                            l10nId: "EditTab.Image.Transparency.Transparent",
                             englishLabel: "Transparent",
                             icon: isTransparent
                                 ? React.createElement(CheckIcon, null)
@@ -760,7 +760,7 @@ export const controlRegistry: Record<TopLevelControlId, IControlDefinition> = {
                             },
                         },
                         {
-                            l10nId: "EditTab.Image.Background.Opaque",
+                            l10nId: "EditTab.Image.Transparency.Opaque",
                             englishLabel: "Opaque",
                             icon: isOpaque
                                 ? React.createElement(CheckIcon, null)

--- a/src/BloomExe/ImageProcessing/RuntimeImageProcessor.cs
+++ b/src/BloomExe/ImageProcessing/RuntimeImageProcessor.cs
@@ -133,6 +133,9 @@ namespace Bloom.ImageProcessing
             if (_imageFilesToReturnUnprocessed.TryGetValue(cacheFileName, out test))
                 return originalPath;
 
+            if (getThumbnail)
+                return GetPathToThumbnail(originalPath, cacheFileName, transparencyMode);
+
             lock (this)
             {
                 // if there is a cached version, return it
@@ -158,57 +161,12 @@ namespace Bloom.ImageProcessing
                     _originalPathToProcessedVersionPath.TryRemove(cacheFileName, out valueRemoved);
                 }
 
-                // No cached version — try to make one.
-                string processedPath;
-                if (getThumbnail)
-                {
-                    // BL-1112: images not loading in page thumbnails
-                    // The HTML div that contains the thumbnails is 80 pixels wide, so make the thumbnails 80 pixels wide
-                    var pathToProcessedImage = Path.Combine(
-                        _cacheFolder,
-                        Path.GetRandomFileName() + Path.GetExtension(originalPath)
-                    );
-                    if (!Directory.Exists(Path.GetDirectoryName(pathToProcessedImage)))
-                        Directory.CreateDirectory(Path.GetDirectoryName(pathToProcessedImage));
-                    if (!GenerateThumbnail(originalPath, pathToProcessedImage, 80))
-                    {
-                        processedPath = null;
-                    }
-                    else
-                    {
-                        if (
-                            transparencyMode != ImageTransparencyMode.None
-                            && ImageUtils.IsPngFile(pathToProcessedImage)
-                        )
-                        {
-                            // Apply transparency to the PNG thumbnail in-place.
-                            // Force: always apply; Auto: apply only if line art.
-                            using var tempFile = TempFile.WithExtension(".png");
-                            var applied =
-                                transparencyMode == ImageTransparencyMode.Force
-                                    ? ImageUtils.MakeTransparentBackground(
-                                        pathToProcessedImage,
-                                        tempFile.Path
-                                    )
-                                    : ImageUtils.MakeTransparentBackgroundIfNeeded(
-                                        pathToProcessedImage,
-                                        tempFile.Path
-                                    );
-                            if (applied)
-                                RobustFile.Copy(tempFile.Path, pathToProcessedImage, true);
-                        }
-                        processedPath = pathToProcessedImage;
-                    }
-                }
-                else
-                {
-                    processedPath = ImageUtils.AdjustImageForDisplay(
-                        originalPath,
-                        _cacheFolder,
-                        transparencyMode,
-                        transparencyOnly: transparencyOnly
-                    );
-                }
+                var processedPath = ImageUtils.AdjustImageForDisplay(
+                    originalPath,
+                    _cacheFolder,
+                    transparencyMode,
+                    transparencyOnly: transparencyOnly
+                );
 
                 if (processedPath == null)
                 {
@@ -217,40 +175,104 @@ namespace Bloom.ImageProcessing
                 }
 
                 _originalPathToProcessedVersionPath.TryAdd(cacheFileName, processedPath); //remember it so we can reuse if they show it again, and later delete
-
                 return processedPath;
             }
         }
 
-        // Overload of the below method that defaults to NOT changing the background color of the thumb.
+        /// <summary>
+        /// Returns the path to an 80-pixel-wide thumbnail, generating it if not cached.
+        /// GenerateThumbnail runs OUTSIDE the global lock so different images can be processed
+        /// concurrently. If two threads race for the same image the loser discards its file.
+        /// </summary>
+        private string GetPathToThumbnail(
+            string originalPath,
+            string cacheFileName,
+            ImageTransparencyMode transparencyMode
+        )
+        {
+            // Step 1: quick cache check under lock
+            lock (this)
+            {
+                if (
+                    _originalPathToProcessedVersionPath.TryGetValue(cacheFileName, out var cached)
+                    && RobustFile.Exists(cached)
+                    && new FileInfo(originalPath).LastWriteTimeUtc
+                        <= new FileInfo(cached).LastWriteTimeUtc
+                )
+                {
+                    return cached;
+                }
+                // stale or missing — remove so the store step can write the fresh version
+                _originalPathToProcessedVersionPath.TryRemove(cacheFileName, out _);
+            }
+
+            // Step 2: generate thumbnail OUTSIDE the lock — different images run concurrently.
+            // BL-1112: page thumbnail div is 80px wide, so resize to 80px.
+            // Always use .png so the thumbnail file can carry an alpha channel; JPEG cannot.
+            // ApplyBloomTransparencyToFile (called below) also requires a .png path.
+            var pathToProcessedImage = Path.Combine(
+                _cacheFolder,
+                Path.GetRandomFileName() + ".png"
+            );
+            if (!Directory.Exists(Path.GetDirectoryName(pathToProcessedImage)))
+                Directory.CreateDirectory(Path.GetDirectoryName(pathToProcessedImage));
+
+            if (!GenerateThumbnail(originalPath, pathToProcessedImage, 80))
+            {
+                _imageFilesToReturnUnprocessed.TryAdd(cacheFileName, true);
+                return originalPath;
+            }
+
+            if (transparencyMode != ImageTransparencyMode.None)
+            {
+                // Apply transparency to the PNG thumbnail in-place.
+                // Force: always apply; Auto: apply only if line art.
+                using var tempFile = TempFile.WithExtension(".png");
+                var applied =
+                    transparencyMode == ImageTransparencyMode.Force
+                        ? ImageUtils.MakeTransparentBackground(pathToProcessedImage, tempFile.Path)
+                        : ImageUtils.MakeTransparentBackgroundIfNeeded(
+                            pathToProcessedImage,
+                            tempFile.Path
+                        );
+                if (applied)
+                    RobustFile.Copy(tempFile.Path, pathToProcessedImage, true);
+            }
+
+            // Step 3: store under lock, discarding our file if another thread got there first.
+            lock (this)
+            {
+                if (
+                    _originalPathToProcessedVersionPath.TryGetValue(cacheFileName, out var winner)
+                    && RobustFile.Exists(winner)
+                )
+                {
+                    RobustFile.Delete(pathToProcessedImage);
+                    return winner;
+                }
+                _originalPathToProcessedVersionPath.TryAdd(cacheFileName, pathToProcessedImage);
+                return pathToProcessedImage;
+            }
+        }
+
+        /// <summary>
+        /// Resize the image at <paramref name="originalPath"/> to at most <paramref name="newWidth"/>
+        /// pixels wide, preserving aspect ratio, and save the result to
+        /// <paramref name="pathToProcessedImage"/>. Transparency handling is left to the caller.
+        /// </summary>
+        /// <returns>false if the image is already no wider than <paramref name="newWidth"/> (no file written).</returns>
         public static bool GenerateThumbnail(
             string originalPath,
             string pathToProcessedImage,
             int newWidth
         )
         {
-            return GenerateThumbnail(originalPath, pathToProcessedImage, newWidth, Color.Empty);
-        }
-
-        // Make a thumbnail of the input image. newWidth and newHeight are both limits; the image will not
-        // be larger than original, but if necessary will be shrunk to fit within the indicated rectangle.
-        // If parameter 'backColor' is not Empty, we fill the background of the thumbnail with that color.
-        public static bool GenerateThumbnail(
-            string originalPath,
-            string pathToProcessedImage,
-            int newWidth,
-            Color backColor
-        )
-        {
             using (var originalImage = PalasoImage.FromFileRobustly(originalPath))
             {
-                // check if it needs resized
                 if (originalImage.Image.Width <= newWidth)
                     return false;
 
-                // calculate dimensions
-                var newW =
-                    (originalImage.Image.Width > newWidth) ? newWidth : originalImage.Image.Width;
+                var newW = newWidth;
                 // allow for proper rounding from the division
                 var newH =
                     (newW * originalImage.Image.Height + (originalImage.Image.Width / 2))
@@ -259,32 +281,12 @@ namespace Bloom.ImageProcessing
                 using (var thumbnail = new Bitmap(newW, newH))
                 using (var g = Graphics.FromImage(thumbnail))
                 {
-                    if (backColor != Color.Empty)
-                    {
-                        using (var brush = new SolidBrush(backColor))
-                        {
-                            g.FillRectangle(brush, new Rectangle(0, 0, newW, newH));
-                        }
-                    }
-                    Image imageToDraw = originalImage.Image;
-                    bool makeTransparentImage = ImageUtils.ShouldMakeBackgroundTransparent(
-                        originalImage
-                    );
-                    if (makeTransparentImage)
-                    {
-                        imageToDraw = MakePngBackgroundTransparent(originalImage);
-                    }
-                    var destRect = new Rectangle(0, 0, newW, newH);
-                    // Note the image size may change when the background is made transparent.
-                    // See https://silbloom.myjetbrains.com/youtrack/issue/BL-5632.
                     g.DrawImage(
-                        imageToDraw,
-                        destRect,
-                        new Rectangle(0, 0, imageToDraw.Width, imageToDraw.Height),
+                        originalImage.Image,
+                        new Rectangle(0, 0, newW, newH),
+                        new Rectangle(0, 0, originalImage.Image.Width, originalImage.Image.Height),
                         GraphicsUnit.Pixel
                     );
-                    if (makeTransparentImage)
-                        imageToDraw.Dispose();
                     RobustImageIO.SaveImage(thumbnail, pathToProcessedImage);
                 }
             }
@@ -516,8 +518,6 @@ namespace Bloom.ImageProcessing
             var pixels = new byte[stride * height];
             Marshal.Copy(srcData.Scan0, pixels, 0, pixels.Length);
             source.UnlockBits(srcData);
-            var totalStopwatch = Stopwatch.StartNew();
-
             // 1. Find the lightest color in the image (max R+G+B sum)
             int maxR = 0,
                 maxG = 0,
@@ -541,10 +541,6 @@ namespace Bloom.ImageProcessing
                     }
                 }
             }
-            var phase1Elapsed = totalStopwatch.Elapsed;
-            Debug.WriteLine(
-                $"RuntimeImageProcessor.RemoveWhiteBackground {width}x{height} phase1={phase1Elapsed.TotalMilliseconds:0.###}ms"
-            );
 
             // 2. Build brightness thresholds for a transparency ramp.
             // t0: pixels at/above this brightness become fully transparent.
@@ -569,10 +565,6 @@ namespace Bloom.ImageProcessing
             var opaqueBrightnessThreshold = Math.Max(
                 kMinOpaqueBrightnessThreshold,
                 Math.Min(kOpaqueBrightnessThreshold, transparentBrightnessThreshold - kMinRampWidth)
-            );
-            var phase2Elapsed = totalStopwatch.Elapsed;
-            Debug.WriteLine(
-                $"RuntimeImageProcessor.RemoveWhiteBackground {width}x{height} phase2={(phase2Elapsed - phase1Elapsed).TotalMilliseconds:0.###}ms bg={detectedBackgroundBrightness:0.###} t0={transparentBrightnessThreshold:0.###} t1={opaqueBrightnessThreshold:0.###}"
             );
 
             // 3. For each pixel, set alpha from perceptual brightness using t0/t1 ramp.
@@ -608,15 +600,8 @@ namespace Bloom.ImageProcessing
                     // Keep RGB as-is to preserve color intensity (e.g. pure red stays red).
                 }
             }
-            var phase3Elapsed = totalStopwatch.Elapsed;
-            Debug.WriteLine(
-                $"RuntimeImageProcessor.RemoveWhiteBackground {width}x{height} phase3={(phase3Elapsed - phase2Elapsed).TotalMilliseconds:0.###}ms"
-            );
             Marshal.Copy(pixels, 0, dstData.Scan0, pixels.Length);
             result.UnlockBits(dstData);
-            Debug.WriteLine(
-                $"RuntimeImageProcessor.RemoveWhiteBackground {width}x{height} total={totalStopwatch.Elapsed.TotalMilliseconds:0.###}ms"
-            );
             return result;
         }
 

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -1100,12 +1100,15 @@ namespace Bloom.Api
                     transparentParam == "force" ? ImageTransparencyMode.Force
                     : transparentParam == "yes" ? ImageTransparencyMode.Auto
                     : ImageTransparencyMode.None;
+
                 imageFile = _cache.GetPathToAdjustedImage(imageFile, thumb, transparencyMode);
 
-                if (String.IsNullOrEmpty(imageFile))
+                if (string.IsNullOrEmpty(imageFile))
                     return false;
             }
 
+            // File served without image processing: either an SVG, a Bloom UI file (BL-2368),
+            // or processImage was false because the file was found in bloomRoot (not the book folder).
             info.ReplyWithImage(imageFile, originalImageFile);
             return true;
         }

--- a/src/BloomExe/web/PageListApi.cs
+++ b/src/BloomExe/web/PageListApi.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Dynamic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -260,9 +259,6 @@ namespace Bloom.web
         ///   book-id - optional book id. If not given, uses the collections "current" book.
         public void HandlePagesRequest(ApiRequest request)
         {
-            //var watch = new Stopwatch();
-            //watch.Start();
-
             var book = _collectionModel.GetRequestedBookOrDefaultOrNull(
                 request.GetParamOrNull("book-id")
             );
@@ -285,8 +281,6 @@ namespace Bloom.web
             answer.selectedPageId = isCurrentBook && SelectedPage != null ? SelectedPage.Id : "";
             answer.pageLayout = book?.GetLayout()?.SizeAndOrientation?.ClassName ?? "A5Portrait";
             request.ReplyWithJson(answer);
-            //watch.Stop();
-            //Debug.WriteLine($"Generating JSON for thumbnails took {watch.ElapsedMilliseconds}ms");
         }
 
         // Requests the content that should be displayed in a single page thumbnail.
@@ -295,8 +289,6 @@ namespace Bloom.web
         //    book-id - the book ID (optional)
         public void HandlePageContentRequest(ApiRequest request)
         {
-            var watch = new Stopwatch();
-            watch.Start();
             var id = request.RequiredParam("page-id");
             var book = _collectionModel.GetRequestedBookOrDefaultOrNull(
                 request.GetParamOrNull("book-id")
@@ -316,7 +308,6 @@ namespace Bloom.web
             dynamic answer = new ExpandoObject();
             answer.content = GetPageContentForThumbnail(page);
             request.ReplyWithJson(answer);
-            watch.Stop();
         }
 
         private static string GetPageContentForThumbnail(IPage page)
@@ -334,6 +325,7 @@ namespace Bloom.web
             }
 
             MarkImageNodesForThumbnail(pageElement);
+
             var pageNeedsTransparent = HtmlDom.PageNeedsTransparentImages(pageElement);
             foreach (
                 SafeXmlElement img in pageElement
@@ -353,6 +345,7 @@ namespace Bloom.web
                     img.SetAttribute("src", HtmlDom.GetSrcWithTransparencyParam(src, paramValue));
                 }
             }
+
             // For WebView2, this prevents any interaction with elements in the page thumbnail.
             // We put an overlay over it to try to prevent such interaction, but this is more
             // reliable. Nothing in the page will ever get focus, be tabbed to, be read by
@@ -391,11 +384,12 @@ namespace Bloom.web
                             // gets interpreted as part of the filename.
                             url = filename + query.NotEncoded + "&thumbnail=1";
                         }
-                        // It's not strictly true that url here is unencoded. In fact it contains a file path that IS
-                        // encoded. But also a query that isn't. So we need to treat it as unencoded.
+                        // filename is already URL-encoded; we must NOT re-encode the whole string or ? becomes
+                        // %3f and lands in the path, making the thumbnail param invisible to GetQueryParameters().
                         HtmlDom.SetImageElementUrl(
                             imgNode,
-                            UrlPathString.CreateFromUnencodedString(url)
+                            UrlPathString.CreateFromUnencodedString(url),
+                            urlEncode: false
                         );
                     }
                 }


### PR DESCRIPTION
Several related improvements to page thumbnail serving and other aspects of line art handling:

1. RuntimeImageProcessor: Extract thumbnail generation into GetPathToThumbnail(),
   which runs *outside* the global lock so different images can be processed
   concurrently. Always write thumbnails as .png (not inheriting the source
   extension) so the file can carry an alpha channel and so
   ApplyBloomTransparencyToFile (which requires a .png path) always applies.
   Simplify GenerateThumbnail to pure resize; remove the backColor overload and
   the in-thumbnail transparency pass (transparency is now applied by the caller
   via MakeTransparentBackground). Remove timing Debug.WriteLines.

2. PageListApi: Fix URL encoding in MarkImageNodesForThumbnail: pass
   urlEncode: false to SetImageElementUrl so the already-encoded filename is not
   double-encoded (which turned '?' into '%3f', hiding the thumbnail= query param
   from GetQueryParameters). Also remove leftover Stopwatch instrumentation.

3. BloomServer: Minor cleanup — use lowercase 'string', add a comment explaining
   why we reach ReplyWithImage without entering the image-processing block.

4. Background menu item renamed to 'Transparency'

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/7984)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7984)
<!-- Reviewable:end -->
