### PR TITLE
Fix low-contrast dashed targets & elements in game themes (BL-16323)

### DIFF
--- a/.github/skills/game-theme-preview/SKILL.md
+++ b/.github/skills/game-theme-preview/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: game-theme-preview
+description: 'Audit and fix WCAG color contrast in Bloom game themes. Generates a scrollable HTML preview showing every element of every theme in its real colors with low-contrast pairs flagged, then drives an AI-curated, human-approved fix loop. Use when adding or editing a game theme in gamesThemes.less, when a game element (dashed target, draggable, button, checkbox) is hard to see, or when a tester wants to eyeball all themes at once.'
+argument-hint: 'optional: a specific theme name or a color pair to check'
+user-invocable: true
+---
+
+# Game Theme Preview & Contrast Fix
+
+## Outcome
+Every part of every Bloom game theme is verifiable at a glance - each element rendered in
+its resolved colors with a WCAG ratio under it - and every low-contrast spot gets an
+**AI-curated, palette-aware fix** that the human approves element-by-element in the page
+itself. The agent then applies the approved colors and re-verifies. Also: a one-shot CLI
+to check the contrast of any two colors.
+
+## When To Use
+- You changed colors in `src/content/templates/template books/Games/gamesThemes.less`.
+- Someone reports a game element (dashed drop target, draggable, button, checkbox) is
+  hard to see against the background.
+- A tester wants to scroll through all themes and confirm they look good.
+- You need the WCAG contrast ratio between two colors.
+
+## The canonical loop (do it this way)
+This is the agreed process. The generator measures, validates, and visualizes; **the
+agent chooses the colors** (fitting each theme's palette and name); **the human approves**
+each change; the agent applies and re-verifies.
+
+1. **Measure.** Generate the preview from the *source* LESS and publish it:
+   ```
+   py ".github/skills/game-theme-preview/generate_preview.py" <out.html>
+   ```
+   (`<out.html>` in the session scratchpad). Publish with the **Artifact** tool; the nav
+   chips show each theme's issue count.
+2. **Curate (agent judgment, not just the algorithm).** For each flagged element, dump the
+   theme's resolved palette and failing checks (call `build()` per theme), then pick a
+   color that a designer eyeballing the *whole* theme would choose:
+   - reuse a color the theme already uses (text, header, an existing outline),
+   - honor the theme's name/identity (keep *coral-reef* coral, *cherry-blossom* pink),
+   - prefer one upstream change that fixes several checks (e.g. deepening
+     `--game-primary-color` slightly), and note when one variable feeds another,
+   - keep intentional translucency (darken / raise alpha rather than going opaque).
+   Write the picks to a curated JSON file (scratchpad - it's a per-review input, not a
+   repo asset):
+   `theme -> "Component title|check label" -> [ {label, why, changes:[[var,value],...]} ]`
+3. **Validate + visualize.** Re-run with the curated file as the 3rd argument:
+   ```
+   py generate_preview.py out.html "<path>/gamesThemes.less" curated.json
+   ```
+   Each curated pick renders first as a blue **Recommended** option with its rationale, in
+   context, and is held to the **same whole-element validation** as a generated one -
+   invalid picks are dropped, never shipped. Mechanical alternatives appear below as
+   fallbacks. Republish to the same Artifact URL.
+4. **Human approves.** The user ticks the options they want and clicks **Copy approved
+   changes**; they paste back an apply-ready block.
+5. **Apply + re-verify.** Edit the named `.bloom-page.game-theme-*` block(s) in
+   `gamesThemes.less` (one variable per line, with a short comment + the issue id).
+   Re-run the generator against the edited file and confirm the affected theme's nav chip
+   is clean and **no other theme regressed**.
+
+For a single quick check, skip the page entirely: `py contrast.py "#ffde00" "#feefb1"`.
+
+## Tools in this folder
+- `contrast.py` - reusable WCAG library. Named colors, 3/6/8-digit hex, alpha compositing
+  over a background. CLI: `py contrast.py <fg> <bg>`.
+- `generate_preview.py` - parses `gamesThemes.less`, resolves the full `--game-*` cascade
+  per theme, measures contrast for every meaningful element pair, generates validated fix
+  options, folds in the curated recommendations, and writes a self-contained HTML page.
+  Args: `[out.html] [gamesThemes.less] [curated.json]`.
+
+## Background: how theming works
+- Themes live in `gamesThemes.less`. Each `.bloom-page.game-theme-NAME` block sets
+  `--game-primary-color` / `--game-secondary-color` plus targeted overrides.
+- The `.apply-game-theme()` mixin pushes those down into ~25 specific `--game-*`
+  variables (text, header, draggable, target outline, buttons, checkboxes, etc.), and
+  some variables derive from others (e.g. the selected-checkbox fill follows the
+  correct-answer fill) - so one change can fix several elements.
+- Elements are styled in `Games.less` (and per-game `.less` files) purely via those
+  variables. The dashed **drop target** outline is a CSS border, not an SVG:
+  `[data-target-of] { border: dashed ... var(--game-draggable-target-outline-color) }`.
+- Key trap: by default `--game-draggable-target-outline-color` follows the draggable
+  background, which follows the primary color. If a theme's primary color is close to its
+  page background, the dashed target nearly vanishes; give that theme its own
+  `--game-draggable-target-outline-color`.
+
+## Contrast thresholds (WCAG 2.1 Level AA)
+Bloom targets **Level AA**, so that is what the generator enforces:
+- **4.5:1** - normal text (text-on-fill pairs).
+- **3.0:1** - large/bold text and non-text UI components / graphics (the dashed target
+  outline, draggable-vs-page, button-vs-page, checkbox outline, etc.).
+The generator picks the right threshold per pair and flags anything under it. A result
+that only just clears its threshold is shown amber, not green, so a barely-passing value
+is never dressed up as high contrast. (AAA would require 7:1 / 4.5:1; if that's ever the
+goal, raise the thresholds in `build()`.)
+
+## How the generated fallback options are computed
+The curated picks come first, but the tool also derives its own options as a backstop, and
+they use the same rules (so understand them):
+- An element usually has more than one contrast relationship at once (a draggable must
+  stand out from the page **and** hold readable text on its fill). Each candidate is
+  validated against **all** of that element's checks - a fix can't pass one relationship
+  while silently breaking another (no black text on a newly-black fill).
+- It picks the right "knob": the foreground, the background fill, or - for a "visible"
+  check - the fill *or* the outline. It never recolors the shared page background.
+- When a text-bearing element must stand out from a same-tone page, a single-color nudge
+  muddies the fill and starves its text, so it also offers a coordinated "darker/lighter
+  fill + opposite-tone text" fix.
+- Every option lists the **before→after** ratio of each relationship it touches.
+
+## What Good Looks Like
+- Every theme's nav chip shows a checkmark (zero low-contrast pairs), or any remaining
+  amber/red pair is a deliberate, explained design choice.
+- The dashed drop target is clearly visible on every theme's page background.
+- Fix colors are drawn from the theme's own palette / identity, not just the nearest
+  passing color - and the rationale is recorded (in `why`, and in the LESS comment).
+- Applied edits carry a short comment and the issue id; a re-run shows no regressions.
+
+## Notes / Limitations
+- The generator reads the **source** `gamesThemes.less`, not the compiled
+  `output/.../gamesThemes.css`, so it reflects your edits before a build runs.
+- It does not resolve `color-mix()` (only used outside the per-theme blocks today). If a
+  theme starts using `color-mix()`, extend `resolve()` in `generate_preview.py`.
+- The artifact runs in a sandboxed iframe, so the async clipboard API is often blocked;
+  the Copy button falls back to `execCommand` and always shows a selectable text box.
+- SVG control-button glyphs are fixed-color image files and are not theme-driven, so they
+  aren't measured here.
+
+## Example Prompts
+- `/game-theme-preview Regenerate the theme preview so I can check my new theme.`
+- `/game-theme-preview Is #ffde00 readable on #feefb1?`
+- `/game-theme-preview The drop targets are invisible in garden-path - curate a fix and let me approve it.`

--- a/.github/skills/game-theme-preview/contrast.py
+++ b/.github/skills/game-theme-preview/contrast.py
@@ -1,0 +1,83 @@
+"""WCAG contrast utilities for Bloom game theme colors.
+
+Reusable helper for measuring the contrast ratio between two colors as defined by
+WCAG 2.x. Handles named colors (white/black), 3/6/8-digit hex, and alpha
+compositing (an 8-digit hex is composited over a supplied background before the
+ratio is computed, which is what a viewer actually perceives).
+
+Thresholds worth remembering:
+  * 4.5:1  - normal text (WCAG 1.4.3 AA)
+  * 3.0:1  - large/bold text AND non-text UI components / graphics (WCAG 1.4.11)
+"""
+
+_NAMED = {"white": "ffffff", "black": "000000", "transparent": "00000000"}
+
+
+def parse(color, bg=None):
+    """Parse a CSS color to an (r, g, b) tuple in 0..255.
+
+    If the color carries alpha (8-digit hex) and `bg` (an r,g,b tuple) is given,
+    the color is alpha-composited over `bg` so the result reflects what is seen.
+    """
+    c = color.strip().lstrip("#").lower()
+    c = _NAMED.get(c, c)
+    if len(c) == 3:
+        c = "".join(ch * 2 for ch in c)
+    if len(c) == 8:
+        r, g, b = int(c[0:2], 16), int(c[2:4], 16), int(c[4:6], 16)
+        a = int(c[6:8], 16) / 255
+        if bg is not None:
+            br, bgc, bb = bg
+            r = round(r * a + br * (1 - a))
+            g = round(g * a + bgc * (1 - a))
+            b = round(b * a + bb * (1 - a))
+        return (r, g, b)
+    if len(c) != 6:
+        raise ValueError(f"Cannot parse color: {color!r}")
+    return (int(c[0:2], 16), int(c[2:4], 16), int(c[4:6], 16))
+
+
+def _lin(v):
+    v = v / 255
+    return v / 12.92 if v <= 0.03928 else ((v + 0.055) / 1.055) ** 2.4
+
+
+def luminance(rgb):
+    """Relative luminance of an (r, g, b) tuple per WCAG."""
+    r, g, b = rgb
+    return 0.2126 * _lin(r) + 0.7152 * _lin(g) + 0.0722 * _lin(b)
+
+
+def contrast(fg, bg):
+    """WCAG contrast ratio (1..21) between two colors.
+
+    `fg` and `bg` may be color strings or pre-parsed (r,g,b) tuples. A string
+    foreground is composited over the (parsed) background when it has alpha.
+    """
+    bg_rgb = bg if isinstance(bg, tuple) else parse(bg)
+    fg_rgb = fg if isinstance(fg, tuple) else parse(fg, bg_rgb)
+    hi, lo = luminance(fg_rgb), luminance(bg_rgb)
+    if hi < lo:
+        hi, lo = lo, hi
+    return (hi + 0.05) / (lo + 0.05)
+
+
+def rating(ratio, threshold=3.0):
+    """Short human label for a ratio against a pass threshold (default UI 3:1)."""
+    if ratio >= 4.5:
+        return "GOOD"
+    if ratio >= threshold:
+        return "OK"
+    if ratio >= 2.0:
+        return "WEAK"
+    return "FAIL"
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) == 3:
+        r = contrast(sys.argv[1], sys.argv[2])
+        print(f"{sys.argv[1]} on {sys.argv[2]}: {r:.2f}:1  ({rating(r)})")
+    else:
+        print("usage: py contrast.py <foreground> <background>")

--- a/.github/skills/game-theme-preview/generate_preview.py
+++ b/.github/skills/game-theme-preview/generate_preview.py
@@ -12,7 +12,11 @@ approve and clicks "Copy approved changes" to put an apply-ready block on the
 clipboard, which can be handed back to an agent to edit gamesThemes.less.
 
 Usage:
-    py generate_preview.py [output.html] [path/to/gamesThemes.less]
+    py generate_preview.py [output.html] [path/to/gamesThemes.less] [curated.json]
+
+The optional third argument is a curated-suggestions JSON file (theme ->
+"Component title|check label" -> [{label, why, changes}]); its picks render first
+as validated "Recommended" options. See SKILL.md for the format.
 """
 
 import colorsys
@@ -53,24 +57,37 @@ def parse_themes(less_text):
     """
     text = _strip_comments(less_text)
 
-    mixin = re.search(r"\.apply-game-theme\(\)\s*\{(.*?)\n\}", text, re.S)
-    mixin_vars = _vars_in(mixin.group(1)) if mixin else []
-
-    base = re.search(r'\.bloom-page\[class\*="game-theme-"\]\s*\{(.*?)\n\}', text, re.S)
-    base_vars = _vars_in(base.group(1)) if base else []
+    # These blocks have no nested braces, so [^{}]* is both correct and robust to
+    # whitespace/formatting (unlike requiring a newline before the closing brace).
+    mixin = re.search(r"\.apply-game-theme\(\)\s*\{([^{}]*)\}", text)
+    base = re.search(r'\.bloom-page\[class\*="game-theme-"\]\s*\{([^{}]*)\}', text)
+    # Fail fast (per AGENTS.md): if the expected structure is gone, say so clearly
+    # rather than silently producing wrong/empty themes that error obscurely later.
+    if not mixin:
+        raise ValueError("Could not find the .apply-game-theme() mixin in gamesThemes.less")
+    if not base:
+        raise ValueError('Could not find the .bloom-page[class*="game-theme-"] base block')
+    mixin_vars = _vars_in(mixin.group(1))
+    base_vars = _vars_in(base.group(1))
 
     themes = {}
-    for m in re.finditer(r"\.bloom-page\.game-theme-([\w-]+)\s*\{(.*?)\n\}", text, re.S):
+    for m in re.finditer(r"\.bloom-page\.game-theme-([\w-]+)\s*\{([^{}]*)\}", text):
         name = m.group(1)
         merged = {}
         for k, v in base_vars + mixin_vars + _vars_in(m.group(2)):
             merged[k] = v
         themes[name] = merged
+    if not themes:
+        raise ValueError("Found no .bloom-page.game-theme-* blocks in gamesThemes.less")
     return themes
 
 
 def resolve(name, vars_map, _seen=None):
-    """Resolve a variable to a concrete color string, following var() chains."""
+    """Resolve a variable to a concrete color string, following var() chains.
+
+    Supports `var(--x)` and `var(--x, fallback)`: if --x is undefined, the fallback
+    (itself possibly a literal or another var()) is used, matching CSS semantics.
+    """
     _seen = _seen or set()
     if name in _seen:
         raise ValueError(f"variable cycle at {name}")
@@ -78,10 +95,27 @@ def resolve(name, vars_map, _seen=None):
     val = vars_map.get(name)
     if val is None:
         return None
-    m = re.fullmatch(r"var\(\s*(--[\w-]+)\s*\)", val)
+    m = re.fullmatch(r"var\(\s*(--[\w-]+)\s*(?:,\s*(.+?))?\s*\)", val)
     if m:
-        return resolve(m.group(1), vars_map, _seen)
+        referenced = resolve(m.group(1), vars_map, _seen)
+        if referenced is not None:
+            return referenced
+        if m.group(2) is not None:  # fall back to the var()'s default
+            return _resolve_value(m.group(2).strip(), vars_map, _seen)
+        return None
     return val  # a literal color (hex / named)
+
+
+def _resolve_value(val, vars_map, _seen):
+    """Resolve a raw value string (used for a var() fallback, which may be a literal
+    color or another var() reference)."""
+    m = re.fullmatch(r"var\(\s*(--[\w-]+)\s*(?:,\s*(.+?))?\s*\)", val)
+    if not m:
+        return val
+    referenced = resolve(m.group(1), vars_map, _seen)
+    if referenced is not None:
+        return referenced
+    return _resolve_value(m.group(2).strip(), vars_map, _seen) if m.group(2) else None
 
 
 # ---------------------------------------------------------------------------
@@ -160,9 +194,15 @@ def curated_options(name, comp, ck, vars_map, curated):
 
 
 def _search_one(var, comp, vars_map):
-    """Smallest same-hue lightness move of `var` that makes the WHOLE component valid."""
+    """Smallest same-hue lightness move of `var` that makes the WHOLE component valid.
+
+    If the current color carries alpha (an 8-digit hex, e.g. a semi-transparent target
+    outline), the suggestion keeps that alpha so we never silently make a translucent
+    color opaque; contrast is judged on the composited result."""
     cur = resolve(var, vars_map)
-    r, g, b = parse(cur)
+    r, g, b = parse(cur)  # raw rgb (alpha, if any, dropped here for the hue/sat)
+    bare = cur.strip().lstrip("#").lower()
+    alpha = bare[6:8] if len(bare) == 8 else ""
     h, l, s = colorsys.rgb_to_hls(r / 255, g / 255, b / 255)
     best = None
     for sign in (-1, 1):
@@ -171,7 +211,7 @@ def _search_one(var, comp, vars_map):
             if l2 < 0 or l2 > 1:
                 break
             rr, gg, bb = colorsys.hls_to_rgb(h, l2, s)
-            val = _hex((round(rr * 255), round(gg * 255), round(bb * 255)))
+            val = _hex((round(rr * 255), round(gg * 255), round(bb * 255))) + alpha
             if _valid(comp, _apply(vars_map, [(var, val)])):
                 if best is None or step < best[1]:
                     best = (val, step, "darken" if sign < 0 else "lighten")
@@ -418,7 +458,6 @@ def render(themes, curated=None):
                         res_html += (f'<span class="mini {cls}">{r["label"]} '
                                      f'{r["before"]:.1f}&rarr;{r["after"]:.1f}</span>')
                     dot = opt["changes"][0]["value"]
-                    swatches = " ".join(c["value"] for c in opt["changes"])
                     var_html = "".join(f'<code>{c["var"]}: {c["value"]}</code>' for c in opt["changes"])
                     data_changes = ";;".join(f'{c["var"]}|{c["value"]}' for c in opt["changes"])
                     rec_cls = " rec" if opt.get("recommended") else ""
@@ -617,7 +656,7 @@ PAGE = r"""<title>Bloom Game Theme Preview</title>
     if(!checked.length) return;
     const byTheme={};
     checked.forEach(o=>{ (byTheme[o.dataset.theme] ??= []).push(o); });
-    let out='# Approved game-theme contrast changes\n# Apply each line as a CSS variable in the named .bloom-page.game-theme-* block of gamesThemes.less\n';
+    let out='# Approved game-theme contrast changes\n# Apply each line as a CSS variable in the named .bloom-page.game-theme-* block of gamesThemes.less.\n# Keep a short comment on each, including the issue id (e.g. BL-16323), for traceability.\n';
     let lines=0;
     for(const [theme,list] of Object.entries(byTheme)){
       out += `\n## ${theme}\n`;

--- a/.github/skills/game-theme-preview/generate_preview.py
+++ b/.github/skills/game-theme-preview/generate_preview.py
@@ -1,0 +1,656 @@
+"""Generate a self-contained HTML preview of every Bloom game theme.
+
+Parses gamesThemes.less, resolves the full --game-* CSS variable cascade for each
+theme to concrete colors, measures WCAG contrast for every meaningful element
+pair, and writes one scrollable HTML page. Testers can scroll through and see every
+element of every theme rendered in its real colors, with any low-contrast pair
+flagged.
+
+Each failing card is outlined orange (weak) or red (bad) and offers one or two
+pre-computed alternative colors as checkboxes. An operator ticks the ones they
+approve and clicks "Copy approved changes" to put an apply-ready block on the
+clipboard, which can be handed back to an agent to edit gamesThemes.less.
+
+Usage:
+    py generate_preview.py [output.html] [path/to/gamesThemes.less]
+"""
+
+import colorsys
+import os
+import re
+import sys
+
+from contrast import parse, contrast, luminance, rating
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.abspath(os.path.join(HERE, "..", "..", ".."))
+DEFAULT_LESS = os.path.join(
+    REPO, "src", "content", "templates", "template books", "Games", "gamesThemes.less"
+)
+
+
+# ---------------------------------------------------------------------------
+# Parsing the LESS into per-theme variable maps
+# ---------------------------------------------------------------------------
+
+def _strip_comments(text):
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    text = re.sub(r"//[^\n]*", "", text)
+    return text
+
+
+def _vars_in(block):
+    """Ordered list of (name, value) for each `--name: value;` in a block."""
+    return [(m.group(1).strip(), m.group(2).strip())
+            for m in re.finditer(r"(--[\w-]+)\s*:\s*([^;]+);", block)]
+
+
+def parse_themes(less_text):
+    """Return (theme_name -> {var: rawvalue}) with the full cascade merged in.
+
+    Cascade order applied (later wins): base literals, the apply-game-theme()
+    mixin, then the theme's own overrides - matching how the CSS resolves.
+    """
+    text = _strip_comments(less_text)
+
+    mixin = re.search(r"\.apply-game-theme\(\)\s*\{(.*?)\n\}", text, re.S)
+    mixin_vars = _vars_in(mixin.group(1)) if mixin else []
+
+    base = re.search(r'\.bloom-page\[class\*="game-theme-"\]\s*\{(.*?)\n\}', text, re.S)
+    base_vars = _vars_in(base.group(1)) if base else []
+
+    themes = {}
+    for m in re.finditer(r"\.bloom-page\.game-theme-([\w-]+)\s*\{(.*?)\n\}", text, re.S):
+        name = m.group(1)
+        merged = {}
+        for k, v in base_vars + mixin_vars + _vars_in(m.group(2)):
+            merged[k] = v
+        themes[name] = merged
+    return themes
+
+
+def resolve(name, vars_map, _seen=None):
+    """Resolve a variable to a concrete color string, following var() chains."""
+    _seen = _seen or set()
+    if name in _seen:
+        raise ValueError(f"variable cycle at {name}")
+    _seen = _seen | {name}
+    val = vars_map.get(name)
+    if val is None:
+        return None
+    m = re.fullmatch(r"var\(\s*(--[\w-]+)\s*\)", val)
+    if m:
+        return resolve(m.group(1), vars_map, _seen)
+    return val  # a literal color (hex / named)
+
+
+# ---------------------------------------------------------------------------
+# Contrast checks per theme
+# ---------------------------------------------------------------------------
+
+def _ratio(fg, bg):
+    return contrast(fg, parse(bg))
+
+
+def _hex(rgb):
+    return "#%02x%02x%02x" % rgb
+
+
+def eval_check(ck, g):
+    """Re-evaluate a check's contrast ratio under a (possibly overridden) resolver g.
+
+    Mirrors how the ratio was first computed in build(): a 'visible' check is the
+    better of fill-vs-page and outline-vs-page; a 'simple' check is fg-vs-bg.
+    """
+    if ck["check_kind"] == "visible":
+        bg = g(ck["bg_var"])
+        return max(_ratio(g(ck["fix_var"]), bg), _ratio(g(ck["outline_var"]), bg))
+    return _ratio(g(ck["fix_var"]), g(ck["bg_var"]))
+
+
+def _apply(vars_map, changes):
+    """vars_map with a list of (var, value) overrides applied."""
+    vm = dict(vars_map)
+    for var, value in changes:
+        vm[var] = value
+    return vm
+
+
+def _valid(comp, vm2, buffer=0.3):
+    """True if EVERY check in the component clears its threshold under overrides vm2.
+
+    The heart of correctness: a candidate is only valid if it keeps *all* of an
+    element's contrast relationships healthy at once - e.g. recoloring a draggable's
+    fill must keep both 'fill vs page' AND 'text on fill' passing."""
+    g2 = lambda n: resolve(n, vm2)
+    return all(eval_check(c, g2) >= c["threshold"] + buffer for c in comp["checks"])
+
+
+def _option(changes, label, comp, vars_map, coord=False, why=None, recommended=False):
+    """Package a candidate (one or more var changes) with before/after ratios.
+
+    `results` records every relationship the change touches, so the operator sees the
+    full trade-off - including a relationship that got *worse* but still passes.
+    `recommended`/`why` mark an AI-curated pick (chosen to fit the whole theme) so the
+    UI can surface it ahead of the mechanically-generated alternatives."""
+    vm2 = _apply(vars_map, changes)
+    g0, g2 = (lambda n: resolve(n, vars_map)), (lambda n: resolve(n, vm2))
+    results = [{"label": c["label"], "before": eval_check(c, g0),
+                "after": eval_check(c, g2), "threshold": c["threshold"]}
+               for c in comp["checks"]]
+    score = min(r["after"] / r["threshold"] for r in results)  # binding margin; higher better
+    return {"changes": [{"var": v, "value": val} for v, val in changes],
+            "label": label, "results": results, "score": score, "coord": coord,
+            "why": why, "recommended": recommended}
+
+
+def curated_options(name, comp, ck, vars_map, curated):
+    """Validated AI-curated fixes for this check, from the curated suggestions file.
+
+    Each is held to the same whole-component validation as a generated candidate, so a
+    hand-picked color that would break a relationship is dropped rather than shipped."""
+    key = f"{comp['title']}|{ck['label']}"
+    out = []
+    for entry in curated.get(name, {}).get(key, []):
+        changes = [(v, val) for v, val in entry["changes"]]
+        if _valid(comp, _apply(vars_map, changes)):
+            out.append(_option(changes, entry["label"], comp, vars_map,
+                               why=entry.get("why"), recommended=True))
+    return out
+
+
+def _search_one(var, comp, vars_map):
+    """Smallest same-hue lightness move of `var` that makes the WHOLE component valid."""
+    cur = resolve(var, vars_map)
+    r, g, b = parse(cur)
+    h, l, s = colorsys.rgb_to_hls(r / 255, g / 255, b / 255)
+    best = None
+    for sign in (-1, 1):
+        for step in range(1, 101):
+            l2 = l + sign * step / 100
+            if l2 < 0 or l2 > 1:
+                break
+            rr, gg, bb = colorsys.hls_to_rgb(h, l2, s)
+            val = _hex((round(rr * 255), round(gg * 255), round(bb * 255)))
+            if _valid(comp, _apply(vars_map, [(var, val)])):
+                if best is None or step < best[1]:
+                    best = (val, step, "darken" if sign < 0 else "lighten")
+                break
+    return best
+
+
+def candidates(ck, comp, vars_map):
+    """Whole-component-valid fixes for a failing check (at most two, best first).
+
+    Knobs depend on the check: a 'visible' check (is the shape distinct from the page?)
+    can be fixed by recoloring the fill OR the outline; a 'simple' fg/bg check can adjust
+    its foreground or its background fill - never the shared page background. Plus, when
+    making a text-bearing element stand out from the page, a single-color nudge muddies
+    the fill and starves its text, so we also offer a coordinated 'darker/lighter fill +
+    opposite-tone text' fix that keeps both relationships strong. Every candidate is
+    validated against all of the component's checks.
+    """
+    page_dark = luminance(parse(resolve("--game-page-bg-color", vars_map))) < 0.5
+
+    if ck["check_kind"] == "visible":
+        knobs = [(ck["fix_var"], "fill"), (ck["outline_var"], "outline")]
+    else:
+        knobs = [(ck["fix_var"], "color")]
+        if not ck["bg_is_page"]:
+            knobs.append((ck["bg_var"], "background"))
+
+    opts = []
+    for var, role in knobs:
+        cur = resolve(var, vars_map)
+        adj = _search_one(var, comp, vars_map)
+        if adj:
+            opts.append(_option([(var, adj[0])], f"{adj[2]} the {role}", comp, vars_map))
+        for prole, pcol in ck["palette"]:  # one on-brand pick per knob, if it validates
+            if pcol.lower() != cur.lower() and _valid(comp, _apply(vars_map, [(var, pcol)])):
+                opts.append(_option([(var, pcol)], f"use {prole}", comp, vars_map))
+                break
+
+    # Coordinated fill+text fix for "element vs page" on a text-bearing element.
+    if ck["bg_is_page"]:
+        fill_var = ck["fix_var"]
+        text_sib = next((c for c in comp["checks"]
+                         if c is not ck and c["check_kind"] == "simple"
+                         and c["bg_var"] == fill_var), None)
+        if text_sib:
+            text_var = text_sib["fix_var"]
+            new_text = "black" if page_dark else "white"
+            adj = _search_one(fill_var, comp, _apply(vars_map, [(text_var, new_text)]))
+            if adj:
+                opts.append(_option([(fill_var, adj[0]), (text_var, new_text)],
+                                    f"{adj[2]} fill + {new_text} text", comp, vars_map, coord=True))
+
+    # dedupe by change-set
+    uniq, seen = [], set()
+    for o in opts:
+        key = tuple(sorted((c["var"], c["value"].lower()) for c in o["changes"]))
+        if key not in seen:
+            seen.add(key)
+            uniq.append(o)
+
+    # Prefer to surface one coordinated (highest-quality) fix plus the best simple one.
+    coord = sorted((o for o in uniq if o["coord"]), key=lambda o: -o["score"])
+    simple = sorted((o for o in uniq if not o["coord"]), key=lambda o: -o["score"])
+    out = (coord[:1] + simple)[:2] if coord else simple[:2]
+    return out
+
+
+# Each component: (heading, kind, checks). A check is a dict; `fix_var` is the
+# theme variable an operator would change to fix it (always the foreground).
+def build(theme):
+    g = lambda n: resolve(n, theme)
+
+    palette = []
+    seen_pal = set()
+    for role, var in [("text color", "--game-text-color"),
+                      ("primary color", "--game-primary-color"),
+                      ("secondary color", "--game-secondary-color"),
+                      ("header text", "--game-header-color"),
+                      ("header bg", "--game-header-bg-color"),
+                      ("button text", "--game-button-text-color")]:
+        c = g(var)
+        if c and c.lower() not in seen_pal:
+            palette.append((role, c))
+            seen_pal.add(c.lower())
+
+    def chk(label, fg_var, bg_var, threshold):
+        fg, bg = g(fg_var), g(bg_var)
+        r = _ratio(fg, bg)
+        return {"label": label, "check_kind": "simple",
+                "fix_var": fg_var, "bg_var": bg_var, "outline_var": None,
+                "bg_is_page": bg_var == "--game-page-bg-color",
+                "fg": fg, "bg": bg, "ratio": r,
+                "threshold": threshold, "pass": r >= threshold,
+                "rate": rating(r, threshold), "palette": palette}
+
+    def chk_visible(label, fill_var, outline_var, bg_var, threshold):
+        """A filled control is 'visible' if EITHER its fill or its outline contrasts
+        with the page. (White-on-white buttons are fine when they have a colored
+        border, so checking the fill alone would cry wolf.) Visibility is judged
+        against the page, so the fill or the outline can be recolored - never the page."""
+        bg = g(bg_var)
+        r = max(_ratio(g(fill_var), bg), _ratio(g(outline_var), bg))
+        return {"label": label, "check_kind": "visible",
+                "fix_var": fill_var, "bg_var": bg_var, "outline_var": outline_var,
+                "bg_is_page": True,
+                "fg": g(fill_var), "bg": bg, "ratio": r,
+                "threshold": threshold, "pass": r >= threshold,
+                "rate": rating(r, threshold), "palette": palette}
+
+    components = [
+        {"title": "Page text", "kind": "page", "checks": [
+            chk("body text on page", "--game-text-color", "--game-page-bg-color", 4.5),
+            chk("page number on page", "--game-page-number-color", "--game-page-bg-color", 4.5)]},
+        {"title": "Header bar", "kind": "header", "checks": [
+            chk("header text on header", "--game-header-color", "--game-header-bg-color", 4.5)]},
+        {"title": "Draggable item", "kind": "draggable", "checks": [
+            chk("text on draggable", "--game-draggable-color", "--game-draggable-bg-color", 4.5),
+            chk("draggable vs page", "--game-draggable-bg-color", "--game-page-bg-color", 3.0)]},
+        {"title": "Empty drop target", "kind": "target", "checks": [
+            chk("dashed outline vs page", "--game-draggable-target-outline-color", "--game-page-bg-color", 3.0)]},
+        {"title": "Answer button", "kind": "button", "checks": [
+            chk("button text on button", "--game-button-text-color", "--game-button-bg-color", 4.5),
+            chk_visible("button visible vs page", "--game-button-bg-color", "--game-button-outline-color", "--game-page-bg-color", 3.0)]},
+        {"title": "Correct / wrong", "kind": "verdict", "checks": [
+            chk("text on correct", "--game-button-correct-color", "--game-button-correct-bg-color", 4.5),
+            chk("text on wrong", "--game-button-wrong-color", "--game-button-wrong-bg-color", 4.5)]},
+        {"title": "Control button (Check)", "kind": "control", "checks": [
+            chk("control button vs page", "--game-control-button-bg-color", "--game-page-bg-color", 3.0)]},
+        {"title": "Checkbox", "kind": "checkbox", "checks": [
+            chk("checkbox outline vs page", "--game-checkbox-outline-color", "--game-page-bg-color", 3.0),
+            chk("checkbox text vs page", "--game-checkbox-text-color", "--game-page-bg-color", 4.5)]},
+        {"title": "Selected checkbox", "kind": "checkbox-sel", "checks": [
+            chk("text on selected", "--game-selected-checkbox-color", "--game-selected-checkbox-bg-color", 4.5),
+            chk_visible("selected visible vs page", "--game-selected-checkbox-bg-color", "--game-selected-checkbox-outline-color", "--game-page-bg-color", 3.0)]},
+    ]
+    return g("--game-page-bg-color"), components
+
+
+# ---------------------------------------------------------------------------
+# HTML rendering
+# ---------------------------------------------------------------------------
+
+def _swatch_html(kind, g):
+    page = g("--game-page-bg-color")
+    if kind == "page":
+        return (f'<div class="mock" style="background:{page};color:{g("--game-text-color")}">'
+                f'Aa Bb Cc <span style="color:{g("--game-page-number-color")};font-weight:700">12</span></div>')
+    if kind == "header":
+        return (f'<div class="mock" style="background:{g("--game-header-bg-color")};'
+                f'color:{g("--game-header-color")};font-weight:700">My Game</div>')
+    if kind == "draggable":
+        return (f'<div class="mock" style="background:{page};justify-content:center">'
+                f'<span class="chip" style="background:{g("--game-draggable-bg-color")};'
+                f'color:{g("--game-draggable-color")}">cat</span></div>')
+    if kind == "target":
+        return (f'<div class="mock" style="background:{page};justify-content:center">'
+                f'<span class="tgt" style="border:2px dashed {g("--game-draggable-target-outline-color")}"></span></div>')
+    if kind == "button":
+        return (f'<div class="mock" style="background:{page};justify-content:center">'
+                f'<span class="btn" style="background:{g("--game-button-bg-color")};'
+                f'color:{g("--game-button-text-color")};border:2px solid {g("--game-button-outline-color")}">cat</span></div>')
+    if kind == "verdict":
+        return (f'<div class="mock" style="background:{page};gap:8px;justify-content:center">'
+                f'<span class="btn" style="background:{g("--game-button-correct-bg-color")};color:{g("--game-button-correct-color")}">right</span>'
+                f'<span class="btn" style="background:{g("--game-button-wrong-bg-color")};color:{g("--game-button-wrong-color")}">wrong</span></div>')
+    if kind == "control":
+        return (f'<div class="mock" style="background:{page};justify-content:center">'
+                f'<span class="btn" style="background:{g("--game-control-button-bg-color")};'
+                f'color:{g("--game-control-button-color")}">Check</span></div>')
+    if kind == "checkbox":
+        return (f'<div class="mock" style="background:{page};align-items:center;gap:8px;justify-content:center">'
+                f'<span class="cbx" style="border:2px solid {g("--game-checkbox-outline-color")}"></span>'
+                f'<span style="color:{g("--game-checkbox-text-color")}">option</span></div>')
+    if kind == "checkbox-sel":
+        return (f'<div class="mock" style="background:{page};align-items:center;gap:8px;justify-content:center">'
+                f'<span class="cbx" style="background:{g("--game-selected-checkbox-bg-color")};'
+                f'color:{g("--game-selected-checkbox-color")};border:2px solid {g("--game-selected-checkbox-outline-color")};'
+                f'display:flex;align-items:center;justify-content:center;font-size:13px">&#10003;</span>'
+                f'<span style="color:{g("--game-checkbox-text-color")}">option</span></div>')
+    return ""
+
+
+def _esc(s):
+    return s.replace("&", "&amp;").replace('"', "&quot;").replace("<", "&lt;")
+
+
+def render(themes, curated=None):
+    curated = curated or {}
+    nav = []
+    sections = ""
+    total_issues = 0
+
+    for name, vars_map in themes.items():
+        g = lambda n, vm=vars_map: resolve(n, vm)
+        page_bg, components = build(vars_map)
+
+        theme_issues = 0
+        cards_html = ""
+        for comp in components:
+            failing = [ck for ck in comp["checks"] if not ck["pass"]]
+            theme_issues += len(failing)
+            severity = ""
+            if failing:
+                severity = "bad" if any(ck["ratio"] < 2.0 for ck in failing) else "weak"
+
+            checks_html = ""
+            for ck in comp["checks"]:
+                cls = "ok" if ck["pass"] else ("weak" if ck["ratio"] >= 2 else "fail")
+                checks_html += (
+                    f'<div class="check {cls}"><span class="ck-label">{ck["label"]}</span>'
+                    f'<span class="ck-ratio">{ck["ratio"]:.2f}:1</span>'
+                    f'<span class="ck-need">need {ck["threshold"]:.1f}</span></div>')
+
+            fixes_html = ""
+            for ck in failing:
+                # AI-curated recommendation(s) first, then de-duplicated generated fallbacks.
+                rec = curated_options(name, comp, ck, vars_map, curated)
+                rec_keys = {tuple(sorted((c["var"], c["value"].lower()) for c in o["changes"])) for o in rec}
+                gen = [o for o in candidates(ck, comp, vars_map)
+                       if tuple(sorted((c["var"], c["value"].lower()) for c in o["changes"])) not in rec_keys]
+                opts = rec + gen
+                if not opts:
+                    fixes_html += (f'<div class="fixrow"><div class="fixhdr">Fix for '
+                                   f'<b>{ck["label"]}</b> &mdash; no single-color fix keeps every '
+                                   f'relationship on this element passing; needs a manual redesign</div></div>')
+                    continue
+                group = f"{name}|{comp['title']}|{ck['label']}"
+                opt_html = ""
+                for opt in opts:
+                    note = f'{name}: fixes {ck["label"]}'
+                    # Render the same element with this candidate's change(s) substituted,
+                    # so the operator sees the fix in context. Override at the variable level
+                    # so dependent variables (e.g. a selected-checkbox outline that follows
+                    # the fill) update too.
+                    vm2 = _apply(vars_map, [(c["var"], c["value"]) for c in opt["changes"]])
+                    preview = _swatch_html(comp["kind"], lambda n, vm=vm2: resolve(n, vm))
+                    # Show before->after for EVERY relationship on this element. A value that
+                    # only just passes (or got worse but still passes) is amber, not green,
+                    # so a barely-passing 5.40 is never dressed up as "high contrast".
+                    res_html = ""
+                    for r in opt["results"]:
+                        comfortable = r["after"] >= 1.6 * r["threshold"]
+                        cls = "ok" if comfortable else "warn"
+                        res_html += (f'<span class="mini {cls}">{r["label"]} '
+                                     f'{r["before"]:.1f}&rarr;{r["after"]:.1f}</span>')
+                    dot = opt["changes"][0]["value"]
+                    swatches = " ".join(c["value"] for c in opt["changes"])
+                    var_html = "".join(f'<code>{c["var"]}: {c["value"]}</code>' for c in opt["changes"])
+                    data_changes = ";;".join(f'{c["var"]}|{c["value"]}' for c in opt["changes"])
+                    rec_cls = " rec" if opt.get("recommended") else ""
+                    rec_tag = '<span class="rectag">Recommended</span>' if opt.get("recommended") else ""
+                    why_html = (f'<div class="why">{opt["why"]}</div>'
+                                if opt.get("why") else "")
+                    opt_html += (
+                        f'<label class="opt{rec_cls}"><div class="opt-body">'
+                        f'<div class="opt-meta"><input type="checkbox" class="fix-opt" '
+                        f'data-group="{_esc(group)}" data-theme="{name}" '
+                        f'data-changes="{_esc(data_changes)}" data-note="{_esc(note)}">'
+                        f'<span class="dot" style="background:{dot}"></span>'
+                        f'<span class="opt-label">{opt["label"]}</span>{rec_tag}</div>'
+                        f'{why_html}'
+                        f'<div class="opt-var">{var_html}</div>'
+                        f'<div class="opt-checks">{res_html}</div>'
+                        f'{preview}</div></label>')
+                fixes_html += (f'<div class="fixrow"><div class="fixhdr">Fix for '
+                               f'<b>{ck["label"]}</b></div>{opt_html}</div>')
+
+            flagged = "flagged" if failing else ""
+            cap = '<div class="cap">current</div>' if failing else ""
+            cards_html += (
+                f'<div class="card {severity} {flagged}">'
+                f'<div class="card-title">{comp["title"]}</div>'
+                f'{_swatch_html(comp["kind"], g)}{cap}'
+                f'<div class="checks">{checks_html}</div>'
+                f'{("<div class=fixes>" + fixes_html + "</div>") if fixes_html else ""}'
+                f'</div>')
+
+        total_issues += theme_issues
+        nav.append((name, theme_issues))
+        badge = ('<span class="sec-badge clean">all pass</span>' if theme_issues == 0
+                 else f'<span class="sec-badge dirty">{theme_issues} low-contrast</span>')
+        sections += (f'<section id="{name}"><div class="sec-head" style="--pg:{page_bg}">'
+                     f'<h2>{name}</h2>{badge}</div><div class="grid">{cards_html}</div></section>')
+
+    nav_html = "".join(
+        f'<a href="#{n}" class="navlink {"clean" if i == 0 else "dirty"}">{n}'
+        f'<span class="navbadge">{"✓" if i == 0 else i}</span></a>'
+        for n, i in nav)
+    summary = ("Every theme passes." if total_issues == 0
+               else f"{total_issues} element pairs fall below threshold across "
+                    f"{sum(1 for _, i in nav if i)} theme(s). Tick the fixes you approve, then Copy.")
+    return PAGE.replace("{{NAV}}", nav_html).replace("{{SECTIONS}}", sections).replace("{{SUMMARY}}", summary)
+
+
+PAGE = r"""<title>Bloom Game Theme Preview</title>
+<style>
+  :root{--ink:#1c1c1e;--muted:#6e6e73;--line:#e5e5ea;--bg:#f5f5f7;--good:#1f8a4c;
+        --warnc:#c07700;--failc:#c2241b;--warnb:#f3a712;--failb:#e23b2e;}
+  *{box-sizing:border-box}
+  body{font-family:-apple-system,Segoe UI,Roboto,sans-serif;color:var(--ink);background:var(--bg);margin:0;padding-bottom:80px;}
+  header.top{position:sticky;top:0;z-index:10;background:rgba(255,255,255,.92);backdrop-filter:blur(8px);
+    border-bottom:1px solid var(--line);padding:14px 24px;}
+  header.top h1{font-size:18px;margin:0 0 8px;}
+  header.top p{margin:0 0 10px;color:var(--muted);font-size:13px;}
+  header.top p.std{font-size:12px;}
+  .stdtag{display:inline-block;background:#eef3fd;color:#1c5fc7;font-weight:700;
+    padding:2px 9px;border-radius:6px;margin-right:6px;}
+  .nav{display:flex;flex-wrap:wrap;gap:8px;}
+  .navlink{display:inline-flex;align-items:center;gap:6px;text-decoration:none;font-size:12.5px;font-weight:600;
+    padding:4px 10px;border-radius:20px;border:1px solid var(--line);color:var(--ink);background:#fff;}
+  .navlink.dirty{border-color:#f2c9c4;background:#fdecec;color:var(--failc);}
+  .navlink.clean{color:var(--good);}
+  .navbadge{font-size:11px;min-width:16px;text-align:center;}
+  main{max-width:1120px;margin:0 auto;padding:24px;}
+  section{margin-bottom:40px;scroll-margin-top:120px;}
+  .sec-head{display:flex;align-items:center;gap:12px;padding:12px 16px;border-radius:10px;margin-bottom:14px;
+    background:var(--pg);border:1px solid var(--line);}
+  .sec-head h2{font-size:20px;margin:0;mix-blend-mode:difference;color:#fff;}
+  .sec-badge{font-size:12px;font-weight:700;padding:3px 10px;border-radius:20px;}
+  .sec-badge.clean{background:#e7f5ec;color:var(--good);}
+  .sec-badge.dirty{background:#fdecec;color:var(--failc);}
+  .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(244px,1fr));gap:14px;align-items:start;}
+  .card{background:#fff;border:1px solid var(--line);border-radius:12px;padding:14px;}
+  .card.weak{border:3px solid var(--warnb);}
+  .card.bad{border:3px solid var(--failb);}
+  .card.addressed{border:3px solid var(--good);box-shadow:0 0 0 1px var(--good) inset;}
+  .card-title{font-size:13px;font-weight:700;margin-bottom:10px;color:var(--ink);}
+  .mock{border-radius:8px;padding:14px 12px;min-height:58px;display:flex;align-items:center;font-size:15px;gap:8px;}
+  .chip{padding:6px 14px;border-radius:8px;font-weight:700;font-size:14px;}
+  .tgt{width:80px;height:40px;border-radius:6px;display:inline-block;}
+  .btn{padding:6px 14px;border-radius:8px;font-weight:700;font-size:13px;}
+  .cbx{width:22px;height:22px;border-radius:5px;display:inline-block;}
+  .cap{font-size:10px;text-transform:uppercase;letter-spacing:.5px;color:var(--muted);margin-top:4px;}
+  .checks{margin-top:12px;display:flex;flex-direction:column;gap:5px;}
+  .check{display:grid;grid-template-columns:1fr auto auto;gap:8px;align-items:center;font-size:11.5px;padding:4px 8px;border-radius:6px;}
+  .check.ok{background:#f1f8f3;} .check.weak{background:#fff6e9;} .check.fail{background:#fdeeed;}
+  .ck-label{color:var(--ink);} .ck-ratio{font-variant-numeric:tabular-nums;font-weight:700;}
+  .check.ok .ck-ratio{color:var(--good);} .check.weak .ck-ratio{color:var(--warnc);} .check.fail .ck-ratio{color:var(--failc);}
+  .ck-need{color:var(--muted);font-size:10.5px;}
+  .fixes{margin-top:12px;border-top:1px dashed var(--line);padding-top:10px;display:flex;flex-direction:column;gap:10px;}
+  .fixhdr{font-size:11px;color:var(--muted);margin-bottom:6px;}
+  .fixhdr code{font-size:10.5px;background:#f0f0f3;padding:1px 4px;border-radius:4px;}
+  .opt{display:block;font-size:11.5px;cursor:pointer;padding:6px;border-radius:8px;border:1px solid var(--line);margin-bottom:8px;}
+  .opt:hover{background:#f7f7fa;}
+  .opt.rec{border-color:#1c6feb;background:#f3f8ff;}
+  .rectag{font-size:9px;font-weight:800;letter-spacing:.4px;text-transform:uppercase;color:#fff;
+    background:#1c6feb;padding:1px 6px;border-radius:10px;}
+  .why{font-size:11px;color:#33405a;line-height:1.45;}
+  .opt-body{display:flex;flex-direction:column;gap:6px;}
+  .opt-meta{display:flex;align-items:center;gap:7px;}
+  .opt-meta input{margin:0;cursor:pointer;}
+  .dot{width:14px;height:14px;border-radius:4px;border:1px solid rgba(0,0,0,.2);flex:none;}
+  .opt-label{flex:1;} .opt-ratio{font-weight:700;color:var(--good);font-variant-numeric:tabular-nums;}
+  .opt-var{display:flex;flex-direction:column;gap:3px;}
+  .opt-var code{font-size:10px;color:var(--muted);background:#f4f4f6;padding:1px 5px;border-radius:4px;word-break:break-all;}
+  .opt-checks{display:flex;flex-wrap:wrap;gap:4px;}
+  .mini{font-size:10px;padding:1px 6px;border-radius:10px;font-variant-numeric:tabular-nums;}
+  .mini.ok{background:#e7f5ec;color:var(--good);}
+  .mini.warn{background:#fff4e5;color:var(--warnc);}
+  .opt .mock{min-height:42px;padding:9px 10px;font-size:13px;}
+  .opt .chip,.opt .btn{padding:4px 11px;font-size:12px;}
+  .opt .tgt{width:64px;height:28px;} .opt .cbx{width:18px;height:18px;}
+  .opt:has(input:checked){border-color:var(--good);background:#f1f8f3;}
+  .bar{position:fixed;bottom:0;left:0;right:0;background:#fff;border-top:1px solid var(--line);
+    padding:12px 24px;display:flex;align-items:center;gap:16px;z-index:20;box-shadow:0 -2px 10px rgba(0,0,0,.05);}
+  .bar .count{font-size:13px;color:var(--muted);} .bar .count b{color:var(--ink);}
+  .copybtn{margin-left:auto;background:#1c6feb;color:#fff;border:none;border-radius:8px;padding:10px 18px;
+    font-size:14px;font-weight:700;cursor:pointer;} .copybtn:disabled{background:#b9c6d8;cursor:default;}
+  .toast{position:fixed;bottom:74px;left:50%;transform:translateX(-50%);background:#1c1c1e;color:#fff;
+    padding:9px 16px;border-radius:8px;font-size:13px;opacity:0;transition:opacity .2s;pointer-events:none;z-index:50;}
+  .toast.show{opacity:1;}
+  .modal{display:none;position:fixed;inset:0;background:rgba(0,0,0,.45);z-index:40;align-items:center;justify-content:center;padding:20px;}
+  .modal.show{display:flex;}
+  .modal-box{background:#fff;border-radius:12px;padding:16px;width:min(700px,94vw);max-height:82vh;display:flex;flex-direction:column;gap:10px;}
+  .modal-hd{display:flex;justify-content:space-between;align-items:center;font-weight:700;}
+  .modal-hd button{border:1px solid var(--line);background:#fff;border-radius:6px;padding:4px 12px;cursor:pointer;font-size:13px;}
+  .modal-tip{margin:0;font-size:12px;color:var(--muted);}
+  #out{width:100%;flex:1;min-height:260px;font-family:ui-monospace,Consolas,monospace;font-size:12px;
+    border:1px solid var(--line);border-radius:8px;padding:10px;resize:vertical;background:#fbfbfd;}
+</style>
+<header class="top">
+  <h1>Bloom game theme preview &mdash; every element, every theme</h1>
+  <p>Each card renders a real element in its resolved colors; badges are WCAG contrast ratios.
+     Cards outlined <b style="color:var(--warnc)">orange</b> are weak,
+     <b style="color:var(--failc)">red</b> are bad. Tick an alternative to approve it
+     (cards turn green), then <b>Copy approved changes</b> and hand the result to your agent.
+     <b>{{SUMMARY}}</b></p>
+  <p class="std"><span class="stdtag">Standard: WCAG 2.1 Level AA</span>
+     normal text needs <b>4.5:1</b>; large/bold text and non-text UI components (the dashed
+     target, draggables, buttons, checkbox outlines) need <b>3:1</b>. Each badge shows the
+     threshold it is judged against. (AAA would require 7:1 / 4.5:1 &mdash; not targeted here.)</p>
+  <nav class="nav">{{NAV}}</nav>
+</header>
+<main>{{SECTIONS}}</main>
+<div class="bar">
+  <span class="count"><b id="n">0</b> fix(es) selected</span>
+  <button class="copybtn" id="copy" disabled>Copy approved changes</button>
+</div>
+<div class="toast" id="toast"></div>
+<div class="modal" id="modal"><div class="modal-box">
+  <div class="modal-hd"><span>Approved changes</span><button id="mclose">Close</button></div>
+  <p class="modal-tip">Copied to your clipboard if the browser allowed it. Otherwise: click in the
+     box, Select All (Ctrl+A), Copy (Ctrl+C), and paste to your agent.</p>
+  <textarea id="out" readonly></textarea>
+</div></div>
+<script>
+  const opts = [...document.querySelectorAll('.fix-opt')];
+  const toast = (msg) => { const t=document.getElementById('toast'); t.textContent=msg;
+    t.classList.add('show'); setTimeout(()=>t.classList.remove('show'),1800); };
+  const parseChanges = (o) => o.dataset.changes.split(';;').map(s=>{
+    const i=s.indexOf('|'); return {var:s.slice(0,i), value:s.slice(i+1)}; });
+  function refresh(){
+    const checked = opts.filter(o=>o.checked);
+    document.getElementById('n').textContent = checked.length;
+    document.getElementById('copy').disabled = checked.length===0;
+    document.querySelectorAll('.card.flagged').forEach(card=>{
+      const any=[...card.querySelectorAll('.fix-opt')].some(o=>o.checked);
+      card.classList.toggle('addressed', any);
+    });
+  }
+  opts.forEach(cb=>cb.addEventListener('change', e=>{
+    if(e.target.checked){ // one choice per element: untick siblings in the same group
+      opts.filter(o=>o!==e.target && o.dataset.group===e.target.dataset.group)
+          .forEach(o=>o.checked=false);
+    }
+    refresh();
+  }));
+  const modal=document.getElementById('modal'), outArea=document.getElementById('out');
+  document.getElementById('mclose').onclick=()=>modal.classList.remove('show');
+  modal.addEventListener('click', e=>{ if(e.target===modal) modal.classList.remove('show'); });
+  function tryCopy(text){
+    // 1) execCommand on a focused, selected textarea works inside sandboxed iframes where
+    //    the async Clipboard API is blocked. 2) fall back to the async API. 3) the modal
+    //    always shows the text so a manual Ctrl+C is possible regardless.
+    outArea.value=text; modal.classList.add('show'); outArea.focus(); outArea.select();
+    let ok=false; try{ ok=document.execCommand('copy'); }catch(e){}
+    if(!ok && navigator.clipboard){ navigator.clipboard.writeText(text).then(
+      ()=>toast('Copied to clipboard'), ()=>{}); }
+    return ok;
+  }
+  document.getElementById('copy').addEventListener('click', ()=>{
+    const checked = opts.filter(o=>o.checked);
+    if(!checked.length) return;
+    const byTheme={};
+    checked.forEach(o=>{ (byTheme[o.dataset.theme] ??= []).push(o); });
+    let out='# Approved game-theme contrast changes\n# Apply each line as a CSS variable in the named .bloom-page.game-theme-* block of gamesThemes.less\n';
+    let lines=0;
+    for(const [theme,list] of Object.entries(byTheme)){
+      out += `\n## ${theme}\n`;
+      const seen=new Set();  // a single change (e.g. one primary-color tweak) can fix several checks
+      list.forEach(o=>{ parseChanges(o).forEach(c=>{
+        const k=c.var+'='+c.value; if(seen.has(k)) return; seen.add(k);
+        out += `${c.var}: ${c.value}; // ${o.dataset.note}\n`; lines++; }); });
+    }
+    const ok=tryCopy(out);
+    toast(ok ? `Copied ${lines} line(s) for ${checked.length} fix(es)`
+             : 'Select the text and press Ctrl+C');
+  });
+  refresh();
+</script>
+"""
+
+
+def main():
+    out = sys.argv[1] if len(sys.argv) > 1 else "game-theme-preview.html"
+    less_path = sys.argv[2] if len(sys.argv) > 2 else DEFAULT_LESS
+    curated_path = sys.argv[3] if len(sys.argv) > 3 else None
+    curated = {}
+    if curated_path:
+        import json
+        with open(curated_path, encoding="utf-8") as f:
+            curated = json.load(f)
+    with open(less_path, encoding="utf-8") as f:
+        themes = parse_themes(f.read())
+    with open(out, "w", encoding="utf-8") as f:
+        f.write(render(themes, curated))
+    extra = f" (+ curated suggestions for {', '.join(curated)})" if curated else ""
+    print(f"Wrote {out} covering {len(themes)} themes: {', '.join(themes)}{extra}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/BloomBrowserUI/bookEdit/toolbox/games/GameTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/games/GameTool.tsx
@@ -449,7 +449,13 @@ const makeArrowShape = (
     // rectangle that contains the arrow, without this it would not get mouse events.
     arrow.style.pointerEvents = "none";
 
-    const color = "#80808080";
+    // Match the arrow to the target's outline color so the two read as a pair. We read the
+    // target's resolved border color rather than the --game-draggable-target-outline-color
+    // variable directly, so themes that define it via color-mix() still yield a concrete color.
+    const color =
+        target.ownerDocument.defaultView!.getComputedStyle(
+            target,
+        ).borderTopColor;
     const strokeWidth = "3";
     const lines = [line, line2, line3];
     lines.forEach((l) => {

--- a/src/content/templates/template books/Games/Games.less
+++ b/src/content/templates/template books/Games/Games.less
@@ -547,6 +547,13 @@
     // If we ever want targets to have a background color (except when hidden), here's the place.
     //background-color: var(--game-draggable-target-bg-color);
 
+    // The preview/answer content copied into a target reads as part of the target, so color
+    // its text with the same color as the dashed outline rather than letting it fall back to
+    // the default (black) editable color, which has no relationship to the theme.
+    .bloom-editable {
+        color: var(--game-draggable-target-outline-color);
+    }
+
     &:focus {
         box-shadow:
             inset 0 1px 3px rgba(0, 0, 0, 0.1),

--- a/src/content/templates/template books/Games/gamesThemes.less
+++ b/src/content/templates/template books/Games/gamesThemes.less
@@ -33,10 +33,6 @@
     --game-draggable-bg-color: var(--game-primary-bg-color);
 
     --game-draggable-target-outline-color: var(--game-draggable-bg-color);
-    // CSS variable cannot reference themselves, so we define this copy
-    // so that we can use color-mix() to make it semi-transparent
-    // when we want.
-    --game-draggable-target-outline-color-base: var(--game-draggable-bg-color);
 
     --game-header-color: var(--game-secondary-color);
     --game-header-bg-color: var(--game-primary-bg-color);
@@ -101,97 +97,58 @@
     --game-checkbox-outline-color: white;
 }
 .bloom-page.game-theme-pollinator {
-    // The 'right answer' terracotta was just shy of AA for its white text (4.09:1);
-    // a slightly deeper terracotta reaches 4.95:1. The selected checkbox derives its
-    // color from this variable, so this fixes that too. (BL-16323)
     --game-button-correct-bg-color: #b35527;
     --game-draggable-bg-color: #6b678d;
+    --game-draggable-target-outline-color: #5d5d98b6;
     --game-primary-color: #617321;
     --game-secondary-color: white;
-    // Kept translucent so it doesn't cover target images, but the previous olive
-    // (#61732185, 2.13:1 on white) was too faint; this darker olive at ~70% alpha
-    // reaches 3.71:1. (BL-16323)
-    --game-draggable-target-outline-color: #4a5719b3;
 }
 .bloom-page.game-theme-garden-path {
-    --game-button-bg-color: #ffffff;
-    --game-button-correct-color: #000000;
-    // The default outline matched the cream page, leaving the white button edgeless
-    // (1.15:1); the theme's dark green outlines it at 8.41:1. (BL-16323)
-    --game-button-outline-color: #2d4c1e;
-    --game-button-text-color: #2d4c1e;
-    --game-checkbox-outline-color: #2d4c1e;
-    // A gold draggable is invisible on the cream page (1.16:1). Darkening the fill to
-    // olive and switching its text to white keeps it readable while it stands out
-    // from the page (text 5.0:1, fill vs page 4.3:1). (BL-16323)
-    --game-draggable-bg-color: #806f00;
-    --game-draggable-color: white;
-    // The default outline color (gold #ffde00) is invisible on the cream page
-    // background (1.16:1); the theme's dark green gives 8.41:1. (BL-16323)
-    --game-draggable-target-outline-color: #2d4c1e;
-    // The Check button's gold fill was invisible on cream (1.16:1); dark green gives
-    // 8.41:1. (BL-16323)
-    --game-control-button-bg-color: #2d4c1e;
-    --game-header-bg-color: #2d4c1e;
-    --game-header-color: #feefb1;
-    --game-primary-color: #ffde00;
-    --game-secondary-color: #feefb1;
-    // The selected checkbox reused the gold fill, invisible on cream (1.16:1). Olive
-    // fill + white check keeps it readable and distinct (text 5.0:1, vs page 4.3:1). (BL-16323)
-    --game-selected-checkbox-bg-color: #806f00;
-    --game-selected-checkbox-color: white;
-    --game-text-color: #2d4c1e;
+    --game-button-correct-bg-color: #ea5252;
+    --game-button-correct-color: #ffffff;
+    --game-draggable-target-outline-color: #5c8a47;
+    --game-header-color: #ffffff;
+    --game-primary-color: #5b7e3c;
+    --game-secondary-color: #ffe18c;
+    --game-selected-checkbox-bg-color: #5b7e3c;
+    --game-text-color: #485e35;
 }
 .bloom-page.game-theme-cherry-blossom {
     --game-button-bg-color: #ffffff;
     --game-button-correct-color: #ffffff;
-    // The white button's edge matched the page (invisible, 1.10:1); reusing the
-    // checkbox-outline magenta gives it a visible cherry border (6.5:1). (BL-16323)
-    --game-button-outline-color: #8c3d56;
+    --game-button-outline-color: #fff0f3;
     --game-button-text-color: #5d2a3a;
     --game-checkbox-outline-color: #8c3d56;
     --game-draggable-color: #ffffff;
-    --game-header-bg-color: #ffb7c5;
-    --game-header-color: #4a1c2b;
-    // Deepened the cherry pink slightly: white text on the magenta chips (draggable,
-    // correct, selected) was only 4.19:1; this lifts them all over AA (4.83:1) in one
-    // change while staying 'cherry blossom'. (BL-16323)
-    --game-primary-color: #c83f64;
+    --game-draggable-target-outline-color: #c94779d0;
+    --game-header-color: #ffffff;
+    --game-primary-color: #d14d72;
     --game-secondary-color: #fff0f3;
     --game-text-color: #7a2e45;
 }
 .bloom-page.game-theme-coral-reef {
     --game-button-bg-color: white;
-    --game-button-correct-color: black;
-    --game-button-outline-color: var(--game-page-bg-color);
+    --game-button-correct-color: #000000;
+    --game-button-outline-color: #00000000;
     --game-button-text-color: black;
+    --game-button-wrong-bg-color: #747474;
     --game-checkbox-outline-color: #e0f2f1;
-    --game-draggable-color: black;
-    // Bold coral was invisible on the teal page (1.98:1). A pale coral keeps the reef's
-    // signature color while standing out (3.5:1) with the black draggable text. Used for
-    // the draggables, the Check button, and the selected checkbox so they read as one
-    // family. (BL-16323)
-    --game-draggable-bg-color: #ffdccf;
     --game-control-button-bg-color: #ffdccf;
-    --game-selected-checkbox-bg-color: #ffdccf;
-    // The default outline color (coral #ff8c6b) is too close in lightness to the
-    // teal page background (1.98:1); a pale coral gives 3.45:1. (BL-16323)
+    --game-draggable-bg-color: #ffdccf;
+    --game-draggable-color: black;
     --game-draggable-target-outline-color: #ffd9c9;
     --game-header-bg-color: #b34525;
     --game-header-color: white;
     --game-primary-color: #ff8c6b;
     --game-secondary-color: #00838f;
+    --game-selected-checkbox-bg-color: #ffdccf;
     --game-text-color: white;
 }
 .bloom-page.game-theme-arctic-dawn {
     --game-button-bg-color: white;
-    --game-button-correct-color: black;
-    --game-button-outline-color: var(--game-page-bg-color);
     --game-button-text-color: #042c53;
+    --game-button-wrong-bg-color: #858585;
     --game-checkbox-outline-color: #85b7eb;
-    --game-draggable-color: black;
-    --game-header-bg-color: #ed93b1;
-    --game-header-color: #042c53;
     --game-primary-color: #ed93b1;
     --game-secondary-color: #042c53;
     --game-text-color: white;
@@ -214,12 +171,9 @@
     .apply-game-theme();
 }
 
-.bloom-page.targets-semi-transparent {
-    // The target outline sticks out and ruins the target image, so we
-    // set the opacity of game-draggable-target-outline-color to 0.5
-    --game-draggable-target-outline-color: color-mix(
-        in srgb,
-        var(--game-draggable-target-outline-color-base) 10%,
-        transparent
-    );
-}
+// Note: target pages still carry the .targets-semi-transparent class, but the target
+// outline color is now controlled entirely by each theme's
+// --game-draggable-target-outline-color (including its alpha). Themes that want a faint
+// target outline bake the desired transparency into that color. This used to be forced
+// here via a color-mix() override, but that shadowed the theme's chosen color/opacity on
+// target pages, so the theme editor's changes appeared to "revert" when you left the page.

--- a/src/content/templates/template books/Games/gamesThemes.less
+++ b/src/content/templates/template books/Games/gamesThemes.less
@@ -76,6 +76,18 @@
 
     --game-draggable-color: black;
 
+    // The theme's orange #ffb453 is only 2.81:1 on the blue page, just under the 3:1 UI
+    // minimum. A slightly brighter orange (3.4:1) keeps the theme's orange identity on
+    // the draggables, Check button, and selected checkbox while clearing AA; black text
+    // on it stays very readable. (BL-16323)
+    --game-draggable-bg-color: #ffce8f;
+    --game-control-button-bg-color: #ffce8f;
+    --game-selected-checkbox-bg-color: #ffce8f;
+
+    // The default outline color (the orange draggable bg) is only 2.81:1 against
+    // the blue page background; a lighter orange clears the 3:1 UI minimum. (BL-16323)
+    --game-draggable-target-outline-color: #ffd9a8;
+
     --game-header-color: white;
     --game-header-bg-color: var(--game-secondary-color);
 
@@ -84,38 +96,67 @@
     --game-button-correct-color: black;
     --game-button-outline-color: var(--game-page-bg-color);
 
-    --game-checkbox-outline-color: #848484;
+    // The previous gray (#848484, 1.32:1 on blue) was off-palette and nearly invisible;
+    // white is the theme's other named color and contrasts strongly (4.95:1). (BL-16323)
+    --game-checkbox-outline-color: white;
 }
 .bloom-page.game-theme-pollinator {
-    --game-button-correct-bg-color: #c46232;
+    // The 'right answer' terracotta was just shy of AA for its white text (4.09:1);
+    // a slightly deeper terracotta reaches 4.95:1. The selected checkbox derives its
+    // color from this variable, so this fixes that too. (BL-16323)
+    --game-button-correct-bg-color: #b35527;
     --game-draggable-bg-color: #6b678d;
     --game-primary-color: #617321;
     --game-secondary-color: white;
-    --game-draggable-target-outline-color: #61732185;
+    // Kept translucent so it doesn't cover target images, but the previous olive
+    // (#61732185, 2.13:1 on white) was too faint; this darker olive at ~70% alpha
+    // reaches 3.71:1. (BL-16323)
+    --game-draggable-target-outline-color: #4a5719b3;
 }
 .bloom-page.game-theme-garden-path {
     --game-button-bg-color: #ffffff;
     --game-button-correct-color: #000000;
-    --game-button-outline-color: var(--game-page-bg-color);
+    // The default outline matched the cream page, leaving the white button edgeless
+    // (1.15:1); the theme's dark green outlines it at 8.41:1. (BL-16323)
+    --game-button-outline-color: #2d4c1e;
     --game-button-text-color: #2d4c1e;
     --game-checkbox-outline-color: #2d4c1e;
-    --game-draggable-color: #000000;
+    // A gold draggable is invisible on the cream page (1.16:1). Darkening the fill to
+    // olive and switching its text to white keeps it readable while it stands out
+    // from the page (text 5.0:1, fill vs page 4.3:1). (BL-16323)
+    --game-draggable-bg-color: #806f00;
+    --game-draggable-color: white;
+    // The default outline color (gold #ffde00) is invisible on the cream page
+    // background (1.16:1); the theme's dark green gives 8.41:1. (BL-16323)
+    --game-draggable-target-outline-color: #2d4c1e;
+    // The Check button's gold fill was invisible on cream (1.16:1); dark green gives
+    // 8.41:1. (BL-16323)
+    --game-control-button-bg-color: #2d4c1e;
     --game-header-bg-color: #2d4c1e;
     --game-header-color: #feefb1;
     --game-primary-color: #ffde00;
     --game-secondary-color: #feefb1;
+    // The selected checkbox reused the gold fill, invisible on cream (1.16:1). Olive
+    // fill + white check keeps it readable and distinct (text 5.0:1, vs page 4.3:1). (BL-16323)
+    --game-selected-checkbox-bg-color: #806f00;
+    --game-selected-checkbox-color: white;
     --game-text-color: #2d4c1e;
 }
 .bloom-page.game-theme-cherry-blossom {
     --game-button-bg-color: #ffffff;
     --game-button-correct-color: #ffffff;
-    --game-button-outline-color: var(--game-page-bg-color);
+    // The white button's edge matched the page (invisible, 1.10:1); reusing the
+    // checkbox-outline magenta gives it a visible cherry border (6.5:1). (BL-16323)
+    --game-button-outline-color: #8c3d56;
     --game-button-text-color: #5d2a3a;
     --game-checkbox-outline-color: #8c3d56;
     --game-draggable-color: #ffffff;
     --game-header-bg-color: #ffb7c5;
     --game-header-color: #4a1c2b;
-    --game-primary-color: #d14d72;
+    // Deepened the cherry pink slightly: white text on the magenta chips (draggable,
+    // correct, selected) was only 4.19:1; this lifts them all over AA (4.83:1) in one
+    // change while staying 'cherry blossom'. (BL-16323)
+    --game-primary-color: #c83f64;
     --game-secondary-color: #fff0f3;
     --game-text-color: #7a2e45;
 }
@@ -126,6 +167,16 @@
     --game-button-text-color: black;
     --game-checkbox-outline-color: #e0f2f1;
     --game-draggable-color: black;
+    // Bold coral was invisible on the teal page (1.98:1). A pale coral keeps the reef's
+    // signature color while standing out (3.5:1) with the black draggable text. Used for
+    // the draggables, the Check button, and the selected checkbox so they read as one
+    // family. (BL-16323)
+    --game-draggable-bg-color: #ffdccf;
+    --game-control-button-bg-color: #ffdccf;
+    --game-selected-checkbox-bg-color: #ffdccf;
+    // The default outline color (coral #ff8c6b) is too close in lightness to the
+    // teal page background (1.98:1); a pale coral gives 3.45:1. (BL-16323)
+    --game-draggable-target-outline-color: #ffd9c9;
     --game-header-bg-color: #b34525;
     --game-header-color: white;
     --game-primary-color: #ff8c6b;


### PR DESCRIPTION
[Claude Opus 4.8]

## What & why (BL-16323)

The game themes were generated without checking the color used for the **dashed
drop-target rectangles** (and several other themed elements) against each theme's
background. In several themes that color was the same as, or too low-contrast
against, the page background, so the dashed targets were hard or impossible to see.

I audited **every element of every game theme** against **WCAG 2.1 Level AA**
(4.5:1 for text, 3:1 for non-text UI / large text) and applied palette-aware,
on-theme color overrides. **All eight themes now pass AA on every measured element.**

## Theme fixes (`gamesThemes.less`)

| Theme | Change |
|---|---|
| garden-path | olive draggable + white text, dark-green target outline / control button / button outline / selected checkbox (gold was invisible on cream) |
| coral-reef | pale coral draggables, Check button, selected checkbox, and target outline (bold coral was invisible on teal) |
| white-and-orange-on-blue | brighter orange chips + target outline; white checkbox outline (orange was just under AA on blue; the old gray was off-palette) |
| cherry-blossom | deepened the primary cherry so white text clears AA on the magenta chips; cherry border on the white button |
| pollinator | deepened the terracotta correct/selected color and the semi-transparent target outline |

(blue-on-white, red-on-white, and arctic-dawn already passed AA on every element and were left unchanged.)

Each override has an inline comment explaining the before/after contrast and the issue id.

## New tooling: `game-theme-preview` skill

`.github/skills/game-theme-preview/` — a reusable way to audit and fix theme contrast:

- **contrast.py** — WCAG contrast library (named/hex/alpha, alpha compositing).
- **generate_preview.py** — parses `gamesThemes.less`, resolves the full `--game-*`
  cascade per theme, measures contrast for every element pair, and writes a
  self-contained HTML preview. Failing cards are outlined orange/red and offer
  validated fix options — each candidate is checked against **all** of an element's
  contrast relationships, so a fix can't pass one while breaking another — with
  before→after ratios and an approval/copy flow. It can fold in AI-curated
  "Recommended" picks.
- **SKILL.md** — documents the canonical loop: measure → agent curates palette-aware
  colors → validate/visualize → human approves → apply → re-verify.

## Notes
- Targets are CSS dashed borders driven by CSS variables, so all fixes are
  one-line variable overrides per theme — no image/SVG assets changed.
- No build was run (per repo guidance); the compiled
  `output/.../gamesThemes.css` will regenerate from this source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7985)
<!-- Reviewable:end -->
