### PR TITLE
Fix PR Review Tracker startup_failure (secret name mismatch)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -21,5 +21,7 @@ jobs:
         if: github.event.pull_request.head.repo.full_name == github.repository
         uses: BloomBooks/.github/.github/workflows/pr-review-tracker.yml@main
         # Pass only this one secret, not `secrets: inherit`, to limit blast radius.
+        # The reusable workflow declares the input as PROJECT_TOKEN; supply it from
+        # this repo's org-level PR_REVIEW_TRACKER_PROJECT_TOKEN secret.
         secrets:
-            PR_REVIEW_TRACKER_PROJECT_TOKEN: ${{ secrets.PR_REVIEW_TRACKER_PROJECT_TOKEN }}
+            PROJECT_TOKEN: ${{ secrets.PR_REVIEW_TRACKER_PROJECT_TOKEN }}


### PR DESCRIPTION
[Claude Opus 4.8]

## Problem

The **PR Review Tracker** workflow has been failing on every PR with conclusion `startup_failure` (e.g. [run 27968739756](https://github.com/BloomBooks/BloomDesktop/actions/runs/27968739756)). A `startup_failure` is raised during workflow *validation*, before any job runs — so it is not caused by the token being empty (an empty token would let the run start and fail later inside the `gh api` step).

The real cause is a **secret-name mismatch** between the caller and the reusable workflow:

- Caller (`.github/workflows/pr-review.yml`) passed a secret named `PR_REVIEW_TRACKER_PROJECT_TOKEN`.
- The reusable workflow (`BloomBooks/.github/.github/workflows/pr-review-tracker.yml@main`) declares its input secret as `PROJECT_TOKEN` with `required: true`.

So validation failed two ways at once: the caller passed an undeclared secret, and the required `PROJECT_TOKEN` was never supplied.

## Fix

Map the org-level secret value onto the input name the reusable workflow expects:

```yaml
secrets:
    PROJECT_TOKEN: ${{ secrets.PR_REVIEW_TRACKER_PROJECT_TOKEN }}
```

Keeping the generic `PROJECT_TOKEN` name in the shared reusable workflow means other caller repos don't have to change.

## Note

Once runs actually start, if the org secret `PR_REVIEW_TRACKER_PROJECT_TOKEN` is empty or lacks Projects write scope, that will surface as a *runtime* failure in the "Set Status" step — a separate issue from this startup failure.

[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/7987)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7987)
<!-- Reviewable:end -->
