### PR TITLE
BL-16456 Fix sub-pixel purple line below active TopBar tab on high-DPI screens

### DIFF
--- a/src/BloomBrowserUI/react_components/TopBar/TopBar.tsx
+++ b/src/BloomBrowserUI/react_components/TopBar/TopBar.tsx
@@ -216,11 +216,11 @@ export const BloomTabs: React.FunctionComponent<{
                     padding: 0;
                     gap: 1px;
                     // Bottom-align the tabs to the TopBar so the active tab's bottom edge
-                    // meets the pane below it. The TopBar's purple background is slightly
-                    // taller than the tabs (its height is driven by the taller right-hand
-                    // controls). With the default top-alignment, that left a sub-pixel strip
-                    // of purple showing below the active tab, which rounds up to a visible
-                    // ~1px line on high-DPI screens (the high-res purple line bug).
+                    // meets the pane below it. The TopBar's background color (based on the active tab)
+                    // is slightly taller than the tabs (its height is driven by the taller right-hand
+                    // controls). With the default top-alignment, that left a sub-pixel strip of the
+                    // TopBar background showing below the active tab, which rounds up to a visible
+                    // ~1px line on high-DPI screens.
                     align-self: flex-end;
                 `
             }

--- a/src/BloomBrowserUI/react_components/TopBar/TopBar.tsx
+++ b/src/BloomBrowserUI/react_components/TopBar/TopBar.tsx
@@ -215,6 +215,13 @@ export const BloomTabs: React.FunctionComponent<{
                     margin: 0;
                     padding: 0;
                     gap: 1px;
+                    // Bottom-align the tabs to the TopBar so the active tab's bottom edge
+                    // meets the pane below it. The TopBar's purple background is slightly
+                    // taller than the tabs (its height is driven by the taller right-hand
+                    // controls). With the default top-alignment, that left a sub-pixel strip
+                    // of purple showing below the active tab, which rounds up to a visible
+                    // ~1px line on high-DPI screens (the high-res purple line bug).
+                    align-self: flex-end;
                 `
             }
         >


### PR DESCRIPTION
[Claude Opus 4.8]

## Problem

On high-DPI screens a thin (~1px) purple line appeared just below the active tab in the TopBar. The TopBar's purple background is slightly taller than the tabs (its height is driven by the taller right-hand controls). With the tab row top-aligned, a sub-pixel strip of the purple background showed below the active tab, which rounds up to a visible line on high-DPI displays.

## Fix

Bottom-align the `BloomTabs` row to the TopBar with `align-self: flex-end`, so the active tab's bottom edge meets the pane below it and no purple strip remains.

## Testing

Verify on a high-DPI screen that no purple line shows beneath the active tab, and that tabs still look correct on standard-DPI screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/7988)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7988)
<!-- Reviewable:end -->
