### PR TITLE
Fix BL-16452 splash screen logos misplaced on high-DPI screens

### DIFF
--- a/src/BloomExe/SplashScreen.Designer.cs
+++ b/src/BloomExe/SplashScreen.Designer.cs
@@ -60,7 +60,7 @@
             //
             // _longVersionInfo
             //
-            this._longVersionInfo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this._longVersionInfo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)));
             this._longVersionInfo.AutoSize = true;
             this._longVersionInfo.BackColor = System.Drawing.Color.Transparent;
             this._longVersionInfo.Font = new System.Drawing.Font("Segoe UI", 9F);
@@ -75,7 +75,7 @@
             //
             // _feedbackStatusLabel
             //
-            this._feedbackStatusLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this._feedbackStatusLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)));
             this._feedbackStatusLabel.AutoSize = true;
             this._feedbackStatusLabel.Font = new System.Drawing.Font("Segoe UI", 9F);
             this._feedbackStatusLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(161)))), ((int)(((byte)(255)))));
@@ -88,7 +88,7 @@
             //
             // _copyrightlabel
             //
-            this._copyrightlabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this._copyrightlabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)));
             this._copyrightlabel.AutoSize = true;
             this._copyrightlabel.BackColor = System.Drawing.Color.Transparent;
             this._copyrightlabel.Font = new System.Drawing.Font("Segoe UI", 9F);
@@ -104,7 +104,7 @@
             //
             // _shortVersionLabel
             //
-            this._shortVersionLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this._shortVersionLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)));
             this._shortVersionLabel.AutoSize = true;
             this._shortVersionLabel.Font = new System.Drawing.Font("Segoe UI", 9F);
             this._shortVersionLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(161)))), ((int)(((byte)(255)))));
@@ -119,7 +119,10 @@
             //
             // pictureBox2
             //
-            this.pictureBox2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            // Anchored Top|Left (the DPI-stable anchor); its lower-right position is set
+            // in code by LayoutBottomControls(). Bottom|Right anchoring mis-rescales on high-DPI
+            // monitor transitions and strands the logo over the Bloom logo (BL-16452).
+            this.pictureBox2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)));
             this.pictureBox2.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox2.Image")));
             this.pictureBox2.Location = new System.Drawing.Point(373, 318);
             this.pictureBox2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);

--- a/src/BloomExe/SplashScreen.cs
+++ b/src/BloomExe/SplashScreen.cs
@@ -34,6 +34,51 @@ namespace Bloom
             _shortVersionLabel.Text = Shell.GetShortVersionInfo();
             _longVersionInfo.Text = "";
             _feedbackStatusLabel.Visible = !DesktopAnalytics.Analytics.AllowTracking;
+            // Keep the bottom-edge controls correctly placed ourselves; see LayoutBottomControls().
+            SizeChanged += (sender, e) => LayoutBottomControls();
+            LayoutBottomControls();
+        }
+
+        // The dimensions of the form as laid out in the designer; the bottom-control
+        // positions below are expressed as fractions of these.
+        private const double kDesignWidth = 618.0;
+        private const double kDesignHeight = 475.0;
+
+        /// <summary>
+        /// Re-positions the controls that hug the bottom of the splash (the SIL logo in the
+        /// lower-right, and the version/feedback/copyright labels in the lower-left). We do
+        /// this in code rather than relying on Bottom/Right anchoring because, on high-DPI
+        /// systems—especially when the splash is created in one monitor's DPI context and then
+        /// shown on a monitor with a different scale—WinForms mis-rescales bottom/right-anchored
+        /// controls, stranding them up over the Bloom logo (BL-16452). The fractions below
+        /// reproduce the original designer layout exactly when there is no DPI mismatch.
+        /// </summary>
+        private void LayoutBottomControls()
+        {
+            // Bottom-left text labels: left margin and vertical position kept proportional.
+            PlaceTopLeftByFraction(_feedbackStatusLabel, 73, 318);
+            PlaceTopLeftByFraction(_shortVersionLabel, 73, 342);
+            PlaceTopLeftByFraction(_longVersionInfo, 73, 365);
+            PlaceTopLeftByFraction(_copyrightlabel, 73, 388);
+
+            // SIL logo, lower-right: its right edge sat at 544/618 across and its bottom at
+            // 413/475 down in the design.
+            var silLeft =
+                (int)Math.Round(544.0 / kDesignWidth * ClientSize.Width) - pictureBox2.Width;
+            var silTop =
+                (int)Math.Round(413.0 / kDesignHeight * ClientSize.Height) - pictureBox2.Height;
+            pictureBox2.Location = new System.Drawing.Point(silLeft, silTop);
+        }
+
+        /// <summary>
+        /// Sets a control's top-left location to the given designer coordinates expressed as
+        /// fractions of the design size, scaled to the current client size.
+        /// </summary>
+        private void PlaceTopLeftByFraction(Control control, int designX, int designY)
+        {
+            var x = (int)Math.Round(designX / kDesignWidth * ClientSize.Width);
+            var y = (int)Math.Round(designY / kDesignHeight * ClientSize.Height);
+            control.Location = new System.Drawing.Point(x, y);
         }
 
         private void _fadeOutTimer_Tick(object sender, EventArgs e)


### PR DESCRIPTION
[Claude Opus 4.8]

Fixes [BL-16452](https://issues.bloomlibrary.org/youtrack/issue/BL-16452).

## Problem
On high-DPI systems the SIL Global logo (and the version/feedback/copyright labels) could be stranded in the upper-left of the splash screen, overlapping the red Bloom logo, instead of sitting in the lower-right / lower-left.

## Root cause
The splash form uses `AutoScaleMode.Font`. When it is created in one monitor's DPI context and then shown on a monitor with a different scale, WinForms mis-rescales `Bottom`/`Right`-anchored controls during the DPI change, moving them up and to the left. (The splash tends to open on whichever monitor launched the process, which is frequently not the monitor Bloom's main window uses, so a cross-DPI transition is common on mixed-DPI multi-monitor setups.)

## Fix
- Anchor the bottom-edge controls `Top|Left` (the DPI-stable anchor).
- Position them ourselves in code (`SplashScreen.LayoutBottomControls`) based on the current `ClientSize`, using the same proportions as the original 618×475 designer layout.

This reproduces the original layout exactly when there is no DPI mismatch and stays correct across DPI transitions.

## Testing
- Reproduced the bug and verified the fix by loading the real `SplashScreen` form and forcing a high→low DPI monitor transition — the SIL logo and all labels land in the correct corners.
- Confirmed in the running app on a multi-monitor, mixed-DPI setup.
- No automated tests were run (none cover the splash layout).


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/7989)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7989)
<!-- Reviewable:end -->
