### PR TITLE
﻿Fix BL-16447 When Adjust Timings dialog opens, Server could not find the file Temp/undefined

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/AdjustTimingsDialog.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/AdjustTimingsDialog.tsx
@@ -246,13 +246,21 @@ export const AdjustTimingsDialog: React.FunctionComponent<{
         >
             <DialogTitle title={dialogTitle} />
             <DialogMiddle>
-                <AdjustTimingsControl
-                    segments={segments!}
-                    audioFileUrl={audioFileUrl!}
-                    setEndTimes={(endTimes) => updateEndTimes(endTimes)}
-                    fontFamily={fontFamily}
-                    shouldAdjustSegments={shouldAdjustSegments}
-                />
+                {/* Don't render the control until both inputs are actually ready.
+                    They are populated asynchronously in the open effect above; rendering
+                    sooner would mount the control with undefined props (the non-null
+                    assertions would be false), causing WaveSurfer to load the literal
+                    "undefined" URL and the server to report a missing Temp/undefined
+                    file (BL-16447). */}
+                {segments && audioFileUrl && (
+                    <AdjustTimingsControl
+                        segments={segments}
+                        audioFileUrl={audioFileUrl}
+                        setEndTimes={(endTimes) => updateEndTimes(endTimes)}
+                        fontFamily={fontFamily}
+                        shouldAdjustSegments={shouldAdjustSegments}
+                    />
+                )}
                 <div
                     id={timingsMenuId}
                     css={css`


### PR DESCRIPTION
https://issues.bloomlibrary.org/youtrack/issue/BL-16447

The Adjust Timings dialog rendered AdjustTimingsControl unconditionally,
passing segments and audioFileUrl with non-null assertions. Those values
are populated asynchronously in the dialog's "open" effect, so on the first
render they were actually undefined. The child then called
ws.load(props.audioFileUrl) with undefined, causing WaveSurfer to fetch the
literal string "undefined" relative to the editing page's base URL (a Temp
folder). The server then reported "Server could not find the file
.../Temp/undefined." The React 18 upgrade exposed this latent bug by
changing effect timing.

Root-cause fix: only render AdjustTimingsControl once both segments and
audioFileUrl are actually available, and drop the false non-null assertions.
The control is now a pure function of valid inputs; WaveSurfer is created
once with a real URL and there is no transient undefined state.

I did not run automated tests for this change (UI-only render guard); the
file passes prettier and eslint (only a pre-existing unused-import warning).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/7990)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7990)
<!-- Reviewable:end -->
