### PR TITLE
Fix BL-16448 alignControlFrameWithActiveElement is not a function

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementBackgroundImageManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementBackgroundImageManager.ts
@@ -293,9 +293,9 @@ export function adjustBackgroundImageSize(
     bloomCanvas: HTMLElement,
     bgCanvasElement: HTMLElement,
     useSizeOfNewImage: boolean,
-    cropInfo?: IImageCropInfo,
     getActiveElement: () => HTMLElement | undefined,
     alignControlFrameWithActiveElement: () => void,
+    cropInfo?: IImageCropInfo,
 ): Promise<void> {
     // adjustBackgroundImageSizeToFit may wait for the image to load and make modifications after,
     // and we want to make sure those modifications are included in any save that occurs in the meantime.

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementManager.ts
@@ -3122,9 +3122,9 @@ export class CanvasElementManager {
             bloomCanvas,
             bgCanvasElement,
             useSizeOfNewImage,
-            cropInfo,
             () => this.activeElement,
             this.alignControlFrameWithActiveElement,
+            cropInfo,
         );
     }
 


### PR DESCRIPTION
https://issues.bloomlibrary.org/youtrack/issue/BL-16448

The exported adjustBackgroundImageSize() in CanvasElementBackgroundImageManager.ts
declared its optional cropInfo? parameter *before* two required callback
parameters (getActiveElement and alignControlFrameWithActiveElement). The
setupBackgroundImageAttributes() caller, which runs when opening the edit tab
for a page with a background image, omits cropInfo and passes only 6 args. Those
two callbacks then landed in the wrong parameter slots, leaving the real
alignControlFrameWithActiveElement parameter undefined. The later call to
alignControlFrameWithActiveElement() threw "alignControlFrameWithActiveElement
is not a function" (surfaced as an error toast).

This type-level mistake ("a required parameter cannot follow an optional
parameter") was not caught because the build uses Vite/esbuild, which strips TS
types without type-checking.

Fix: move cropInfo? to the end of adjustBackgroundImageSize()'s parameter list
(after the required callbacks) and update the matching call in
CanvasElementManager.adjustBackgroundImageSize to pass cropInfo last.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/7991)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7991)
<!-- Reviewable:end -->
