### PR TITLE
Fix BL-16459 Copying Text Failed

### DIFF
--- a/DistFiles/localization/en/BloomLowPriority.xlf
+++ b/DistFiles/localization/en/BloomLowPriority.xlf
@@ -353,6 +353,16 @@
         <note>ID: CollectionTab.BookMenu.MoveToCurrentCollection</note>
         <note>{0} will be replaced with the name of the collection that the user currently has open for editing.</note>
       </trans-unit>
+      <trans-unit id="EditTab.CopyTextFailed" translate="no" sil:dynamic="true">
+        <source xml:lang="en">Bloom was not able to copy that.</source>
+        <note>ID: EditTab.CopyTextFailed</note>
+        <note>Shown as a toast when Bloom fails to put text on the computer's clipboard, usually because some other program is momentarily holding the clipboard.</note>
+      </trans-unit>
+      <trans-unit id="EditTab.PasteTextFailed" translate="no" sil:dynamic="true">
+        <source xml:lang="en">Bloom was not able to paste.</source>
+        <note>ID: EditTab.PasteTextFailed</note>
+        <note>Shown as a toast when Bloom fails to read text from the computer's clipboard, usually because some other program is momentarily holding the clipboard.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/BloomExe/web/controllers/CommonApi.cs
+++ b/src/BloomExe/web/controllers/CommonApi.cs
@@ -130,10 +130,17 @@ namespace Bloom.web.controllers
                                     // Need to make sure to handle exceptions.
                                     // If the worker thread dies with an unhandled exception,
                                     // it causes the whole program to immediately crash without opportunity for error reporting
+                                    // A clipboard failure is not worth a modal problem-report dialog: whatever the
+                                    // cause, all the user can do is try again (BL-16459). So we just toast, which
+                                    // still offers a "Report" link and still tells Sentry.
                                     NonFatalProblem.Report(
-                                        ModalIf.All,
-                                        PassiveIf.None,
-                                        "Error pasting text",
+                                        ModalIf.None,
+                                        PassiveIf.All,
+                                        LocalizationManager.GetDynamicString(
+                                            "BloomLowPriority",
+                                            "EditTab.PasteTextFailed",
+                                            "Bloom was not able to paste."
+                                        ),
                                         exception: e
                                     );
                                 }
@@ -161,10 +168,17 @@ namespace Bloom.web.controllers
                                         // Need to make sure to handle exceptions.
                                         // If the worker thread dies with an unhandled exception,
                                         // it causes the whole program to immediately crash without opportunity for error reporting
+                                        // A clipboard failure is not worth a modal problem-report dialog: whatever the
+                                        // cause, all the user can do is try again (BL-16459). So we just toast, which
+                                        // still offers a "Report" link and still tells Sentry.
                                         NonFatalProblem.Report(
-                                            ModalIf.All,
-                                            PassiveIf.None,
-                                            "Error copying text",
+                                            ModalIf.None,
+                                            PassiveIf.All,
+                                            LocalizationManager.GetDynamicString(
+                                                "BloomLowPriority",
+                                                "EditTab.CopyTextFailed",
+                                                "Bloom was not able to copy that."
+                                            ),
                                             exception: e
                                         );
                                     }


### PR DESCRIPTION
https://issues.bloomlibrary.org/youtrack/issue/BL-16459

The common/clipboardText endpoint copies/pastes text via the Windows clipboard. When another
program is momentarily holding the clipboard, Windows throws
System.Runtime.InteropServices.ExternalException ("Requested Clipboard operation did not
succeed"). The handler reported this with ModalIf.All, popping a scary "report this problem"
dialog the user could do nothing about but retry.

Rather than try to infer the cause from the exception type, this stops treating any clipboard
failure as modal-worthy: whatever went wrong, all the user can do is try again. So both the copy
(SetText) and paste (GetText) paths now report with ModalIf.None/PassiveIf.All, which shows a
toast instead of a dialog. showSendReport stays at its default of true, so the toast still
carries a "Report" link if the user does want to tell us about it, and Sentry still hears about
it either way. (An earlier revision of this PR caught ExternalException specifically and kept the
modal for everything else; John's review asked us not to guess at the cause, so the special case
is gone and the pre-existing generic catch does the toast.)

While here, localize the two messages, which were previously hardcoded English ("Error pasting
text"/"Error copying text"): new low-priority strings EditTab.CopyTextFailed and
EditTab.PasteTextFailed.

One consequence worth noting: with the modal threshold now ModalIf.None, NonFatalProblem no
longer calls Analytics.ReportException for these, so clipboard failures stop counting toward the
analytics exception total. The log and Sentry still receive them.

[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/7992)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7992)
<!-- Reviewable:end -->