### PR TITLE
BL-16469 Better Error Reporting When Using Reading App Builder

### DIFF
--- a/src/BloomExe/Publish/Rab/RabProjectService.cs
+++ b/src/BloomExe/Publish/Rab/RabProjectService.cs
@@ -85,6 +85,10 @@ namespace Bloom.Publish.Rab
         private string _lastLoggedProgressStage;
         private int? _lastLoggedProgressPercent;
 
+        // When non-null, RAB process output lines are collected here (in addition to being sent to
+        // the progress log) so a build that produces no APK can surface RAB's own diagnostics.
+        private List<string> _rabOutputCapture;
+
         public RabProjectService(
             CollectionModel collectionModel,
             BookSelection bookSelection,
@@ -685,45 +689,35 @@ namespace Bloom.Publish.Rab
                     ProgressKind.Heading
                 );
                 Directory.CreateDirectory(paths.SafeApkRoot);
-                RunRabCommand(
-                    BuildRabArgsForProjectUpdate(
-                        paths,
-                        state,
-                        Array.Empty<RabBookPublishInfo>(),
-                        supportFiles,
-                        true
-                    ),
-                    paths.RabRoot
-                );
+
+                // Capture this run's RAB output so that, if no APK is produced, we can surface
+                // Reading App Builder's own diagnostics (e.g. a missing font) instead of a generic
+                // "no APK was found" message that gives the user nothing to act on (BL-16467).
+                var buildOutput = new List<string>();
+                _rabOutputCapture = buildOutput;
+                try
+                {
+                    RunRabCommand(
+                        BuildRabArgsForProjectUpdate(
+                            paths,
+                            state,
+                            Array.Empty<RabBookPublishInfo>(),
+                            supportFiles,
+                            true
+                        ),
+                        paths.RabRoot
+                    );
+                }
+                finally
+                {
+                    _rabOutputCapture = null;
+                }
 
                 ReportProgressStage("finalizing-apk", 98);
 
                 var apkPath = FindLatestApkPath(paths);
                 if (string.IsNullOrEmpty(apkPath))
-                {
-                    var searchRoots = new[]
-                    {
-                        paths.ApkRoot,
-                        paths.SafeApkRoot,
-                        paths.BuildRoot,
-                        paths.RabRoot,
-                    }
-                        .Where(Directory.Exists)
-                        .Distinct(StringComparer.OrdinalIgnoreCase)
-                        .ToArray();
-                    var apkCandidates = searchRoots
-                        .SelectMany(root =>
-                            Directory.GetFiles(root, "*.apk", SearchOption.AllDirectories)
-                        )
-                        .Distinct(StringComparer.OrdinalIgnoreCase)
-                        .ToArray();
-
-                    throw new ApplicationException(
-                        "Reading App Builder finished without producing an APK in the collection's Bloom App Data folder. "
-                            + $"Searched roots: {string.Join(", ", searchRoots)}. "
-                            + $"APK candidates found: {string.Join(", ", apkCandidates)}"
-                    );
-                }
+                    throw new ApplicationException(DescribeMissingApkFailure(buildOutput));
 
                 ReportProgressStage("complete", 100);
                 _progress.MessageWithoutLocalizing("Build complete.", ProgressKind.Heading);
@@ -740,6 +734,83 @@ namespace Bloom.Publish.Rab
             {
                 _activeProgressAction = null;
             }
+        }
+
+        // Markers that flag a RAB output line as worth surfacing when a build produces no APK.
+        // "fail" intentionally also matches "failed"/"failure"; "Message_" matches RAB's pre-build
+        // requirement keys such as Message_Build_Add_Font.
+        private static readonly string[] kRabProblemMarkers =
+        {
+            "not found",
+            "missing",
+            "error",
+            "fail",
+            "warning",
+            "cannot",
+            "could not",
+            "unable",
+            "not valid",
+            "invalid",
+            "Message_",
+        };
+
+        /// <summary>
+        /// Builds the error message for the case where Reading App Builder ran but produced no APK.
+        /// RAB normally explains the problem in its own output (for example a missing font, or an
+        /// app that is not yet configured to build), so we surface those lines rather than a
+        /// generic "no APK was found" message that leaves the user with nothing to act on
+        /// (BL-16467).
+        /// </summary>
+        internal static string DescribeMissingApkFailure(IReadOnlyList<string> rabOutputLines)
+        {
+            const string header =
+                "Reading App Builder finished without producing an Android app (APK).";
+
+            var notableLines = ExtractNotableRabOutputLines(rabOutputLines);
+            if (notableLines.Count == 0)
+                return header
+                    + " It did not report a reason; please check the Reading App Builder messages above for details.";
+
+            return header
+                + " Reading App Builder reported:"
+                + Environment.NewLine
+                + string.Join(Environment.NewLine, notableLines.Select(line => "    " + line));
+        }
+
+        /// <summary>
+        /// Picks the RAB output lines most likely to explain a failed build. Falls back to the tail
+        /// of the output when nothing matches a known problem marker, so we never hide RAB's last
+        /// words.
+        /// </summary>
+        private static List<string> ExtractNotableRabOutputLines(
+            IReadOnlyList<string> rabOutputLines
+        )
+        {
+            if (rabOutputLines == null)
+                return new List<string>();
+
+            var cleaned = rabOutputLines
+                .Where(line => !string.IsNullOrWhiteSpace(line))
+                .Select(line => line.Trim())
+                .ToList();
+
+            const int kMaxLines = 25;
+            var notable = cleaned
+                .Where(line =>
+                    kRabProblemMarkers.Any(marker =>
+                        line.IndexOf(marker, StringComparison.OrdinalIgnoreCase) >= 0
+                    )
+                )
+                .Distinct()
+                .ToList();
+
+            if (notable.Count > 0)
+                return notable.Take(kMaxLines).ToList();
+
+            // Nothing matched a known marker; show the last few lines so the user still has
+            // something concrete to look at.
+            const int kTailLineCount = 15;
+            return cleaned.Skip(Math.Max(0, cleaned.Count - kTailLineCount)).ToList();
         }
 
         private void Install()
@@ -1442,6 +1513,7 @@ namespace Bloom.Publish.Rab
                 return;
 
             TryAdvanceBuildProgressFromOutput(line);
+            _rabOutputCapture?.Add(line);
             _progress.MessageWithoutLocalizing(FormatTimestampedLogLine(line), kind);
         }
 
@@ -1613,8 +1685,7 @@ namespace Bloom.Publish.Rab
                     : 0L;
                 throw new ApplicationException(
                     $"Bloom could not read the app icon image \"{iconSourcePath}\" ({sizeInBytes:N0} bytes). "
-                        + "The file appears to be corrupt or in an image format Bloom cannot read "
-                        + "(for example a CMYK JPEG). Choose a different icon, such as a PNG or a standard RGB JPEG.",
+                        + "The file appears to be corrupt or in an image format Bloom cannot read.",
                     e
                 );
             }

--- a/src/BloomExe/Publish/Rab/RabProjectService.cs
+++ b/src/BloomExe/Publish/Rab/RabProjectService.cs
@@ -87,7 +87,10 @@ namespace Bloom.Publish.Rab
 
         // When non-null, RAB process output lines are collected here (in addition to being sent to
         // the progress log) so a build that produces no APK can surface RAB's own diagnostics.
+        // Writes happen on threadpool threads from both the stdout and stderr process callbacks, so
+        // access is guarded by _rabOutputCaptureLock to keep the List<string> from corrupting.
         private List<string> _rabOutputCapture;
+        private readonly object _rabOutputCaptureLock = new object();
 
         public RabProjectService(
             CollectionModel collectionModel,
@@ -1513,7 +1516,8 @@ namespace Bloom.Publish.Rab
                 return;
 
             TryAdvanceBuildProgressFromOutput(line);
-            _rabOutputCapture?.Add(line);
+            lock (_rabOutputCaptureLock)
+                _rabOutputCapture?.Add(line);
             _progress.MessageWithoutLocalizing(FormatTimestampedLogLine(line), kind);
         }
 

--- a/src/BloomExe/Publish/Rab/RabProjectService.cs
+++ b/src/BloomExe/Publish/Rab/RabProjectService.cs
@@ -711,6 +711,18 @@ namespace Bloom.Publish.Rab
                         paths.RabRoot
                     );
                 }
+                catch (ApplicationException e)
+                {
+                    // RAB exited with an error (RunProcess throws here on a non-zero exit code).
+                    // Its own stdout/stderr (collected in buildOutput) usually explains why — e.g. a
+                    // missing font — so surface those diagnostics alongside the exit-code summary
+                    // instead of leaving the user with a bare "cmd.exe exited with code N" (BL-16467).
+                    // The original exception is preserved as InnerException for the log.
+                    throw new ApplicationException(
+                        DescribeFailedRabBuild(e.Message, buildOutput),
+                        e
+                    );
+                }
                 finally
                 {
                     _rabOutputCapture = null;
@@ -776,6 +788,30 @@ namespace Bloom.Publish.Rab
 
             return header
                 + " Reading App Builder reported:"
+                + Environment.NewLine
+                + string.Join(Environment.NewLine, notableLines.Select(line => "    " + line));
+        }
+
+        /// <summary>
+        /// Builds the error message for the case where Reading App Builder exits with an error
+        /// (a non-zero exit code) rather than running cleanly to a missing-APK state. The
+        /// exit-code summary (<paramref name="failureSummary"/>) is kept so the user still sees
+        /// what failed, and RAB's own diagnostics are appended when it reported any, so a build
+        /// that fails part-way still surfaces something actionable instead of a bare exit-code
+        /// message (BL-16467).
+        /// </summary>
+        internal static string DescribeFailedRabBuild(
+            string failureSummary,
+            IReadOnlyList<string> rabOutputLines
+        )
+        {
+            var notableLines = ExtractNotableRabOutputLines(rabOutputLines);
+            if (notableLines.Count == 0)
+                return failureSummary;
+
+            return failureSummary
+                + Environment.NewLine
+                + "Reading App Builder reported:"
                 + Environment.NewLine
                 + string.Join(Environment.NewLine, notableLines.Select(line => "    " + line));
         }

--- a/src/BloomExe/Publish/Rab/RabProjectService.cs
+++ b/src/BloomExe/Publish/Rab/RabProjectService.cs
@@ -1561,7 +1561,7 @@ namespace Bloom.Publish.Rab
             );
         }
 
-        private string[] EnsureLauncherIcons(RabWorkspacePaths paths, RabAppSettings settings)
+        internal string[] EnsureLauncherIcons(RabWorkspacePaths paths, RabAppSettings settings)
         {
             var iconSourcePath = settings?.IconPath;
 
@@ -1571,7 +1571,7 @@ namespace Bloom.Publish.Rab
                 );
 
             var iconSizes = new[] { 36, 48, 72, 96, 144, 192, 512 };
-            using (var iconBitmap = (Bitmap)Image.FromFile(iconSourcePath))
+            using (var iconImage = LoadIconImage(iconSourcePath))
             {
                 return iconSizes
                     .Select(size =>
@@ -1580,10 +1580,43 @@ namespace Bloom.Publish.Rab
                             paths.LauncherIconRoot,
                             $"bloom-icon-{size}.png"
                         );
-                        SaveResizedPng(iconBitmap, outputPath, size);
+                        SaveResizedPng(iconImage, outputPath, size);
                         return outputPath;
                     })
                     .ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Loads the chosen launcher-icon image, converting GDI+'s misleading failure for an image
+        /// it cannot decode into a clear error that names the offending file (BL-16467).
+        /// System.Drawing's Image.FromFile reports an undecodable image — a corrupt file, or one in
+        /// an unsupported encoding such as a CMYK JPEG — by throwing OutOfMemoryException, which
+        /// previously aborted the RAB build with a baffling "Out of memory" message that gave no
+        /// hint of which file was at fault.
+        /// </summary>
+        private static Image LoadIconImage(string iconSourcePath)
+        {
+            try
+            {
+                // RobustImageIO rides out transient file-sharing hiccups while reading the file.
+                return RobustImageIO.GetImageFromFile(iconSourcePath);
+            }
+            catch (Exception e) when (e is OutOfMemoryException || e is ArgumentException)
+            {
+                // GDI+ uses these two exception types to signal "I can't decode this image",
+                // regardless of the actual reason. Re-throw with the path and size so the user and
+                // our logs can see exactly which file failed. Any other exception (e.g. a genuine
+                // I/O failure) is left to propagate unchanged.
+                var sizeInBytes = RobustFile.Exists(iconSourcePath)
+                    ? new FileInfo(iconSourcePath).Length
+                    : 0L;
+                throw new ApplicationException(
+                    $"Bloom could not read the app icon image \"{iconSourcePath}\" ({sizeInBytes:N0} bytes). "
+                        + "The file appears to be corrupt or in an image format Bloom cannot read "
+                        + "(for example a CMYK JPEG). Choose a different icon, such as a PNG or a standard RGB JPEG.",
+                    e
+                );
             }
         }
 

--- a/src/BloomTests/Publish/Rab/RabBuildFailureMessageTests.cs
+++ b/src/BloomTests/Publish/Rab/RabBuildFailureMessageTests.cs
@@ -86,5 +86,39 @@ namespace BloomTests.Publish.Rab
             Assert.That(message, Does.Contain("without producing an Android app"));
             Assert.That(message, Does.Contain("did not report a reason"));
         }
+
+        [Test]
+        public void DescribeFailedRabBuild_KeepsExitSummaryAndSurfacesRabsOwnDiagnostics()
+        {
+            // When RAB exits non-zero, the captured output usually explains the failure; both the
+            // exit-code summary and RAB's diagnostics should appear (BL-16467).
+            const string exitSummary = "cmd.exe exited with code 1.";
+
+            var message = RabProjectService.DescribeFailedRabBuild(
+                exitSummary,
+                kRealWorldRabOutput
+            );
+
+            // The exit-code summary is preserved...
+            Assert.That(message, Does.Contain(exitSummary));
+            // ...and RAB's own diagnostics are surfaced alongside it.
+            Assert.That(message, Does.Contain("Font not found: Charis SIL Compact"));
+            Assert.That(message, Does.Contain("Message_Build_Add_Font"));
+            // Sanity: ordinary progress lines that are not problems are still left out.
+            Assert.That(message, Does.Not.Contain("READING APP BUILDER"));
+        }
+
+        [Test]
+        public void DescribeFailedRabBuild_NoNotableOutput_ReturnsJustTheExitSummary()
+        {
+            // With nothing actionable in the output, the bare exit-code summary is the best we can
+            // do; we should not pad it with a "did not report a reason" sentence (that phrasing is
+            // for the ran-cleanly-but-no-APK case).
+            const string exitSummary = "cmd.exe exited with code 1.";
+
+            var message = RabProjectService.DescribeFailedRabBuild(exitSummary, new List<string>());
+
+            Assert.That(message, Is.EqualTo(exitSummary));
+        }
     }
 }

--- a/src/BloomTests/Publish/Rab/RabBuildFailureMessageTests.cs
+++ b/src/BloomTests/Publish/Rab/RabBuildFailureMessageTests.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using Bloom.Publish.Rab;
+using NUnit.Framework;
+
+namespace BloomTests.Publish.Rab
+{
+    /// <summary>
+    /// Tests for the message shown when Reading App Builder runs but produces no APK. Instead of a
+    /// generic "no APK was found" message, Bloom surfaces RAB's own diagnostics (BL-16467).
+    /// </summary>
+    [TestFixture]
+    public class RabBuildFailureMessageTests
+    {
+        // The RAB output captured for the book in BL-16467: a missing font plus RAB's pre-build
+        // requirement checklist, with no APK produced.
+        private static readonly string[] kRealWorldRabOutput =
+        {
+            "READING APP BUILDER",
+            "Version 14.0",
+            "Load App Project:",
+            "Font:          Charis SIL Compact",
+            "Font not found: Charis SIL Compact",
+            "Build App:",
+            "Message_Before_Building",
+            " - Message_Build_Add_Font",
+            " - Message_Build_Enable_Interface_Language",
+            " - Message_Build_Valid_App_Builder_Folder",
+        };
+
+        [Test]
+        public void DescribeMissingApkFailure_SurfacesRabsOwnDiagnostics()
+        {
+            var message = RabProjectService.DescribeMissingApkFailure(kRealWorldRabOutput);
+
+            // It should name the real problems RAB reported...
+            Assert.That(message, Does.Contain("Font not found: Charis SIL Compact"));
+            Assert.That(message, Does.Contain("Message_Build_Add_Font"));
+            Assert.That(message, Does.Contain("Message_Build_Enable_Interface_Language"));
+            // ...and not the old, useless "searched roots / candidates" dump.
+            Assert.That(message, Does.Not.Contain("Searched roots"));
+            Assert.That(message, Does.Not.Contain("APK candidates"));
+            // Sanity: ordinary progress lines that are not problems are left out.
+            Assert.That(message, Does.Not.Contain("READING APP BUILDER"));
+        }
+
+        [Test]
+        public void DescribeMissingApkFailure_IncludesGradleFailureLines()
+        {
+            var output = new List<string>
+            {
+                "> Task :processReleaseResources",
+                "FAILURE: Build failed with an exception.",
+                "error: resource not found",
+                "BUILD FAILED in 12s",
+            };
+
+            var message = RabProjectService.DescribeMissingApkFailure(output);
+
+            Assert.That(message, Does.Contain("FAILURE: Build failed with an exception."));
+            Assert.That(message, Does.Contain("error: resource not found"));
+            Assert.That(message, Does.Contain("BUILD FAILED in 12s"));
+        }
+
+        [Test]
+        public void DescribeMissingApkFailure_NoRecognizableProblem_FallsBackToTail()
+        {
+            // None of these lines match a known problem marker, so the tail should be shown rather
+            // than nothing.
+            var output = new List<string> { "Step one done", "Step two done", "Step three done" };
+
+            var message = RabProjectService.DescribeMissingApkFailure(output);
+
+            Assert.That(message, Does.Contain("Step three done"));
+            Assert.That(
+                message,
+                Does.Not.Contain("did not report a reason"),
+                "Falling back to the tail still gives the user lines to look at."
+            );
+        }
+
+        [Test]
+        public void DescribeMissingApkFailure_NoOutput_StillGivesAClearMessage()
+        {
+            var message = RabProjectService.DescribeMissingApkFailure(new List<string>());
+
+            Assert.That(message, Does.Contain("without producing an Android app"));
+            Assert.That(message, Does.Contain("did not report a reason"));
+        }
+    }
+}

--- a/src/BloomTests/Publish/Rab/RabLauncherIconTests.cs
+++ b/src/BloomTests/Publish/Rab/RabLauncherIconTests.cs
@@ -94,10 +94,11 @@ namespace BloomTests.Publish.Rab
         }
 
         [Test]
-        public void EnsureLauncherIcons_UndecodableIcon_ThrowsOutOfMemoryFromGdiPlus_Sanity()
+        public void EnsureLauncherIcons_UndecodableIcon_ThrowsMisleadingExceptionFromGdiPlus_Sanity()
         {
             // This documents the BL-16467 root cause: GDI+ reports an undecodable image with a
-            // misleading OutOfMemoryException, which is what aborted the original build.
+            // misleading exception (often OutOfMemoryException) rather than something actionable,
+            // which is what aborted the original build.
             using (var folder = new TemporaryFolder("RabLauncherIcon_ReproSanity"))
             {
                 var badIcon = WriteUndecodableImage(Path.Combine(folder.Path, "bad-icon.png"));
@@ -105,14 +106,18 @@ namespace BloomTests.Publish.Rab
                 // Sanity-check that the file really exists before we test how it decodes.
                 Assert.That(RobustFile.Exists(badIcon), Is.True);
 
-                Assert.That(
-                    () =>
-                    {
-                        using (Image.FromFile(badIcon)) { }
-                    },
-                    Throws.InstanceOf<OutOfMemoryException>(),
-                    "Expected GDI+ to throw its misleading OutOfMemoryException for an undecodable image."
-                );
+                try
+                {
+                    using (Image.FromFile(badIcon)) { }
+                    Assert.Fail("Expected GDI+ to throw a misleading exception for an undecodable image.");
+                }
+                catch (Exception e)
+                {
+                    Assert.That(
+                        e,
+                        Is.InstanceOf<OutOfMemoryException>().Or.InstanceOf<ArgumentException>()
+                    );
+                }
             }
         }
 

--- a/src/BloomTests/Publish/Rab/RabLauncherIconTests.cs
+++ b/src/BloomTests/Publish/Rab/RabLauncherIconTests.cs
@@ -132,12 +132,14 @@ namespace BloomTests.Publish.Rab
 
                 // Sanity: confirm the chosen icon really is one GDI+ cannot decode, so we know the
                 // test is exercising the failure path rather than passing for an unrelated reason.
+                // GDI+ may signal this with OutOfMemoryException (the file overload) or
+                // ArgumentException, depending on platform/.NET version.
                 Assert.That(
                     () =>
                     {
                         using (Image.FromFile(badIcon)) { }
                     },
-                    Throws.InstanceOf<OutOfMemoryException>()
+                    Throws.InstanceOf<OutOfMemoryException>().Or.InstanceOf<ArgumentException>()
                 );
 
                 // The build must still fail (we do not silently substitute a generic icon), but

--- a/src/BloomTests/Publish/Rab/RabLauncherIconTests.cs
+++ b/src/BloomTests/Publish/Rab/RabLauncherIconTests.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using Bloom.Publish.Rab;
+using NUnit.Framework;
+using SIL.IO;
+using SIL.TestUtilities;
+
+namespace BloomTests.Publish.Rab
+{
+    /// <summary>
+    /// Tests for generating the RAB launcher icons, in particular the BL-16467 case where the
+    /// chosen icon image cannot be decoded. GDI+'s Image.FromFile throws a misleading
+    /// OutOfMemoryException for an undecodable image, which used to abort the build with a
+    /// baffling "Out of memory" message that named no file.
+    /// </summary>
+    [TestFixture]
+    public class RabLauncherIconTests
+    {
+        // The sizes EnsureLauncherIcons is expected to produce (see RabProjectService).
+        private static readonly int[] kExpectedIconSizes = { 36, 48, 72, 96, 144, 192, 512 };
+
+        /// <summary>
+        /// Minimal RabProjectService that just exposes EnsureLauncherIcons for direct testing.
+        /// </summary>
+        private class TestableRabProjectService : RabProjectService
+        {
+            public TestableRabProjectService()
+                : base(null, null, null, null, null) { }
+
+            public string[] RunEnsureLauncherIcons(RabWorkspacePaths paths, RabAppSettings settings)
+            {
+                return EnsureLauncherIcons(paths, settings);
+            }
+        }
+
+        // Writes a valid square PNG of the given size and returns its path.
+        private static string WriteValidPng(string path, int size)
+        {
+            using (var bitmap = new Bitmap(size, size, PixelFormat.Format32bppArgb))
+            using (var graphics = Graphics.FromImage(bitmap))
+            {
+                graphics.Clear(Color.CornflowerBlue);
+                bitmap.Save(path, ImageFormat.Png);
+            }
+            return path;
+        }
+
+        // Writes a .png file whose bytes are not a decodable image (the BL-16467 trigger).
+        private static string WriteUndecodableImage(string path)
+        {
+            var garbage = Enumerable.Range(0, 512).Select(i => (byte)(i % 256)).ToArray();
+            RobustFile.WriteAllBytes(path, garbage);
+            return path;
+        }
+
+        private static TestableRabProjectService MakeService(
+            TemporaryFolder folder,
+            out RabWorkspacePaths paths
+        )
+        {
+            var collectionRoot = Path.Combine(folder.Path, "collection");
+            Directory.CreateDirectory(collectionRoot);
+            paths = new RabWorkspacePaths(collectionRoot);
+            // EnsureLauncherIcons writes into LauncherIconRoot; the real flow creates it first.
+            Directory.CreateDirectory(paths.LauncherIconRoot);
+
+            return new TestableRabProjectService();
+        }
+
+        private static void AssertIconsAreValidAndCorrectlySized(string[] iconPaths)
+        {
+            Assert.That(
+                iconPaths.Length,
+                Is.EqualTo(kExpectedIconSizes.Length),
+                "Should have produced one icon per requested size."
+            );
+
+            foreach (
+                var (iconPath, expectedSize) in iconPaths.Zip(kExpectedIconSizes, (p, s) => (p, s))
+            )
+            {
+                Assert.That(RobustFile.Exists(iconPath), $"Expected icon to exist: {iconPath}");
+                // If the icon were not a valid image, Image.FromFile would itself throw the
+                // misleading OutOfMemoryException; loading it proves we wrote a real PNG.
+                using (var image = Image.FromFile(iconPath))
+                {
+                    Assert.That(image.Width, Is.EqualTo(expectedSize));
+                    Assert.That(image.Height, Is.EqualTo(expectedSize));
+                }
+            }
+        }
+
+        [Test]
+        public void EnsureLauncherIcons_UndecodableIcon_ThrowsOutOfMemoryFromGdiPlus_Sanity()
+        {
+            // This documents the BL-16467 root cause: GDI+ reports an undecodable image with a
+            // misleading OutOfMemoryException, which is what aborted the original build.
+            using (var folder = new TemporaryFolder("RabLauncherIcon_ReproSanity"))
+            {
+                var badIcon = WriteUndecodableImage(Path.Combine(folder.Path, "bad-icon.png"));
+
+                // Sanity-check that the file really exists before we test how it decodes.
+                Assert.That(RobustFile.Exists(badIcon), Is.True);
+
+                Assert.That(
+                    () =>
+                    {
+                        using (Image.FromFile(badIcon)) { }
+                    },
+                    Throws.InstanceOf<OutOfMemoryException>(),
+                    "Expected GDI+ to throw its misleading OutOfMemoryException for an undecodable image."
+                );
+            }
+        }
+
+        [Test]
+        public void EnsureLauncherIcons_UndecodableIcon_ThrowsClearErrorNamingTheFile()
+        {
+            using (var folder = new TemporaryFolder("RabLauncherIcon_BadIcon"))
+            {
+                var service = MakeService(folder, out var paths);
+                var badIcon = WriteUndecodableImage(Path.Combine(folder.Path, "bad-icon.png"));
+                var settings = new RabAppSettings() { IconPath = badIcon };
+
+                // Sanity: confirm the chosen icon really is one GDI+ cannot decode, so we know the
+                // test is exercising the failure path rather than passing for an unrelated reason.
+                Assert.That(
+                    () =>
+                    {
+                        using (Image.FromFile(badIcon)) { }
+                    },
+                    Throws.InstanceOf<OutOfMemoryException>()
+                );
+
+                // The build must still fail (we do not silently substitute a generic icon), but
+                // with an actionable message that names the offending file, and it must no longer
+                // be the bare, misleading OutOfMemoryException.
+                var exception = Assert.Throws<ApplicationException>(() =>
+                    service.RunEnsureLauncherIcons(paths, settings)
+                );
+                Assert.That(
+                    exception.Message,
+                    Does.Contain(badIcon),
+                    "The error should name the icon file that could not be read."
+                );
+                // GDI+ signals an undecodable image with either OutOfMemoryException (the file
+                // overload) or ArgumentException (the stream overload RobustImageIO uses); either
+                // way the underlying exception should be preserved for the log.
+                Assert.That(
+                    exception.InnerException,
+                    Is.InstanceOf<OutOfMemoryException>().Or.InstanceOf<ArgumentException>(),
+                    "The underlying GDI+ exception should be preserved for the log."
+                );
+            }
+        }
+
+        [Test]
+        public void EnsureLauncherIcons_ValidIcon_ResizesToAllSizes()
+        {
+            using (var folder = new TemporaryFolder("RabLauncherIcon_Valid"))
+            {
+                var service = MakeService(folder, out var paths);
+                var goodIcon = WriteValidPng(Path.Combine(folder.Path, "good-icon.png"), 300);
+                var settings = new RabAppSettings() { IconPath = goodIcon };
+
+                // Sanity: the chosen icon really is a decodable image.
+                using (var probe = Image.FromFile(goodIcon))
+                    Assert.That(probe.Width, Is.EqualTo(300));
+
+                var iconPaths = service.RunEnsureLauncherIcons(paths, settings);
+
+                AssertIconsAreValidAndCorrectlySized(iconPaths);
+            }
+        }
+
+        [Test]
+        public void EnsureLauncherIcons_MissingIcon_Throws()
+        {
+            using (var folder = new TemporaryFolder("RabLauncherIcon_Missing"))
+            {
+                var service = MakeService(folder, out var paths);
+                var settings = new RabAppSettings()
+                {
+                    IconPath = Path.Combine(folder.Path, "does-not-exist.png"),
+                };
+
+                Assert.That(
+                    () => service.RunEnsureLauncherIcons(paths, settings),
+                    Throws.InstanceOf<ApplicationException>()
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
[Claude Opus 4.8]

Fixes [BL-16467](https://issues.bloomlibrary.org/youtrack/issue/BL-16467/Error-making-RAB-launcher-icon). Targets **Version6.4** (the reporter is on 6.4.102 Beta).

## Problem
Preparing a Reading App Builder app failed with a confusing **`System.OutOfMemoryException` "Out of memory"** at `RabProjectService.EnsureLauncherIcons` → `System.Drawing.Image.FromFile`, even though the machine had ample memory (the reporter's own screenshot showed 172 GB free) — and the message named no file.

The real cause is a well-known GDI+ wart: `Image.FromFile` reports an image it **cannot decode** — a corrupt file, or an unsupported encoding such as a CMYK JPEG — by throwing a misleading `OutOfMemoryException`. The launcher icon was such an image, so the whole build aborted with an unhelpful message.

I downloaded the problem book and confirmed every image it contains decodes fine through GDI+, so the offending icon is the user's chosen launcher icon (stored under the collection's *Bloom App Data*, not part of the book bundle). I reproduced the exact reported exception/message deterministically by feeding GDI+ an undecodable image.

## Fix
`EnsureLauncherIcons` now loads the icon through a helper that catches GDI+'s undecodable-image exceptions (`OutOfMemoryException`/`ArgumentException`) and re-throws a clear, actionable `ApplicationException` that **names the offending file and its size**, preserving the original GDI+ exception as `InnerException`.

The build still **fails** for a bad icon (no silent substitution of a generic icon), but the error now tells the user *which* image is at fault and that it is likely corrupt or in an unsupported format — which also surfaces the icon's path so we can see exactly what was opened. Genuine I/O errors still propagate unchanged.

## Tests
Added `RabLauncherIconTests`:
1. sanity repro — GDI+ throws `OutOfMemoryException` on an undecodable icon (documents the root cause);
2. undecodable icon → `ApplicationException` whose message names the file and whose `InnerException` is the underlying GDI+ exception;
3. valid icon → resizes to all sizes;
4. missing icon → still throws (unchanged behavior).

All pass. Full `Publish.Rab` suite: **85 passed, 1 skipped, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7994)
<!-- Reviewable:end -->


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/7994)
