### PR TITLE
Fix BL-16470 RAB missing interface language

### DIFF
--- a/src/BloomExe/Publish/Rab/RabAppProject.cs
+++ b/src/BloomExe/Publish/Rab/RabAppProject.cs
@@ -451,6 +451,109 @@ namespace Bloom.Publish.Rab
             return _document.Root?.Element(name)?.Value;
         }
 
+        /// <summary>
+        /// Returns true if the project already has at least one enabled interface (app UI)
+        /// language — for example one the user selected in Reading App Builder. Bloom checks this
+        /// so it does not overwrite an existing choice when defaulting the interface language.
+        /// A writing-system counts as enabled unless it explicitly says enabled="false", matching
+        /// how Reading App Builder reads the attribute.
+        /// </summary>
+        internal bool HasEnabledInterfaceLanguage()
+        {
+            var writingSystems = _document
+                .Root?.Element("interface-languages")
+                ?.Element("writing-systems");
+            if (writingSystems == null)
+                return false;
+
+            return writingSystems
+                .Elements("writing-system")
+                .Any(element =>
+                    !string.Equals(
+                        (string)element.Attribute("enabled"),
+                        "false",
+                        StringComparison.OrdinalIgnoreCase
+                    )
+                );
+        }
+
+        /// <summary>
+        /// Enables the given language as the app's interface (UI) language, adding it to
+        /// &lt;interface-languages&gt; if it is not already present. Reading App Builder requires at
+        /// least one enabled interface language to build (BL-16467).
+        /// </summary>
+        internal void SetInterfaceLanguage(string code, string englishName, bool isRightToLeft)
+        {
+            if (string.IsNullOrWhiteSpace(code))
+                throw new ArgumentException("Interface language code is required.", nameof(code));
+
+            var root = _document.Root;
+            if (root == null)
+                throw new ApplicationException("RAB project file is missing its root element.");
+
+            var interfaceLanguages = GetOrCreateInterfaceLanguagesElement(root);
+
+            var writingSystems = interfaceLanguages.Element("writing-systems");
+            if (writingSystems == null)
+            {
+                writingSystems = new XElement("writing-systems");
+                interfaceLanguages.Add(writingSystems);
+            }
+
+            // Replace any existing entry for this language so the method is idempotent across
+            // repeated prepare/build runs.
+            writingSystems
+                .Elements("writing-system")
+                .Where(element =>
+                    string.Equals(
+                        (string)element.Attribute("code"),
+                        code,
+                        StringComparison.OrdinalIgnoreCase
+                    )
+                )
+                .ToList()
+                .ForEach(element => element.Remove());
+
+            writingSystems.Add(
+                new XElement(
+                    "writing-system",
+                    new XAttribute("code", code),
+                    new XAttribute("type", "interface"),
+                    new XAttribute("enabled", "true"),
+                    new XElement(
+                        "display-names",
+                        new XElement("form", new XAttribute("lang", "en"), englishName)
+                    ),
+                    new XElement("font-family", "system"),
+                    new XElement(
+                        "trait",
+                        new XAttribute("name", "text-direction"),
+                        new XAttribute("value", isRightToLeft ? "RTL" : "LTR")
+                    )
+                )
+            );
+        }
+
+        private XElement GetOrCreateInterfaceLanguagesElement(XElement root)
+        {
+            var interfaceLanguages = root.Element("interface-languages");
+            if (interfaceLanguages != null)
+                return interfaceLanguages;
+
+            interfaceLanguages = new XElement("interface-languages");
+            var insertBefore =
+                root.Element("translation-mappings")
+                ?? root.Element("fonts")
+                ?? root.Element("color-scheme")
+                ?? root.Element("books");
+            if (insertBefore != null)
+                insertBefore.AddBeforeSelf(interfaceLanguages);
+            else
+                root.Add(interfaceLanguages);
+
+            return interfaceLanguages;
+        }
+
         private XElement GetOrCreateFontsElement(XElement root)
         {
             var fontsElement = root.Element("fonts");

--- a/src/BloomExe/Publish/Rab/RabAppProject.cs
+++ b/src/BloomExe/Publish/Rab/RabAppProject.cs
@@ -480,7 +480,7 @@ namespace Bloom.Publish.Rab
         /// <summary>
         /// Enables the given language as the app's interface (UI) language, adding it to
         /// &lt;interface-languages&gt; if it is not already present. Reading App Builder requires at
-        /// least one enabled interface language to build (BL-16467).
+        /// least one enabled interface language to build (BL-16470).
         /// </summary>
         internal void SetInterfaceLanguage(string code, string englishName, bool isRightToLeft)
         {

--- a/src/BloomExe/Publish/Rab/RabProjectService.cs
+++ b/src/BloomExe/Publish/Rab/RabProjectService.cs
@@ -1237,7 +1237,7 @@ namespace Bloom.Publish.Rab
 
         // The interface (app UI) languages Reading App Builder offers, keyed by their language
         // subtag. RAB requires at least one enabled interface language or it refuses to build
-        // (BL-16467). Keep this in sync with the languages RAB actually ships UI translations for.
+        // (BL-16470). Keep this in sync with the languages RAB actually ships UI translations for.
         private static readonly Dictionary<
             string,
             RabInterfaceLanguage

--- a/src/BloomExe/Publish/Rab/RabProjectService.cs
+++ b/src/BloomExe/Publish/Rab/RabProjectService.cs
@@ -1286,7 +1286,7 @@ namespace Bloom.Publish.Rab
 
         /// <summary>
         /// Ensures the RAB project has an enabled interface (app UI) language. Without one, RAB
-        /// stops with a "select an interface language" message and produces no APK (BL-16467).
+        /// stops with a "select an interface language" message and produces no APK (BL-16470).
         /// Bloom only supplies a default when none is enabled, deriving it from the collection's
         /// languages (L1, then L2, then L3) and falling back to English; if an interface language
         /// is already enabled — for example one the user chose in Reading App Builder — we leave

--- a/src/BloomExe/Publish/Rab/RabProjectService.cs
+++ b/src/BloomExe/Publish/Rab/RabProjectService.cs
@@ -538,6 +538,7 @@ namespace Bloom.Publish.Rab
 
                 ReconcileProjectWithImportedBooks(existingProjectPath, trackedBooks);
                 SynchronizeProjectFonts(existingProjectPath, trackedBooks);
+                EnsureProjectInterfaceLanguage(existingProjectPath);
                 ReportProgressStage("updating-project", 85);
                 SaveState(paths, state);
 
@@ -676,6 +677,7 @@ namespace Bloom.Publish.Rab
                 );
                 ReconcileProjectWithImportedBooks(state.AppDefPath, trackedBooks);
                 SynchronizeProjectFonts(state.AppDefPath, trackedBooks);
+                EnsureProjectInterfaceLanguage(state.AppDefPath);
                 state.Books = trackedBooks;
                 SaveState(paths, state);
 
@@ -1214,6 +1216,109 @@ namespace Bloom.Publish.Rab
             var project = RabAppProject.Load(appDefPath);
             project.SynchronizeFonts(ReadFontDefinitionsFromBloomPubs(trackedBooks));
             project.Save();
+        }
+
+        /// <summary>
+        /// One interface (app UI) language that Reading App Builder ships translations for.
+        /// </summary>
+        internal class RabInterfaceLanguage
+        {
+            public RabInterfaceLanguage(string code, string englishName, bool isRightToLeft)
+            {
+                Code = code;
+                EnglishName = englishName;
+                IsRightToLeft = isRightToLeft;
+            }
+
+            public string Code { get; }
+            public string EnglishName { get; }
+            public bool IsRightToLeft { get; }
+        }
+
+        // The interface (app UI) languages Reading App Builder offers, keyed by their language
+        // subtag. RAB requires at least one enabled interface language or it refuses to build
+        // (BL-16467). Keep this in sync with the languages RAB actually ships UI translations for.
+        private static readonly Dictionary<
+            string,
+            RabInterfaceLanguage
+        > kSupportedInterfaceLanguages = new Dictionary<string, RabInterfaceLanguage>(
+            StringComparer.OrdinalIgnoreCase
+        )
+        {
+            ["en"] = new RabInterfaceLanguage("en", "English", false),
+            ["fr"] = new RabInterfaceLanguage("fr", "French", false),
+            ["de"] = new RabInterfaceLanguage("de", "German", false),
+            ["es"] = new RabInterfaceLanguage("es", "Spanish", false),
+            ["pt"] = new RabInterfaceLanguage("pt", "Portuguese", false),
+            ["ru"] = new RabInterfaceLanguage("ru", "Russian", false),
+            ["ar"] = new RabInterfaceLanguage("ar", "Arabic", true),
+            ["uk"] = new RabInterfaceLanguage("uk", "Ukrainian", false),
+            ["tr"] = new RabInterfaceLanguage("tr", "Turkish", false),
+            ["fa"] = new RabInterfaceLanguage("fa", "Farsi", true),
+            ["id"] = new RabInterfaceLanguage("id", "Indonesian", false),
+            ["zh"] = new RabInterfaceLanguage("zh", "Chinese (Simplified)", false),
+            ["vi"] = new RabInterfaceLanguage("vi", "Vietnamese", false),
+            ["hi"] = new RabInterfaceLanguage("hi", "Hindi", false),
+            ["ml"] = new RabInterfaceLanguage("ml", "Malayalam", false),
+        };
+
+        /// <summary>
+        /// Chooses the app's interface (UI) language from the collection's languages, in order
+        /// L1, L2, L3, picking the first one Reading App Builder supports. Falls back to English
+        /// when none of the collection languages is a supported interface language.
+        /// </summary>
+        internal static RabInterfaceLanguage ChooseInterfaceLanguage(
+            IEnumerable<string> preferredLanguageTags
+        )
+        {
+            foreach (var tag in preferredLanguageTags ?? Array.Empty<string>())
+            {
+                if (string.IsNullOrWhiteSpace(tag))
+                    continue;
+
+                var subtag = tag.Trim().Split('-')[0];
+                if (kSupportedInterfaceLanguages.TryGetValue(subtag, out var language))
+                    return language;
+            }
+
+            return kSupportedInterfaceLanguages["en"];
+        }
+
+        /// <summary>
+        /// Ensures the RAB project has an enabled interface (app UI) language. Without one, RAB
+        /// stops with a "select an interface language" message and produces no APK (BL-16467).
+        /// Bloom only supplies a default when none is enabled, deriving it from the collection's
+        /// languages (L1, then L2, then L3) and falling back to English; if an interface language
+        /// is already enabled — for example one the user chose in Reading App Builder — we leave
+        /// it untouched.
+        /// </summary>
+        private void EnsureProjectInterfaceLanguage(string appDefPath)
+        {
+            var project = RabAppProject.Load(appDefPath);
+
+            // Don't override a choice already made (e.g. in Reading App Builder).
+            if (project.HasEnabledInterfaceLanguage())
+                return;
+
+            var language = ChooseInterfaceLanguage(
+                new[]
+                {
+                    _collectionSettings?.Language1Tag,
+                    _collectionSettings?.Language2Tag,
+                    _collectionSettings?.Language3Tag,
+                }
+            );
+
+            project.SetInterfaceLanguage(
+                language.Code,
+                language.EnglishName,
+                language.IsRightToLeft
+            );
+            project.Save();
+
+            _progress.MessageWithoutLocalizing(
+                $"Set the app's interface language to {language.EnglishName} ({language.Code})."
+            );
         }
 
         internal static List<RabAppFontDefinition> ReadFontDefinitionsFromBloomPub(

--- a/src/BloomTests/Publish/Rab/RabInterfaceLanguageTests.cs
+++ b/src/BloomTests/Publish/Rab/RabInterfaceLanguageTests.cs
@@ -1,0 +1,275 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+using Bloom.Publish.Rab;
+using NUnit.Framework;
+using SIL.IO;
+using SIL.TestUtilities;
+
+namespace BloomTests.Publish.Rab
+{
+    /// <summary>
+    /// Tests for choosing and setting the app's interface (UI) language for a Reading App Builder
+    /// project. RAB requires at least one enabled interface language or it will not build
+    /// (BL-16467); Bloom derives a default from the collection's languages (L1, then L2, then L3),
+    /// falling back to English, but never overrides an interface language that is already enabled.
+    /// </summary>
+    [TestFixture]
+    public class RabInterfaceLanguageTests
+    {
+        // Builds a minimal RAB appDef whose <writing-systems> contains the given inner XML.
+        private static string AppDefWithInterfaceWritingSystems(string writingSystemsInnerXml)
+        {
+            return $@"<?xml version='1.0' encoding='utf-8'?>
+<app-definition type='RAB' program-version='13.4'>
+  <project-name>Sample Project</project-name>
+  <app-name lang='default'>Sample Project</app-name>
+  <package>org.sil.sample</package>
+  <version code='1' name='1.0'/>
+  <interface-languages>
+    <trait name='use-system-language' value='true'/>
+    <writing-systems>{writingSystemsInnerXml}</writing-systems>
+  </interface-languages>
+  <books id='C01'>
+    <book-collection-name>Main Collection</book-collection-name>
+  </books>
+</app-definition>";
+        }
+
+        // Same project but with no <interface-languages> element at all.
+        private const string kAppDefWithoutInterfaceLanguages =
+            @"<?xml version='1.0' encoding='utf-8'?>
+<app-definition type='RAB' program-version='13.4'>
+  <project-name>Sample Project</project-name>
+  <app-name lang='default'>Sample Project</app-name>
+  <package>org.sil.sample</package>
+  <version code='1' name='1.0'/>
+  <books id='C01'>
+    <book-collection-name>Main Collection</book-collection-name>
+  </books>
+</app-definition>";
+
+        #region ChooseInterfaceLanguage
+
+        [Test]
+        public void ChooseInterfaceLanguage_UsesFirstSupportedCollectionLanguage()
+        {
+            // L1 (Sena) is not a supported interface language, but L2 (Portuguese) is. This is the
+            // BL-16467 collection: minority L1, Portuguese L2, no L3.
+            var language = RabProjectService.ChooseInterfaceLanguage(new[] { "seh", "pt", null });
+
+            Assert.That(language.Code, Is.EqualTo("pt"));
+            Assert.That(language.EnglishName, Is.EqualTo("Portuguese"));
+        }
+
+        [Test]
+        public void ChooseInterfaceLanguage_PrefersL1WhenItIsSupported()
+        {
+            var language = RabProjectService.ChooseInterfaceLanguage(new[] { "es", "fr" });
+
+            Assert.That(language.Code, Is.EqualTo("es"));
+        }
+
+        [Test]
+        public void ChooseInterfaceLanguage_IgnoresRegionAndScriptSubtags()
+        {
+            var language = RabProjectService.ChooseInterfaceLanguage(new[] { "fr-FR" });
+
+            Assert.That(language.Code, Is.EqualTo("fr"));
+        }
+
+        [Test]
+        public void ChooseInterfaceLanguage_NoSupportedLanguage_FallsBackToEnglish()
+        {
+            // A collection whose languages RAB does not have UI translations for.
+            var language = RabProjectService.ChooseInterfaceLanguage(new[] { "seh", "tpi", "" });
+
+            Assert.That(language.Code, Is.EqualTo("en"));
+        }
+
+        [Test]
+        public void ChooseInterfaceLanguage_NoLanguages_FallsBackToEnglish()
+        {
+            Assert.That(RabProjectService.ChooseInterfaceLanguage(null).Code, Is.EqualTo("en"));
+            Assert.That(
+                RabProjectService.ChooseInterfaceLanguage(new string[] { null, "" }).Code,
+                Is.EqualTo("en")
+            );
+        }
+
+        [Test]
+        public void ChooseInterfaceLanguage_MarksRightToLeftLanguages()
+        {
+            Assert.That(
+                RabProjectService.ChooseInterfaceLanguage(new[] { "ar" }).IsRightToLeft,
+                Is.True
+            );
+            Assert.That(
+                RabProjectService.ChooseInterfaceLanguage(new[] { "en" }).IsRightToLeft,
+                Is.False
+            );
+        }
+
+        #endregion
+
+        #region HasEnabledInterfaceLanguage
+
+        private static bool HasEnabledInterfaceLanguage(string appDefContents)
+        {
+            using var tempFile = TempFile.WithExtension(".appDef");
+            RobustFile.WriteAllText(tempFile.Path, appDefContents);
+            return RabAppProject.Load(tempFile.Path).HasEnabledInterfaceLanguage();
+        }
+
+        [Test]
+        public void HasEnabledInterfaceLanguage_EmptyWritingSystems_False()
+        {
+            Assert.That(
+                HasEnabledInterfaceLanguage(AppDefWithInterfaceWritingSystems("")),
+                Is.False
+            );
+        }
+
+        [Test]
+        public void HasEnabledInterfaceLanguage_NoInterfaceLanguagesElement_False()
+        {
+            Assert.That(HasEnabledInterfaceLanguage(kAppDefWithoutInterfaceLanguages), Is.False);
+        }
+
+        [Test]
+        public void HasEnabledInterfaceLanguage_AnEnabledLanguage_True()
+        {
+            var appDef = AppDefWithInterfaceWritingSystems(
+                "<writing-system code='fr' type='interface' enabled='true'/>"
+            );
+            Assert.That(HasEnabledInterfaceLanguage(appDef), Is.True);
+        }
+
+        [Test]
+        public void HasEnabledInterfaceLanguage_OnlyDisabledLanguages_False()
+        {
+            var appDef = AppDefWithInterfaceWritingSystems(
+                "<writing-system code='fr' type='interface' enabled='false'/>"
+            );
+            Assert.That(HasEnabledInterfaceLanguage(appDef), Is.False);
+        }
+
+        [Test]
+        public void HasEnabledInterfaceLanguage_EnabledAttributeOmitted_TreatedAsEnabled()
+        {
+            // Reading App Builder treats a missing enabled attribute as enabled, so we must too.
+            var appDef = AppDefWithInterfaceWritingSystems(
+                "<writing-system code='fr' type='interface'/>"
+            );
+            Assert.That(HasEnabledInterfaceLanguage(appDef), Is.True);
+        }
+
+        #endregion
+
+        #region SetInterfaceLanguage
+
+        private static XElement SetInterfaceLanguageAndReload(
+            string appDefContents,
+            string code,
+            string englishName,
+            bool isRightToLeft
+        )
+        {
+            using var tempFile = TempFile.WithExtension(".appDef");
+            RobustFile.WriteAllText(tempFile.Path, appDefContents);
+
+            var project = RabAppProject.Load(tempFile.Path);
+            project.SetInterfaceLanguage(code, englishName, isRightToLeft);
+            project.Save();
+
+            return XDocument.Load(tempFile.Path).Root;
+        }
+
+        private static List<XElement> InterfaceWritingSystems(XElement root)
+        {
+            return root.Element("interface-languages")
+                    ?.Element("writing-systems")
+                    ?.Elements("writing-system")
+                    .ToList() ?? new List<XElement>();
+        }
+
+        [Test]
+        public void SetInterfaceLanguage_EmptyWritingSystems_AddsEnabledInterfaceLanguage()
+        {
+            var root = SetInterfaceLanguageAndReload(
+                AppDefWithInterfaceWritingSystems(""),
+                "pt",
+                "Portuguese",
+                false
+            );
+
+            var writingSystems = InterfaceWritingSystems(root);
+            Assert.That(writingSystems, Has.Count.EqualTo(1));
+
+            var ws = writingSystems.Single();
+            Assert.That((string)ws.Attribute("code"), Is.EqualTo("pt"));
+            Assert.That((string)ws.Attribute("type"), Is.EqualTo("interface"));
+            Assert.That((string)ws.Attribute("enabled"), Is.EqualTo("true"));
+            Assert.That(
+                ws.Element("trait")?.Attribute("value")?.Value,
+                Is.EqualTo("LTR"),
+                "Portuguese should be left-to-right."
+            );
+        }
+
+        [Test]
+        public void SetInterfaceLanguage_NoInterfaceLanguagesElement_CreatesItAndEnablesLanguage()
+        {
+            var root = SetInterfaceLanguageAndReload(
+                kAppDefWithoutInterfaceLanguages,
+                "pt",
+                "Portuguese",
+                false
+            );
+
+            Assert.That(
+                root.Element("interface-languages"),
+                Is.Not.Null,
+                "The interface-languages element should be created when missing."
+            );
+            var writingSystems = InterfaceWritingSystems(root);
+            Assert.That(writingSystems, Has.Count.EqualTo(1));
+            Assert.That((string)writingSystems.Single().Attribute("code"), Is.EqualTo("pt"));
+        }
+
+        [Test]
+        public void SetInterfaceLanguage_RightToLeftLanguage_MarksDirectionRtl()
+        {
+            var root = SetInterfaceLanguageAndReload(
+                AppDefWithInterfaceWritingSystems(""),
+                "ar",
+                "Arabic",
+                true
+            );
+
+            var ws = InterfaceWritingSystems(root).Single();
+            Assert.That(ws.Element("trait")?.Attribute("value")?.Value, Is.EqualTo("RTL"));
+        }
+
+        [Test]
+        public void SetInterfaceLanguage_CalledTwice_DoesNotDuplicate()
+        {
+            using var tempFile = TempFile.WithExtension(".appDef");
+            RobustFile.WriteAllText(tempFile.Path, AppDefWithInterfaceWritingSystems(""));
+
+            var project = RabAppProject.Load(tempFile.Path);
+            project.SetInterfaceLanguage("pt", "Portuguese", false);
+            project.SetInterfaceLanguage("pt", "Portuguese", false);
+            project.Save();
+
+            var writingSystems = InterfaceWritingSystems(XDocument.Load(tempFile.Path).Root);
+            Assert.That(
+                writingSystems.Count(ws => (string)ws.Attribute("code") == "pt"),
+                Is.EqualTo(1),
+                "Setting the same interface language twice should not duplicate it."
+            );
+        }
+
+        #endregion
+    }
+}

--- a/src/BloomTests/Publish/Rab/RabInterfaceLanguageTests.cs
+++ b/src/BloomTests/Publish/Rab/RabInterfaceLanguageTests.cs
@@ -11,7 +11,7 @@ namespace BloomTests.Publish.Rab
     /// <summary>
     /// Tests for choosing and setting the app's interface (UI) language for a Reading App Builder
     /// project. RAB requires at least one enabled interface language or it will not build
-    /// (BL-16467); Bloom derives a default from the collection's languages (L1, then L2, then L3),
+    /// (BL-16470); Bloom derives a default from the collection's languages (L1, then L2, then L3),
     /// falling back to English, but never overrides an interface language that is already enabled.
     /// </summary>
     [TestFixture]
@@ -55,7 +55,7 @@ namespace BloomTests.Publish.Rab
         public void ChooseInterfaceLanguage_UsesFirstSupportedCollectionLanguage()
         {
             // L1 (Sena) is not a supported interface language, but L2 (Portuguese) is. This is the
-            // BL-16467 collection: minority L1, Portuguese L2, no L3.
+            // BL-16470 collection: minority L1, Portuguese L2, no L3.
             var language = RabProjectService.ChooseInterfaceLanguage(new[] { "seh", "pt", null });
 
             Assert.That(language.Code, Is.EqualTo("pt"));
@@ -185,10 +185,10 @@ namespace BloomTests.Publish.Rab
             return XDocument.Load(tempFile.Path).Root;
         }
 
-            return root.Element("interface-languages")
-                    ?.Element("writing-systems")
-                    ?.Elements("writing-system")
-                    ?.ToList() ?? new List<XElement>();
+        private static List<XElement> InterfaceWritingSystems(XElement root)
+        {
+            var writingSystems = root.Element("interface-languages")?.Element("writing-systems");
+            return writingSystems?.Elements("writing-system").ToList() ?? new List<XElement>();
         }
 
         [Test]

--- a/src/BloomTests/Publish/Rab/RabInterfaceLanguageTests.cs
+++ b/src/BloomTests/Publish/Rab/RabInterfaceLanguageTests.cs
@@ -185,12 +185,10 @@ namespace BloomTests.Publish.Rab
             return XDocument.Load(tempFile.Path).Root;
         }
 
-        private static List<XElement> InterfaceWritingSystems(XElement root)
-        {
             return root.Element("interface-languages")
                     ?.Element("writing-systems")
                     ?.Elements("writing-system")
-                    .ToList() ?? new List<XElement>();
+                    ?.ToList() ?? new List<XElement>();
         }
 
         [Test]


### PR DESCRIPTION
[Claude Opus 4.8]

Fixes [BL-16470](https://issues.bloomlibrary.org/youtrack/issue/BL-16470/RAB-missing-interface-language). Targets **Version6.4**.

## Problem
Reading App Builder requires at least one **enabled interface (app UI) language** or it stops without producing an APK (it reports `Message_Build_Enable_Interface_Language`). Bloom never set one: the appDef RAB's `-new` produces has an empty `<interface-languages>/<writing-systems>`, and Bloom only set name/package/color/about/icon/copyright — nothing language-related. So RAB-built apps for collections like the reported one (minority L1 = Sena, L2 = Portuguese, no L3) failed to build.

## Fix
Bloom now supplies a **default** interface language when none is enabled:
- Walks the collection's languages **L1 → L2 → L3** and picks the first one RAB ships UI translations for: English, French, German, Spanish, Portuguese, Russian, Arabic, Ukrainian, Turkish, Farsi, Indonesian, Chinese (Simplified), Vietnamese, Hindi, Malayalam. Falls back to **English** if none match. (For the reported collection this selects **Portuguese**.)
- Writes it as an enabled interface `<writing-system>` with the correct LTR/RTL direction, matching the structure in RAB's own sample appDef. Creates `<interface-languages>` if absent.

### Does not override the user's choice
Bloom only fills in a default when **no** interface language is already enabled (`HasEnabledInterfaceLanguage()`), mirroring RAB's rule that a writing-system is enabled unless `enabled="false"`. If the user picks a different interface language in Reading App Builder, Bloom leaves it alone. The step runs on every prepare/build against the existing appDef and is idempotent, so **existing projects pick up the default without being recreated**.

## Tests
Added `RabInterfaceLanguageTests`:
- selection: L1→L2→L3 order (incl. the Sena/Portuguese case), L1-wins, region-subtag stripping (`fr-FR`→`fr`), English fallback, RTL flag;
- the "don't override an enabled language" guard (empty / none / enabled / only-disabled / omitted-attribute);
- writing the writing-system into the appDef (empty list, missing `<interface-languages>`, RTL, idempotency).

Full `Publish.Rab` suite: **96 passed, 1 skipped, 0 failed**.

> Note: codes use 2-letter ISO (e.g. `zh`, `hi`, `ml`), matching RAB's sample reader-app appDef. RAB's *desktop* strings file writes Hindi/Malayalam as `hin`/`mal`; if the reader app's interface expects those, the two entries can be adjusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/7996)
<!-- Reviewable:end -->


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/7996)
