### PR TITLE
Fix missing dot in .jpeg image extension

### DIFF
--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -850,7 +850,7 @@ namespace Bloom.Api
         }
 
         static HashSet<string> _imageExtensions = new HashSet<string>(
-            new[] { ".jpg", "jpeg", ".png", ".svg" }
+            new[] { ".jpg", ".jpeg", ".png", ".svg" }
         );
 
         internal static bool IsImageTypeThatCanBeReturned(string path)


### PR DESCRIPTION
## Problem
The `_imageExtensions` set in `BloomServer.cs` listed `jpeg` without a leading dot, while every other entry (`.jpg`, `.png`, `.svg`) has one. Since extensions are compared with the dot included, `.jpeg` files were never matched by `IsImageTypeThatCanBeReturned` / `IsImageTypeThatCanBeDegraded`.

## Fix
Add the missing dot so the entry reads `.jpeg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8003)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8003)
<!-- Reviewable:end -->
