### PR TITLE
Fix missing dot in .jpeg image extension

### DIFF
--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -850,7 +850,7 @@ namespace Bloom.Api
         }
 
         static HashSet<string> _imageExtensions = new HashSet<string>(
-            new[] { ".jpg", "jpeg", ".png", ".svg" }
+            new[] { ".jpg", ".jpeg", ".png", ".svg" }
         );
 
         internal static bool IsImageTypeThatCanBeReturned(string path)


### PR DESCRIPTION
The _imageExtensions set had jpeg instead of .jpeg, so .jpeg files
were not recognized by IsImageTypeThatCanBeReturned/Degraded.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8004)
<!-- Reviewable:end -->
