### PR TITLE
BL-16478: StoryWeaver ebook sizes & page-size picker redesign

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -2043,6 +2043,21 @@
         <note>ID: EditTab.NoOtherLayouts</note>
         <note>Show in the size/orientation chooser dropdown of the edit tab, if there was only a single choice</note>
       </trans-unit>
+      <trans-unit id="EditTab.LayoutChoicesMenu.Ebooks" translate="no">
+        <source xml:lang="en">Ebooks</source>
+        <note>ID: EditTab.LayoutChoicesMenu.Ebooks</note>
+        <note>Heading for the ebook-size column in the page size and orientation chooser dropdown on the edit tab.</note>
+      </trans-unit>
+      <trans-unit id="EditTab.LayoutChoicesMenu.Metric" translate="no">
+        <source xml:lang="en">Metric Paper</source>
+        <note>ID: EditTab.LayoutChoicesMenu.Metric</note>
+        <note>Heading for the metric paper-size group in the page size and orientation chooser dropdown on the edit tab.</note>
+      </trans-unit>
+      <trans-unit id="EditTab.LayoutChoicesMenu.USPaper" translate="no">
+        <source xml:lang="en">Imperial Paper</source>
+        <note>ID: EditTab.LayoutChoicesMenu.USPaper</note>
+        <note>Heading for the imperial paper-size group in the page size and orientation chooser dropdown on the edit tab. This includes sizes like Letter, Legal, Half Folio, Quarter Letter, US Comic, and 6x9.</note>
+      </trans-unit>
       <trans-unit id="EditTab.Overflow" sil:dynamic="true">
         <source xml:lang="en">This box has more text than will fit</source>
         <note>ID: EditTab.Overflow</note>

--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -3334,6 +3334,14 @@
         <source xml:lang="en">Device16x9 Portrait</source>
         <note>ID: LayoutChoices.Device16x9Portrait</note>
       </trans-unit>
+      <trans-unit id="LayoutChoices.Ebook7x5Landscape" sil:dynamic="true" translate="no">
+        <source xml:lang="en">Ebook 7x5 Landscape</source>
+        <note>ID: LayoutChoices.Ebook7x5Landscape</note>
+      </trans-unit>
+      <trans-unit id="LayoutChoices.Ebook2x3Portrait" sil:dynamic="true" translate="no">
+        <source xml:lang="en">Ebook 2x3 Portrait</source>
+        <note>ID: LayoutChoices.Ebook2x3Portrait</note>
+      </trans-unit>
       <trans-unit id="LayoutChoices.HalfFolioPortrait" sil:dynamic="true">
         <source xml:lang="en">Half Folio Portrait</source>
         <note>ID: LayoutChoices.HalfFolioPortrait</note>

--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -2058,6 +2058,21 @@
         <note>ID: EditTab.LayoutChoicesMenu.USPaper</note>
         <note>Heading for the imperial paper-size group in the page size and orientation chooser dropdown on the edit tab. This includes sizes like Letter, Legal, Half Folio, Quarter Letter, US Comic, and 6x9.</note>
       </trans-unit>
+      <trans-unit id="EditTab.LayoutChoicesMenu.Portrait" translate="no">
+        <source xml:lang="en">Portrait</source>
+        <note>ID: EditTab.LayoutChoicesMenu.Portrait</note>
+        <note>Section heading for portrait page sizes in the page size and orientation chooser dropdown on the edit tab.</note>
+      </trans-unit>
+      <trans-unit id="EditTab.LayoutChoicesMenu.Landscape" translate="no">
+        <source xml:lang="en">Landscape</source>
+        <note>ID: EditTab.LayoutChoicesMenu.Landscape</note>
+        <note>Section heading for landscape page sizes in the page size and orientation chooser dropdown on the edit tab.</note>
+      </trans-unit>
+      <trans-unit id="EditTab.LayoutChoicesMenu.Square" translate="no">
+        <source xml:lang="en">Square</source>
+        <note>ID: EditTab.LayoutChoicesMenu.Square</note>
+        <note>Section heading for square page sizes in the page size and orientation chooser dropdown on the edit tab.</note>
+      </trans-unit>
       <trans-unit id="EditTab.Overflow" sil:dynamic="true">
         <source xml:lang="en">This box has more text than will fit</source>
         <note>ID: EditTab.Overflow</note>

--- a/DistFiles/pageSizes.json
+++ b/DistFiles/pageSizes.json
@@ -45,6 +45,16 @@
             "width": "177.77777778mm",
             "height": "100mm"
         },
+        {
+            "size": "Ebook2x3Portrait",
+            "width": "475px",
+            "height": "700px"
+        },
+        {
+            "size": "Ebook7x5Landscape",
+            "width": "959px",
+            "height": "690px"
+        },
         { "size": "Size6x9Portrait", "width": "6in", "height": "9in" },
         { "size": "Size6x9Landscape", "width": "9in", "height": "6in" }
     ]

--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
@@ -505,7 +505,11 @@ export default class OverflowChecker {
             }
             const isButton =
                 $editable.closest("." + kBloomButtonClass).length > 0;
-            if ($editable.parents("[class*=Device]").length === 0 || isButton) {
+            if (
+                $editable.parents("[class*=Device],[class*=Ebook]").length ===
+                    0 ||
+                isButton
+            ) {
                 // don't show an overflow warning if we have scrolling available (unless it's a button)
                 theOneLocalizationManager
                     .asyncGetText(
@@ -713,7 +717,9 @@ export default class OverflowChecker {
         const $page = $(page);
         return (
             $page.hasClass("Device16x9Portrait") ||
-            $page.hasClass("Device16x9Landscape")
+            $page.hasClass("Device16x9Landscape") ||
+            $page.hasClass("Ebook2x3Portrait") ||
+            $page.hasClass("Ebook7x5Landscape")
         );
     }
     // Make sure there are no boxes with class 'overflow' or 'thisOverflowingParent' on the page before removing

--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -77,7 +77,9 @@ body {
         pointer-events: auto; // start up clicks again a the next level
     }
 
-    :not(.Device16x9Portrait):not(.Device16x9Landscape)&::before {
+    :not(.Device16x9Portrait):not(.Device16x9Landscape):not(
+            .Ebook2x3Portrait
+        ):not(.Ebook7x5Landscape)&::before {
         // show bleed area
         content: "";
         position: absolute;
@@ -90,7 +92,9 @@ body {
         z-index: 1;
     }
 
-    :not(.Device16x9Portrait):not(.Device16x9Landscape)&:after {
+    :not(.Device16x9Portrait):not(.Device16x9Landscape):not(
+            .Ebook2x3Portrait
+        ):not(.Ebook7x5Landscape)&:after {
         // show safety area (the area inside of the trim box that still could get cut)
         content: "";
         position: absolute;
@@ -793,9 +797,9 @@ div.bloom-templateMode {
     border: 3px dashed black;
 }
 
-// We only make a big deal out of "overflow" if the layout is a *paper* size, rather than a *device* size.
+// We only make a big deal out of "overflow" if the layout is a *paper* size, rather than a *device* or *ebook* size.
 // Or the overflowing text is on a button
-.bloom-page:not([class*="Device"]),
+.bloom-page:not([class*="Device"]):not([class*="Ebook"]),
 .bloom-page .bloom-canvas-button.bloom-canvas-button {
     // We need this three times to beat a rule that gives the focusd editable box a blue outline
     // And for buttons we need to beat the rule on .bloom-canvas-element[data-bloom-active="true"] div.bloom-editable

--- a/src/BloomBrowserUI/bookEdit/pageThumbnailList/PageThumbnail.tsx
+++ b/src/BloomBrowserUI/bookEdit/pageThumbnailList/PageThumbnail.tsx
@@ -99,7 +99,9 @@ export const PageThumbnail: React.FunctionComponent<{
     const reForOverflow = /^[^>]*class="[^"]*pageOverflows/;
     const overflowing = reForOverflow.test(content); // enhance: memo?
 
-    const scrollingWillBeAvailable = props.pageLayout.indexOf("Device") > -1;
+    const scrollingWillBeAvailable =
+        props.pageLayout.indexOf("Device") > -1 ||
+        props.pageLayout.indexOf("Ebook") > -1;
 
     useEffect(() => {
         if (Math.abs(Date.now() - lastPageRequestTime) > 5000) {

--- a/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.less
+++ b/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.less
@@ -188,6 +188,20 @@ body {
             transform: scale(0.095);
         }
     }
+    &.Ebook2x3Portrait {
+        height: 67px;
+        width: 46px;
+        .bloom-page {
+            transform: scale(0.096);
+        }
+    }
+    &.Ebook7x5Landscape {
+        height: 48px;
+        width: 67px;
+        .bloom-page {
+            transform: scale(0.07);
+        }
+    }
     &.A6Portrait {
         .bloom-page {
             transform: scale(0.11);

--- a/src/BloomBrowserUI/bookEdit/topbar/editTopBarControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/topbar/editTopBarControls.tsx
@@ -1,7 +1,7 @@
-import { css } from "@emotion/react";
+import { css, SerializedStyles } from "@emotion/react";
 import BloomButton from "../../react_components/bloomButton";
 import { get, getBloomApiPrefix, post, postJson } from "../../utils/bloomApi";
-import { useCallback, useEffect, useState } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import { BloomTooltip } from "../../react_components/BloomToolTip";
 import { useSubscribeToWebSocketForObject } from "../../utils/WebSocketManager";
 import {
@@ -17,6 +17,7 @@ import Checkbox from "@mui/material/Checkbox";
 import { useL10n } from "../../react_components/l10nHooks";
 import { LocalizableMenuItem } from "../../react_components/localizableMenuItem";
 import { callOnBlur } from "../../utils/menuCloseOnBlur";
+import { LayoutChoicesDropdown } from "./layoutChoicesDropdown";
 
 interface IDropdownData {
     contentLanguagesEnabled: boolean;
@@ -24,7 +25,7 @@ interface IDropdownData {
     layoutChoicesText: string;
 }
 
-interface ITopBarMenuItem {
+export interface ITopBarMenuItem {
     id: string;
     label: string;
     enabled: boolean;
@@ -41,6 +42,13 @@ interface IEditingControlDropdownProps {
     loadMenuItems: (onLoaded?: (itemCount: number) => void) => void;
     onMenuItemClick: (item: ITopBarMenuItem) => void;
     showChecks: boolean;
+    renderMenuItems?: (
+        menuItems: ITopBarMenuItem[],
+        onMenuItemClick: (item: ITopBarMenuItem) => void,
+        showChecks: boolean,
+        buttonId: string,
+    ) => ReactNode;
+    menuPaperCss?: SerializedStyles;
 }
 
 interface IEditingDropdownMenuBehaviorProps {
@@ -121,39 +129,6 @@ const normalizeContentLanguageUsageItems = (
         checked: language.checked,
         enabled: !language.checked || selectedCount > 1,
     }));
-};
-
-const normalizeLayoutChoiceItems = (
-    choices: unknown,
-    currentLayoutChoiceId: unknown,
-    noOtherLayoutsText: string,
-): ITopBarMenuItem[] => {
-    if (!Array.isArray(choices)) {
-        return [];
-    }
-
-    const currentId = String(currentLayoutChoiceId ?? "");
-    const normalizedChoices = choices.map((choice) => {
-        const choiceInfo = choice as Record<string, unknown>;
-        const id = String(choiceInfo.id ?? "");
-        return {
-            id,
-            label: String(choiceInfo.label ?? ""),
-            enabled: true,
-            checked: id === currentId,
-        };
-    });
-
-    if (normalizedChoices.length < 2) {
-        normalizedChoices.push({
-            id: "",
-            label: noOtherLayoutsText,
-            enabled: false,
-            checked: false,
-        });
-    }
-
-    return normalizedChoices;
 };
 
 export const EditTopBarControls: React.FunctionComponent = () => {
@@ -501,68 +476,6 @@ export const ContentLanguagesDropdown: React.FunctionComponent<{
     );
 };
 
-export const LayoutChoicesDropdown: React.FunctionComponent<{
-    localizedText: string;
-}> = (props) => {
-    const [layoutChoiceMenuItems, setLayoutChoiceMenuItems] = useState<
-        ITopBarMenuItem[]
-    >([]);
-    const [fallbackLocalizedText, setFallbackLocalizedText] = useState("");
-    const noOtherLayoutsText = useL10n(
-        "There are no other options for this template.",
-        "EditTab.NoOtherLayouts",
-        "Show in the size/orientation chooser dropdown of the edit tab, if there was only a single choice",
-    );
-
-    const loadLayoutChoiceData = useCallback(
-        (onLoaded?: (itemCount: number) => void) => {
-            get("editView/topBar/layoutChoiceData", (result) => {
-                const items = normalizeLayoutChoiceItems(
-                    result.data?.choices,
-                    result.data?.currentLayoutChoiceId,
-                    noOtherLayoutsText,
-                );
-                const currentChoice = items.find((item) => item.checked);
-                if (currentChoice?.label) {
-                    setFallbackLocalizedText(currentChoice.label);
-                }
-                onLoaded?.(items.length);
-                setLayoutChoiceMenuItems(items);
-            });
-        },
-        [noOtherLayoutsText],
-    );
-
-    const loadMenuItems = (onLoaded?: (itemCount: number) => void) => {
-        loadLayoutChoiceData(onLoaded);
-    };
-
-    useEffect(() => {
-        loadLayoutChoiceData();
-    }, [loadLayoutChoiceData]);
-
-    const onMenuItemClick = (item: ITopBarMenuItem) => {
-        setFallbackLocalizedText(item.label);
-        postJson("editView/topBar/layoutChoiceChange", {
-            layoutChoiceId: item.id,
-        });
-        post("editView/updateTopBarDropdownDisplay");
-    };
-
-    return (
-        <EditingControlDropdown
-            enabled={true}
-            localizedText={props.localizedText || fallbackLocalizedText}
-            tooltipL10nKey={"EditTab.PageSizeAndOrientation.Tooltip"}
-            buttonId="layoutChoicesDropdownButton"
-            menuItems={layoutChoiceMenuItems}
-            loadMenuItems={loadMenuItems}
-            onMenuItemClick={onMenuItemClick}
-            showChecks={false}
-        />
-    );
-};
-
 export const EditingControlDropdown: React.FunctionComponent<
     IEditingControlDropdownProps
 > = (props) => {
@@ -601,32 +514,41 @@ export const EditingControlDropdown: React.FunctionComponent<
                     css: css`
                         min-width: 220px;
                         max-width: 440px;
+
+                        ${props.menuPaperCss}
                     `,
                 },
             }}
         >
-            {props.menuItems.map((item) => (
-                <LocalizableMenuItem
-                    key={`${props.buttonId}-${item.id}-${item.label}`}
-                    english={item.label}
-                    l10nId={null}
-                    onClick={() => onMenuItemClick(item)}
-                    disabled={!item.enabled}
-                    icon={
-                        props.showChecks ? (
-                            <Checkbox
-                                checked={Boolean(item.checked)}
-                                size="small"
-                                disableRipple
-                                css={css`
-                                    padding: 0 6px 0 0;
-                                `}
-                            />
-                        ) : undefined
-                    }
-                    hasLeadingIconSpace={props.showChecks}
-                />
-            ))}
+            {props.renderMenuItems
+                ? props.renderMenuItems(
+                      props.menuItems,
+                      onMenuItemClick,
+                      props.showChecks,
+                      props.buttonId,
+                  )
+                : props.menuItems.map((item) => (
+                      <LocalizableMenuItem
+                          key={`${props.buttonId}-${item.id}-${item.label}`}
+                          english={item.label}
+                          l10nId={null}
+                          onClick={() => onMenuItemClick(item)}
+                          disabled={!item.enabled}
+                          icon={
+                              props.showChecks ? (
+                                  <Checkbox
+                                      checked={Boolean(item.checked)}
+                                      size="small"
+                                      disableRipple
+                                      css={css`
+                                          padding: 0 6px 0 0;
+                                      `}
+                                  />
+                              ) : undefined
+                          }
+                          hasLeadingIconSpace={props.showChecks}
+                      />
+                  ))}
         </Menu>
     );
 
@@ -681,3 +603,5 @@ export const EditingControlDropdown: React.FunctionComponent<
         </BloomTooltip>
     );
 };
+
+export { LayoutChoicesDropdown };

--- a/src/BloomBrowserUI/bookEdit/topbar/layoutChoicesDropdown.tsx
+++ b/src/BloomBrowserUI/bookEdit/topbar/layoutChoicesDropdown.tsx
@@ -348,7 +348,10 @@ function renderLayoutChoiceSection(
                         ? "1fr 1fr"
                         : "1fr"};
                     column-gap: 18px;
-                    padding-left: 19px;
+                    /* Indent so a label lines up under the header text. Each item
+                       carries 14px of internal (pill) left padding, so this is
+                       19px (the desired text indent) minus that 14px. */
+                    padding-left: 5px;
                 `}
             >
                 {items.map((item) =>

--- a/src/BloomBrowserUI/bookEdit/topbar/layoutChoicesDropdown.tsx
+++ b/src/BloomBrowserUI/bookEdit/topbar/layoutChoicesDropdown.tsx
@@ -542,10 +542,12 @@ export const LayoutChoicesDropdown: React.FunctionComponent<{
             <div
                 css={css`
                     display: grid;
-                    grid-template-columns: 1fr 1fr;
+                    /* size each column to its own content so the card hugs the
+                       content and the white space is even on all sides */
+                    grid-template-columns: auto auto;
                     gap: 26px;
                     align-items: start;
-                    padding: 18px 22px 22px;
+                    padding: 22px;
                 `}
             >
                 <div
@@ -698,7 +700,6 @@ export const LayoutChoicesDropdown: React.FunctionComponent<{
                     slotProps={{
                         paper: {
                             css: css`
-                                min-width: 440px;
                                 background-color: #fff;
                                 border: 1px solid #e2e2e2;
                                 border-radius: 6px;

--- a/src/BloomBrowserUI/bookEdit/topbar/layoutChoicesDropdown.tsx
+++ b/src/BloomBrowserUI/bookEdit/topbar/layoutChoicesDropdown.tsx
@@ -1,0 +1,468 @@
+import { css } from "@emotion/react";
+import { ArrowDropDown } from "@mui/icons-material";
+import CheckIcon from "@mui/icons-material/Check";
+import Menu from "@mui/material/Menu";
+import { useCallback, useEffect, useState } from "react";
+import {
+    kBloomBlue,
+    kBloomPurple,
+    kTextOnPurple,
+} from "../../bloomMaterialUITheme";
+import { BloomTooltip } from "../../react_components/BloomToolTip";
+import BloomButton from "../../react_components/bloomButton";
+import { get, post, postJson } from "../../utils/bloomApi";
+import { callOnBlur } from "../../utils/menuCloseOnBlur";
+import { useL10n } from "../../react_components/l10nHooks";
+import { LocalizableMenuItem } from "../../react_components/localizableMenuItem";
+
+interface ITopBarMenuItem {
+    id: string;
+    label: string;
+    enabled: boolean;
+    checked?: boolean;
+}
+
+const metricLayoutOrder = [
+    "A6Portrait",
+    "A6Landscape",
+    "Cm13Landscape",
+    "A5Portrait",
+    "A5Landscape",
+    "B5Portrait",
+    "A4Portrait",
+    "A4Landscape",
+    "A3Portrait",
+    "A3Landscape",
+];
+
+const imperialLayoutOrder = [
+    "QuarterLetterPortrait",
+    "QuarterLetterLandscape",
+    "HalfLetterPortrait",
+    "HalfLetterLandscape",
+    "HalfFolioPortrait",
+    "Size6x9Portrait",
+    "Size6x9Landscape",
+    "USComicPortrait",
+    "LetterPortrait",
+    "LetterLandscape",
+    "LegalPortrait",
+    "LegalLandscape",
+];
+
+const ebookLayoutOrder = [
+    "Device16x9Portrait",
+    "Device16x9Landscape",
+    "Ebook2x3Portrait",
+    "Ebook7x5Landscape",
+];
+
+const emphasizedLayoutIds = new Set([
+    "A5Portrait",
+    "Device16x9Portrait",
+    "Device16x9Landscape",
+]);
+
+function useLayoutChoicesMenuBehavior(props: {
+    buttonId: string;
+    menuItems: ITopBarMenuItem[];
+    loadMenuItems: (onLoaded?: (itemCount: number) => void) => void;
+}) {
+    const [anchorEl, setAnchorEl] = useState<HTMLElement>();
+
+    const openMenuAtAnchor = (anchorElement: HTMLElement) => {
+        setAnchorEl(anchorElement);
+        callOnBlur(() => setAnchorEl(undefined));
+    };
+
+    const onClose = () => {
+        setAnchorEl(undefined);
+    };
+
+    const onOpen = () => {
+        const anchorElement = document.getElementById(props.buttonId);
+        if (!anchorElement) {
+            return;
+        }
+
+        if (props.menuItems.length > 0) {
+            openMenuAtAnchor(anchorElement);
+            props.loadMenuItems();
+            return;
+        }
+
+        props.loadMenuItems((itemCount) => {
+            if (itemCount > 0) {
+                openMenuAtAnchor(anchorElement);
+            } else {
+                setAnchorEl(undefined);
+            }
+        });
+    };
+
+    return {
+        anchorEl,
+        onClose,
+        onOpen,
+    };
+}
+
+function normalizeLayoutChoiceItems(
+    choices: unknown,
+    currentLayoutChoiceId: unknown,
+    noOtherLayoutsText: string,
+): ITopBarMenuItem[] {
+    if (!Array.isArray(choices)) {
+        return [];
+    }
+
+    const currentId = String(currentLayoutChoiceId ?? "");
+    const normalizedChoices = choices.map((choice) => {
+        const choiceInfo = choice as Record<string, unknown>;
+        const id = String(choiceInfo.id ?? "");
+        return {
+            id,
+            label: String(choiceInfo.label ?? ""),
+            enabled: true,
+            checked: id === currentId,
+        };
+    });
+
+    if (normalizedChoices.length < 2) {
+        normalizedChoices.push({
+            id: "",
+            label: noOtherLayoutsText,
+            enabled: false,
+            checked: false,
+        });
+    }
+
+    return normalizedChoices;
+}
+
+function isEbookLayout(item: ITopBarMenuItem): boolean {
+    return (
+        item.id.startsWith("Device16x9") ||
+        item.id.startsWith("Ebook2x3") ||
+        item.id.startsWith("Ebook7x5")
+    );
+}
+
+function isMetricPaperLayout(item: ITopBarMenuItem): boolean {
+    return /^(A\d|B\d|Cm\d)/.test(item.id);
+}
+
+function isUsPaperLayout(item: ITopBarMenuItem): boolean {
+    return /^(Letter|Legal|HalfLetter|HalfFolio|QuarterLetter|USComic|Size6x9)/.test(
+        item.id,
+    );
+}
+
+function orderLayoutItems(
+    items: ITopBarMenuItem[],
+    orderedIds: string[],
+): ITopBarMenuItem[] {
+    const itemsById = new Map(items.map((item) => [item.id, item]));
+    const orderedItems = orderedIds
+        .map((id) => itemsById.get(id))
+        .filter((item): item is ITopBarMenuItem => item !== undefined);
+    const remainingItems = items.filter(
+        (item) => !orderedIds.includes(item.id),
+    );
+    return [...orderedItems, ...remainingItems];
+}
+
+function renderLayoutChoiceItem(
+    item: ITopBarMenuItem,
+    onMenuItemClick: (item: ITopBarMenuItem) => void,
+    buttonId: string,
+) {
+    return (
+        <LocalizableMenuItem
+            key={`${buttonId}-${item.id}-${item.label}`}
+            english={item.label}
+            l10nId={null}
+            onClick={() => onMenuItemClick(item)}
+            disabled={!item.enabled}
+            icon={
+                item.checked ? (
+                    <CheckIcon
+                        css={css`
+                            color: ${kBloomBlue};
+                            font-size: 22px;
+                            font-weight: 700;
+                        `}
+                    />
+                ) : undefined
+            }
+            hasLeadingIconSpace={true}
+            labelCss={css`
+                white-space: nowrap;
+                font-weight: ${emphasizedLayoutIds.has(item.id)
+                    ? 700
+                    : 400} !important;
+            `}
+        />
+    );
+}
+
+function renderLayoutChoiceGroup(
+    heading: string,
+    items: ITopBarMenuItem[],
+    onMenuItemClick: (item: ITopBarMenuItem) => void,
+    buttonId: string,
+) {
+    if (items.length === 0) {
+        return undefined;
+    }
+
+    return (
+        <div
+            key={heading}
+            css={css`
+                display: flex;
+                flex-direction: column;
+                padding-bottom: 4px;
+            `}
+        >
+            <div
+                css={css`
+                    font-size: 12px;
+                    font-weight: 700;
+                    padding: 8px 16px 4px;
+                `}
+            >
+                {heading}
+            </div>
+            {items.map((item) =>
+                renderLayoutChoiceItem(item, onMenuItemClick, buttonId),
+            )}
+        </div>
+    );
+}
+
+export const LayoutChoicesDropdown: React.FunctionComponent<{
+    localizedText: string;
+}> = (props) => {
+    const [layoutChoiceMenuItems, setLayoutChoiceMenuItems] = useState<
+        ITopBarMenuItem[]
+    >([]);
+    const [fallbackLocalizedText, setFallbackLocalizedText] = useState("");
+    const noOtherLayoutsText = useL10n(
+        "There are no other options for this template.",
+        "EditTab.NoOtherLayouts",
+        "Show in the size/orientation chooser dropdown of the edit tab, if there was only a single choice",
+    );
+    const ebooksHeading = useL10n(
+        "Ebooks",
+        "EditTab.LayoutChoicesMenu.Ebooks",
+        "Heading for the ebook-size column in the page size and orientation chooser dropdown on the edit tab.",
+    );
+    const metricHeading = useL10n(
+        "Metric Paper",
+        "EditTab.LayoutChoicesMenu.Metric",
+        "Heading for the metric paper-size group in the page size and orientation chooser dropdown on the edit tab.",
+    );
+    const usPaperHeading = useL10n(
+        "Imperial Paper",
+        "EditTab.LayoutChoicesMenu.USPaper",
+        "Heading for the US paper-size group in the page size and orientation chooser dropdown on the edit tab. This includes sizes like Letter, Legal, Quarter Letter, US Comic, and 6x9.",
+    );
+
+    const loadLayoutChoiceData = useCallback(
+        (onLoaded?: (itemCount: number) => void) => {
+            get("editView/topBar/layoutChoiceData", (result) => {
+                const items = normalizeLayoutChoiceItems(
+                    result.data?.choices,
+                    result.data?.currentLayoutChoiceId,
+                    noOtherLayoutsText,
+                );
+                const currentChoice = items.find((item) => item.checked);
+                if (currentChoice?.label) {
+                    setFallbackLocalizedText(currentChoice.label);
+                }
+                onLoaded?.(items.length);
+                setLayoutChoiceMenuItems(items);
+            });
+        },
+        [noOtherLayoutsText],
+    );
+
+    useEffect(() => {
+        loadLayoutChoiceData();
+    }, [loadLayoutChoiceData]);
+
+    const { anchorEl, onClose, onOpen } = useLayoutChoicesMenuBehavior({
+        buttonId: "layoutChoicesDropdownButton",
+        menuItems: layoutChoiceMenuItems,
+        loadMenuItems: loadLayoutChoiceData,
+    });
+
+    const onMenuItemClick = (item: ITopBarMenuItem) => {
+        if (!item.enabled) {
+            return;
+        }
+        setFallbackLocalizedText(item.label);
+        postJson("editView/topBar/layoutChoiceChange", {
+            layoutChoiceId: item.id,
+        });
+        post("editView/updateTopBarDropdownDisplay");
+        onClose();
+    };
+
+    const renderMenuItems = (
+        menuItems: ITopBarMenuItem[],
+        onClick: (item: ITopBarMenuItem) => void,
+        _showChecks: boolean,
+        buttonId: string,
+    ) => {
+        if (menuItems.some((item) => item.id === "" && !item.enabled)) {
+            return menuItems.map((item) =>
+                renderLayoutChoiceItem(item, onClick, buttonId),
+            );
+        }
+
+        const ebookItems = menuItems.filter(isEbookLayout);
+        const paperItems = menuItems.filter((item) => !isEbookLayout(item));
+        const metricItems = orderLayoutItems(
+            paperItems.filter(isMetricPaperLayout),
+            metricLayoutOrder,
+        );
+        const usPaperItems = orderLayoutItems(
+            paperItems.filter(isUsPaperLayout),
+            imperialLayoutOrder,
+        );
+        const orderedEbookItems = orderLayoutItems(
+            ebookItems,
+            ebookLayoutOrder,
+        );
+
+        return (
+            <div
+                css={css`
+                    display: grid;
+                    grid-template-columns: minmax(220px, 1fr) minmax(200px, 1fr);
+                    column-gap: 8px;
+                    align-items: start;
+                `}
+            >
+                <div
+                    css={css`
+                        display: flex;
+                        flex-direction: column;
+                        justify-content: flex-start;
+                        gap: 20px;
+                        padding-bottom: 8px;
+                    `}
+                >
+                    {renderLayoutChoiceGroup(
+                        metricHeading,
+                        metricItems,
+                        onClick,
+                        buttonId,
+                    )}
+                    {renderLayoutChoiceGroup(
+                        ebooksHeading,
+                        orderedEbookItems,
+                        onClick,
+                        buttonId,
+                    )}
+                </div>
+                <div
+                    css={css`
+                        display: flex;
+                        flex-direction: column;
+                        padding-bottom: 8px;
+                    `}
+                >
+                    <div
+                        css={css`
+                            font-size: 12px;
+                            font-weight: 700;
+                            padding: 10px 16px 6px;
+                        `}
+                    >
+                        {usPaperHeading}
+                    </div>
+                    {usPaperItems.map((item) =>
+                        renderLayoutChoiceItem(item, onClick, buttonId),
+                    )}
+                </div>
+            </div>
+        );
+    };
+
+    return (
+        <BloomTooltip
+            tip={{ l10nKey: "EditTab.PageSizeAndOrientation.Tooltip" }}
+            slotProps={{
+                tooltip: { sx: { maxWidth: "167px", "font-size": "11px" } },
+            }}
+        >
+            <>
+                <BloomButton
+                    id="layoutChoicesDropdownButton"
+                    onClick={onOpen}
+                    enabled={true}
+                    l10nKey="layoutChoicesDropdownButton"
+                    alreadyLocalized={true}
+                    iconBeforeText={<ArrowDropDown />}
+                    size="small"
+                    variant="text"
+                    disableRipple
+                    disableElevation
+                    disableFocusRipple
+                    disableTouchRipple
+                    css={css`
+                        font-size: 11px;
+                        padding: 1px 5px 2px 5px;
+                        text-transform: none;
+                        width: fit-content;
+                        min-width: unset;
+                        background-color: ${kBloomPurple};
+                        color: ${kTextOnPurple};
+                        border: hidden;
+                        flex-direction: row-reverse;
+
+                        .MuiButton-startIcon {
+                            margin-right: 0;
+                            margin-left: 4px;
+                        }
+                    `}
+                >
+                    {props.localizedText || fallbackLocalizedText}
+                </BloomButton>
+                <Menu
+                    open={Boolean(anchorEl)}
+                    anchorEl={anchorEl}
+                    onClose={onClose}
+                    disablePortal={false}
+                    keepMounted={false}
+                    anchorOrigin={{
+                        vertical: "bottom",
+                        horizontal: "left",
+                    }}
+                    transformOrigin={{
+                        vertical: "top",
+                        horizontal: "left",
+                    }}
+                    slotProps={{
+                        paper: {
+                            css: css`
+                                min-width: 500px;
+                                max-width: 560px;
+                            `,
+                        },
+                    }}
+                >
+                    {renderMenuItems(
+                        layoutChoiceMenuItems,
+                        onMenuItemClick,
+                        false,
+                        "layoutChoicesDropdownButton",
+                    )}
+                </Menu>
+            </>
+        </BloomTooltip>
+    );
+};

--- a/src/BloomBrowserUI/bookEdit/topbar/layoutChoicesDropdown.tsx
+++ b/src/BloomBrowserUI/bookEdit/topbar/layoutChoicesDropdown.tsx
@@ -1,19 +1,18 @@
 import { css } from "@emotion/react";
 import { ArrowDropDown } from "@mui/icons-material";
-import CheckIcon from "@mui/icons-material/Check";
 import Menu from "@mui/material/Menu";
-import { useCallback, useEffect, useState } from "react";
-import {
-    kBloomBlue,
-    kBloomPurple,
-    kTextOnPurple,
-} from "../../bloomMaterialUITheme";
+import { kBloomPurple, kTextOnPurple } from "../../bloomMaterialUITheme";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { BloomTooltip } from "../../react_components/BloomToolTip";
 import BloomButton from "../../react_components/bloomButton";
 import { get, post, postJson } from "../../utils/bloomApi";
 import { callOnBlur } from "../../utils/menuCloseOnBlur";
 import { useL10n } from "../../react_components/l10nHooks";
-import { LocalizableMenuItem } from "../../react_components/localizableMenuItem";
+
+// The page-size/orientation picker that lives in the edit-tab top bar. The
+// trigger button shows the current size; clicking it opens a popover card that
+// groups every available size under Metric / Ebooks / Imperial headings, split
+// by orientation, with the current size shown as a solid purple "pill".
 
 interface ITopBarMenuItem {
     id: string;
@@ -22,47 +21,110 @@ interface ITopBarMenuItem {
     checked?: boolean;
 }
 
-const metricLayoutOrder = [
-    "A6Portrait",
-    "A6Landscape",
-    "Cm13Landscape",
-    "A5Portrait",
-    "A5Landscape",
-    "B5Portrait",
-    "A4Portrait",
-    "A4Landscape",
-    "A3Portrait",
-    "A3Landscape",
+// Maps a backend layout id to the short label we show for it in the grid (the
+// backend's full label is used only as a fallback, e.g. the "no other options"
+// row). The arrays below also define which sizes appear, in what order, and in
+// which group/orientation.
+interface ILayoutDisplayItem {
+    id: string;
+    shortLabel: string;
+}
+
+const metricPortraitItems: ILayoutDisplayItem[] = [
+    { id: "A3Portrait", shortLabel: "A3" },
+    { id: "A4Portrait", shortLabel: "A4" },
+    { id: "A5Portrait", shortLabel: "A5" },
+    { id: "A6Portrait", shortLabel: "A6" },
+    { id: "B5Portrait", shortLabel: "B5" },
 ];
 
-const imperialLayoutOrder = [
-    "QuarterLetterPortrait",
-    "QuarterLetterLandscape",
-    "HalfLetterPortrait",
-    "HalfLetterLandscape",
-    "HalfFolioPortrait",
-    "Size6x9Portrait",
-    "Size6x9Landscape",
-    "USComicPortrait",
-    "LetterPortrait",
-    "LetterLandscape",
-    "LegalPortrait",
-    "LegalLandscape",
+const metricLandscapeItems: ILayoutDisplayItem[] = [
+    { id: "A3Landscape", shortLabel: "A3" },
+    { id: "A4Landscape", shortLabel: "A4" },
+    { id: "A5Landscape", shortLabel: "A5" },
+    { id: "A6Landscape", shortLabel: "A6" },
 ];
 
-const ebookLayoutOrder = [
-    "Device16x9Portrait",
-    "Device16x9Landscape",
-    "Ebook2x3Portrait",
-    "Ebook7x5Landscape",
+const metricSquareItems: ILayoutDisplayItem[] = [
+    { id: "Cm13Landscape", shortLabel: "13cm" },
 ];
 
+const imperialPortraitItems: ILayoutDisplayItem[] = [
+    { id: "QuarterLetterPortrait", shortLabel: "Quarter Letter" },
+    { id: "HalfLetterPortrait", shortLabel: "Half Letter" },
+    { id: "HalfFolioPortrait", shortLabel: "Half Folio" },
+    { id: "Size6x9Portrait", shortLabel: '6"x9"' },
+    { id: "USComicPortrait", shortLabel: "US Comic" },
+    { id: "LetterPortrait", shortLabel: "Letter" },
+    { id: "LegalPortrait", shortLabel: "Legal" },
+];
+
+const imperialLandscapeItems: ILayoutDisplayItem[] = [
+    { id: "QuarterLetterLandscape", shortLabel: "Quarter Letter" },
+    { id: "HalfLetterLandscape", shortLabel: "Half Letter" },
+    { id: "Size6x9Landscape", shortLabel: '9"x6"' },
+    { id: "LetterLandscape", shortLabel: "Letter" },
+    { id: "LegalLandscape", shortLabel: "Legal" },
+];
+
+const ebookPortraitItems: ILayoutDisplayItem[] = [
+    { id: "Device16x9Portrait", shortLabel: "9x16" },
+    { id: "Ebook2x3Portrait", shortLabel: "2x3" },
+];
+
+const ebookLandscapeItems: ILayoutDisplayItem[] = [
+    { id: "Device16x9Landscape", shortLabel: "16x9" },
+    { id: "Ebook7x5Landscape", shortLabel: "7x5" },
+];
+
+// Sizes we want to draw the eye to (the common/recommended choices). These are
+// shown bold in the menu when not selected.
 const emphasizedLayoutIds = new Set([
     "A5Portrait",
     "Device16x9Portrait",
     "Device16x9Landscape",
 ]);
 
+type OrientationShape = "portrait" | "landscape" | "square";
+
+// A 14x14 rounded-rectangle orientation glyph (stroke follows the surrounding
+// text color via currentColor) drawn per shape: an upright rectangle for
+// portrait, a wide one for landscape, and a square.
+const OrientationIcon: React.FunctionComponent<{ shape: OrientationShape }> = (
+    props,
+) => {
+    const rect =
+        props.shape === "portrait"
+            ? { x: 4.5, y: 2, width: 7, height: 12 }
+            : props.shape === "landscape"
+              ? { x: 2, y: 4.5, width: 12, height: 7 }
+              : { x: 3, y: 3, width: 10, height: 10 };
+    return (
+        <svg
+            width={12}
+            height={12}
+            viewBox="0 0 14 14"
+            fill="none"
+            css={css`
+                flex: 0 0 auto;
+            `}
+        >
+            <rect
+                x={rect.x}
+                y={rect.y}
+                width={rect.width}
+                height={rect.height}
+                rx="1.5"
+                stroke="currentColor"
+                strokeWidth={1.4}
+                fill="none"
+            />
+        </svg>
+    );
+};
+
+// Manages opening/closing of the popover: it anchors the menu to the trigger
+// button and arranges to close it when the containing window loses focus.
 function useLayoutChoicesMenuBehavior(props: {
     buttonId: string;
     menuItems: ITopBarMenuItem[];
@@ -85,6 +147,9 @@ function useLayoutChoicesMenuBehavior(props: {
             return;
         }
 
+        // If we already have items, open immediately and refresh in the
+        // background; otherwise wait for the load and only open if there is
+        // something to show.
         if (props.menuItems.length > 0) {
             openMenuAtAnchor(anchorElement);
             props.loadMenuItems();
@@ -107,6 +172,9 @@ function useLayoutChoicesMenuBehavior(props: {
     };
 }
 
+// Convert the raw API response into menu items, marking the current choice as
+// checked. If there is only one (or no) real choice, add a disabled
+// "no other options" row so the menu is not empty.
 function normalizeLayoutChoiceItems(
     choices: unknown,
     currentLayoutChoiceId: unknown,
@@ -140,77 +208,108 @@ function normalizeLayoutChoiceItems(
     return normalizedChoices;
 }
 
-function isEbookLayout(item: ITopBarMenuItem): boolean {
-    return (
-        item.id.startsWith("Device16x9") ||
-        item.id.startsWith("Ebook2x3") ||
-        item.id.startsWith("Ebook7x5")
-    );
+// For a group's definition list, return the corresponding loaded menu items
+// (with their short labels), skipping any sizes the current template does not
+// offer.
+function getDisplayItems(
+    itemsById: Map<string, ITopBarMenuItem>,
+    definitions: ILayoutDisplayItem[],
+): Array<ITopBarMenuItem & { shortLabel: string }> {
+    return definitions
+        .map((definition) => {
+            const item = itemsById.get(definition.id);
+            return item
+                ? {
+                      ...item,
+                      shortLabel: definition.shortLabel,
+                  }
+                : undefined;
+        })
+        .filter(
+            (
+                item,
+            ): item is ITopBarMenuItem & {
+                shortLabel: string;
+            } => item !== undefined,
+        );
 }
 
-function isMetricPaperLayout(item: ITopBarMenuItem): boolean {
-    return /^(A\d|B\d|Cm\d)/.test(item.id);
-}
-
-function isUsPaperLayout(item: ITopBarMenuItem): boolean {
-    return /^(Letter|Legal|HalfLetter|HalfFolio|QuarterLetter|USComic|Size6x9)/.test(
-        item.id,
-    );
-}
-
-function orderLayoutItems(
-    items: ITopBarMenuItem[],
-    orderedIds: string[],
-): ITopBarMenuItem[] {
-    const itemsById = new Map(items.map((item) => [item.id, item]));
-    const orderedItems = orderedIds
-        .map((id) => itemsById.get(id))
-        .filter((item): item is ITopBarMenuItem => item !== undefined);
-    const remainingItems = items.filter(
-        (item) => !orderedIds.includes(item.id),
-    );
-    return [...orderedItems, ...remainingItems];
-}
-
+// Render one clickable size. The selected item is a solid purple pill sized to
+// its content; an unselected item is a left-aligned row that fills its grid cell
+// and highlights on hover. A few "recommended" sizes are shown bold.
 function renderLayoutChoiceItem(
-    item: ITopBarMenuItem,
+    item: ITopBarMenuItem & { shortLabel: string },
     onMenuItemClick: (item: ITopBarMenuItem) => void,
     buttonId: string,
+    variant: "metric" | "imperial",
 ) {
+    const selectedCss = css`
+        justify-self: start;
+        background-color: #8a5a96;
+        color: #fff;
+        font-size: 15px;
+        font-weight: 700;
+        padding: 4px 14px;
+        border-radius: 999px;
+    `;
+    // Metric/Ebook rows live in a 2-column grid and carry a small right pad;
+    // Imperial rows are single-column with no right pad. The left indent comes
+    // from the grid container in both cases.
+    const rowCss = css`
+        color: #222;
+        font-size: 15px;
+        font-weight: ${emphasizedLayoutIds.has(item.id) ? 700 : 400};
+        border-radius: 4px;
+        padding: 3px ${variant === "metric" ? "6px" : "0"} 3px 0;
+
+        &:hover {
+            background-color: #f5f1f7;
+        }
+    `;
+
     return (
-        <LocalizableMenuItem
-            key={`${buttonId}-${item.id}-${item.label}`}
-            english={item.label}
-            l10nId={null}
+        <button
+            key={`${buttonId}-${item.id}-${item.shortLabel}`}
+            type="button"
             onClick={() => onMenuItemClick(item)}
             disabled={!item.enabled}
-            icon={
-                item.checked ? (
-                    <CheckIcon
-                        css={css`
-                            color: ${kBloomBlue};
-                            font-size: 22px;
-                            font-weight: 700;
-                        `}
-                    />
-                ) : undefined
-            }
-            hasLeadingIconSpace={true}
-            labelCss={css`
-                white-space: nowrap;
-                font-weight: ${emphasizedLayoutIds.has(item.id)
-                    ? 700
-                    : 400} !important;
-            `}
-        />
+            css={[
+                css`
+                    display: inline-flex;
+                    align-items: center;
+                    border: 0;
+                    background: transparent;
+                    cursor: ${item.enabled ? "pointer" : "default"};
+                    opacity: ${item.enabled ? 1 : 0.5};
+                    text-align: left;
+                    white-space: nowrap;
+                    font-family: inherit;
+
+                    &:focus-visible {
+                        outline: 2px solid #1d94a4;
+                        outline-offset: 1px;
+                    }
+                `,
+                item.checked ? selectedCss : rowCss,
+            ]}
+        >
+            {item.shortLabel}
+        </button>
     );
 }
 
-function renderLayoutChoiceGroup(
+// Render an orientation block: a "PORTRAIT"/"LANDSCAPE"/"SQUARE" header preceded
+// by its icon, followed by the grid of sizes for that orientation.
+function renderLayoutChoiceSection(
     heading: string,
-    items: ITopBarMenuItem[],
+    items: Array<ITopBarMenuItem & { shortLabel: string }>,
     onMenuItemClick: (item: ITopBarMenuItem) => void,
     buttonId: string,
+    shape: OrientationShape,
+    variant: "metric" | "imperial",
+    // When this is the first section of a group that has no system heading above
+    // it, collapse the header's top margin so it sits flush with the body padding.
+    collapseTopMargin: boolean,
 ) {
     if (items.length === 0) {
         return undefined;
@@ -222,21 +321,43 @@ function renderLayoutChoiceGroup(
             css={css`
                 display: flex;
                 flex-direction: column;
-                padding-bottom: 4px;
             `}
         >
             <div
                 css={css`
-                    font-size: 12px;
+                    display: flex;
+                    align-items: center;
+                    gap: 6px;
+                    margin: ${collapseTopMargin ? 0 : 12}px 0 1px;
+                    font-size: 10.5px;
                     font-weight: 700;
-                    padding: 8px 16px 4px;
+                    letter-spacing: 0.08em;
+                    text-transform: uppercase;
+                    color: #9a8aa0;
                 `}
             >
+                <OrientationIcon shape={shape} />
                 {heading}
             </div>
-            {items.map((item) =>
-                renderLayoutChoiceItem(item, onMenuItemClick, buttonId),
-            )}
+            <div
+                css={css`
+                    display: grid;
+                    grid-template-columns: ${variant === "metric"
+                        ? "1fr 1fr"
+                        : "1fr"};
+                    column-gap: 18px;
+                    padding-left: 19px;
+                `}
+            >
+                {items.map((item) =>
+                    renderLayoutChoiceItem(
+                        item,
+                        onMenuItemClick,
+                        buttonId,
+                        variant,
+                    ),
+                )}
+            </div>
         </div>
     );
 }
@@ -248,6 +369,9 @@ export const LayoutChoicesDropdown: React.FunctionComponent<{
         ITopBarMenuItem[]
     >([]);
     const [fallbackLocalizedText, setFallbackLocalizedText] = useState("");
+    // Holds the pending "apply the layout change" timer (see onMenuItemClick) so
+    // we can restart it on a rapid re-click and cancel it if we unmount first.
+    const applyChangeTimerRef = useRef<number | undefined>(undefined);
     const noOtherLayoutsText = useL10n(
         "There are no other options for this template.",
         "EditTab.NoOtherLayouts",
@@ -258,17 +382,25 @@ export const LayoutChoicesDropdown: React.FunctionComponent<{
         "EditTab.LayoutChoicesMenu.Ebooks",
         "Heading for the ebook-size column in the page size and orientation chooser dropdown on the edit tab.",
     );
-    const metricHeading = useL10n(
-        "Metric Paper",
-        "EditTab.LayoutChoicesMenu.Metric",
-        "Heading for the metric paper-size group in the page size and orientation chooser dropdown on the edit tab.",
+    const portraitHeading = useL10n(
+        "Portrait",
+        "EditTab.LayoutChoicesMenu.Portrait",
+        "Section heading for portrait page sizes in the page size and orientation chooser dropdown on the edit tab.",
     );
-    const usPaperHeading = useL10n(
-        "Imperial Paper",
-        "EditTab.LayoutChoicesMenu.USPaper",
-        "Heading for the US paper-size group in the page size and orientation chooser dropdown on the edit tab. This includes sizes like Letter, Legal, Quarter Letter, US Comic, and 6x9.",
+    const landscapeHeading = useL10n(
+        "Landscape",
+        "EditTab.LayoutChoicesMenu.Landscape",
+        "Section heading for landscape page sizes in the page size and orientation chooser dropdown on the edit tab.",
+    );
+    const squareHeading = useL10n(
+        "Square",
+        "EditTab.LayoutChoicesMenu.Square",
+        "Section heading for square page sizes in the page size and orientation chooser dropdown on the edit tab.",
     );
 
+    // Fetch the available layout choices (and which one is current) from the
+    // backend. onLoaded is used by the open logic to decide whether to show the
+    // menu.
     const loadLayoutChoiceData = useCallback(
         (onLoaded?: (itemCount: number) => void) => {
             get("editView/topBar/layoutChoiceData", (result) => {
@@ -292,100 +424,218 @@ export const LayoutChoicesDropdown: React.FunctionComponent<{
         loadLayoutChoiceData();
     }, [loadLayoutChoiceData]);
 
+    // Cancel any pending layout-change timer if we unmount before it fires, so we
+    // don't post a change / set state on an unmounted component.
+    useEffect(() => {
+        return () => {
+            if (applyChangeTimerRef.current !== undefined) {
+                window.clearTimeout(applyChangeTimerRef.current);
+            }
+        };
+    }, []);
+
     const { anchorEl, onClose, onOpen } = useLayoutChoicesMenuBehavior({
         buttonId: "layoutChoicesDropdownButton",
         menuItems: layoutChoiceMenuItems,
         loadMenuItems: loadLayoutChoiceData,
     });
 
+    // Apply the user's size choice. We briefly leave the menu open showing the
+    // new selection before actually changing the layout.
     const onMenuItemClick = (item: ITopBarMenuItem) => {
         if (!item.enabled) {
             return;
         }
-        setFallbackLocalizedText(item.label);
-        postJson("editView/topBar/layoutChoiceChange", {
-            layoutChoiceId: item.id,
-        });
-        post("editView/updateTopBarDropdownDisplay");
-        onClose();
+        // Reflect the new selection immediately so the selected pill moves to the
+        // clicked item and is visible briefly before the menu closes.
+        setLayoutChoiceMenuItems((prev) =>
+            prev.map((menuItem) => ({
+                ...menuItem,
+                checked: menuItem.id === item.id,
+            })),
+        );
+        // Delay the actual layout change: posting it re-lays-out the page and
+        // re-renders the top bar, which tears down the open menu. We want the
+        // user to see the selected pill for a moment first, so we apply the
+        // change (and close) only after a short delay. Restart the timer on each
+        // click so a rapid re-click just updates the selection (last one wins)
+        // rather than posting multiple changes.
+        if (applyChangeTimerRef.current !== undefined) {
+            window.clearTimeout(applyChangeTimerRef.current);
+        }
+        applyChangeTimerRef.current = window.setTimeout(() => {
+            applyChangeTimerRef.current = undefined;
+            setFallbackLocalizedText(item.label);
+            postJson("editView/topBar/layoutChoiceChange", {
+                layoutChoiceId: item.id,
+            });
+            post("editView/updateTopBarDropdownDisplay");
+            onClose();
+        }, 300);
     };
 
+    // Build the popover body: the two-column grid of size groups. If the only
+    // "item" is the disabled placeholder, render just that.
     const renderMenuItems = (
         menuItems: ITopBarMenuItem[],
         onClick: (item: ITopBarMenuItem) => void,
-        _showChecks: boolean,
         buttonId: string,
     ) => {
         if (menuItems.some((item) => item.id === "" && !item.enabled)) {
-            return menuItems.map((item) =>
-                renderLayoutChoiceItem(item, onClick, buttonId),
+            return (
+                <div
+                    css={css`
+                        padding: 18px 22px 22px;
+                    `}
+                >
+                    {menuItems.map((item) =>
+                        renderLayoutChoiceItem(
+                            { ...item, shortLabel: item.label },
+                            onClick,
+                            buttonId,
+                            "imperial",
+                        ),
+                    )}
+                </div>
             );
         }
 
-        const ebookItems = menuItems.filter(isEbookLayout);
-        const paperItems = menuItems.filter((item) => !isEbookLayout(item));
-        const metricItems = orderLayoutItems(
-            paperItems.filter(isMetricPaperLayout),
-            metricLayoutOrder,
+        const itemsById = new Map(menuItems.map((item) => [item.id, item]));
+        const metricPortraitDisplayItems = getDisplayItems(
+            itemsById,
+            metricPortraitItems,
         );
-        const usPaperItems = orderLayoutItems(
-            paperItems.filter(isUsPaperLayout),
-            imperialLayoutOrder,
+        const metricLandscapeDisplayItems = getDisplayItems(
+            itemsById,
+            metricLandscapeItems,
         );
-        const orderedEbookItems = orderLayoutItems(
-            ebookItems,
-            ebookLayoutOrder,
+        const metricSquareDisplayItems = getDisplayItems(
+            itemsById,
+            metricSquareItems,
         );
+        const imperialPortraitDisplayItems = getDisplayItems(
+            itemsById,
+            imperialPortraitItems,
+        );
+        const imperialLandscapeDisplayItems = getDisplayItems(
+            itemsById,
+            imperialLandscapeItems,
+        );
+        const ebookPortraitDisplayItems = getDisplayItems(
+            itemsById,
+            ebookPortraitItems,
+        );
+        const ebookLandscapeDisplayItems = getDisplayItems(
+            itemsById,
+            ebookLandscapeItems,
+        );
+
+        // The group heading style (currently used only for "Ebooks"; the Metric
+        // and Imperial headings are intentionally omitted from the design).
+        const systemHeadingCss = css`
+            font-size: 13px;
+            font-weight: 700;
+            letter-spacing: 0.02em;
+            color: #5f5f5f;
+        `;
 
         return (
             <div
                 css={css`
                     display: grid;
-                    grid-template-columns: minmax(220px, 1fr) minmax(200px, 1fr);
-                    column-gap: 8px;
+                    grid-template-columns: 1fr 1fr;
+                    gap: 26px;
                     align-items: start;
+                    padding: 18px 22px 22px;
                 `}
             >
                 <div
                     css={css`
                         display: flex;
                         flex-direction: column;
-                        justify-content: flex-start;
-                        gap: 20px;
-                        padding-bottom: 8px;
                     `}
                 >
-                    {renderLayoutChoiceGroup(
-                        metricHeading,
-                        metricItems,
-                        onClick,
-                        buttonId,
-                    )}
-                    {renderLayoutChoiceGroup(
-                        ebooksHeading,
-                        orderedEbookItems,
-                        onClick,
-                        buttonId,
-                    )}
+                    {/* Metric group (heading intentionally omitted) */}
+                    <div>
+                        {renderLayoutChoiceSection(
+                            portraitHeading,
+                            metricPortraitDisplayItems,
+                            onClick,
+                            buttonId,
+                            "portrait",
+                            "metric",
+                            true,
+                        )}
+                        {renderLayoutChoiceSection(
+                            landscapeHeading,
+                            metricLandscapeDisplayItems,
+                            onClick,
+                            buttonId,
+                            "landscape",
+                            "metric",
+                            false,
+                        )}
+                        {renderLayoutChoiceSection(
+                            squareHeading,
+                            metricSquareDisplayItems,
+                            onClick,
+                            buttonId,
+                            "square",
+                            "metric",
+                            false,
+                        )}
+                    </div>
+                    {/* Ebooks group, set off from the metric group above it */}
+                    <div
+                        css={css`
+                            margin-top: 22px;
+                        `}
+                    >
+                        <div css={systemHeadingCss}>{ebooksHeading}</div>
+                        {renderLayoutChoiceSection(
+                            portraitHeading,
+                            ebookPortraitDisplayItems,
+                            onClick,
+                            buttonId,
+                            "portrait",
+                            "metric",
+                            false,
+                        )}
+                        {renderLayoutChoiceSection(
+                            landscapeHeading,
+                            ebookLandscapeDisplayItems,
+                            onClick,
+                            buttonId,
+                            "landscape",
+                            "metric",
+                            false,
+                        )}
+                    </div>
                 </div>
+                {/* Imperial group (heading intentionally omitted) */}
                 <div
                     css={css`
                         display: flex;
                         flex-direction: column;
-                        padding-bottom: 8px;
                     `}
                 >
-                    <div
-                        css={css`
-                            font-size: 12px;
-                            font-weight: 700;
-                            padding: 10px 16px 6px;
-                        `}
-                    >
-                        {usPaperHeading}
-                    </div>
-                    {usPaperItems.map((item) =>
-                        renderLayoutChoiceItem(item, onClick, buttonId),
+                    {renderLayoutChoiceSection(
+                        portraitHeading,
+                        imperialPortraitDisplayItems,
+                        onClick,
+                        buttonId,
+                        "portrait",
+                        "imperial",
+                        true,
+                    )}
+                    {renderLayoutChoiceSection(
+                        landscapeHeading,
+                        imperialLandscapeDisplayItems,
+                        onClick,
+                        buttonId,
+                        "landscape",
+                        "imperial",
+                        false,
                     )}
                 </div>
             </div>
@@ -449,8 +699,12 @@ export const LayoutChoicesDropdown: React.FunctionComponent<{
                     slotProps={{
                         paper: {
                             css: css`
-                                min-width: 500px;
-                                max-width: 560px;
+                                min-width: 440px;
+                                background-color: #fff;
+                                border: 1px solid #e2e2e2;
+                                border-radius: 6px;
+                                box-shadow: 0 6px 22px rgba(40, 20, 55, 0.14);
+                                overflow: hidden;
                             `,
                         },
                     }}
@@ -458,7 +712,6 @@ export const LayoutChoicesDropdown: React.FunctionComponent<{
                     {renderMenuItems(
                         layoutChoiceMenuItems,
                         onMenuItemClick,
-                        false,
                         "layoutChoicesDropdownButton",
                     )}
                 </Menu>

--- a/src/BloomBrowserUI/bookEdit/topbar/layoutChoicesDropdown.tsx
+++ b/src/BloomBrowserUI/bookEdit/topbar/layoutChoicesDropdown.tsx
@@ -234,66 +234,68 @@ function getDisplayItems(
         );
 }
 
-// Render one clickable size. The selected item is a solid purple pill sized to
-// its content; an unselected item is a left-aligned row that fills its grid cell
-// and highlights on hover. A few "recommended" sizes are shown bold.
+// Render one clickable size. Every item — selected or not — occupies the exact
+// same box as the selected purple pill (same padding, radius, and reserved bold
+// width), so selecting an item only changes its background/color/weight and never
+// reflows the menu. A few "recommended" sizes are shown bold even when unselected.
 function renderLayoutChoiceItem(
     item: ITopBarMenuItem & { shortLabel: string },
     onMenuItemClick: (item: ITopBarMenuItem) => void,
     buttonId: string,
-    variant: "metric" | "imperial",
 ) {
-    const selectedCss = css`
-        justify-self: start;
-        background-color: #8a5a96;
-        color: #fff;
-        font-size: 15px;
-        font-weight: 700;
-        padding: 4px 14px;
-        border-radius: 999px;
-    `;
-    // Metric/Ebook rows live in a 2-column grid and carry a small right pad;
-    // Imperial rows are single-column with no right pad. The left indent comes
-    // from the grid container in both cases.
-    const rowCss = css`
-        color: #222;
-        font-size: 15px;
-        font-weight: ${emphasizedLayoutIds.has(item.id) ? 700 : 400};
-        border-radius: 4px;
-        padding: 3px ${variant === "metric" ? "6px" : "0"} 3px 0;
-
-        &:hover {
-            background-color: #f5f1f7;
-        }
-    `;
-
+    const bold = item.checked || emphasizedLayoutIds.has(item.id);
     return (
         <button
             key={`${buttonId}-${item.id}-${item.shortLabel}`}
             type="button"
             onClick={() => onMenuItemClick(item)}
             disabled={!item.enabled}
-            css={[
-                css`
-                    display: inline-flex;
-                    align-items: center;
-                    border: 0;
-                    background: transparent;
-                    cursor: ${item.enabled ? "pointer" : "default"};
-                    opacity: ${item.enabled ? 1 : 0.5};
-                    text-align: left;
-                    white-space: nowrap;
-                    font-family: inherit;
+            css={css`
+                justify-self: start;
+                display: inline-flex;
+                align-items: center;
+                border: 0;
+                cursor: ${item.enabled ? "pointer" : "default"};
+                opacity: ${item.enabled ? 1 : 0.5};
+                text-align: left;
+                white-space: nowrap;
+                font-family: inherit;
+                font-size: 15px;
+                padding: 4px 14px;
+                border-radius: 999px;
+                background-color: ${item.checked ? "#8a5a96" : "transparent"};
+                color: ${item.checked ? "#fff" : "#222"};
+                font-weight: ${bold ? 700 : 400};
 
-                    &:focus-visible {
-                        outline: 2px solid #1d94a4;
-                        outline-offset: 1px;
-                    }
-                `,
-                item.checked ? selectedCss : rowCss,
-            ]}
+                &:hover {
+                    background-color: ${item.checked ? "#8a5a96" : "#f5f1f7"};
+                }
+
+                &:focus-visible {
+                    outline: 2px solid #1d94a4;
+                    outline-offset: 1px;
+                }
+            `}
         >
-            {item.shortLabel}
+            {/* The hidden bold copy (::after) reserves the bold width so that
+                becoming selected/bold does not change the item's width. */}
+            <span
+                data-text={item.shortLabel}
+                css={css`
+                    display: flex;
+                    flex-direction: column;
+
+                    &::after {
+                        content: attr(data-text);
+                        height: 0;
+                        font-weight: 700;
+                        overflow: hidden;
+                        visibility: hidden;
+                    }
+                `}
+            >
+                {item.shortLabel}
+            </span>
         </button>
     );
 }
@@ -350,12 +352,7 @@ function renderLayoutChoiceSection(
                 `}
             >
                 {items.map((item) =>
-                    renderLayoutChoiceItem(
-                        item,
-                        onMenuItemClick,
-                        buttonId,
-                        variant,
-                    ),
+                    renderLayoutChoiceItem(item, onMenuItemClick, buttonId),
                 )}
             </div>
         </div>
@@ -493,7 +490,6 @@ export const LayoutChoicesDropdown: React.FunctionComponent<{
                             { ...item, shortLabel: item.label },
                             onClick,
                             buttonId,
-                            "imperial",
                         ),
                     )}
                 </div>

--- a/src/BloomBrowserUI/bookEdit/topbar/layoutChoicesDropdown.tsx
+++ b/src/BloomBrowserUI/bookEdit/topbar/layoutChoicesDropdown.tsx
@@ -93,12 +93,14 @@ type OrientationShape = "portrait" | "landscape" | "square";
 const OrientationIcon: React.FunctionComponent<{ shape: OrientationShape }> = (
     props,
 ) => {
+    // Keep each glyph centered within the 14x14 viewBox (so y = (14 - height)/2)
+    // so it vertical-centers cleanly against the heading text beside it.
     const rect =
         props.shape === "portrait"
-            ? { x: 4.5, y: 2, width: 7, height: 12 }
+            ? { x: 4.5, y: 1, width: 7, height: 12 }
             : props.shape === "landscape"
-              ? { x: 2, y: 4.5, width: 12, height: 7 }
-              : { x: 3, y: 3, width: 10, height: 10 };
+              ? { x: 2, y: 3.5, width: 12, height: 7 }
+              : { x: 3, y: 2, width: 10, height: 10 };
     return (
         <svg
             width={12}
@@ -333,6 +335,10 @@ function renderLayoutChoiceSection(
                     margin: ${collapseTopMargin ? 0 : 12}px 0 1px;
                     font-size: 10.5px;
                     font-weight: 700;
+                    /* Tight line box so centering aligns the icon to the visible
+                       (uppercase) caps rather than to a tall line box whose empty
+                       descender space would pull the icon below the text. */
+                    line-height: 1;
                     letter-spacing: 0.08em;
                     text-transform: uppercase;
                     color: #9a8aa0;

--- a/src/BloomExe/Book/Layout.cs
+++ b/src/BloomExe/Book/Layout.cs
@@ -81,7 +81,15 @@ namespace Bloom.Book
 
         public bool IsDeviceLayout
         {
-            get { return SizeAndOrientation.ToString().StartsWith("Device"); }
+            get
+            {
+                // "Device*" is the original family of screen-oriented (non-paper) layouts.
+                // Layouts whose name contains "Ebook" (e.g. Ebook2x3/Ebook7x5) are the same kind of
+                // thing; eventually the "Device" name is expected to be retired in favor of a family
+                // of ebook layouts.
+                var name = SizeAndOrientation.ToString();
+                return name.StartsWith("Device") || name.Contains("Ebook");
+            }
         }
 
         public override string ToString()
@@ -149,6 +157,22 @@ namespace Bloom.Book
                 else if (englishNameLowerCase == "size6x9 landscape")
                 {
                     englishName = "6\"x9\" Landscape";
+                }
+                else if (englishNameLowerCase == "ebook2x3 portrait")
+                {
+                    englishName = "Ebook 2x3 Portrait";
+                }
+                else if (englishNameLowerCase == "ebook7x5 landscape")
+                {
+                    englishName = "Ebook 7x5 Landscape";
+                }
+                else if (englishNameLowerCase == "device16x9 portrait")
+                {
+                    englishName = "Ebook 9x16 Portrait";
+                }
+                else if (englishNameLowerCase == "device16x9 landscape")
+                {
+                    englishName = "Ebook 16x9 Landscape";
                 }
 
                 englishName = englishName.Replace("letter", " Letter");

--- a/src/BloomExe/Book/SizeAndOrientation.cs
+++ b/src/BloomExe/Book/SizeAndOrientation.cs
@@ -54,10 +54,13 @@ namespace Bloom.Book
                 return new SizeAndOrientation() { IsLandScape = false, PageSizeName = "A5" };
             }
 
+            var isLandscape = nameLower.Contains("landscape");
             return new SizeAndOrientation()
             {
-                IsLandScape = nameLower.Contains("landscape"),
-                PageSizeName = ExtractPageSizeName(name, startOfOrientationName),
+                IsLandScape = isLandscape,
+                PageSizeName = NormalizeLegacyPageSizeName(
+                    ExtractPageSizeName(name, startOfOrientationName)
+                ),
             };
         }
 
@@ -69,7 +72,19 @@ namespace Bloom.Book
             name = name.Replace("legal", "Legal");
             name = name.Replace("folio", "Folio");
             name = name.Replace("Uscomic", "USComic");
+            name = name.Replace("weaver", "Weaver");
+            name = name.Replace("ebook", "Ebook");
             return name;
+        }
+
+        private static string NormalizeLegacyPageSizeName(string pageSizeName)
+        {
+            // Handle books created in a future version of Bloom
+            // that may use the planned for "Ebook16x9Landscape" and "Ebook9x16Portrait" names.
+            if (pageSizeName == "Ebook9x16" || pageSizeName == "Ebook16x9")
+                return "Device16x9";
+
+            return pageSizeName;
         }
 
         /// <summary>
@@ -197,6 +212,8 @@ namespace Bloom.Book
             yield return new Layout { SizeAndOrientation = FromString("QuarterLetterLandscape") };
             yield return new Layout { SizeAndOrientation = FromString("Device16x9Portrait") };
             yield return new Layout { SizeAndOrientation = FromString("Device16x9Landscape") };
+            yield return new Layout { SizeAndOrientation = FromString("Ebook2x3Portrait") };
+            yield return new Layout { SizeAndOrientation = FromString("Ebook7x5Landscape") };
             yield return new Layout { SizeAndOrientation = FromString("Cm13Landscape") }; // actually square, but acts more like landscape than portrait
             yield return new Layout { SizeAndOrientation = FromString("USComicPortrait") };
             yield return new Layout { SizeAndOrientation = FromString("Size6x9Portrait") };

--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -609,6 +609,8 @@ namespace Bloom.Publish.Epub
 
         // Method must parse the json input in a culture invariant manner, since the computer's culture may not match
         // the culture of the json file.
+        // Returns the dimension in pixels at 96 DPI. Supported units: "px" (already pixels),
+        // "mm", and anything else is treated as inches.
         private static double ConvertDimension(string input)
         {
             string unit = input.Substring(input.Length - 2);
@@ -616,7 +618,11 @@ namespace Bloom.Publish.Epub
                 input.Substring(0, input.Length - 2),
                 CultureInfo.InvariantCulture
             );
-            return num * (unit == "mm" ? 96 / 25.4 : 96);
+            double pixelsPerUnit =
+                unit == "px" ? 1
+                : unit == "mm" ? 96 / 25.4
+                : 96;
+            return num * pixelsPerUnit;
         }
 
         /// <summary>

--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -593,6 +593,9 @@ namespace Bloom.Publish
                         && size != "B5"
                         && size != "Letter"
                         && size != "Device16x9"
+                        // Ebook2x3/Ebook7x5 are screen/ebook sizes, like Device16x9; booklets don't make sense for them.
+                        && size != "Ebook2x3"
+                        && size != "Ebook7x5"
                     );
             }
         }

--- a/src/BloomTests/Book/LayoutTests.cs
+++ b/src/BloomTests/Book/LayoutTests.cs
@@ -8,6 +8,21 @@ namespace BloomTests.Book
     [TestFixture]
     public class LayoutTests
     {
+        [TestCase("Device16x9Portrait", "Ebook 9x16 Portrait")]
+        [TestCase("Device16x9Landscape", "Ebook 16x9 Landscape")]
+        public void DisplayName_Device16x9Layouts_UsesEbookLabels(
+            string layoutClassName,
+            string expectedDisplayName
+        )
+        {
+            var layout = new Layout
+            {
+                SizeAndOrientation = SizeAndOrientation.FromString(layoutClassName),
+            };
+
+            Assert.That(layout.DisplayName, Is.EqualTo(expectedDisplayName));
+        }
+
         [Test]
         public void UpdatePageSplitMode_WasCombinedAndShouldStayThatWay_PageUntouched()
         {

--- a/src/BloomTests/Book/SizeAndOrientationTests.cs
+++ b/src/BloomTests/Book/SizeAndOrientationTests.cs
@@ -90,5 +90,57 @@ namespace BloomTests.Book
             );
             Assert.IsTrue(SizeAndOrientation.GetSizeAndOrientation(dom, "A5Portrait").IsLandScape);
         }
+
+        [TestCase("Ebook2x3Portrait", "Ebook2x3", false)]
+        [TestCase("Ebook7x5Landscape", "Ebook7x5", true)]
+        public void FromString_EbookLayouts_RoundTrip(
+            string layout,
+            string expectedPageSizeName,
+            bool expectedLandscape
+        )
+        {
+            var sizeAndOrientation = SizeAndOrientation.FromString(layout);
+
+            Assert.That(sizeAndOrientation.PageSizeName, Is.EqualTo(expectedPageSizeName));
+            Assert.That(sizeAndOrientation.IsLandScape, Is.EqualTo(expectedLandscape));
+            // ToString() is PageSizeName + OrientationName; this is the exact class used in the
+            // markup and the pageSizes.json / CSS keys, so it must match case-for-case.
+            Assert.That(sizeAndOrientation.ToString(), Is.EqualTo(layout));
+        }
+
+        [TestCase("Ebook9x16Portrait", "Device16x9Portrait", false)]
+        [TestCase("EBook16x9Landscape", "Device16x9Landscape", true)]
+        public void FromString_Ebook16x9Aliases_NormalizeToDevice16x9(
+            string layout,
+            string expectedCanonicalLayout,
+            bool expectedLandscape
+        )
+        {
+            var sizeAndOrientation = SizeAndOrientation.FromString(layout);
+
+            Assert.That(sizeAndOrientation.PageSizeName, Is.EqualTo("Device16x9"));
+            Assert.That(sizeAndOrientation.IsLandScape, Is.EqualTo(expectedLandscape));
+            Assert.That(sizeAndOrientation.ToString(), Is.EqualTo(expectedCanonicalLayout));
+        }
+
+        // Ebook2x3/Ebook7x5 are screen/ebook sizes, so they should be treated like the Device family.
+        [TestCase("Ebook2x3Portrait")]
+        [TestCase("Ebook7x5Landscape")]
+        [TestCase("Device16x9Portrait")]
+        public void IsDeviceLayout_TrueForEbookAndDeviceSizes(string layout)
+        {
+            var sizeAndOrientation = SizeAndOrientation.FromString(layout);
+            var bloomLayout = new Layout { SizeAndOrientation = sizeAndOrientation };
+            Assert.That(bloomLayout.IsDeviceLayout, Is.True);
+        }
+
+        [TestCase("A5Portrait")]
+        [TestCase("LetterLandscape")]
+        public void IsDeviceLayout_FalseForPaperSizes(string layout)
+        {
+            var sizeAndOrientation = SizeAndOrientation.FromString(layout);
+            var bloomLayout = new Layout { SizeAndOrientation = sizeAndOrientation };
+            Assert.That(bloomLayout.IsDeviceLayout, Is.False);
+        }
     }
 }

--- a/src/BloomTests/Publish/Epub/EPubMakerTests.cs
+++ b/src/BloomTests/Publish/Epub/EPubMakerTests.cs
@@ -278,6 +278,8 @@ namespace BloomTests.Publish.Epub
         [TestCase("A5Portrait", 559.37, 793.7)] // gets most common case right
         [TestCase("A5Landscape", 793.7, 559.37)] // make sure orientation matters
         [TestCase("LetterPortrait", 816, 1056)] // one where dimensions are inches
+        [TestCase("Ebook2x3Portrait", 475, 700)] // dimensions given in exact px
+        [TestCase("Ebook7x5Landscape", 959, 690)] // px, and different aspect ratio than portrait
         [TestCase("Garbage", 559.37, 793.7)] // default to A5Portrait
         public void GetPageDimensions(string name, double expectedWidth, double expectedHeight)
         {

--- a/src/content/appearanceThemes/appearance-theme-default.css
+++ b/src/content/appearanceThemes/appearance-theme-default.css
@@ -168,10 +168,12 @@
 .Cm13Landscape {
     --page-margin: 5mm;
 }
+.bloom-page[class*="Ebook"],
 .bloom-page[class*="Device"] {
     --page-margin: 10px;
 }
 
+.bloom-page[class*="Ebook"],
 .bloom-page[class*="Device"],
 .bloomPlayer-page .bloom-page {
     /* Deliberately set both of these, which combines with a special device/bloom-player rule
@@ -182,6 +184,7 @@
     --pageNumber-always-left-margin: 0px;
 }
 
+.numberedPage[class*="Ebook"],
 .numberedPage[class*="Device"] {
     /* These page sizes have small margins, so we need extra height on numbered ones.
     (Note that this disappears if page numbers are turned off, because --pageNumber-show-multiplicand is 0.) */

--- a/src/content/appearanceThemes/appearance-theme-rounded-border-ebook.css
+++ b/src/content/appearanceThemes/appearance-theme-rounded-border-ebook.css
@@ -5,6 +5,7 @@
 /* The below statements control the size and color of the marginbox. It holds the text and picture of that page.
  * The top and left numbers determine the position of the margin box on the page. */
 
+[class*="Ebook"].numberedPage:not(.bloom-interactive-page),
 [class*="Device"].numberedPage:not(.bloom-interactive-page) {
     --page-margin-top: 2mm;
     --page-margin-bottom: 2mm;
@@ -24,13 +25,16 @@
 }
 
 /* using "where:" so that the user's custom appearance can override the theme if specified */
+.numberedPage:where([class*="Ebook"]:not(.bloom-interactive-page)),
 .numberedPage:where([class*="Device"]:not(.bloom-interactive-page)) {
     --topLevel-text-padding: 0.5em;
 }
+[class*="Ebook"].numberedPage:not(.bloom-interactive-page),
 [class*="Device"].numberedPage:not(.bloom-interactive-page) {
     --pageNumber-extra-height: 0mm !important; /* we put the page number on top of the image so we don't need a margin boost */
     --pageNumber-outline-color: white;
 }
+[class*="Ebook"].numberedPage:not(.bloom-interactive-page)::after,
 [class*="Device"].numberedPage:not(.bloom-interactive-page)::after {
     --pageNumber-bottom: var(--page-margin-bottom);
     --pageNumber-top: unset;
@@ -49,6 +53,12 @@
 
 /* Rules for rounding the corner of images */
 /* Picture on left */
+.Ebook7x5Landscape.numberedPage
+    .marginBox
+    > .vertical-percent
+    > .position-left
+    > .split-pane-component-inner
+    > .bloom-canvas,
 .Device16x9Landscape.numberedPage
     .marginBox
     > .vertical-percent
@@ -59,6 +69,12 @@
         var(--marginBox-border-radius); /* left corners */
 }
 /* Picture on right */
+.Ebook7x5Landscape.numberedPage
+    .marginBox
+    > .vertical-percent
+    > .position-right
+    > .split-pane-component-inner
+    > .bloom-canvas,
 .Device16x9Landscape.numberedPage
     .marginBox
     > .vertical-percent
@@ -69,6 +85,12 @@
         var(--marginBox-border-radius) 0px; /* right corners */
 }
 /* Picture on top */
+.Ebook2x3Portrait.numberedPage
+    .marginBox
+    > .horizontal-percent
+    > .position-top
+    > .split-pane-component-inner
+    > .bloom-canvas,
 .Device16x9Portrait.numberedPage
     .marginBox
     > .horizontal-percent
@@ -79,6 +101,12 @@
         var(--marginBox-border-radius) 0px 0px; /* top corners */
 }
 /* Picture on bottom */
+.Ebook2x3Portrait.numberedPage
+    .marginBox
+    > .horizontal-percent
+    > .position-bottom
+    > .split-pane-component-inner
+    > .bloom-canvas,
 .Device16x9Portrait.numberedPage
     .marginBox
     > .horizontal-percent
@@ -89,6 +117,10 @@
         var(--marginBox-border-radius); /* bottom corners */
 }
 /* Picture only */
+[class*="Ebook"].numberedPage
+    .marginBox
+    > .split-pane-component-inner
+    > .bloom-canvas,
 [class*="Device"].numberedPage
     .marginBox
     > .split-pane-component-inner
@@ -98,6 +130,7 @@
 
 /* End Rules for rounding the corner of images */
 
+.Ebook7x5Landscape.numberedPage.pictureOnRight.pictureOnRight::after,
 .Device16x9Landscape.numberedPage.pictureOnRight.pictureOnRight::after {
     --pageNumber-right-margin: var(--page-margin-right);
     --pageNumber-left-margin: deliberately-invalid; /* prevents left being set at all. unset does not work. Prevent centering for this layout */

--- a/src/content/appearanceThemes/appearance-theme-zero-margin-ebook.css
+++ b/src/content/appearanceThemes/appearance-theme-zero-margin-ebook.css
@@ -1,6 +1,8 @@
 /* replaces the pre-v6.0 "EFL Template 1" custom CSS: which had no margins, no page numbers.
 Note that hiding the page numbers is done by a setting in appearance.json, not here. */
 
+[class*="Ebook"].bloom-frontMatter,
+[class*="Ebook"].bloom-backMatter,
 [class*="Device"].bloom-frontMatter,
 [class*="Device"].bloom-backMatter {
     --page-margin: 3mm;
@@ -8,6 +10,8 @@ Note that hiding the page numbers is done by a setting in appearance.json, not h
 
 /* This statement sets the margins on the numbered content pages */
 
+:not(.bloom-interactive-page).numberedPage.Ebook7x5Landscape,
+:not(.bloom-interactive-page).numberedPage.Ebook2x3Portrait,
 :not(.bloom-interactive-page).numberedPage.Device16x9Landscape,
 :not(.bloom-interactive-page).numberedPage.Device16x9Portrait {
     --page-margin: 0mm;
@@ -17,11 +21,13 @@ Note that hiding the page numbers is done by a setting in appearance.json, not h
     --page-horizontalSplit-height: 0mm;
 }
 
+[class*="Ebook"].numberedPage,
 [class*="Device"].numberedPage {
     --pageNumber-background-color: transparent;
     --pageNumber-outline-color: white;
     --pageNumber-extra-height: 0mm !important; /* we put the page number on top of the image so we don't need a margin boost */
 }
+.Ebook2x3Portrait.numberedPage,
 .Device16x9Portrait.numberedPage {
     /* this rule will apply more generally than we'd prefer, but the common situation we're improving here
     is picture on top, text on the bottom, we need to make room for the page number */
@@ -36,6 +42,7 @@ Note that hiding the page numbers is done by a setting in appearance.json, not h
         var(--full-bleed-excess-width) / 2
     );
 }
+.Ebook7x5Landscape.numberedPage::after,
 .Device16x9Landscape.numberedPage::after {
     --pageNumber-bottom: 0mm;
 
@@ -55,6 +62,7 @@ Note that hiding the page numbers is done by a setting in appearance.json, not h
             (var(--full-bleed-excess-width, 0mm) / 2)
     );
 }
+.Ebook7x5Landscape.numberedPage.pictureOnRight.pictureOnRight::after,
 .Device16x9Landscape.numberedPage.pictureOnRight.pictureOnRight::after {
     --pageNumber-right-margin: var(--page-margin-right);
     --pageNumber-left-margin: deliberately-invalid; /* prevents left being set at all. unset does not work. Prevent centering for this layout */
@@ -62,9 +70,11 @@ Note that hiding the page numbers is done by a setting in appearance.json, not h
 }
 
 /* using "where:" so that the user's custom appearance can override the theme if specified */
+.numberedPage:where([class*="Ebook"]:not(.bloom-interactive-page)),
 .numberedPage:where([class*="Device"]:not(.bloom-interactive-page)) {
     --topLevel-text-padding: 0.5em;
 }
+[class*="Ebook"].numberedPage:not(.bloom-interactive-page),
 [class*="Device"].numberedPage:not(.bloom-interactive-page) {
     /* move so that page number doesn't it hide it if the text box is in the lower left */
     --formatButton-pageNumber-dodge: 20px;

--- a/src/content/bookLayout/basePage.less
+++ b/src/content/bookLayout/basePage.less
@@ -707,7 +707,8 @@ div.bloom-page.coverColor {
 // pages that are symmetrical left vs. right, so that we only use --page-margin-left
 // (or --cover-margin-side).
 // --------------------------------------------------------------------------------------
-// if the page is set to a Device one
+// if the page is set to a Device or ebook one
+.bloom-page[class*="Ebook"],
 .bloom-page[class*="Device"],
 .calendarFold,
 // this name "screen-only" is rather out of date now, but what it means is that the page is only shown

--- a/src/content/bookLayout/pageBoxesSizing.less
+++ b/src/content/bookLayout/pageBoxesSizing.less
@@ -182,6 +182,22 @@ body.publishingWithoutFullBleed {
                 ) *
                 25.4;
         }
+
+        // The ebook sizes are defined in exact pixels, which are already on WebView2's
+        // 1/96-inch PDF grid (1px = 1/96in), so they don't need the mm->grid rounding above.
+        &.Ebook2x3Portrait {
+            min-width: @Ebook2x3Portrait-Width;
+            max-width: @Ebook2x3Portrait-Width;
+            min-height: @Ebook2x3Portrait-Height;
+            max-height: @Ebook2x3Portrait-Height;
+        }
+
+        &.Ebook7x5Landscape {
+            min-width: @Ebook7x5Landscape-Width;
+            max-width: @Ebook7x5Landscape-Width;
+            min-height: @Ebook7x5Landscape-Height;
+            max-height: @Ebook7x5Landscape-Height;
+        }
     }
 }
 
@@ -339,5 +355,16 @@ body.publishingWithoutFullBleed {
     .SetPageDimensions(
         @PictureStoryLandscape-Width,
         @PictureStoryLandscape-Height
+    );
+}
+
+.Ebook2x3Portrait {
+    .SetPageDimensions(@Ebook2x3Portrait-Width, @Ebook2x3Portrait-Height);
+}
+
+.Ebook7x5Landscape {
+    .SetPageDimensions(
+        @Ebook7x5Landscape-Width,
+        @Ebook7x5Landscape-Height
     );
 }

--- a/src/content/bookLayout/pageNumbers.less
+++ b/src/content/bookLayout/pageNumbers.less
@@ -52,6 +52,7 @@
     // special behaviors for side-left for device page sizes, I decided to let this
     // rule go ahead and set left for them, too, just in case we encounter a case where
     // --pageNumber-always-left-margin has no value.
+    &[class*="Ebook"]:after,
     &[class*="Device"]:after,
     .bloomPlayer-page &:after,
     &.side-left:after {
@@ -68,6 +69,7 @@
         );
     }
 
+    &[class*="Ebook"]:after,
     &[class*="Device"]:after,
     .bloomPlayer-page &:after {
         // note that here the property has "always"
@@ -85,6 +87,7 @@
      * To defeat that, either right: or left: must not be set, which I've only managed
      * to achieve (since the default theme sets them both) by setting to something
      * deliberately invalid. */
+    &[class*="Ebook"]:after,
     &[class*="Device"]:after,
     .bloomPlayer-page &:after {
         // in the default theme, we always center the page number; both right and left will be 0 for that

--- a/src/content/bookLayout/paperDimensions.less
+++ b/src/content/bookLayout/paperDimensions.less
@@ -48,6 +48,18 @@
 @Device16x9Landscape-Width: 177.77777778mm;
 @PictureStoryLandscape-Height: 100mm;
 @PictureStoryLandscape-Width: 177.77777778mm;
+// Exact pixel dimensions taken from StoryWeaver's ePUB page-container CSS, so that books
+// converted from StoryWeaver match the layout StoryWeaver declares:
+//   #story_epub .page-container-portrait  { width: 475px; height: 700px }
+//   #story_epub .page-container-landscape { width: 959px; height: 690px }
+// The Ebook2x3 / Ebook7x5 names are only approximate shorthand for these aspect ratios;
+// we did not have a better concise naming scheme for the two non-paper ebook layouts.
+// Deliberately kept in px (not converted to mm) and note that portrait and landscape are
+// intentionally NOT the same aspect ratio.
+@Ebook2x3Portrait-Height: 700px;
+@Ebook2x3Portrait-Width: 475px;
+@Ebook7x5Landscape-Height: 690px;
+@Ebook7x5Landscape-Width: 959px;
 @Size6x9Portrait-Height: 9in;
 @Size6x9Portrait-Width: 6in;
 @Size6x9Landscape-Height: 6in;

--- a/src/content/templates/template books/Digital Comic Book/common-comics.less
+++ b/src/content/templates/template books/Digital Comic Book/common-comics.less
@@ -33,6 +33,7 @@
     // Make comic book pages have no margin or page number.  See BL-13602.
     --page-margin: 0mm;
     --pageNumber-show: none;
+    &.numberedPage[class*="Ebook"],
     &.numberedPage[class*="Device"] {
         --pageNumber-extra-height: 0mm !important;
     }


### PR DESCRIPTION
[Claude Opus 4.8]

## BL-16478 — StoryWeaver ebook sizes & page-size picker redesign

This branch adds the StoryWeaver ebook page sizes and reworks the edit-tab page size/orientation chooser into a richer, grouped "paper-size picker".

### Commits
1. **Add StoryWeaver eBook page size (portrait and landscape)** — new ebook sizes.
2. **2D the page size menu** — lay the menu out in two dimensions (groups × orientations).
3. **Restyle the page-size picker menu** — the visual + behavior pass described below.

### What the menu looks like now
- The popover is a white card (1px `#e2e2e2` border, 6px radius, soft drop shadow).
- Sizes are grouped **Metric / Ebooks / Imperial**, each split by orientation, with small SVG orientation glyphs (upright / wide / square) before each **PORTRAIT / LANDSCAPE / SQUARE** sub-header.
- The **current size is a solid purple pill**; other sizes are left-aligned rows that highlight on hover.
- A few recommended sizes (**A5**, **9x16**, **16x9**) are shown bold.
- The Metric and Imperial group headings are intentionally omitted; the first orientation row collapses its top margin so there's no leftover gap.
- The landscape `6"x9"` size is relabeled `9"x6"`.

### Behavior
- On selecting a size, the pill is shown for ~300ms before the change is applied — applying it re-lays-out the page and tears down the menu, so the brief delay lets the user see their choice land. The timer restarts on rapid re-clicks (last choice wins) and is cleared on unmount.

### Notes
- The trigger button in the top bar is unchanged.
- Adds `Portrait` / `Landscape` / `Square` strings to `Bloom.xlf` (`translate="no"`).
- A throwaway in-app design tuner used to dial in these values was removed; the chosen values are inlined directly into the component's CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8007)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8007)
<!-- Reviewable:end -->
