### PR TITLE
Add StoryWeaver eBook page size (portrait and landscape)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -3334,6 +3334,14 @@
         <source xml:lang="en">Device16x9 Portrait</source>
         <note>ID: LayoutChoices.Device16x9Portrait</note>
       </trans-unit>
+      <trans-unit id="LayoutChoices.Ebook7x5Landscape" sil:dynamic="true" translate="no">
+        <source xml:lang="en">Ebook 7x5 Landscape</source>
+        <note>ID: LayoutChoices.Ebook7x5Landscape</note>
+      </trans-unit>
+      <trans-unit id="LayoutChoices.Ebook2x3Portrait" sil:dynamic="true" translate="no">
+        <source xml:lang="en">Ebook 2x3 Portrait</source>
+        <note>ID: LayoutChoices.Ebook2x3Portrait</note>
+      </trans-unit>
       <trans-unit id="LayoutChoices.HalfFolioPortrait" sil:dynamic="true">
         <source xml:lang="en">Half Folio Portrait</source>
         <note>ID: LayoutChoices.HalfFolioPortrait</note>

--- a/DistFiles/pageSizes.json
+++ b/DistFiles/pageSizes.json
@@ -45,6 +45,16 @@
             "width": "177.77777778mm",
             "height": "100mm"
         },
+        {
+            "size": "Ebook2x3Portrait",
+            "width": "475px",
+            "height": "700px"
+        },
+        {
+            "size": "Ebook7x5Landscape",
+            "width": "959px",
+            "height": "690px"
+        },
         { "size": "Size6x9Portrait", "width": "6in", "height": "9in" },
         { "size": "Size6x9Landscape", "width": "9in", "height": "6in" }
     ]

--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
@@ -505,7 +505,11 @@ export default class OverflowChecker {
             }
             const isButton =
                 $editable.closest("." + kBloomButtonClass).length > 0;
-            if ($editable.parents("[class*=Device]").length === 0 || isButton) {
+            if (
+                $editable.parents("[class*=Device],[class*=Ebook]").length ===
+                    0 ||
+                isButton
+            ) {
                 // don't show an overflow warning if we have scrolling available (unless it's a button)
                 theOneLocalizationManager
                     .asyncGetText(
@@ -713,7 +717,9 @@ export default class OverflowChecker {
         const $page = $(page);
         return (
             $page.hasClass("Device16x9Portrait") ||
-            $page.hasClass("Device16x9Landscape")
+            $page.hasClass("Device16x9Landscape") ||
+            $page.hasClass("Ebook2x3Portrait") ||
+            $page.hasClass("Ebook7x5Landscape")
         );
     }
     // Make sure there are no boxes with class 'overflow' or 'thisOverflowingParent' on the page before removing

--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -77,7 +77,9 @@ body {
         pointer-events: auto; // start up clicks again a the next level
     }
 
-    :not(.Device16x9Portrait):not(.Device16x9Landscape)&::before {
+    :not(.Device16x9Portrait):not(.Device16x9Landscape):not(
+            .Ebook2x3Portrait
+        ):not(.Ebook7x5Landscape)&::before {
         // show bleed area
         content: "";
         position: absolute;
@@ -90,7 +92,9 @@ body {
         z-index: 1;
     }
 
-    :not(.Device16x9Portrait):not(.Device16x9Landscape)&:after {
+    :not(.Device16x9Portrait):not(.Device16x9Landscape):not(
+            .Ebook2x3Portrait
+        ):not(.Ebook7x5Landscape)&:after {
         // show safety area (the area inside of the trim box that still could get cut)
         content: "";
         position: absolute;
@@ -793,9 +797,9 @@ div.bloom-templateMode {
     border: 3px dashed black;
 }
 
-// We only make a big deal out of "overflow" if the layout is a *paper* size, rather than a *device* size.
+// We only make a big deal out of "overflow" if the layout is a *paper* size, rather than a *device* or *ebook* size.
 // Or the overflowing text is on a button
-.bloom-page:not([class*="Device"]),
+.bloom-page:not([class*="Device"]):not([class*="Ebook"]),
 .bloom-page .bloom-canvas-button.bloom-canvas-button {
     // We need this three times to beat a rule that gives the focusd editable box a blue outline
     // And for buttons we need to beat the rule on .bloom-canvas-element[data-bloom-active="true"] div.bloom-editable

--- a/src/BloomBrowserUI/bookEdit/pageThumbnailList/PageThumbnail.tsx
+++ b/src/BloomBrowserUI/bookEdit/pageThumbnailList/PageThumbnail.tsx
@@ -99,7 +99,9 @@ export const PageThumbnail: React.FunctionComponent<{
     const reForOverflow = /^[^>]*class="[^"]*pageOverflows/;
     const overflowing = reForOverflow.test(content); // enhance: memo?
 
-    const scrollingWillBeAvailable = props.pageLayout.indexOf("Device") > -1;
+    const scrollingWillBeAvailable =
+        props.pageLayout.indexOf("Device") > -1 ||
+        props.pageLayout.indexOf("Ebook") > -1;
 
     useEffect(() => {
         if (Math.abs(Date.now() - lastPageRequestTime) > 5000) {

--- a/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.less
+++ b/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.less
@@ -188,6 +188,20 @@ body {
             transform: scale(0.095);
         }
     }
+    &.Ebook2x3Portrait {
+        height: 67px;
+        width: 46px;
+        .bloom-page {
+            transform: scale(0.096);
+        }
+    }
+    &.Ebook7x5Landscape {
+        height: 48px;
+        width: 67px;
+        .bloom-page {
+            transform: scale(0.07);
+        }
+    }
     &.A6Portrait {
         .bloom-page {
             transform: scale(0.11);

--- a/src/BloomExe/Book/Layout.cs
+++ b/src/BloomExe/Book/Layout.cs
@@ -81,7 +81,15 @@ namespace Bloom.Book
 
         public bool IsDeviceLayout
         {
-            get { return SizeAndOrientation.ToString().StartsWith("Device"); }
+            get
+            {
+                // "Device*" is the original family of screen-oriented (non-paper) layouts.
+                // Layouts whose name contains "Ebook" (e.g. Ebook2x3/Ebook7x5) are the same kind of
+                // thing; eventually the "Device" name is expected to be retired in favor of a family
+                // of ebook layouts.
+                var name = SizeAndOrientation.ToString();
+                return name.StartsWith("Device") || name.Contains("Ebook");
+            }
         }
 
         public override string ToString()
@@ -149,6 +157,22 @@ namespace Bloom.Book
                 else if (englishNameLowerCase == "size6x9 landscape")
                 {
                     englishName = "6\"x9\" Landscape";
+                }
+                else if (englishNameLowerCase == "ebook2x3 portrait")
+                {
+                    englishName = "Ebook 2x3 Portrait";
+                }
+                else if (englishNameLowerCase == "ebook7x5 landscape")
+                {
+                    englishName = "Ebook 7x5 Landscape";
+                }
+                else if (englishNameLowerCase == "device16x9 portrait")
+                {
+                    englishName = "Ebook 9x16 Portrait";
+                }
+                else if (englishNameLowerCase == "device16x9 landscape")
+                {
+                    englishName = "Ebook 16x9 Landscape";
                 }
 
                 englishName = englishName.Replace("letter", " Letter");

--- a/src/BloomExe/Book/SizeAndOrientation.cs
+++ b/src/BloomExe/Book/SizeAndOrientation.cs
@@ -54,10 +54,13 @@ namespace Bloom.Book
                 return new SizeAndOrientation() { IsLandScape = false, PageSizeName = "A5" };
             }
 
+            var isLandscape = nameLower.Contains("landscape");
             return new SizeAndOrientation()
             {
-                IsLandScape = nameLower.Contains("landscape"),
-                PageSizeName = ExtractPageSizeName(name, startOfOrientationName),
+                IsLandScape = isLandscape,
+                PageSizeName = NormalizeLegacyPageSizeName(
+                    ExtractPageSizeName(name, startOfOrientationName)
+                ),
             };
         }
 
@@ -69,7 +72,19 @@ namespace Bloom.Book
             name = name.Replace("legal", "Legal");
             name = name.Replace("folio", "Folio");
             name = name.Replace("Uscomic", "USComic");
+            name = name.Replace("weaver", "Weaver");
+            name = name.Replace("ebook", "Ebook");
             return name;
+        }
+
+        private static string NormalizeLegacyPageSizeName(string pageSizeName)
+        {
+            // Handle books created in a future version of Bloom
+            // that may use the planned for "Ebook16x9Landscape" and "Ebook9x16Portrait" names.
+            if (pageSizeName == "Ebook9x16" || pageSizeName == "Ebook16x9")
+                return "Device16x9";
+
+            return pageSizeName;
         }
 
         /// <summary>
@@ -197,6 +212,8 @@ namespace Bloom.Book
             yield return new Layout { SizeAndOrientation = FromString("QuarterLetterLandscape") };
             yield return new Layout { SizeAndOrientation = FromString("Device16x9Portrait") };
             yield return new Layout { SizeAndOrientation = FromString("Device16x9Landscape") };
+            yield return new Layout { SizeAndOrientation = FromString("Ebook2x3Portrait") };
+            yield return new Layout { SizeAndOrientation = FromString("Ebook7x5Landscape") };
             yield return new Layout { SizeAndOrientation = FromString("Cm13Landscape") }; // actually square, but acts more like landscape than portrait
             yield return new Layout { SizeAndOrientation = FromString("USComicPortrait") };
             yield return new Layout { SizeAndOrientation = FromString("Size6x9Portrait") };

--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -609,6 +609,8 @@ namespace Bloom.Publish.Epub
 
         // Method must parse the json input in a culture invariant manner, since the computer's culture may not match
         // the culture of the json file.
+        // Returns the dimension in pixels at 96 DPI. Supported units: "px" (already pixels),
+        // "mm", and anything else is treated as inches.
         private static double ConvertDimension(string input)
         {
             string unit = input.Substring(input.Length - 2);
@@ -616,7 +618,11 @@ namespace Bloom.Publish.Epub
                 input.Substring(0, input.Length - 2),
                 CultureInfo.InvariantCulture
             );
-            return num * (unit == "mm" ? 96 / 25.4 : 96);
+            double pixelsPerUnit =
+                unit == "px" ? 1
+                : unit == "mm" ? 96 / 25.4
+                : 96;
+            return num * pixelsPerUnit;
         }
 
         /// <summary>

--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -593,6 +593,9 @@ namespace Bloom.Publish
                         && size != "B5"
                         && size != "Letter"
                         && size != "Device16x9"
+                        // Ebook2x3/Ebook7x5 are screen/ebook sizes, like Device16x9; booklets don't make sense for them.
+                        && size != "Ebook2x3"
+                        && size != "Ebook7x5"
                     );
             }
         }

--- a/src/BloomTests/Book/LayoutTests.cs
+++ b/src/BloomTests/Book/LayoutTests.cs
@@ -8,6 +8,21 @@ namespace BloomTests.Book
     [TestFixture]
     public class LayoutTests
     {
+        [TestCase("Device16x9Portrait", "Ebook 9x16 Portrait")]
+        [TestCase("Device16x9Landscape", "Ebook 16x9 Landscape")]
+        public void DisplayName_Device16x9Layouts_UsesEbookLabels(
+            string layoutClassName,
+            string expectedDisplayName
+        )
+        {
+            var layout = new Layout
+            {
+                SizeAndOrientation = SizeAndOrientation.FromString(layoutClassName),
+            };
+
+            Assert.That(layout.DisplayName, Is.EqualTo(expectedDisplayName));
+        }
+
         [Test]
         public void UpdatePageSplitMode_WasCombinedAndShouldStayThatWay_PageUntouched()
         {

--- a/src/BloomTests/Book/SizeAndOrientationTests.cs
+++ b/src/BloomTests/Book/SizeAndOrientationTests.cs
@@ -90,5 +90,57 @@ namespace BloomTests.Book
             );
             Assert.IsTrue(SizeAndOrientation.GetSizeAndOrientation(dom, "A5Portrait").IsLandScape);
         }
+
+        [TestCase("Ebook2x3Portrait", "Ebook2x3", false)]
+        [TestCase("Ebook7x5Landscape", "Ebook7x5", true)]
+        public void FromString_EbookLayouts_RoundTrip(
+            string layout,
+            string expectedPageSizeName,
+            bool expectedLandscape
+        )
+        {
+            var sizeAndOrientation = SizeAndOrientation.FromString(layout);
+
+            Assert.That(sizeAndOrientation.PageSizeName, Is.EqualTo(expectedPageSizeName));
+            Assert.That(sizeAndOrientation.IsLandScape, Is.EqualTo(expectedLandscape));
+            // ToString() is PageSizeName + OrientationName; this is the exact class used in the
+            // markup and the pageSizes.json / CSS keys, so it must match case-for-case.
+            Assert.That(sizeAndOrientation.ToString(), Is.EqualTo(layout));
+        }
+
+        [TestCase("Ebook9x16Portrait", "Device16x9Portrait", false)]
+        [TestCase("EBook16x9Landscape", "Device16x9Landscape", true)]
+        public void FromString_Ebook16x9Aliases_NormalizeToDevice16x9(
+            string layout,
+            string expectedCanonicalLayout,
+            bool expectedLandscape
+        )
+        {
+            var sizeAndOrientation = SizeAndOrientation.FromString(layout);
+
+            Assert.That(sizeAndOrientation.PageSizeName, Is.EqualTo("Device16x9"));
+            Assert.That(sizeAndOrientation.IsLandScape, Is.EqualTo(expectedLandscape));
+            Assert.That(sizeAndOrientation.ToString(), Is.EqualTo(expectedCanonicalLayout));
+        }
+
+        // Ebook2x3/Ebook7x5 are screen/ebook sizes, so they should be treated like the Device family.
+        [TestCase("Ebook2x3Portrait")]
+        [TestCase("Ebook7x5Landscape")]
+        [TestCase("Device16x9Portrait")]
+        public void IsDeviceLayout_TrueForEbookAndDeviceSizes(string layout)
+        {
+            var sizeAndOrientation = SizeAndOrientation.FromString(layout);
+            var bloomLayout = new Layout { SizeAndOrientation = sizeAndOrientation };
+            Assert.That(bloomLayout.IsDeviceLayout, Is.True);
+        }
+
+        [TestCase("A5Portrait")]
+        [TestCase("LetterLandscape")]
+        public void IsDeviceLayout_FalseForPaperSizes(string layout)
+        {
+            var sizeAndOrientation = SizeAndOrientation.FromString(layout);
+            var bloomLayout = new Layout { SizeAndOrientation = sizeAndOrientation };
+            Assert.That(bloomLayout.IsDeviceLayout, Is.False);
+        }
     }
 }

--- a/src/BloomTests/Publish/Epub/EPubMakerTests.cs
+++ b/src/BloomTests/Publish/Epub/EPubMakerTests.cs
@@ -278,6 +278,8 @@ namespace BloomTests.Publish.Epub
         [TestCase("A5Portrait", 559.37, 793.7)] // gets most common case right
         [TestCase("A5Landscape", 793.7, 559.37)] // make sure orientation matters
         [TestCase("LetterPortrait", 816, 1056)] // one where dimensions are inches
+        [TestCase("Ebook2x3Portrait", 475, 700)] // dimensions given in exact px
+        [TestCase("Ebook7x5Landscape", 959, 690)] // px, and different aspect ratio than portrait
         [TestCase("Garbage", 559.37, 793.7)] // default to A5Portrait
         public void GetPageDimensions(string name, double expectedWidth, double expectedHeight)
         {

--- a/src/content/appearanceThemes/appearance-theme-default.css
+++ b/src/content/appearanceThemes/appearance-theme-default.css
@@ -168,10 +168,12 @@
 .Cm13Landscape {
     --page-margin: 5mm;
 }
+.bloom-page[class*="Ebook"],
 .bloom-page[class*="Device"] {
     --page-margin: 10px;
 }
 
+.bloom-page[class*="Ebook"],
 .bloom-page[class*="Device"],
 .bloomPlayer-page .bloom-page {
     /* Deliberately set both of these, which combines with a special device/bloom-player rule
@@ -182,6 +184,7 @@
     --pageNumber-always-left-margin: 0px;
 }
 
+.numberedPage[class*="Ebook"],
 .numberedPage[class*="Device"] {
     /* These page sizes have small margins, so we need extra height on numbered ones.
     (Note that this disappears if page numbers are turned off, because --pageNumber-show-multiplicand is 0.) */

--- a/src/content/appearanceThemes/appearance-theme-rounded-border-ebook.css
+++ b/src/content/appearanceThemes/appearance-theme-rounded-border-ebook.css
@@ -5,6 +5,7 @@
 /* The below statements control the size and color of the marginbox. It holds the text and picture of that page.
  * The top and left numbers determine the position of the margin box on the page. */
 
+[class*="Ebook"].numberedPage:not(.bloom-interactive-page),
 [class*="Device"].numberedPage:not(.bloom-interactive-page) {
     --page-margin-top: 2mm;
     --page-margin-bottom: 2mm;
@@ -24,13 +25,16 @@
 }
 
 /* using "where:" so that the user's custom appearance can override the theme if specified */
+.numberedPage:where([class*="Ebook"]:not(.bloom-interactive-page)),
 .numberedPage:where([class*="Device"]:not(.bloom-interactive-page)) {
     --topLevel-text-padding: 0.5em;
 }
+[class*="Ebook"].numberedPage:not(.bloom-interactive-page),
 [class*="Device"].numberedPage:not(.bloom-interactive-page) {
     --pageNumber-extra-height: 0mm !important; /* we put the page number on top of the image so we don't need a margin boost */
     --pageNumber-outline-color: white;
 }
+[class*="Ebook"].numberedPage:not(.bloom-interactive-page)::after,
 [class*="Device"].numberedPage:not(.bloom-interactive-page)::after {
     --pageNumber-bottom: var(--page-margin-bottom);
     --pageNumber-top: unset;
@@ -49,6 +53,12 @@
 
 /* Rules for rounding the corner of images */
 /* Picture on left */
+.Ebook7x5Landscape.numberedPage
+    .marginBox
+    > .vertical-percent
+    > .position-left
+    > .split-pane-component-inner
+    > .bloom-canvas,
 .Device16x9Landscape.numberedPage
     .marginBox
     > .vertical-percent
@@ -59,6 +69,12 @@
         var(--marginBox-border-radius); /* left corners */
 }
 /* Picture on right */
+.Ebook7x5Landscape.numberedPage
+    .marginBox
+    > .vertical-percent
+    > .position-right
+    > .split-pane-component-inner
+    > .bloom-canvas,
 .Device16x9Landscape.numberedPage
     .marginBox
     > .vertical-percent
@@ -69,6 +85,12 @@
         var(--marginBox-border-radius) 0px; /* right corners */
 }
 /* Picture on top */
+.Ebook2x3Portrait.numberedPage
+    .marginBox
+    > .horizontal-percent
+    > .position-top
+    > .split-pane-component-inner
+    > .bloom-canvas,
 .Device16x9Portrait.numberedPage
     .marginBox
     > .horizontal-percent
@@ -79,6 +101,12 @@
         var(--marginBox-border-radius) 0px 0px; /* top corners */
 }
 /* Picture on bottom */
+.Ebook2x3Portrait.numberedPage
+    .marginBox
+    > .horizontal-percent
+    > .position-bottom
+    > .split-pane-component-inner
+    > .bloom-canvas,
 .Device16x9Portrait.numberedPage
     .marginBox
     > .horizontal-percent
@@ -89,6 +117,10 @@
         var(--marginBox-border-radius); /* bottom corners */
 }
 /* Picture only */
+[class*="Ebook"].numberedPage
+    .marginBox
+    > .split-pane-component-inner
+    > .bloom-canvas,
 [class*="Device"].numberedPage
     .marginBox
     > .split-pane-component-inner
@@ -98,6 +130,7 @@
 
 /* End Rules for rounding the corner of images */
 
+.Ebook7x5Landscape.numberedPage.pictureOnRight.pictureOnRight::after,
 .Device16x9Landscape.numberedPage.pictureOnRight.pictureOnRight::after {
     --pageNumber-right-margin: var(--page-margin-right);
     --pageNumber-left-margin: deliberately-invalid; /* prevents left being set at all. unset does not work. Prevent centering for this layout */

--- a/src/content/appearanceThemes/appearance-theme-zero-margin-ebook.css
+++ b/src/content/appearanceThemes/appearance-theme-zero-margin-ebook.css
@@ -1,6 +1,8 @@
 /* replaces the pre-v6.0 "EFL Template 1" custom CSS: which had no margins, no page numbers.
 Note that hiding the page numbers is done by a setting in appearance.json, not here. */
 
+[class*="Ebook"].bloom-frontMatter,
+[class*="Ebook"].bloom-backMatter,
 [class*="Device"].bloom-frontMatter,
 [class*="Device"].bloom-backMatter {
     --page-margin: 3mm;
@@ -8,6 +10,8 @@ Note that hiding the page numbers is done by a setting in appearance.json, not h
 
 /* This statement sets the margins on the numbered content pages */
 
+:not(.bloom-interactive-page).numberedPage.Ebook7x5Landscape,
+:not(.bloom-interactive-page).numberedPage.Ebook2x3Portrait,
 :not(.bloom-interactive-page).numberedPage.Device16x9Landscape,
 :not(.bloom-interactive-page).numberedPage.Device16x9Portrait {
     --page-margin: 0mm;
@@ -17,11 +21,13 @@ Note that hiding the page numbers is done by a setting in appearance.json, not h
     --page-horizontalSplit-height: 0mm;
 }
 
+[class*="Ebook"].numberedPage,
 [class*="Device"].numberedPage {
     --pageNumber-background-color: transparent;
     --pageNumber-outline-color: white;
     --pageNumber-extra-height: 0mm !important; /* we put the page number on top of the image so we don't need a margin boost */
 }
+.Ebook2x3Portrait.numberedPage,
 .Device16x9Portrait.numberedPage {
     /* this rule will apply more generally than we'd prefer, but the common situation we're improving here
     is picture on top, text on the bottom, we need to make room for the page number */
@@ -36,6 +42,7 @@ Note that hiding the page numbers is done by a setting in appearance.json, not h
         var(--full-bleed-excess-width) / 2
     );
 }
+.Ebook7x5Landscape.numberedPage::after,
 .Device16x9Landscape.numberedPage::after {
     --pageNumber-bottom: 0mm;
 
@@ -55,6 +62,7 @@ Note that hiding the page numbers is done by a setting in appearance.json, not h
             (var(--full-bleed-excess-width, 0mm) / 2)
     );
 }
+.Ebook7x5Landscape.numberedPage.pictureOnRight.pictureOnRight::after,
 .Device16x9Landscape.numberedPage.pictureOnRight.pictureOnRight::after {
     --pageNumber-right-margin: var(--page-margin-right);
     --pageNumber-left-margin: deliberately-invalid; /* prevents left being set at all. unset does not work. Prevent centering for this layout */
@@ -62,9 +70,11 @@ Note that hiding the page numbers is done by a setting in appearance.json, not h
 }
 
 /* using "where:" so that the user's custom appearance can override the theme if specified */
+.numberedPage:where([class*="Ebook"]:not(.bloom-interactive-page)),
 .numberedPage:where([class*="Device"]:not(.bloom-interactive-page)) {
     --topLevel-text-padding: 0.5em;
 }
+[class*="Ebook"].numberedPage:not(.bloom-interactive-page),
 [class*="Device"].numberedPage:not(.bloom-interactive-page) {
     /* move so that page number doesn't it hide it if the text box is in the lower left */
     --formatButton-pageNumber-dodge: 20px;

--- a/src/content/bookLayout/basePage.less
+++ b/src/content/bookLayout/basePage.less
@@ -707,7 +707,8 @@ div.bloom-page.coverColor {
 // pages that are symmetrical left vs. right, so that we only use --page-margin-left
 // (or --cover-margin-side).
 // --------------------------------------------------------------------------------------
-// if the page is set to a Device one
+// if the page is set to a Device or ebook one
+.bloom-page[class*="Ebook"],
 .bloom-page[class*="Device"],
 .calendarFold,
 // this name "screen-only" is rather out of date now, but what it means is that the page is only shown

--- a/src/content/bookLayout/pageBoxesSizing.less
+++ b/src/content/bookLayout/pageBoxesSizing.less
@@ -182,6 +182,22 @@ body.publishingWithoutFullBleed {
                 ) *
                 25.4;
         }
+
+        // The ebook sizes are defined in exact pixels, which are already on WebView2's
+        // 1/96-inch PDF grid (1px = 1/96in), so they don't need the mm->grid rounding above.
+        &.Ebook2x3Portrait {
+            min-width: @Ebook2x3Portrait-Width;
+            max-width: @Ebook2x3Portrait-Width;
+            min-height: @Ebook2x3Portrait-Height;
+            max-height: @Ebook2x3Portrait-Height;
+        }
+
+        &.Ebook7x5Landscape {
+            min-width: @Ebook7x5Landscape-Width;
+            max-width: @Ebook7x5Landscape-Width;
+            min-height: @Ebook7x5Landscape-Height;
+            max-height: @Ebook7x5Landscape-Height;
+        }
     }
 }
 
@@ -339,5 +355,16 @@ body.publishingWithoutFullBleed {
     .SetPageDimensions(
         @PictureStoryLandscape-Width,
         @PictureStoryLandscape-Height
+    );
+}
+
+.Ebook2x3Portrait {
+    .SetPageDimensions(@Ebook2x3Portrait-Width, @Ebook2x3Portrait-Height);
+}
+
+.Ebook7x5Landscape {
+    .SetPageDimensions(
+        @Ebook7x5Landscape-Width,
+        @Ebook7x5Landscape-Height
     );
 }

--- a/src/content/bookLayout/pageNumbers.less
+++ b/src/content/bookLayout/pageNumbers.less
@@ -52,6 +52,7 @@
     // special behaviors for side-left for device page sizes, I decided to let this
     // rule go ahead and set left for them, too, just in case we encounter a case where
     // --pageNumber-always-left-margin has no value.
+    &[class*="Ebook"]:after,
     &[class*="Device"]:after,
     .bloomPlayer-page &:after,
     &.side-left:after {
@@ -68,6 +69,7 @@
         );
     }
 
+    &[class*="Ebook"]:after,
     &[class*="Device"]:after,
     .bloomPlayer-page &:after {
         // note that here the property has "always"
@@ -85,6 +87,7 @@
      * To defeat that, either right: or left: must not be set, which I've only managed
      * to achieve (since the default theme sets them both) by setting to something
      * deliberately invalid. */
+    &[class*="Ebook"]:after,
     &[class*="Device"]:after,
     .bloomPlayer-page &:after {
         // in the default theme, we always center the page number; both right and left will be 0 for that

--- a/src/content/bookLayout/paperDimensions.less
+++ b/src/content/bookLayout/paperDimensions.less
@@ -48,6 +48,18 @@
 @Device16x9Landscape-Width: 177.77777778mm;
 @PictureStoryLandscape-Height: 100mm;
 @PictureStoryLandscape-Width: 177.77777778mm;
+// Exact pixel dimensions taken from StoryWeaver's ePUB page-container CSS, so that books
+// converted from StoryWeaver match the layout StoryWeaver declares:
+//   #story_epub .page-container-portrait  { width: 475px; height: 700px }
+//   #story_epub .page-container-landscape { width: 959px; height: 690px }
+// The Ebook2x3 / Ebook7x5 names are only approximate shorthand for these aspect ratios;
+// we did not have a better concise naming scheme for the two non-paper ebook layouts.
+// Deliberately kept in px (not converted to mm) and note that portrait and landscape are
+// intentionally NOT the same aspect ratio.
+@Ebook2x3Portrait-Height: 700px;
+@Ebook2x3Portrait-Width: 475px;
+@Ebook7x5Landscape-Height: 690px;
+@Ebook7x5Landscape-Width: 959px;
 @Size6x9Portrait-Height: 9in;
 @Size6x9Portrait-Width: 6in;
 @Size6x9Landscape-Height: 6in;

--- a/src/content/templates/template books/Digital Comic Book/common-comics.less
+++ b/src/content/templates/template books/Digital Comic Book/common-comics.less
@@ -33,6 +33,7 @@
     // Make comic book pages have no margin or page number.  See BL-13602.
     --page-margin: 0mm;
     --pageNumber-show: none;
+    &.numberedPage[class*="Ebook"],
     &.numberedPage[class*="Device"] {
         --pageNumber-extra-height: 0mm !important;
     }


### PR DESCRIPTION
Introduces a new screen/ebook page size, Ebook2x3Portait and Ebook7xLandscape for books converted from StoryWeaver.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8008)
<!-- Reviewable:end -->
