### PR TITLE
Fix BL-16428 MarkedUpText.HasFormatting always returns true

### DIFF
--- a/src/BloomExe/Spreadsheet/MarkedUpText.cs
+++ b/src/BloomExe/Spreadsheet/MarkedUpText.cs
@@ -231,7 +231,9 @@ namespace Bloom.Spreadsheet
         public bool Superscript { get; set; }
         public Color Color { get; set; }
 
-        public bool HasFormatting => Bold | Italic | Underlined | Superscript | Color != null;
+        // Color is a struct, so it can never be null; an unset Color defaults to Color.Empty.
+        // We therefore test !Color.IsEmpty to detect when a color has actually been specified.
+        public bool HasFormatting => Bold | Italic | Underlined | Superscript | !Color.IsEmpty;
 
         public void setProperty(string propertyName, string styleAttribute)
         {

--- a/src/BloomTests/Spreadsheet/SpreadsheetFormattingTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetFormattingTests.cs
@@ -335,6 +335,62 @@ namespace BloomTests.Spreadsheet
             );
         }
 
+        [Test]
+        public void HasFormatting_PlainText_IsFalse()
+        {
+            // Sanity check: a run with no formatting set should have an empty color.
+            var run = new MarkedUpTextRun("plain");
+            Assert.That(run.Color.IsEmpty, Is.True, "test setup: expected an unset color");
+            Assert.That(run.HasFormatting, Is.False);
+        }
+
+        [Test]
+        public void HasFormatting_Bold_IsTrue()
+        {
+            var run = new MarkedUpTextRun("text");
+            Assert.That(
+                run.HasFormatting,
+                Is.False,
+                "test setup: expected no formatting initially"
+            );
+            run.Bold = true;
+            Assert.That(run.HasFormatting, Is.True);
+        }
+
+        [Test]
+        public void HasFormatting_Italic_IsTrue()
+        {
+            var run = new MarkedUpTextRun("text") { Italic = true };
+            Assert.That(run.HasFormatting, Is.True);
+        }
+
+        [Test]
+        public void HasFormatting_Underlined_IsTrue()
+        {
+            var run = new MarkedUpTextRun("text") { Underlined = true };
+            Assert.That(run.HasFormatting, Is.True);
+        }
+
+        [Test]
+        public void HasFormatting_Superscript_IsTrue()
+        {
+            var run = new MarkedUpTextRun("text") { Superscript = true };
+            Assert.That(run.HasFormatting, Is.True);
+        }
+
+        [Test]
+        public void HasFormatting_Color_IsTrue()
+        {
+            var run = new MarkedUpTextRun("text");
+            Assert.That(
+                run.HasFormatting,
+                Is.False,
+                "test setup: expected no formatting initially"
+            );
+            run.Color = ColorTranslator.FromHtml("#123def");
+            Assert.That(run.HasFormatting, Is.True);
+        }
+
         private void AssertHasFormatting(
             MarkedUpTextRun textRun,
             string text,


### PR DESCRIPTION
https://issues.bloomlibrary.org/youtrack/issue/BL-16428

HasFormatting tested `Color != null`, but System.Drawing.Color is a
struct, so that comparison is always true (compiler warning CS8073) and
HasFormatting always returned true. As a result every WYSIWYG-formatted
spreadsheet cell was written as Excel rich text and the plain-text export
path in SpreadsheetIO was never used.

Changed the test to `!Color.IsEmpty`, since an unset Color defaults to
Color.Empty and a specified color (via ColorTranslator.FromHtml) is
non-empty.

Added unit tests in SpreadsheetFormattingTests verifying HasFormatting is
false for plain text and true when bold, italic, underline, superscript,
or a color is set.

Tests: ran `dotnet test --filter SpreadsheetFormattingTests` (built the
test project) — all 32 tests passed, including the 6 new ones.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8014)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8014)
<!-- Reviewable:end -->
