### PR TITLE
Add transitional pre-commit dispatcher (.githooks) for husky->vp migration

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,61 @@
+# `.githooks/` — transitional pre-commit dispatcher
+
+This directory exists **only** to bridge the front-end's migration from
+**yarn + husky 4** to **pnpm + vite-plus (vp)**. It is temporary scaffolding and
+is meant to be deleted once the migration is complete (see
+[When this can be removed](#when-this-can-be-removed)).
+
+## The problem it solves
+
+Different branches use different git-hook systems during the transition:
+
+| Branch type | Where its pre-commit checks live |
+| --- | --- |
+| pnpm / vite-plus | `src/BloomBrowserUI/.vite-hooks/pre-commit` |
+| yarn / husky 4 | the default `.git/hooks/pre-commit` (installed by husky) |
+
+Git decides which hook to run from `core.hooksPath`, and that setting:
+
+- is chosen **before** git knows which branch is checked out, and
+- is **shared across all worktrees** of a clone.
+
+So if a worktree is set up for one system and you switch it to a branch that uses
+the other, git runs the wrong hook — or, in the worst case, points at a hooks
+directory that doesn't exist on that branch and **silently runs nothing**. Silent,
+unchecked commits are exactly what we want to avoid.
+
+## How it works
+
+`core.hooksPath` is set to `.githooks`, and **this dispatcher is committed to every
+maintained branch at the same path**. So whatever branch a worktree is on, git
+always finds `.githooks/pre-commit`, and the dispatcher routes — at commit time, the
+one moment branch-aware logic can run — to whichever checker that branch actually
+ships:
+
+1. if `src/BloomBrowserUI/.vite-hooks/pre-commit` exists → run the vite-plus checks;
+2. else if a husky hook exists in `.git/hooks/pre-commit` → run that;
+3. else → **fail loudly** with instructions, instead of skipping silently.
+
+## How to enable it (per clone)
+
+`core.hooksPath` is git config, not a tracked file, so each clone sets it once:
+
+```sh
+git config core.hooksPath .githooks
+```
+
+On pnpm/vite-plus branches the install step (`prepare`) does this for you. On husky
+branches you can run it manually (or wire it into the install) so the dispatcher is
+active there too and you get the loud-fail safety net everywhere.
+
+## When this can be removed
+
+This is **transition-only**. Once every actively maintained branch has moved to
+pnpm + vite-plus — i.e. there are no husky branches left that anyone checks out:
+
+1. point `core.hooksPath` back at the vite-plus hooks directory (or let `vp config`
+   manage it), and
+2. delete this `.githooks/` directory and the dispatcher with it.
+
+At that point every branch uses the same hook system, so a router is no longer
+needed.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,71 @@
+#!/bin/sh
+#
+# .githooks/pre-commit  --  TRANSITIONAL pre-commit DISPATCHER
+# ============================================================
+#
+# WHAT THIS IS
+#   A tiny router that git runs as the pre-commit hook (when core.hooksPath is set
+#   to ".githooks", see "HOW TO ENABLE" below). It figures out which pre-commit
+#   checker the *currently checked-out branch* ships, runs that one, and -- if it
+#   finds none -- exits non-zero with a message instead of silently doing nothing.
+#
+# WHY IT EXISTS
+#   We are migrating the front-end from yarn + husky 4 to pnpm + vite-plus (vp).
+#   During the transition, different branches carry different hook systems:
+#       * pnpm / vite-plus branches commit  src/BloomBrowserUI/.vite-hooks/pre-commit
+#       * husky 4 branches keep their hook in the default  .git/hooks/pre-commit
+#
+#   The catch: git picks the hook location from config (core.hooksPath) BEFORE it
+#   knows which branch is checked out, and that setting is shared across every
+#   worktree of a clone. So if a worktree is configured for one system and you
+#   switch it to a branch that uses the other, git runs the wrong hook -- or, worse,
+#   silently runs NO hook (the path it points at doesn't exist on that branch).
+#
+#   This dispatcher fixes that by being committed to every maintained branch at the
+#   same path. Whatever branch a worktree lands on, git always finds THIS file and
+#   it routes to the correct checker *at commit time* (the one moment branch-aware
+#   logic can run). No silent skips.
+#
+# HOW TO ENABLE (per clone -- this is git config, which is NOT committed):
+#       git config core.hooksPath .githooks
+#   On pnpm/vite-plus branches the install step ("prepare") sets this for you. On
+#   husky branches you can run it once, or add it to the install, so the dispatcher
+#   is active there too and you get the loud-fail safety net.
+#
+# WHEN THIS CAN BE DELETED
+#   This is scaffolding for the husky->vp transition ONLY. Once EVERY actively
+#   maintained branch has migrated to pnpm + vite-plus (i.e. there are no husky
+#   branches left that anyone checks out), this router serves no purpose:
+#       1. point core.hooksPath back at the vp hooks dir (or let vp manage it), and
+#       2. delete this .githooks/ directory.
+#   See .githooks/README.md for the full story.
+#
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+echo "[pre-commit dispatcher] running (.githooks/pre-commit)"
+
+# We delegate with `exec "$target"` (NOT `exec sh "$target"`) so the target runs
+# under its OWN shebang. Forcing `sh` would run a bash-requiring hook under dash
+# on Debian/Ubuntu and break it. Consequence: each delegated hook MUST be
+# executable and carry a valid shebang. Husky installs its hook that way already;
+# the vite-plus hook must likewise be committed mode 0755 with a shebang (ensured
+# when the pnpm/vite-plus branch adopts this dispatcher).
+
+# 1) pnpm / vite-plus branches ship their own pre-commit script.
+if [ -f src/BloomBrowserUI/.vite-hooks/pre-commit ]; then
+    echo "[pre-commit dispatcher] -> vite-plus hook (src/BloomBrowserUI/.vite-hooks/pre-commit)"
+    exec ./src/BloomBrowserUI/.vite-hooks/pre-commit "$@"
+fi
+
+# 2) husky 4 branches install their hook in the default location.
+husky_hook="$(git rev-parse --git-common-dir)/hooks/pre-commit"
+if [ -f "$husky_hook" ]; then
+    echo "[pre-commit dispatcher] -> husky hook ($husky_hook)"
+    exec "$husky_hook" "$@"
+fi
+
+# 3) Neither runner is present -- fail loudly rather than skip silently.
+echo "[pre-commit dispatcher] ERROR: no pre-commit runner found for this branch." >&2
+echo "  - pnpm / vite-plus branch?  run 'pnpm install' in src/BloomBrowserUI" >&2
+echo "  - yarn / husky branch?      run 'yarn install' in src/BloomBrowserUI" >&2
+exit 1


### PR DESCRIPTION
While the front-end migrates from yarn+husky 4 to pnpm+vite-plus, different
branches carry different git-hook systems. core.hooksPath is chosen before git
knows the branch and is shared across a clone's worktrees, so switching a
worktree across that boundary can run the wrong hook or, worse, silently run
none.

This adds .githooks/pre-commit: a small dispatcher, committed to every
maintained branch at the same path, that routes at commit time to whichever
checker the current branch ships -- the vite-plus hook if present, else husky's
default hook -- and fails loudly if it finds neither (no more silent skips).

Enable per clone with: git config core.hooksPath .githooks
(pnpm branches' install does this automatically.)

This is transition-only scaffolding: once every maintained branch uses
pnpm+vite-plus, point core.hooksPath back at the vp hooks and delete .githooks/.
See .githooks/README.md.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8018)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8018)
<!-- Reviewable:end -->
