### PR TITLE
Collapse nested character markup to single level (BL-16387)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -2628,7 +2628,13 @@ namespace Bloom.Book
 
         /// <summary>
         /// Convert old &lt;b&gt; and &lt;i&gt; to &lt;strong&gt; and &lt;em&gt; respectively.
-        /// Also remove instances like &lt;/b&gt;&lt;b&gt; altogether since such markup is redundant.
+        /// Remove instances like &lt;/b&gt;&lt;b&gt; altogether since such markup is redundant.
+        /// Cleanup instances like &lt;strong&gt;&lt;strong&gt;...&lt;/strong&gt;&lt;/strong&gt; to just &lt;strong&gt;...&lt;/strong&gt;.
+        /// Remove empty character markup like &lt;strong&gt;&lt;/strong&gt;, and seemingly empty markup that contains
+        /// only zero-width characters.
+        /// Doubled (nested) markup is handled only to one level, but that should be enough since Bloom can't
+        /// introduce such markup on its own.  Handling general nested markup would require more than regular
+        /// expressions to handle properly.
         /// </summary>
         public static void UpdateCharacterStyleMarkup(HtmlDom bookDOM)
         {
@@ -2667,10 +2673,33 @@ namespace Bloom.Book
                     "<strong>$1</strong>",
                     RegexOptions.CultureInvariant | RegexOptions.IgnoreCase
                 );
+                if (inner.IndexOf("<b>", StringComparison.OrdinalIgnoreCase) >= 0) // handle one level of nesting
+                    inner = Regex.Replace(
+                        inner,
+                        @"<b>(.*?)</b>",
+                        "<strong>$1</strong>",
+                        RegexOptions.CultureInvariant | RegexOptions.IgnoreCase
+                    );
                 inner = Regex.Replace(
                     inner,
                     @"<i>(.*?)</i>",
                     "<em>$1</em>",
+                    RegexOptions.CultureInvariant | RegexOptions.IgnoreCase
+                );
+                if (inner.IndexOf("<i>", StringComparison.OrdinalIgnoreCase) >= 0) // handle one level of nesting
+                    inner = Regex.Replace(
+                        inner,
+                        @"<i>(.*?)</i>",
+                        "<em>$1</em>",
+                        RegexOptions.CultureInvariant | RegexOptions.IgnoreCase
+                    );
+                // Replace doubled (nested) markup with single markup.  This shouldn't happen, but it
+                // has been seen in the wild, possibly as a result of pasting text. (BL-16378)
+                // Only one level of nesting is handled, but that should (almost always) be enough.
+                inner = Regex.Replace(
+                    inner,
+                    @"<(strong|em|sup|u)><\1>(.*?)</\1></\1>",
+                    "<$1>$2</$1>",
                     RegexOptions.CultureInvariant | RegexOptions.IgnoreCase
                 );
                 // Remove empty (or essentially empty) character markup tags.  (BL-16387)
@@ -2679,7 +2708,8 @@ namespace Bloom.Book
                 inner = Regex.Replace(
                     inner,
                     @"<(strong|em|sup|u)>(\u200B|\u200C|\u200D)*</\1>",
-                    ""
+                    "",
+                    RegexOptions.CultureInvariant | RegexOptions.IgnoreCase
                 );
                 if (inner != para.InnerXml)
                     para.InnerXml = inner;

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -2694,7 +2694,7 @@ namespace Bloom.Book
                         RegexOptions.CultureInvariant | RegexOptions.IgnoreCase
                     );
                 // Replace doubled (nested) markup with single markup.  This shouldn't happen, but it
-                // has been seen in the wild, possibly as a result of pasting text. (BL-16378)
+                // has been seen in the wild, possibly as a result of pasting text. (BL-16387)
                 // Only one level of nesting is handled, but that should (almost always) be enough.
                 inner = Regex.Replace(
                     inner,

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -2698,8 +2698,8 @@ namespace Bloom.Book
                 // Only one level of nesting is handled, but that should (almost always) be enough.
                 inner = Regex.Replace(
                     inner,
-                    @"<(strong|em|sup|u)><\1>(.*?)</\1></\1>",
-                    "<$1>$2</$1>",
+                    @"<(strong|em|u)>([^<>]*)<\1>([^<>]*)</\1>([^<>]*)</\1>",
+                    "<$1>$2$3$4</$1>",
                     RegexOptions.CultureInvariant | RegexOptions.IgnoreCase
                 );
                 // Remove empty (or essentially empty) character markup tags.  (BL-16387)

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -3183,12 +3183,12 @@ namespace BloomTests.Book
         public void UpdateCharacterStyleMarkup_ReducesNestingOfSameTags()
         {
             var dom = new HtmlDom(
-                "<html><body><div class='bloom-editable'><p><b><b style='color:red'>text</b></b></p></div></body></html>"
+                "<html><body><div class='bloom-editable'><p><b>some <b style='color:red'>text</b> here</b></p></div></body></html>"
             );
             Bloom.Book.Book.UpdateCharacterStyleMarkup(dom);
             Assert.That(
                 GetFirstEditableParagraph(dom).InnerXml,
-                Is.EqualTo("<strong>text</strong>")
+                Is.EqualTo("<strong>some text here</strong>")
             );
             var dom1 = new HtmlDom(
                 "<html><body><div class='bloom-editable'><p><i><i style='color:red'>text</i></i></p></div></body></html>"
@@ -3199,7 +3199,11 @@ namespace BloomTests.Book
                 "<html><body><div class='bloom-editable'><p><sup><sup style='color:red'>text</sup></sup></p></div></body></html>"
             );
             Bloom.Book.Book.UpdateCharacterStyleMarkup(dom2);
-            Assert.That(GetFirstEditableParagraph(dom2).InnerXml, Is.EqualTo("<sup>text</sup>"));
+            // <sup> does have a nesting effect, so we don't collapse them. We just remove the attributes from the inner tag.
+            Assert.That(
+                GetFirstEditableParagraph(dom2).InnerXml,
+                Is.EqualTo("<sup><sup>text</sup></sup>")
+            );
             var dom3 = new HtmlDom(
                 "<html><body><div class='bloom-editable'><p>This is <u><u style='color:red'>some text.</u></u></p></div></body></html>"
             );

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -3180,6 +3180,78 @@ namespace BloomTests.Book
         }
 
         [Test]
+        public void UpdateCharacterStyleMarkup_ReducesNestingOfSameTags()
+        {
+            var dom = new HtmlDom(
+                "<html><body><div class='bloom-editable'><p><b><b style='color:red'>text</b></b></p></div></body></html>"
+            );
+            Bloom.Book.Book.UpdateCharacterStyleMarkup(dom);
+            Assert.That(
+                GetFirstEditableParagraph(dom).InnerXml,
+                Is.EqualTo("<strong>text</strong>")
+            );
+            var dom1 = new HtmlDom(
+                "<html><body><div class='bloom-editable'><p><i><i style='color:red'>text</i></i></p></div></body></html>"
+            );
+            Bloom.Book.Book.UpdateCharacterStyleMarkup(dom1);
+            Assert.That(GetFirstEditableParagraph(dom1).InnerXml, Is.EqualTo("<em>text</em>"));
+            var dom2 = new HtmlDom(
+                "<html><body><div class='bloom-editable'><p><sup><sup style='color:red'>text</sup></sup></p></div></body></html>"
+            );
+            Bloom.Book.Book.UpdateCharacterStyleMarkup(dom2);
+            Assert.That(GetFirstEditableParagraph(dom2).InnerXml, Is.EqualTo("<sup>text</sup>"));
+            var dom3 = new HtmlDom(
+                "<html><body><div class='bloom-editable'><p>This is <u><u style='color:red'>some text.</u></u></p></div></body></html>"
+            );
+            Bloom.Book.Book.UpdateCharacterStyleMarkup(dom3);
+            Assert.That(
+                GetFirstEditableParagraph(dom3).InnerXml,
+                Is.EqualTo("This is <u>some text.</u>")
+            );
+        }
+
+        [Test]
+        public void UpdateCharacterStyleMarkup_HandlesMultipleTags()
+        {
+            var dom = new HtmlDom(
+                "<html><body><div class='bloom-editable'><p><b>text</b>, <b><i>more text</i></b> and <i><b>yet more.</b></i></p></div></body></html>"
+            );
+            Bloom.Book.Book.UpdateCharacterStyleMarkup(dom);
+            Assert.That(
+                GetFirstEditableParagraph(dom).InnerXml,
+                Is.EqualTo(
+                    "<strong>text</strong>, <strong><em>more text</em></strong> and <em><strong>yet more.</strong></em>"
+                )
+            );
+            var dom1 = new HtmlDom(
+                "<html><body><div class='bloom-editable'><p><i><i>text</i></i> with <i><i>more text</i></i></p></div></body></html>"
+            );
+            Bloom.Book.Book.UpdateCharacterStyleMarkup(dom1);
+            Assert.That(
+                GetFirstEditableParagraph(dom1).InnerXml,
+                Is.EqualTo("<em>text</em> with <em>more text</em>")
+            );
+            var dom2 = new HtmlDom(
+                "<html><body><div class='bloom-editable'><p><sup>number</sup> of <sup style='color:red'>text</sup> with <sup>xyz</sup></p></div></body></html>"
+            );
+            Bloom.Book.Book.UpdateCharacterStyleMarkup(dom2);
+            Assert.That(
+                GetFirstEditableParagraph(dom2).InnerXml,
+                Is.EqualTo("<sup>number</sup> of <sup>text</sup> with <sup>xyz</sup>")
+            );
+            var dom3 = new HtmlDom(
+                "<html><body><div class='bloom-editable'><p>This is <b><b>some text.</b></b> x <b>More stuff</b> of <b>sorts</b></p></div></body></html>"
+            );
+            Bloom.Book.Book.UpdateCharacterStyleMarkup(dom3);
+            Assert.That(
+                GetFirstEditableParagraph(dom3).InnerXml,
+                Is.EqualTo(
+                    "This is <strong>some text.</strong> x <strong>More stuff</strong> of <strong>sorts</strong>"
+                )
+            );
+        }
+
+        [Test]
         public void BringBookUpToDate_FixesDuplicateAudioIds_SentenceRecording()
         {
             _bookDom = new HtmlDom(


### PR DESCRIPTION
For example, <em><em>...</em></em> goes to <em>...</em>.

[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8019)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8019)
<!-- Reviewable:end -->
