### PR TITLE
Fix some image gallery glitches

### DIFF
--- a/src/BloomBrowserUI/react_components/image-gallery/ImageGalleryDialog.tsx
+++ b/src/BloomBrowserUI/react_components/image-gallery/ImageGalleryDialog.tsx
@@ -144,6 +144,14 @@ const ImageGalleryDialog: React.FunctionComponent<{
                     margin-left: -16px;
                     margin-right: -16px;
                     margin-bottom: -10px;
+                    /* bloom-image-gallery's content div uses height:100% + padding:20px
+                       with box-sizing:content-box, making its total height 40px taller
+                       than its parent and pushing the OK/Cancel buttons below the clipping
+                       boundary. Switching to border-box makes height:100% include the
+                       padding, so buttons stay visible even when the dialog is shrunk. */
+                    main > div {
+                        box-sizing: border-box;
+                    }
                 `}
             >
                 {keysLoaded && (

--- a/src/BloomBrowserUI/yarn.lock
+++ b/src/BloomBrowserUI/yarn.lock
@@ -4336,8 +4336,8 @@ bindings@^1.5.0:
     file-uri-to-path "1.0.0"
 
 bloom-image-gallery@BloomBooks/bloom-image-gallery:
-  version "0.0.0"
-  resolved "https://codeload.github.com/BloomBooks/bloom-image-gallery/tar.gz/e84eb712b2ebcac1c3fd1107fd48269cf45b149a"
+  version "0.0.2"
+  resolved "https://codeload.github.com/BloomBooks/bloom-image-gallery/tar.gz/51c5a75bb611c51dd24b40c9162929c6e75473eb"
   dependencies:
     "@emotion/react" "^11.14.0"
     "@emotion/styled" "^11.14.0"
@@ -7168,14 +7168,14 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
-is-core-module@^2.13.0, is-core-module@^2.16.1:
+is-core-module@^2.13.0:
   version "2.16.1"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.1.tgz#2a98801a849f43e2add644fbb6bc6229b19a4ef4"
   integrity sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==
   dependencies:
     hasown "^2.0.2"
 
-is-core-module@^2.16.0:
+is-core-module@^2.16.0, is-core-module@^2.16.1:
   version "2.16.2"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.2.tgz#3e07450a8080ebce3fbf0cac494f4d2ab324e082"
   integrity sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==


### PR DESCRIPTION
- Hide the previously selected tool after choosing an image from disk
- make sure the OK and Cancel button stay visible.


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8022)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8022)
<!-- Reviewable:end -->
