### PR TITLE
Fix overflow checker error (BL-16503)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
@@ -729,9 +729,12 @@ export default class OverflowChecker {
         else $page.addClass("pageOverflows");
 
         // BL-11949: books with device layouts can ignore overflows because we'll show a scrollbar.
-        // Note: our caller passes a jQuery object here, so hand GetScrollInsteadOfOverflow the
-        // underlying DOM element (it reads classList directly). $page may be empty if the element
-        // has no .bloom-page ancestor, so guard for that. See BL-16503.
+        // GetScrollInsteadOfOverflow needs the DOM element; our caller passes a jQuery
+        // object, so unwrap it. $page can be empty here because this runs on a deferred
+        // (1s) timer — by the time it fires, the element may have been detached (page
+        // switched or deleted), leaving no .bloom-page ancestor. That's a valid "nothing
+        // to do" case the rest of this module already no-ops on, so guard rather than
+        // crash. See BL-16503.
         if ($page[0] && this.GetScrollInsteadOfOverflow($page[0])) {
             $page.removeClass("pageOverflows");
             // note, we don't yet remove the bubble that says there is too much text. This code is already spaghetti enough, I didn't want to pay that price at this time. --JH

--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
@@ -728,8 +728,11 @@ export default class OverflowChecker {
             $page.removeClass("pageOverflows");
         else $page.addClass("pageOverflows");
 
-        // BL-11949: books with device layouts can ignore overflows because we'll show a scrollbar
-        if (this.GetScrollInsteadOfOverflow(page)) {
+        // BL-11949: books with device layouts can ignore overflows because we'll show a scrollbar.
+        // Note: our caller passes a jQuery object here, so hand GetScrollInsteadOfOverflow the
+        // underlying DOM element (it reads classList directly). $page may be empty if the element
+        // has no .bloom-page ancestor, so guard for that. See BL-16503.
+        if ($page[0] && this.GetScrollInsteadOfOverflow($page[0])) {
             $page.removeClass("pageOverflows");
             // note, we don't yet remove the bubble that says there is too much text. This code is already spaghetti enough, I didn't want to pay that price at this time. --JH
         }

--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
@@ -718,7 +718,7 @@ export default class OverflowChecker {
     }
     // Make sure there are no boxes with class 'overflow' or 'thisOverflowingParent' on the page before removing
     // the page-level overflow marker 'pageOverflows', or add it if there are.
-    private static UpdatePageOverflow(page) {
+    private static UpdatePageOverflow(page: JQuery) {
         // TODO: Investigate BL-6686. It seems that it takes more clicks to propagate the pageOverflows class onto a FrontCover page than a normal page??? Repro in both 4.4 and 4.5
         const $page = $(page);
         if (


### PR DESCRIPTION
[Claude Opus 4.8]

Fixes the runtime JS error `Uncaught TypeError: Cannot read properties of undefined (reading 'contains')` thrown from the overflow checker.

**Root cause:** `OverflowChecker.UpdatePageOverflow` receives a jQuery object (from `container.closest(".bloom-page")` in `CheckPageAncestorOverflow`) and passed it straight to `GetScrollInsteadOfOverflow`. Since commit c613ca7c59 ("de-duplicate split-config and scroll-vs-overflow logic"), that method delegates to `pageScrollsInsteadOfOverflowing`, which reads `page.classList` directly. A jQuery object has no `.classList`, so `.contains(...)` threw. Before that refactor the check used `$(page).hasClass(...)`, which tolerated a jQuery object; the refactor tightened the contract to a DOM element without updating the caller.

**Fix:** pass `$page[0]` (the underlying DOM element) to `GetScrollInsteadOfOverflow`, and guard the empty case where the element has no `.bloom-page` ancestor.

**Testing:** front-end typecheck, eslint on the changed file, and the full vitest suite (499 passed, 5 skipped) all pass. Not yet manually re-verified in a running Bloom.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16503

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8027)
<!-- Reviewable:end -->


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8027)
