### PR TITLE
Fix BL-16429 Replace obsolete WebClient/WebRequest with HttpClient (SYSLIB0014)

### DIFF
--- a/src/BloomExe/BloomWebClient.cs
+++ b/src/BloomExe/BloomWebClient.cs
@@ -1,19 +1,35 @@
-using System.Net;
+using System.Net.Http;
+using Bloom.Utils;
 
 namespace Bloom
 {
     /// <summary>
-    /// We need a class that inherits from both System.Net.WebClient and this interface
-    /// so that we can test what happens when Bloom is used behind a captive portal.
+    /// A concrete implementation of IBloomWebClient backed by HttpClient.
+    /// Having this behind the interface lets us mock DownloadString in tests
+    /// to simulate things like a captive portal.
     /// </summary>
-    public class BloomWebClient : WebClient, IBloomWebClient { }
+    public class BloomWebClient : IBloomWebClient
+    {
+        // A single shared HttpClient is the recommended pattern; reusing it avoids socket exhaustion.
+        private static readonly HttpClient s_client = new HttpClient();
+
+        /// <summary>
+        /// Synchronously GET the given url and return the response body as a string.
+        /// Throws HttpRequestException (or TaskCanceledException on timeout), which callers handle.
+        /// </summary>
+        public string DownloadString(string url)
+        {
+            // RunSync executes on the thread pool so we don't deadlock if called on a thread
+            // with a synchronization context (e.g. the WinForms UI thread).
+            return AsyncUtil.RunSync(() => s_client.GetStringAsync(url));
+        }
+    }
 
     /// <summary>
     /// Allows moq-ing of DownloadString to return a simulated captive portal.
     /// </summary>
     public interface IBloomWebClient
     {
-        // WebClient method
         string DownloadString(string url);
     }
 }

--- a/src/BloomExe/Book/LicenseChecker.cs
+++ b/src/BloomExe/Book/LicenseChecker.cs
@@ -3,8 +3,9 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Net;
+using System.Net.Http;
 using System.Text;
+using System.Threading.Tasks;
 using Bloom.Api;
 using L10NSharp;
 using SIL.IO;
@@ -23,6 +24,16 @@ namespace Bloom.Book
     // For offline checking we cache the keys whenever we read it.
     public class LicenseChecker
     {
+        // A single shared HttpClient is the recommended pattern; reusing it avoids socket exhaustion.
+        private static HttpClient s_httpClient = new HttpClient();
+
+        // Test seam: lets tests inject an HttpClient backed by a fake handler (e.g. to simulate a
+        // network failure and exercise the offline-cache fallback).
+        internal static void SetHttpClientForTests(HttpClient client)
+        {
+            s_httpClient = client;
+        }
+
         private static string _offlineFolderPath = ProjectContext.GetBloomAppDataFolder(); // normally stays here except in unit tests
         private static bool _allowInternetAccess = true;
         public static string kUnlicenseLanguageMessage =
@@ -63,8 +74,10 @@ namespace Bloom.Book
             {
                 try
                 {
-                    permissionsJson = new WebClient().DownloadString(
-                        "https://content-licenses.bloomlibrary.org"
+                    // RunSync executes on the thread pool so we don't deadlock if called on a
+                    // thread with a synchronization context (e.g. the WinForms UI thread).
+                    permissionsJson = Bloom.Utils.AsyncUtil.RunSync(() =>
+                        s_httpClient.GetStringAsync("https://content-licenses.bloomlibrary.org")
                     );
                     if (!string.IsNullOrEmpty(_offlineFolderPath))
                     {
@@ -80,8 +93,9 @@ namespace Bloom.Book
                         }
                     }
                 }
-                catch (WebException w)
+                catch (Exception w) when (w is HttpRequestException || w is TaskCanceledException)
                 {
+                    // A network failure (or timeout) reaching the license server: fall back to any cached copy.
                     Bloom.Utils.MiscUtils.SuppressUnusedExceptionVarWarning(w);
                     if (!TryGetOfflineCache(out permissionsJson))
                     {

--- a/src/BloomExe/Publish/BloomPub/wifi/WiFiPublisher.cs
+++ b/src/BloomExe/Publish/BloomPub/wifi/WiFiPublisher.cs
@@ -3,9 +3,10 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
-using System.Net;
+using System.Net.Http;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Bloom.Book;
 using Bloom.Collection;
 using Bloom.web;
@@ -26,13 +27,55 @@ namespace Bloom.Publish.BloomPub.wifi
         private BloomReaderUDPListener _wifiListener;
         public const string ProtocolVersion = "2.0";
 
-        // This is the web client we use in StartSendBookToClientOnLocalSubNet() to send a book to an android.
-        // It is non-null only for the duration of a send, being destroyed in its own UploadDataCompleted
-        // event. Thus, its non-null status indicates a transfer is in progress, and we won't start any
-        // others. One reason for this is that depending on various network latencies, it is possible
-        // for us to get another request from the same device to which we are already sending.
-        // Trying to send the same thing to the same device twice at the same time does not work well.
-        private WebClient _wifiSender;
+        // A single shared HttpClient is the recommended pattern; reusing it avoids socket exhaustion.
+        // We give it no timeout (rely on cancellation instead), since sending a book over local WiFi
+        // can take a while and we don't want to abort a legitimate, slow transfer.
+        private static readonly HttpClient s_defaultHttpClient = new HttpClient
+        {
+            Timeout = System.Threading.Timeout.InfiniteTimeSpan,
+        };
+
+        // Defaults to the shared client; tests substitute one backed by a fake handler.
+        private HttpClient _httpClient = s_defaultHttpClient;
+
+        // This indicates a send (in StartSendBookToClientOnLocalSubNet) is in progress: it is non-null
+        // only for the duration of a send, being cleared when the send completes (or is canceled).
+        // Its non-null status means we won't start another send. One reason for this is that depending
+        // on various network latencies, it is possible for us to get another request from the same
+        // device to which we are already sending. Trying to send the same thing to the same device
+        // twice at the same time does not work well. Canceling this token aborts an in-progress send.
+        private CancellationTokenSource _wifiSendCancellation;
+
+        // Test seam: lets tests inject an HttpClient with a fake handler so the upload can be
+        // exercised without a real device.
+        internal void SetHttpClientForTests(HttpClient client)
+        {
+            _httpClient = client;
+        }
+
+        // Test seam: lets tests set/inspect the in-progress indicator without going through SendBook.
+        // Locked so the seam follows the same discipline as every production access of the field.
+        internal CancellationTokenSource WifiSendCancellationForTests
+        {
+            get
+            {
+                lock (this)
+                    return _wifiSendCancellation;
+            }
+            set
+            {
+                lock (this)
+                    _wifiSendCancellation = value;
+            }
+        }
+
+        // Test seam: lets tests set/inspect the advertiser so they can verify Paused handling
+        // without starting a real advertisement.
+        internal WiFiAdvertiser WifiAdvertiserForTests
+        {
+            get { return _wifiAdvertiser; }
+            set { _wifiAdvertiser = value; }
+        }
 
         public WiFiPublisher(WebSocketProgress progress, BookServer bookServer)
         {
@@ -73,7 +116,7 @@ namespace Bloom.Publish.BloomPub.wifi
                     // Of course, there are async effects from network latency. But if we do get another request while
                     // handling this one, we will ignore it, since StartSendBook checks for a transfer in progress.
                     _wifiAdvertiser.Paused = true;
-                    StartSendBookOverWiFi(
+                    StartSendBookToClientOnLocalSubNet(
                         book,
                         androidIpAddress,
                         androidName,
@@ -133,7 +176,7 @@ namespace Bloom.Publish.BloomPub.wifi
         public void Stop()
         {
             // Locked to avoid contention with code in the thread that reports a transfer complete,
-            // which disposes of _wifiSender and tries to restart the advertiser.
+            // which clears _wifiSendCancellation and tries to restart the advertiser.
             lock (this)
             {
                 if (_wifiAdvertiser != null)
@@ -142,41 +185,32 @@ namespace Bloom.Publish.BloomPub.wifi
                     _wifiAdvertiser.Dispose();
                     _wifiAdvertiser = null;
                 }
-                if (_wifiSender != null)
+                if (_wifiSendCancellation != null)
                 {
-                    _wifiSender.CancelAsync();
-                    Debug.WriteLine("attempting async cancel send");
-                }
-                if (_uploadTimer != null)
-                {
-                    _uploadTimer.Stop();
-                    _uploadTimer.Dispose();
-                    _uploadTimer = null;
+                    _wifiSendCancellation.Cancel();
+                    Debug.WriteLine("attempting to cancel send");
                 }
             }
             // To avoid leaving a thread around when quitting, try to wait for the sender to cancel or complete.
-            // We expect another thread to set _wifiSender to null in the UploadDataCompleted event
-            // (which is supposed to be triggered also by canceling).
-            for (int i = 0; i < 30 && _wifiSender != null; i++)
+            // We expect the send's completion continuation to clear _wifiSendCancellation (the cancel above
+            // triggers that completion).
+            for (int i = 0; i < 30 && _wifiSendCancellation != null; i++)
             {
                 Thread.Sleep(100);
             }
             lock (this)
             {
-                if (_wifiSender != null)
+                if (_wifiSendCancellation != null)
                 {
-                    // If it's still null we give up on the Cancel and try to shut it down any way we can.
-                    // Note that if the cancelAsync didn't work, as it generally seems not to, this could
-                    // cancel a file transfer rather abruptly. But the alternative is to leave the thread
-                    // running, possibly after Bloom has otherwise exited, causing problems like BL-5272.
-                    // (In practice even aborting this thread doesn't seem to force the file transfer to
-                    // stop, nor does anything else I've tried, so we just do our best to make sure
-                    // the thread won't outlive the application by much. Not allowing requests to queue
-                    // up is one thing that helps. At worst there's only one in progress that either
-                    // finishes or aborts before too long.)
-                    _wifiSender.Dispose();
-                    _wifiSender = null;
-                    Debug.WriteLine("had to force dispose sender");
+                    // The completion continuation didn't run within our wait. We've already canceled the
+                    // token (which aborts the underlying transfer), so stop tracking this send to avoid
+                    // leaving a thread that could outlive the application (see BL-5272). We deliberately
+                    // do NOT Dispose the CancellationTokenSource here: the continuation owns disposal, and
+                    // the request may still hold a registration on the token, so disposing now could race.
+                    // Once we null the field, a late continuation will see it's no longer current
+                    // (ReferenceEquals fails) and will not disturb any newer send.
+                    _wifiSendCancellation = null;
+                    Debug.WriteLine("had to force-abandon sender");
                 }
             }
             if (_wifiListener != null)
@@ -187,8 +221,6 @@ namespace Bloom.Publish.BloomPub.wifi
                 }
             }
         }
-
-        private System.Timers.Timer _uploadTimer;
 
         /// <summary>
         /// Send the book to a client over local network, typically WiFi (at least on Android end).
@@ -209,148 +241,216 @@ namespace Bloom.Publish.BloomPub.wifi
             BloomPubPublishSettings settings = null
         )
         {
+            CancellationTokenSource cancellation;
             // Locked in case more than one thread at a time can handle incoming packets, though I don't think
-            // this is true. Also, Stop() on the main thread cares whether _wifiSender is null.
+            // this is true. Also, Stop() on the main thread cares whether _wifiSendCancellation is null.
             lock (this)
             {
                 // We only support one send at a time. If we somehow get more than one request, we ignore the other.
                 // The device will retry soon if still listening and we are still advertising.
-                if (_wifiSender != null) // indicates transfer in progress
+                if (_wifiSendCancellation != null) // indicates transfer in progress
                     return;
                 // now THIS transfer is 'in progress' as far as any thread checking this is concerned.
-                _wifiSender = new WebClient();
+                cancellation = _wifiSendCancellation = new CancellationTokenSource();
             }
-            _wifiSender.UploadDataCompleted += WifiSenderUploadCompleted;
-            // Now we actually start the send...but using an async API, so there's no long delay here.
-            PublishToBloomPubApi.SendBook(
-                book,
-                _bookServer,
-                destFileName: null,
-                sendAction: (publishedFileName, bloomDPath) =>
-                {
-                    var androidHttpAddress = "http://" + androidIpAddress + ":5914"; // must match BloomReader SyncServer._serverPort.
-                    _wifiSender.UploadDataAsync(
-                        new Uri(
-                            androidHttpAddress
-                                + "/putfile?path="
-                                + Uri.EscapeDataString(publishedFileName)
-                        ),
-                        RobustFile.ReadAllBytes(bloomDPath)
-                    );
-                    Debug.WriteLine(
-                        $"upload started to http://{androidIpAddress}:5914 ({androidName}) for {publishedFileName}"
-                    );
-                },
-                _progress,
-                startingMessageFunction: (publishedFileName, bookTitle) =>
-                    _progress.GetMessageWithParams(
-                        idSuffix: "Sending",
-                        comment: "{0} is the name of the book, {1} is the name of the device",
-                        message: "Sending \"{0}\" to device {1}",
-                        parameters: new object[] { bookTitle, androidName }
-                    ),
-                confirmFunction: null,
-                backColor,
-                settings
-            );
-            // Occasionally preparing a book for sending will, despite our best efforts, result in a different sha.
-            // For example, it might change missing or out-of-date mp3 files. In case the sha we just computed
-            // is different from the one we're advertising, update the advertisement, so at least subsequent
-            // advertisements will conform to the version the device just got.
-            _wifiAdvertiser.BookVersion = BloomPubMaker.HashOfMostRecentlyCreatedBook;
-            lock (this)
-            {
-                // The UploadDataCompleted event handler quit working at Bloom 4.6.1238 Alpha (Windows test build).
-                // The data upload still works, but the event handler is *NEVER* called.  Trying to revise the upload
-                // by using UploadDataTaskAsync with async/await  did not work any better: the await never happened.
-                // To get around this bug, we introduce a timer that periodically checks the IsBusy flag of the
-                // _wifiSender object.  It's a hack, but I haven't come up with anything better in two days of
-                // looking at this problem.
-                // See https://issues.bloomlibrary.org/youtrack/issue/BL-7227 for details.
-                if (_uploadTimer == null)
-                {
-                    _uploadTimer = new System.Timers.Timer { Interval = 500.0, Enabled = false };
-                    _uploadTimer.Elapsed += (sender, args) =>
-                    {
-                        if (_wifiSender != null && _wifiSender.IsBusy)
-                            return;
-                        _uploadTimer.Stop();
-                        Debug.WriteLine("upload timed out, appears to be finished");
-                        WifiSenderUploadCompleted(_uploadTimer, null);
-                    };
-                }
-                _uploadTimer.Start();
-            }
-            PublishToBloomPubApi.ReportAnalytics("wifi", book);
-        }
-
-        private void WifiSenderUploadCompleted(object sender, UploadDataCompletedEventArgs args)
-        {
-            // Runs on the async transfer thread after the transfer initiated above.  (Or on the async
-            // timer thread if the completion event handler is not called, as seems to be happening
-            // since Bloom 4.6.1238 Alpha according to BL-7227)
-            if (args?.Error != null)
-            {
-                ReportException(args.Error);
-            }
-            // Should we report if canceled? Thinking not, we typically only cancel while shutting down,
-            // it's probably too late for a useful report.
-
-            // To avoid contention with Stop(), which may try to cancel the send if it finds
-            // an existing wifiSender, and may destroy the advertiser we are trying to restart.
-            lock (this)
-            {
-                Debug.WriteLine(
-                    $"upload completed, sender is {sender}, cancelled is {args?.Cancelled}"
-                );
-                if (_wifiSender != null) // should be null only in a desperate abort-the-thread situation.
-                {
-                    _wifiSender.Dispose();
-                    _wifiSender = null;
-                }
-                if (_wifiAdvertiser != null)
-                    _wifiAdvertiser.Paused = false;
-                if (_uploadTimer != null)
-                {
-                    _uploadTimer.Stop();
-                    _uploadTimer.Dispose();
-                    _uploadTimer = null;
-                }
-            }
-        }
-
-        private void StartSendBookOverWiFi(
-            Book.Book book,
-            string androidIpAddress,
-            string androidName,
-            Color backColor,
-            BloomPubPublishSettings settings = null
-        )
-        {
+            // Tracks whether the async upload was actually started (and thus a completion continuation
+            // attached). It is set inside the synchronous sendAction callback below.
+            var uploadStarted = false;
             try
             {
-                StartSendBookToClientOnLocalSubNet(
+                // Now we actually start the send...but using an async API, so there's no long delay here.
+                PublishToBloomPubApi.SendBook(
                     book,
-                    androidIpAddress,
-                    androidName,
+                    _bookServer,
+                    destFileName: null,
+                    sendAction: (publishedFileName, bloomDPath) =>
+                    {
+                        UploadToDevice(
+                            androidIpAddress,
+                            publishedFileName,
+                            RobustFile.ReadAllBytes(bloomDPath),
+                            cancellation
+                        );
+                        // From here on, the upload's completion continuation owns clearing the
+                        // in-progress state and disposing the CancellationTokenSource.
+                        uploadStarted = true;
+                        Debug.WriteLine(
+                            $"upload started to http://{androidIpAddress}:5914 ({androidName}) for {publishedFileName}"
+                        );
+                    },
+                    _progress,
+                    startingMessageFunction: (publishedFileName, bookTitle) =>
+                        _progress.GetMessageWithParams(
+                            idSuffix: "Sending",
+                            comment: "{0} is the name of the book, {1} is the name of the device",
+                            message: "Sending \"{0}\" to device {1}",
+                            parameters: new object[] { bookTitle, androidName }
+                        ),
+                    confirmFunction: null,
                     backColor,
                     settings
                 );
+                // Occasionally preparing a book for sending will, despite our best efforts, result in a different sha.
+                // For example, it might change missing or out-of-date mp3 files. In case the sha we just computed
+                // is different from the one we're advertising, update the advertisement, so at least subsequent
+                // advertisements will conform to the version the device just got.
+                _wifiAdvertiser.BookVersion = BloomPubMaker.HashOfMostRecentlyCreatedBook;
+                PublishToBloomPubApi.ReportAnalytics("wifi", book);
             }
             catch (Exception e)
             {
-                ReportException(e);
+                HandleSendSetupFailure(e, cancellation, uploadStarted);
             }
         }
 
-        private void ReportException(Exception e)
+        /// <summary>
+        /// Handles an exception thrown while setting up/starting a send. Reports it, and—only if the
+        /// upload never actually started—clears the in-progress state and resumes advertising. If the
+        /// upload had started, its completion continuation owns the CancellationTokenSource and will do
+        /// that cleanup; clearing/disposing here would clobber an in-flight transfer and could let a
+        /// second send start concurrently.
+        /// </summary>
+        internal void HandleSendSetupFailure(
+            Exception e,
+            CancellationTokenSource cancellation,
+            bool uploadStarted
+        )
         {
-            // If this happens while _wifiSender is null, it can only be because Stop() tried to abort a transfer
-            // and CancelAsync didn't work (as usual). At this point the exception is being reported on an orphan thread
-            // very possibly after Bloom has closed down and the localization manager is disposed.
+            // Report while the send still counts as 'in progress' (ReportException suppresses itself
+            // once the in-progress state has been cleared).
+            ReportException(e);
+            if (uploadStarted)
+                return;
+            lock (this)
+            {
+                if (ReferenceEquals(_wifiSendCancellation, cancellation))
+                {
+                    ClearWifiSend();
+                    if (_wifiAdvertiser != null)
+                        _wifiAdvertiser.Paused = false;
+                }
+                else
+                {
+                    // This send was abandoned (Stop() gave up waiting for it) and a newer send may be
+                    // in progress, so leave the shared state and the advertiser's Paused status alone.
+                    // Since the upload never started, no completion continuation exists to dispose our
+                    // CancellationTokenSource, so dispose it here.
+                    cancellation.Dispose();
+                }
+            }
+        }
+
+        /// <summary>
+        /// POSTs the given book bytes to the device's putfile endpoint and wires up completion
+        /// handling. The continuation (which runs on a thread-pool thread when the transfer finishes,
+        /// faults, or is canceled) reports any error and clears the in-progress state. Unlike the old
+        /// WebClient.UploadDataCompleted event, an HttpClient continuation fires reliably, so the
+        /// BL-7227 IsBusy/timer hack is no longer needed.
+        /// Returns the completion task; production code ignores it, but tests await it.
+        /// </summary>
+        internal Task UploadToDevice(
+            string androidIpAddress,
+            string publishedFileName,
+            byte[] bytes,
+            CancellationTokenSource cancellation
+        )
+        {
+            var androidHttpAddress = "http://" + androidIpAddress + ":5914"; // must match BloomReader SyncServer._serverPort.
+            var uri = new Uri(
+                androidHttpAddress + "/putfile?path=" + Uri.EscapeDataString(publishedFileName)
+            );
+            var content = new ByteArrayContent(bytes);
+            // The old WebClient sent application/octet-stream by default; set it explicitly so the
+            // bytes-on-the-wire to the BloomReader device are guaranteed unchanged by the HttpClient
+            // migration (ByteArrayContent sends no Content-Type on its own).
+            content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(
+                "application/octet-stream"
+            );
+            return _httpClient
+                .PostAsync(uri, content, cancellation.Token)
+                .ContinueWith(task => WifiSendCompleted(task, content, cancellation));
+        }
+
+        // Runs on a thread-pool thread when the upload started above finishes, faults, or is canceled.
+        // 'cancellation' is the CancellationTokenSource that belongs to *this* send.
+        private void WifiSendCompleted(
+            Task<HttpResponseMessage> task,
+            ByteArrayContent content,
+            CancellationTokenSource cancellation
+        )
+        {
+            content.Dispose();
+            // The finally guarantees the state cleanup below runs even if reporting the outcome throws
+            // (e.g. the progress channel is being torn down); otherwise the in-progress flag would stay
+            // set and the advertiser paused, silently blocking all future sends. This continuation is
+            // fire-and-forget in production, so a throw here would not even be observed.
+            try
+            {
+                if (task.IsFaulted)
+                {
+                    var error = task.Exception?.GetBaseException();
+                    // Don't report cancellation: we typically only cancel while shutting down, when it's
+                    // too late for a useful report.
+                    if (error != null && !(error is OperationCanceledException))
+                        ReportException(error);
+                }
+                else if (!task.IsCanceled)
+                {
+                    using (var response = task.Result)
+                    {
+                        if (!response.IsSuccessStatusCode)
+                            ReportException(
+                                new HttpRequestException(
+                                    $"Device returned {(int)response.StatusCode} {response.ReasonPhrase}"
+                                )
+                            );
+                    }
+                }
+            }
+            finally
+            {
+                // To avoid contention with Stop(), which may try to cancel the send if it finds
+                // an existing transfer, and may destroy the advertiser we are trying to restart.
+                lock (this)
+                {
+                    Debug.WriteLine($"upload completed, cancelled is {task.IsCanceled}");
+                    // A newer send may have started (e.g. after Stop() abandoned this one) while this
+                    // continuation was still pending. Only clear the shared in-progress state and resume
+                    // advertising if we are still the current send; otherwise we would wrongly cancel the
+                    // newer send's "in progress" status and resume advertising during its transfer.
+                    if (ReferenceEquals(_wifiSendCancellation, cancellation))
+                    {
+                        _wifiSendCancellation = null;
+                        if (_wifiAdvertiser != null)
+                            _wifiAdvertiser.Paused = false;
+                    }
+                }
+                // This continuation owns its CancellationTokenSource. The request has finished using the
+                // token by the time the continuation runs, so disposing here is safe (and is the single
+                // place the CTS gets disposed).
+                cancellation.Dispose();
+            }
+        }
+
+        // Disposes and clears the in-progress send. Callers must hold the lock on 'this'.
+        // Used only when a send fails during setup, before its completion continuation is attached.
+        private void ClearWifiSend()
+        {
+            if (_wifiSendCancellation != null)
+            {
+                _wifiSendCancellation.Dispose();
+                _wifiSendCancellation = null;
+            }
+        }
+
+        protected virtual void ReportException(Exception e)
+        {
+            // If this happens while _wifiSendCancellation is null, it can only be because Stop() tried to
+            // abort a transfer. At this point the exception is being reported on an orphan thread, very
+            // possibly after Bloom has closed down and the localization manager is disposed.
             // Certainly the _progress thing is no longer visible. So no point in trying to send something
             // there, it will just cause exceptions.
-            if (_wifiSender != null)
+            if (_wifiSendCancellation != null)
             {
                 // This method is called on a background thread in response to receiving a request from Bloom Reader.
                 // Exceptions somehow get discarded, so there is no point in letting them propagate further.

--- a/src/BloomExe/UpdateVersionTable.cs
+++ b/src/BloomExe/UpdateVersionTable.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Net;
+using System.Net.Http;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using SIL.Reporting;
 
 namespace Bloom
@@ -192,30 +194,48 @@ namespace Bloom
                     return false;
                 }
             }
-            catch (WebException e)
+            catch (HttpRequestException e)
             {
                 Logger.WriteEvent(
-                    "***Error (WebException) in CanGetVersionTableFromWeb: " + e.Message
+                    "***Error (HttpRequestException) in CanGetVersionTableFromWeb: " + e.Message
                 );
-                if (e.Status == WebExceptionStatus.ProtocolError)
+                // Translate the HttpClient exception into a WebException carrying an equivalent
+                // WebExceptionStatus, since that is what UpdateTableLookupResult exposes to callers.
+                var status = WebExceptionStatus.UnknownError;
+                if (e.HttpRequestError == HttpRequestError.NameResolutionError)
                 {
-                    if (
-                        e.Response is HttpWebResponse resp
-                        && resp.StatusCode == HttpStatusCode.NotFound
-                    )
+                    status = WebExceptionStatus.NameResolutionFailure;
+                    Logger.WriteEvent(
+                        "***Error: UpdateVersionTable could not connect to the server"
+                    );
+                }
+                else if (e.StatusCode != null)
+                {
+                    status = WebExceptionStatus.ProtocolError;
+                    if (e.StatusCode == HttpStatusCode.NotFound)
                     {
                         Logger.WriteEvent(
                             $"***Error: UpdateVersionTable failed to find a file at {GetUrlOfTable()} (channel='{ApplicationUpdateSupport.ChannelName}'"
                         );
                     }
                 }
-                else if (IsConnectionError(e))
+                errorResult = new UpdateTableLookupResult()
                 {
-                    Logger.WriteEvent(
-                        "***Error: UpdateVersionTable could not connect to the server"
-                    );
-                }
-                errorResult = new UpdateTableLookupResult() { Error = e };
+                    // Keep the original exception as InnerException so diagnostics don't lose
+                    // the underlying transport detail.
+                    Error = new WebException(e.Message, e, status, null),
+                };
+                return false;
+            }
+            catch (TaskCanceledException e)
+            {
+                // HttpClient throws TaskCanceledException when its Timeout elapses.
+                Logger.WriteEvent("***Error (Timeout) in CanGetVersionTableFromWeb: " + e.Message);
+                Logger.WriteEvent("***Error: UpdateVersionTable could not connect to the server");
+                errorResult = new UpdateTableLookupResult()
+                {
+                    Error = new WebException(e.Message, e, WebExceptionStatus.Timeout, null),
+                };
                 return false;
             }
             catch (Exception e)
@@ -248,15 +268,6 @@ namespace Bloom
                 ApplicationUpdateSupport.ChannelName,
                 UpdateVersionTable.ArchitectureSuffix
             );
-        }
-
-        private bool IsConnectionError(WebException ex)
-        {
-            return ex.Status == WebExceptionStatus.Timeout
-                || ex.Status == WebExceptionStatus.NameResolutionFailure;
-            //I'm not sure if you'd ever get one of these?
-            //				ex.Status == WebExceptionStatus.ReceiveFailure ||
-            //			ex.Status == WebExceptionStatus.ConnectFailure;
         }
     }
 }

--- a/src/BloomExe/Utils/DropboxUtils.cs
+++ b/src/BloomExe/Utils/DropboxUtils.cs
@@ -1,8 +1,10 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using SIL.IO;
 using SIL.PlatformUtilities;
 
@@ -27,6 +29,10 @@ namespace Bloom.Utils
         // it's online and it's not. It could go offline any time, even after we check
         // and before we complete whatever we are doing.
         private static readonly TimeSpan _cacheTimeout = TimeSpan.FromSeconds(10);
+
+        // A single shared HttpClient is the recommended pattern; reusing it avoids socket exhaustion.
+        // It follows redirects by default, matching the old request's AllowAutoRedirect = true.
+        private static readonly HttpClient s_httpClient = new HttpClient();
 
         /// <summary>
         /// Location(s) for the Dropbox info.json file based on information in
@@ -180,13 +186,23 @@ namespace Bloom.Utils
         {
             try
             {
-                var request = (System.Net.HttpWebRequest)
-                    System.Net.WebRequest.Create("https://www.dropbox.com/");
-                request.Method = "HEAD";
-                request.Timeout = 5000; // 5 seconds
-                request.AllowAutoRedirect = true;
-
-                using (var response = (System.Net.HttpWebResponse)request.GetResponse())
+                // The timeout starts inside the delegate so that thread-pool queueing delay (possible
+                // when the pool is busy) doesn't count against the 5-second budget for the request itself.
+                // (RunSync executes on the thread pool so we don't deadlock if called on a thread
+                // with a synchronization context, e.g. the WinForms UI thread.)
+                using (
+                    var response = AsyncUtil.RunSync(async () =>
+                    {
+                        using (var cts = new CancellationTokenSource(5000)) // 5 seconds
+                        using (
+                            var request = new HttpRequestMessage(
+                                HttpMethod.Head,
+                                "https://www.dropbox.com/"
+                            )
+                        )
+                            return await s_httpClient.SendAsync(request, cts.Token);
+                    })
+                )
                 {
                     var code = (int)response.StatusCode;
                     return code >= 200 && code < 400;

--- a/src/BloomExe/web/UrlLookup.cs
+++ b/src/BloomExe/web/UrlLookup.cs
@@ -5,7 +5,8 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Net;
+using System.Net.Http;
+using System.Threading;
 using Bloom.Properties;
 using Bloom.WebLibraryIntegration;
 using Newtonsoft.Json;
@@ -83,6 +84,15 @@ namespace Bloom.web
 
         private static readonly ConcurrentDictionary<UrlType, string> s_liveUrlCache =
             new ConcurrentDictionary<UrlType, string>();
+
+        // A single shared HttpClient is the recommended pattern; reusing it avoids socket exhaustion.
+        private static HttpClient s_httpClient = new HttpClient();
+
+        // Test seam: lets tests inject an HttpClient backed by a fake handler.
+        internal static void SetHttpClientForTests(HttpClient client)
+        {
+            s_httpClient = client;
+        }
 
         private static bool _internetAvailable = true; // assume it's available to start out
 
@@ -283,19 +293,37 @@ namespace Bloom.web
             return _internetAvailable;
         }
 
-        private static bool TestInternetConnection(string url)
+        internal static bool TestInternetConnection(string url)
         {
             try
             {
-                var iNetRequest = (HttpWebRequest)WebRequest.Create(url);
-                iNetRequest.Timeout = 2500;
-                iNetRequest.KeepAlive = false;
-                var iNetResponse = iNetRequest.GetResponse();
-                iNetResponse.Close();
-                return true;
+                // We only care whether we can reach the site, so don't bother downloading the body.
+                // The timeout starts inside the delegate so that thread-pool queueing delay (possible
+                // when the pool is busy) doesn't count against the 2500ms budget for the request itself.
+                // (RunSync executes on the thread pool so we don't deadlock if called on a thread
+                // with a synchronization context, e.g. the WinForms UI thread.)
+                using (
+                    var response = Bloom.Utils.AsyncUtil.RunSync(async () =>
+                    {
+                        using (var cts = new CancellationTokenSource(2500))
+                            return await s_httpClient.GetAsync(
+                                url,
+                                HttpCompletionOption.ResponseHeadersRead,
+                                cts.Token
+                            );
+                    })
+                )
+                {
+                    // Treat only a "clean" response as success, matching the old HttpWebRequest behavior
+                    // (which threw, and so returned false, on 4xx/5xx). Otherwise a captive portal or
+                    // proxy that answers with an error/interstitial would be mistaken for real internet.
+                    var code = (int)response.StatusCode;
+                    return code >= 200 && code < 400;
+                }
             }
-            catch (WebException ex)
+            catch (Exception ex)
             {
+                // Being offline (or a timeout) shows up as an exception rather than a nice failure.
                 Bloom.Utils.MiscUtils.SuppressUnusedExceptionVarWarning(ex);
                 return false;
             }

--- a/src/BloomExe/web/WebClientWithTimeout.cs
+++ b/src/BloomExe/web/WebClientWithTimeout.cs
@@ -1,41 +1,92 @@
-﻿// Copyright (c) 2014 SIL International
+// Copyright (c) 2014 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
-using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Bloom.Utils;
 
 namespace Bloom.Api
 {
     /// <summary>
-    /// the base class waits for 30 seconds, which is too long for local thing like we are doing
+    /// A small synchronous HTTP helper for talking to our own local BloomServer (and used by tests).
+    /// The default HttpClient timeout (100 seconds) is far too long for the local calls we make here,
+    /// so this lets the caller specify a short timeout.
+    /// This replaces the formerly used System.Net.WebClient subclass (obsolete: SYSLIB0014).
     /// </summary>
-    public class WebClientWithTimeout : WebClient
+    public class WebClientWithTimeout
     {
-        private int _timeout;
+        // A single shared HttpClient is the recommended pattern; reusing it avoids socket exhaustion
+        // and lets all instances (e.g. one per request in test helpers) share one connection pool.
+        // Its own timeout is disabled; the per-instance Timeout is applied per request via a
+        // CancellationTokenSource, which also keeps Timeout settable at any time.
+        private static readonly HttpClient s_client = new HttpClient
+        {
+            Timeout = System.Threading.Timeout.InfiniteTimeSpan,
+        };
 
         /// <summary>
-        /// Time in milliseconds
+        /// Time in milliseconds. On timeout, requests throw TaskCanceledException.
         /// </summary>
-        public int Timeout
-        {
-            get { return _timeout; }
-            set { _timeout = value; }
-        }
+        public int Timeout { get; set; }
+
+        /// <summary>
+        /// The Content-Type header sent with the body of upload (e.g. POST) requests, such as
+        /// "text/plain" or "application/json". Not used by DownloadString: a GET has no body,
+        /// so no Content-Type header is sent.
+        /// </summary>
+        public string ContentType { get; set; }
 
         public WebClientWithTimeout()
-        {
-            this._timeout = 60000;
-        }
+            : this(60000) { }
 
         public WebClientWithTimeout(int timeout)
         {
-            this._timeout = timeout;
+            Timeout = timeout;
         }
 
-        protected override WebRequest GetWebRequest(Uri address)
+        /// <summary>
+        /// Synchronously GET the given url and return the response body as a string.
+        /// (RunSync executes on the thread pool so we don't deadlock if called on a thread
+        /// with a synchronization context, e.g. the WinForms UI thread.)
+        /// </summary>
+        public string DownloadString(string url)
         {
-            var result = base.GetWebRequest(address);
-            result.Timeout = this._timeout;
-            return result;
+            return AsyncUtil.RunSync(async () =>
+            {
+                // The timeout starts inside the delegate so thread-pool queueing delay doesn't
+                // count against it.
+                using (var cts = new CancellationTokenSource(Timeout))
+                    return await s_client.GetStringAsync(url, cts.Token);
+            });
+        }
+
+        /// <summary>
+        /// Synchronously send the given data to the url using the given HTTP method (e.g. "POST")
+        /// and return the response body as a string.
+        /// </summary>
+        public string UploadString(string url, string method, string data)
+        {
+            return AsyncUtil.RunSync(async () =>
+            {
+                using (var cts = new CancellationTokenSource(Timeout))
+                using (
+                    var request = new HttpRequestMessage(new HttpMethod(method), url)
+                    {
+                        Content = new StringContent(
+                            data,
+                            Encoding.UTF8,
+                            ContentType ?? "text/plain"
+                        ),
+                    }
+                )
+                using (var response = await s_client.SendAsync(request, cts.Token))
+                {
+                    response.EnsureSuccessStatusCode();
+                    return await response.Content.ReadAsStringAsync();
+                }
+            });
         }
     }
 }

--- a/src/BloomTests/Book/LicenseCheckerTests.cs
+++ b/src/BloomTests/Book/LicenseCheckerTests.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 using Bloom.Api;
 using Bloom.Book;
 using BloomTemp;
@@ -11,6 +14,28 @@ namespace BloomTests.Book
 {
     public class LicenseCheckerTests
     {
+        // Always restore the static state we touch, so these tests don't leak into the others
+        // (which rely on internet access being allowed, no offline folder, and a real HttpClient).
+        [TearDown]
+        public void TearDown()
+        {
+            LicenseChecker.SetAllowInternetAccess(true);
+            LicenseChecker.SetOfflineFolder(null);
+            LicenseChecker.SetHttpClientForTests(new HttpClient());
+        }
+
+        // An HttpClient handler that always fails, to simulate the license server being unreachable.
+        private sealed class FailingHttpMessageHandler : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken
+            )
+            {
+                throw new HttpRequestException("simulated network failure");
+            }
+        }
+
         [Test]
         public void ProblemLanguages_KeepsExactMatchNeedingTrim_RemovesNotMatched_WritesOfflineCache()
         {
@@ -61,6 +86,71 @@ namespace BloomTests.Book
             Assert.That(result, Does.Contain("fr"));
             Assert.That(result, Does.Not.Contain("ru"));
             Assert.That(result, Does.Not.Contain("zh-CN"));
+        }
+
+        [Test]
+        public void GetProblemLanguages_NetworkFailsAndNoCache_DidCheckFalseAndReturnsAllInput()
+        {
+            LicenseChecker.SetAllowInternetAccess(true);
+            LicenseChecker.SetOfflineFolder(null); // no offline cache available
+            LicenseChecker.SetHttpClientForTests(new HttpClient(new FailingHttpMessageHandler()));
+            var checker = new LicenseChecker();
+            var inputLangs = new[] { "en", "bjn" };
+
+            var result = checker.GetProblemLanguages(
+                inputLangs,
+                "kingstone.superbible.ruth",
+                out bool didCheck
+            );
+
+            Assert.That(
+                didCheck,
+                Is.False,
+                "a network failure with no cache means we could not check the license"
+            );
+            Assert.That(
+                result,
+                Is.EquivalentTo(inputLangs),
+                "when we cannot check, no language is flagged as a problem"
+            );
+        }
+
+        [Test]
+        public void GetProblemLanguages_NetworkFailsButCacheExists_FallsBackToCache()
+        {
+            using (var folder = SetupDefaultOfflineLicenseInfo())
+            {
+                // SetupDefaultOfflineLicenseInfo disables internet access; re-enable it so we take the
+                // online path, hit the failing client, and fall back to the cache it wrote.
+                LicenseChecker.SetAllowInternetAccess(true);
+                LicenseChecker.SetHttpClientForTests(
+                    new HttpClient(new FailingHttpMessageHandler())
+                );
+                var checker = new LicenseChecker();
+                var inputLangs = new[] { "en", "bjn" };
+
+                var result = checker.GetProblemLanguages(
+                    inputLangs,
+                    "kingstone.superbible.ruth",
+                    out bool didCheck
+                );
+
+                Assert.That(
+                    didCheck,
+                    Is.True,
+                    "a network failure should fall back to the offline cache"
+                );
+                Assert.That(
+                    result,
+                    Does.Contain("en"),
+                    "en is not licensed per the cached data, so it is a problem language"
+                );
+                Assert.That(
+                    result,
+                    Does.Not.Contain("bjn"),
+                    "bjn is licensed per the cached data, so it is not a problem"
+                );
+            }
         }
 
         private TemporaryFolder SetupDefaultOfflineLicenseInfo()

--- a/src/BloomTests/Publish/BloomPub/WiFiPublisherTests.cs
+++ b/src/BloomTests/Publish/BloomPub/WiFiPublisherTests.cs
@@ -1,0 +1,412 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Bloom.Publish.BloomPub.wifi;
+using Bloom.web;
+using NUnit.Framework;
+
+namespace BloomTests.Publish.BloomPub
+{
+    /// <summary>
+    /// Tests the HttpClient-based upload that WiFiPublisher uses to send a book to an Android device.
+    /// The "device" is just an HTTP endpoint, so we exercise the real upload + completion/cancellation
+    /// logic against a fake HttpMessageHandler, with no real network and no device required.
+    /// </summary>
+    [TestFixture]
+    public class WiFiPublisherTests
+    {
+        // Captures the outgoing request and returns (or throws) whatever the test configures.
+        private sealed class FakeHttpMessageHandler : HttpMessageHandler
+        {
+            public HttpRequestMessage CapturedRequest;
+            public byte[] CapturedBody;
+            public string CapturedContentType;
+            public HttpStatusCode StatusToReturn = HttpStatusCode.OK;
+            public Exception ExceptionToThrow;
+
+            protected override async Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken
+            )
+            {
+                CapturedRequest = request;
+                if (request.Content != null)
+                {
+                    CapturedBody = await request.Content.ReadAsByteArrayAsync();
+                    // Captured here because the content is disposed when the send completes.
+                    CapturedContentType = request.Content.Headers.ContentType?.ToString();
+                }
+                cancellationToken.ThrowIfCancellationRequested();
+                if (ExceptionToThrow != null)
+                    throw ExceptionToThrow;
+                return new HttpResponseMessage(StatusToReturn);
+            }
+        }
+
+        // A WiFiPublisher that records reported exceptions instead of routing them to the (UI) progress
+        // reporter, so tests can assert on the error-handling behavior. Setting ThrowFromReport
+        // simulates the reporting channel itself failing (e.g. progress websocket torn down).
+        private sealed class TestableWiFiPublisher : WiFiPublisher
+        {
+            public Exception ReportedException;
+            public Exception ThrowFromReport;
+
+            public TestableWiFiPublisher()
+                : base(new NullWebSocketProgress(), null) { }
+
+            protected override void ReportException(Exception e)
+            {
+                ReportedException = e;
+                if (ThrowFromReport != null)
+                    throw ThrowFromReport;
+            }
+        }
+
+        private static TestableWiFiPublisher MakePublisher(FakeHttpMessageHandler handler)
+        {
+            var publisher = new TestableWiFiPublisher();
+            publisher.SetHttpClientForTests(new HttpClient(handler));
+            // A real send sets this to indicate a transfer is in progress; we set it directly so we can
+            // verify that completion clears it.
+            publisher.WifiSendCancellationForTests = new CancellationTokenSource();
+            return publisher;
+        }
+
+        [Test]
+        public void UploadToDevice_PostsBookBytesToPutfileEndpoint()
+        {
+            var handler = new FakeHttpMessageHandler();
+            var publisher = MakePublisher(handler);
+            var bytes = Encoding.UTF8.GetBytes("pretend bloompub contents");
+            Assert.That(bytes.Length, Is.GreaterThan(0), "sanity: test data should be non-empty");
+
+            publisher
+                .UploadToDevice(
+                    "192.168.1.50",
+                    "my book.bloompub",
+                    bytes,
+                    publisher.WifiSendCancellationForTests
+                )
+                .Wait();
+
+            Assert.That(
+                handler.CapturedRequest,
+                Is.Not.Null,
+                "the device never received a request"
+            );
+            Assert.That(handler.CapturedRequest.Method, Is.EqualTo(HttpMethod.Post));
+            Assert.That(
+                handler.CapturedRequest.RequestUri.AbsoluteUri,
+                Is.EqualTo("http://192.168.1.50:5914/putfile?path=my%20book.bloompub"),
+                "the filename should be URL-escaped in the path query of the putfile endpoint"
+            );
+            Assert.That(
+                handler.CapturedBody,
+                Is.EqualTo(bytes),
+                "the exact book bytes should be sent as the request body"
+            );
+            Assert.That(
+                handler.CapturedContentType,
+                Is.EqualTo("application/octet-stream"),
+                "the book upload should declare the same Content-Type the old WebClient sent"
+            );
+        }
+
+        [Test]
+        public void UploadToDevice_OnSuccess_ClearsInProgressStateAndReportsNoError()
+        {
+            var handler = new FakeHttpMessageHandler { StatusToReturn = HttpStatusCode.OK };
+            var publisher = MakePublisher(handler);
+            Assert.That(
+                publisher.WifiSendCancellationForTests,
+                Is.Not.Null,
+                "sanity: a send should be marked in progress before completion"
+            );
+
+            publisher
+                .UploadToDevice(
+                    "10.0.0.5",
+                    "book.bloompub",
+                    new byte[] { 1, 2, 3 },
+                    publisher.WifiSendCancellationForTests
+                )
+                .Wait();
+
+            Assert.That(
+                publisher.WifiSendCancellationForTests,
+                Is.Null,
+                "the in-progress state should be cleared once the send completes, allowing the next send"
+            );
+            Assert.That(
+                publisher.ReportedException,
+                Is.Null,
+                "no error should be reported on success"
+            );
+        }
+
+        [Test]
+        public void UploadToDevice_OnErrorResponse_ReportsException()
+        {
+            var handler = new FakeHttpMessageHandler
+            {
+                StatusToReturn = HttpStatusCode.InternalServerError,
+            };
+            var publisher = MakePublisher(handler);
+
+            publisher
+                .UploadToDevice(
+                    "10.0.0.5",
+                    "book.bloompub",
+                    new byte[] { 1 },
+                    publisher.WifiSendCancellationForTests
+                )
+                .Wait();
+
+            Assert.That(
+                publisher.ReportedException,
+                Is.TypeOf<HttpRequestException>(),
+                "a non-success response from the device should be reported as an error"
+            );
+            Assert.That(
+                publisher.WifiSendCancellationForTests,
+                Is.Null,
+                "the in-progress state should be cleared even when the send fails"
+            );
+        }
+
+        [Test]
+        public void UploadToDevice_WhenSendThrows_ReportsTheException()
+        {
+            var thrown = new HttpRequestException("simulated network failure");
+            var handler = new FakeHttpMessageHandler { ExceptionToThrow = thrown };
+            var publisher = MakePublisher(handler);
+
+            publisher
+                .UploadToDevice(
+                    "10.0.0.5",
+                    "book.bloompub",
+                    new byte[] { 1 },
+                    publisher.WifiSendCancellationForTests
+                )
+                .Wait();
+
+            Assert.That(
+                publisher.ReportedException,
+                Is.SameAs(thrown),
+                "an exception thrown during the send should be reported"
+            );
+            Assert.That(publisher.WifiSendCancellationForTests, Is.Null);
+        }
+
+        [Test]
+        public void UploadToDevice_WhenCanceled_DoesNotReportAndClearsState()
+        {
+            var handler = new FakeHttpMessageHandler();
+            var publisher = MakePublisher(handler);
+            // Simulate Stop() canceling an in-progress send (e.g. during shutdown).
+            publisher.WifiSendCancellationForTests.Cancel();
+
+            publisher
+                .UploadToDevice(
+                    "10.0.0.5",
+                    "book.bloompub",
+                    new byte[] { 1 },
+                    publisher.WifiSendCancellationForTests
+                )
+                .Wait();
+
+            Assert.That(
+                publisher.ReportedException,
+                Is.Null,
+                "cancellation (typically during shutdown) should not be reported as an error"
+            );
+            Assert.That(publisher.WifiSendCancellationForTests, Is.Null);
+        }
+
+        [Test]
+        public void UploadToDevice_StaleCompletion_DoesNotClearNewerSend()
+        {
+            // Models the race where Stop() abandons send A and a newer send B becomes the current one
+            // BEFORE A's (slow) completion continuation finally runs. A's completion must not clear or
+            // resume B's transfer.
+            var handler = new FakeHttpMessageHandler();
+            var publisher = MakePublisher(handler);
+
+            var sendA = publisher.WifiSendCancellationForTests;
+            var sendB = new CancellationTokenSource();
+            // By the time A completes, B is the send the publisher is tracking.
+            publisher.WifiSendCancellationForTests = sendB;
+
+            // Run A's upload to completion (still using A's own token source).
+            publisher.UploadToDevice("10.0.0.5", "a.bloompub", new byte[] { 1 }, sendA).Wait();
+
+            Assert.That(
+                publisher.WifiSendCancellationForTests,
+                Is.SameAs(sendB),
+                "a stale send's completion must not clear the newer send's in-progress state"
+            );
+            Assert.That(
+                publisher.ReportedException,
+                Is.Null,
+                "the stale completion succeeded, so nothing should be reported"
+            );
+
+            sendB.Dispose();
+        }
+
+        [Test]
+        public void HandleSendSetupFailure_UploadNotStarted_ReportsAndClearsState()
+        {
+            // A failure before the upload started (e.g. packaging the book threw): no completion
+            // continuation will ever run, so the in-progress state must be cleared here.
+            var publisher = MakePublisher(new FakeHttpMessageHandler());
+            var cancellation = publisher.WifiSendCancellationForTests;
+            var error = new InvalidOperationException("packaging failed");
+
+            publisher.HandleSendSetupFailure(error, cancellation, uploadStarted: false);
+
+            Assert.That(publisher.ReportedException, Is.SameAs(error));
+            Assert.That(
+                publisher.WifiSendCancellationForTests,
+                Is.Null,
+                "a setup failure with no upload started must clear the in-progress state so future sends work"
+            );
+        }
+
+        [Test]
+        public void HandleSendSetupFailure_UploadAlreadyStarted_DoesNotClearState()
+        {
+            // A failure AFTER the upload started (e.g. updating the advertiser threw): the upload's
+            // completion continuation owns the in-progress state and its CancellationTokenSource, so
+            // this path must NOT clear/dispose it (doing so would clobber the in-flight transfer and
+            // could let a second send start).
+            var publisher = MakePublisher(new FakeHttpMessageHandler());
+            var cancellation = publisher.WifiSendCancellationForTests;
+            var error = new InvalidOperationException(
+                "advertiser update failed after upload started"
+            );
+
+            publisher.HandleSendSetupFailure(error, cancellation, uploadStarted: true);
+
+            Assert.That(
+                publisher.ReportedException,
+                Is.SameAs(error),
+                "the error should still be reported"
+            );
+            Assert.That(
+                publisher.WifiSendCancellationForTests,
+                Is.SameAs(cancellation),
+                "an in-flight upload's in-progress state must be left for its completion to clear"
+            );
+
+            cancellation.Dispose();
+        }
+
+        [Test]
+        public void HandleSendSetupFailure_StaleSend_DoesNotClearNewerSendOrResumeAdvertising()
+        {
+            // Models the race where Stop() abandoned send A while its setup was still running, and a
+            // newer send B is now in progress (advertiser paused). When A's setup finally throws, it
+            // must not clear B's in-progress state NOR resume advertising mid-B-transfer.
+            var publisher = MakePublisher(new FakeHttpMessageHandler());
+            var advertiser = new WiFiAdvertiser(new NullWebSocketProgress()) { Paused = true };
+            publisher.WifiAdvertiserForTests = advertiser;
+            var staleA = publisher.WifiSendCancellationForTests;
+            var sendB = new CancellationTokenSource();
+            publisher.WifiSendCancellationForTests = sendB;
+
+            publisher.HandleSendSetupFailure(
+                new InvalidOperationException("stale setup failed"),
+                staleA,
+                uploadStarted: false
+            );
+
+            Assert.That(
+                publisher.WifiSendCancellationForTests,
+                Is.SameAs(sendB),
+                "a stale setup failure must not clear the newer send's in-progress state"
+            );
+            Assert.That(
+                advertiser.Paused,
+                Is.True,
+                "a stale setup failure must not resume advertising while the newer send is transferring"
+            );
+
+            sendB.Dispose();
+        }
+
+        [Test]
+        public void HandleSendSetupFailure_CurrentSend_ResumesAdvertising()
+        {
+            // The normal setup-failure case: the failing send is still the current one, so the state
+            // is cleared and advertising resumes so devices can request again.
+            var publisher = MakePublisher(new FakeHttpMessageHandler());
+            var advertiser = new WiFiAdvertiser(new NullWebSocketProgress()) { Paused = true };
+            publisher.WifiAdvertiserForTests = advertiser;
+            var cancellation = publisher.WifiSendCancellationForTests;
+
+            publisher.HandleSendSetupFailure(
+                new InvalidOperationException("setup failed"),
+                cancellation,
+                uploadStarted: false
+            );
+
+            Assert.That(publisher.WifiSendCancellationForTests, Is.Null);
+            Assert.That(
+                advertiser.Paused,
+                Is.False,
+                "after a current send's setup failure, advertising must resume"
+            );
+        }
+
+        [Test]
+        public void UploadToDevice_WhenReportingThrows_StillClearsInProgressState()
+        {
+            // If reporting the outcome itself throws (e.g. the progress channel is being torn down),
+            // the completion must still clear the in-progress state and resume advertising; otherwise
+            // WiFi publishing is silently wedged for the rest of the session.
+            var handler = new FakeHttpMessageHandler
+            {
+                StatusToReturn = HttpStatusCode.InternalServerError,
+            };
+            var publisher = MakePublisher(handler);
+            publisher.ThrowFromReport = new InvalidOperationException("progress channel is gone");
+            var advertiser = new WiFiAdvertiser(new NullWebSocketProgress()) { Paused = true };
+            publisher.WifiAdvertiserForTests = advertiser;
+
+            var task = publisher.UploadToDevice(
+                "10.0.0.5",
+                "book.bloompub",
+                new byte[] { 1 },
+                publisher.WifiSendCancellationForTests
+            );
+            // The reporting exception propagates out of the continuation; we only care that
+            // cleanup ran anyway.
+            var aggregate = Assert.Throws<AggregateException>(() => task.Wait());
+            Assert.That(
+                aggregate.GetBaseException(),
+                Is.SameAs(publisher.ThrowFromReport),
+                "sanity: the failure should be the simulated reporting exception"
+            );
+
+            Assert.That(
+                publisher.ReportedException,
+                Is.Not.Null,
+                "sanity: the device error should have reached ReportException"
+            );
+            Assert.That(
+                publisher.WifiSendCancellationForTests,
+                Is.Null,
+                "the in-progress state must be cleared even when reporting throws"
+            );
+            Assert.That(
+                advertiser.Paused,
+                Is.False,
+                "advertising must resume even when reporting throws"
+            );
+        }
+    }
+}

--- a/src/BloomTests/TeamCollection/TeamCollectionApiTests.cs
+++ b/src/BloomTests/TeamCollection/TeamCollectionApiTests.cs
@@ -278,13 +278,9 @@ namespace BloomTests.TeamCollection
 
                 // System Under Test
                 TestDelegate systemUnderTest = () =>
-                    ApiTest.GetString(
-                        _server,
-                        endPoint: "teamCollection/currentBookStatus",
-                        returnType: ApiTest.ContentType.Text
-                    );
+                    ApiTest.GetString(_server, endPoint: "teamCollection/currentBookStatus");
 
-                Assert.Throws(typeof(System.Net.WebException), systemUnderTest);
+                Assert.Throws(typeof(System.Net.Http.HttpRequestException), systemUnderTest);
             }
             finally
             {
@@ -316,8 +312,7 @@ namespace BloomTests.TeamCollection
                 // System Under Test
                 var result = ApiTest.GetString(
                     _server,
-                    endPoint: "teamCollection/selectedBookStatus",
-                    returnType: ApiTest.ContentType.Text
+                    endPoint: "teamCollection/selectedBookStatus"
                 );
 
                 // Verification
@@ -388,8 +383,7 @@ namespace BloomTests.TeamCollection
                 // System Under Test
                 var result = ApiTest.GetString(
                     _server,
-                    endPoint: "teamCollection/selectedBookStatus",
-                    returnType: ApiTest.ContentType.Text
+                    endPoint: "teamCollection/selectedBookStatus"
                 );
 
                 // Verification
@@ -418,14 +412,10 @@ namespace BloomTests.TeamCollection
 
             TestDelegate systemUnderTest = () =>
             {
-                ApiTest.GetString(
-                    _server,
-                    endPoint: "teamCollection/getLog",
-                    returnType: ApiTest.ContentType.JSON
-                );
+                ApiTest.GetString(_server, endPoint: "teamCollection/getLog");
             };
 
-            Assert.Throws(typeof(System.Net.WebException), systemUnderTest);
+            Assert.Throws(typeof(System.Net.Http.HttpRequestException), systemUnderTest);
         }
 
         [Test]
@@ -450,11 +440,7 @@ namespace BloomTests.TeamCollection
                 );
 
             // System Under Test
-            var result = ApiTest.GetString(
-                _server,
-                endPoint: "teamCollection/getLog",
-                returnType: ApiTest.ContentType.JSON
-            );
+            var result = ApiTest.GetString(_server, endPoint: "teamCollection/getLog");
 
             // Verification
             var deserializedArray = JsonConvert.DeserializeObject<BloomWebSocketProgressEvent[]>(
@@ -480,8 +466,7 @@ namespace BloomTests.TeamCollection
             // System Under Test
             var result = ApiTest.GetString(
                 _server,
-                endPoint: "teamCollection/isTeamCollectionEnabled",
-                returnType: ApiTest.ContentType.Text
+                endPoint: "teamCollection/isTeamCollectionEnabled"
             );
 
             Assert.That(result, Is.EqualTo("false"));
@@ -507,8 +492,7 @@ namespace BloomTests.TeamCollection
             // System Under Test
             var result = ApiTest.GetString(
                 _server,
-                endPoint: "teamCollection/isTeamCollectionEnabled",
-                returnType: ApiTest.ContentType.Text
+                endPoint: "teamCollection/isTeamCollectionEnabled"
             );
 
             Assert.That(result, Is.EqualTo("false"));
@@ -531,8 +515,7 @@ namespace BloomTests.TeamCollection
             // System Under Test
             var result = ApiTest.GetString(
                 _server,
-                endPoint: "teamCollection/isTeamCollectionEnabled",
-                returnType: ApiTest.ContentType.Text
+                endPoint: "teamCollection/isTeamCollectionEnabled"
             );
 
             Assert.That(result, Is.EqualTo("true"));
@@ -558,8 +541,7 @@ namespace BloomTests.TeamCollection
             // System Under Test
             var result = ApiTest.GetString(
                 _server,
-                endPoint: "teamCollection/isTeamCollectionEnabled",
-                returnType: ApiTest.ContentType.Text
+                endPoint: "teamCollection/isTeamCollectionEnabled"
             );
 
             Assert.That(result, Is.EqualTo("true"));
@@ -578,13 +560,9 @@ namespace BloomTests.TeamCollection
 
             // System Under Test
             TestDelegate systemUnderTest = () =>
-                ApiTest.GetString(
-                    _server,
-                    endPoint: "teamCollection/isTeamCollectionEnabled",
-                    returnType: ApiTest.ContentType.Text
-                );
+                ApiTest.GetString(_server, endPoint: "teamCollection/isTeamCollectionEnabled");
 
-            Assert.Throws(typeof(System.Net.WebException), systemUnderTest);
+            Assert.Throws(typeof(System.Net.Http.HttpRequestException), systemUnderTest);
         }
         #endregion
 
@@ -600,11 +578,7 @@ namespace BloomTests.TeamCollection
             api.RegisterWithApiHandler(_server.ApiHandler);
 
             // System Under Test
-            var result = ApiTest.GetString(
-                _server,
-                endPoint: "teamCollection/repoFolderPath",
-                returnType: ApiTest.ContentType.Text
-            );
+            var result = ApiTest.GetString(_server, endPoint: "teamCollection/repoFolderPath");
 
             Assert.That(result, Is.EqualTo(""));
         }
@@ -624,11 +598,7 @@ namespace BloomTests.TeamCollection
                 .Returns(mockTeamCollection.Object);
 
             // System Under Test
-            var result = ApiTest.GetString(
-                _server,
-                endPoint: "teamCollection/repoFolderPath",
-                returnType: ApiTest.ContentType.Text
-            );
+            var result = ApiTest.GetString(_server, endPoint: "teamCollection/repoFolderPath");
 
             Assert.That(result, Is.EqualTo("Fake Description"));
         }
@@ -645,13 +615,9 @@ namespace BloomTests.TeamCollection
                 .Returns(() => throw new ApplicationException());
 
             TestDelegate systemUnderTest = () =>
-                ApiTest.GetString(
-                    _server,
-                    endPoint: "teamCollection/repoFolderPath",
-                    returnType: ApiTest.ContentType.Text
-                );
+                ApiTest.GetString(_server, endPoint: "teamCollection/repoFolderPath");
 
-            Assert.Throws(typeof(System.Net.WebException), systemUnderTest);
+            Assert.Throws(typeof(System.Net.Http.HttpRequestException), systemUnderTest);
         }
 
         #endregion

--- a/src/BloomTests/UpdateVersionTableTests.cs
+++ b/src/BloomTests/UpdateVersionTableTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
 using Bloom;
 using Moq;
 using NUnit.Framework;
@@ -225,6 +227,89 @@ namespace BloomTests
             );
             Assert.That(errorResult.URL, Is.EqualTo(string.Empty));
             Assert.That(errorResult.Error.Message, Does.StartWith("Internet connection"));
+        }
+
+        // The following three tests deterministically pin the translation of HttpClient failures into the
+        // WebException/WebExceptionStatus that UpdateTableLookupResult exposes (and that IsConnectivityError
+        // and callers depend on), using the IBloomWebClient seam instead of relying on live-network behavior.
+
+        [Test]
+        public void CanGetVersionTableFromWeb_NameResolutionError_MapsToNameResolutionFailure()
+        {
+            var t = new UpdateVersionTable();
+            var mockClient = new Mock<IBloomWebClient>();
+            var thrown = new HttpRequestException(
+                HttpRequestError.NameResolutionError,
+                "dns failed"
+            );
+            mockClient.Setup(x => x.DownloadString(It.IsAny<string>())).Throws(thrown);
+
+            var result = t.CanGetVersionTableFromWeb(
+                mockClient.Object,
+                out TableLookupResult errorResult
+            );
+
+            Assert.That(result, Is.False);
+            Assert.That(errorResult.Error, Is.Not.Null);
+            Assert.That(
+                errorResult.Error.Status,
+                Is.EqualTo(WebExceptionStatus.NameResolutionFailure)
+            );
+            Assert.That(errorResult.IsConnectivityError, Is.True);
+            Assert.That(
+                errorResult.Error.InnerException,
+                Is.SameAs(thrown),
+                "the original exception should be preserved for diagnostics"
+            );
+        }
+
+        [Test]
+        public void CanGetVersionTableFromWeb_HttpStatusError_MapsToProtocolError()
+        {
+            var t = new UpdateVersionTable();
+            var mockClient = new Mock<IBloomWebClient>();
+            // GetStringAsync's EnsureSuccessStatusCode throws an HttpRequestException with StatusCode set;
+            // the production code maps any exception carrying a StatusCode to ProtocolError.
+            mockClient
+                .Setup(x => x.DownloadString(It.IsAny<string>()))
+                .Throws(new HttpRequestException("not found", null, HttpStatusCode.NotFound));
+
+            var result = t.CanGetVersionTableFromWeb(
+                mockClient.Object,
+                out TableLookupResult errorResult
+            );
+
+            Assert.That(result, Is.False);
+            Assert.That(errorResult.Error, Is.Not.Null);
+            Assert.That(errorResult.Error.Status, Is.EqualTo(WebExceptionStatus.ProtocolError));
+            // A protocol error means we reached the server, so it is not a connectivity error.
+            Assert.That(errorResult.IsConnectivityError, Is.False);
+        }
+
+        [Test]
+        public void CanGetVersionTableFromWeb_Timeout_MapsToTimeout()
+        {
+            var t = new UpdateVersionTable();
+            var mockClient = new Mock<IBloomWebClient>();
+            // HttpClient surfaces a timeout as TaskCanceledException.
+            mockClient
+                .Setup(x => x.DownloadString(It.IsAny<string>()))
+                .Throws(new TaskCanceledException());
+
+            var result = t.CanGetVersionTableFromWeb(
+                mockClient.Object,
+                out TableLookupResult errorResult
+            );
+
+            Assert.That(result, Is.False);
+            Assert.That(errorResult.Error, Is.Not.Null);
+            Assert.That(errorResult.Error.Status, Is.EqualTo(WebExceptionStatus.Timeout));
+            Assert.That(errorResult.IsConnectivityError, Is.True);
+            Assert.That(
+                errorResult.Error.InnerException,
+                Is.TypeOf<TaskCanceledException>(),
+                "the original exception should be preserved for diagnostics"
+            );
         }
 
         private static IBloomWebClient GetMockWebClient()

--- a/src/BloomTests/web/UrlLookupTests.cs
+++ b/src/BloomTests/web/UrlLookupTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Bloom.web;
+using NUnit.Framework;
+
+namespace BloomTests.web
+{
+    /// <summary>
+    /// Tests UrlLookup.TestInternetConnection, which decides whether the internet is reachable.
+    /// We drive it through a fake HttpMessageHandler so no real network is needed.
+    /// </summary>
+    [TestFixture]
+    public class UrlLookupTests
+    {
+        // Returns a configurable response, or throws, for any request.
+        private sealed class FakeHttpMessageHandler : HttpMessageHandler
+        {
+            public HttpStatusCode StatusToReturn = HttpStatusCode.OK;
+            public Exception ExceptionToThrow;
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken
+            )
+            {
+                if (ExceptionToThrow != null)
+                    throw ExceptionToThrow;
+                return Task.FromResult(new HttpResponseMessage(StatusToReturn));
+            }
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            // Restore a real client so we don't affect other tests/fixtures.
+            UrlLookup.SetHttpClientForTests(new HttpClient());
+        }
+
+        [Test]
+        public void TestInternetConnection_SuccessStatus_ReturnsTrue()
+        {
+            UrlLookup.SetHttpClientForTests(
+                new HttpClient(new FakeHttpMessageHandler { StatusToReturn = HttpStatusCode.OK })
+            );
+
+            Assert.That(UrlLookup.TestInternetConnection("https://example.com"), Is.True);
+        }
+
+        [Test]
+        public void TestInternetConnection_ServerError_ReturnsFalse()
+        {
+            // A captive portal or proxy that answers with an error/interstitial instead of the real
+            // site must NOT be treated as "internet available".
+            UrlLookup.SetHttpClientForTests(
+                new HttpClient(
+                    new FakeHttpMessageHandler
+                    {
+                        StatusToReturn = HttpStatusCode.InternalServerError,
+                    }
+                )
+            );
+
+            Assert.That(UrlLookup.TestInternetConnection("https://example.com"), Is.False);
+        }
+
+        [Test]
+        public void TestInternetConnection_ClientError_ReturnsFalse()
+        {
+            UrlLookup.SetHttpClientForTests(
+                new HttpClient(
+                    new FakeHttpMessageHandler { StatusToReturn = HttpStatusCode.Forbidden }
+                )
+            );
+
+            Assert.That(UrlLookup.TestInternetConnection("https://example.com"), Is.False);
+        }
+
+        [Test]
+        public void TestInternetConnection_RequestThrows_ReturnsFalse()
+        {
+            UrlLookup.SetHttpClientForTests(
+                new HttpClient(
+                    new FakeHttpMessageHandler
+                    {
+                        ExceptionToThrow = new HttpRequestException("offline"),
+                    }
+                )
+            );
+
+            Assert.That(UrlLookup.TestInternetConnection("https://example.com"), Is.False);
+        }
+    }
+}

--- a/src/BloomTests/web/controllers/ApiTest.cs
+++ b/src/BloomTests/web/controllers/ApiTest.cs
@@ -1,5 +1,4 @@
-﻿using System.Net;
-using Bloom.Api;
+﻿using Bloom.Api;
 
 namespace BloomTests
 {
@@ -11,11 +10,13 @@ namespace BloomTests
             JSON,
         }
 
+        // Issues a GET to the given endpoint and returns the response body.
+        // (Unlike PostString, there is no ContentType/returnType option: a GET has no body, so
+        // no Content-Type request header is sent, and the server ignores it for GETs anyway.)
         public static string GetString(
             BloomServer server,
             string endPoint,
             string query = "",
-            ContentType returnType = ContentType.Text,
             EndpointHandler handler = null,
             string endOfUrlForTest = null,
             int? timeoutInMilliseconds = null
@@ -27,8 +28,6 @@ namespace BloomTests
             }
             server.EnsureListening();
             var client = new WebClientWithTimeout { Timeout = timeoutInMilliseconds ?? 3000 };
-            client.Headers[HttpRequestHeader.ContentType] =
-                returnType == ContentType.Text ? "text/plain" : "application/json";
 
             if (endOfUrlForTest != null)
             {
@@ -61,8 +60,7 @@ namespace BloomTests
             }
             server.EnsureListening();
             var client = new WebClientWithTimeout { Timeout = timeoutInMilliseconds ?? 3000 };
-            client.Headers[HttpRequestHeader.ContentType] =
-                returnType == ContentType.Text ? "text/plain" : "application/json";
+            client.ContentType = returnType == ContentType.Text ? "text/plain" : "application/json";
 
             return client.UploadString(
                 BloomServer.ServerUrlWithBloomPrefixEndingInSlash + "api/" + endPoint,

--- a/src/BloomTests/web/controllers/EditingViewApiTests.cs
+++ b/src/BloomTests/web/controllers/EditingViewApiTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net;
+using System.Net.Http;
 using Bloom;
 using Bloom.Api;
 using Bloom.Book;
@@ -66,7 +67,7 @@ namespace BloomTests.web.controllers
             _api.PasteImageAction = (_, __, ___) =>
                 throw new InvalidOperationException("No image on clipboard for paste image.");
 
-            var exception = Assert.Throws<WebException>(() =>
+            var exception = Assert.Throws<HttpRequestException>(() =>
                 ApiTest.PostString(
                     _server,
                     "editView/pasteImage",
@@ -75,9 +76,7 @@ namespace BloomTests.web.controllers
                 )
             );
 
-            var response = exception.Response as HttpWebResponse;
-            Assert.That(response, Is.Not.Null);
-            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+            Assert.That(exception.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
         }
 
         private class TestEditingViewApi : EditingViewApi

--- a/src/BloomTests/web/controllers/EndpointHandlerTests.cs
+++ b/src/BloomTests/web/controllers/EndpointHandlerTests.cs
@@ -35,7 +35,6 @@ namespace BloomTests.web
                 _server,
                 endPoint: "test",
                 query: "color=blue",
-                returnType: ApiTest.ContentType.Text,
                 handler: request =>
                 {
                     Assert.That(request.RequiredParam("color"), Is.EqualTo("blue"));
@@ -69,7 +68,6 @@ namespace BloomTests.web
                 _server,
                 endPoint: "parent/child",
                 query: "color=blue",
-                returnType: ApiTest.ContentType.Text,
                 handler: request => request.PostSucceeded()
             );
             Assert.That(result, Is.EqualTo("OK"));
@@ -90,7 +88,7 @@ namespace BloomTests.web
         [Test]
         public void Get_Unrecognized_Throws()
         {
-            Assert.Throws<System.Net.WebException>(() =>
+            Assert.Throws<System.Net.Http.HttpRequestException>(() =>
                 ApiTest.GetString(
                     _server,
                     endPoint: "foo88bar",


### PR DESCRIPTION
https://issues.bloomlibrary.org/youtrack/issue/BL-16429

Replace all uses of the obsolete System.Net.WebClient / WebRequest /
HttpWebRequest APIs with System.Net.Http.HttpClient, eliminating every
SYSLIB0014 build warning while preserving observable behavior.

- WebClientWithTimeout: now a thin synchronous wrapper over a shared
  HttpClient, with the per-instance timeout applied per request.
- BloomWebClient: implements the unchanged IBloomWebClient over HttpClient.
- UpdateVersionTable: translates HttpClient failures into the WebException/
  WebExceptionStatus surface callers rely on (DNS failure, HTTP status,
  timeout), preserving the original exception for diagnostics.
- LicenseChecker: network failure or timeout falls back to the offline cache.
- UrlLookup / DropboxUtils: connectivity probes keep their old semantics
  (2xx-3xx = reachable) and timeouts.
- WiFiPublisher: sends books to BloomReader via HttpClient.PostAsync with a
  CancellationTokenSource as the single in-progress indicator. Completion now
  fires reliably, so the BL-7227 IsBusy/timer polling hack is gone; Stop()
  cancellation actually aborts the transfer; completion and failure handling
  are guarded so a stale or abandoned send can never disturb a newer one, and
  state cleanup runs even if error reporting throws.
- Sync-over-async call sites use the existing AsyncUtil.RunSync helper.

Tests: new device-free WiFiPublisher upload tests (fake HttpMessageHandler
covering success, error status, thrown exception, cancellation, stale
completion, setup failure, and reporting failure), new UrlLookup connectivity
tests, deterministic UpdateVersionTable error-mapping tests, and LicenseChecker
offline-fallback tests, using small internal test seams. Existing API tests
updated for the HttpRequestException surface.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8028)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8028)
<!-- Reviewable:end -->
