### PR TITLE
Retire the sync-dangerous WebView2 call in PublishHelper via an OffScreenBrowser

### DIFF
--- a/src/BloomExe/Book/BookProcessor.cs
+++ b/src/BloomExe/Book/BookProcessor.cs
@@ -22,7 +22,7 @@ namespace Bloom.Book
     /// that initialization run, pull the resulting DOM back out, and save it through the normal
     /// editing save path (Book.UpdateDomFromEditedPage), which strips editing markup and extracts
     /// metadata. This mirrors the publish tab's off-screen page-check browser
-    /// (PublishHelper.BrowserForPageChecks).
+    /// (PublishHelper.GetOrCreatePageChecksBrowser).
     /// </summary>
     public static class BookProcessor
     {

--- a/src/BloomExe/CLI/CreateArtifactsCommand.cs
+++ b/src/BloomExe/CLI/CreateArtifactsCommand.cs
@@ -183,9 +183,6 @@ namespace Bloom.CLI
                 exitCode |= CreateJsonTextsArtifact(jsonTextsOutputPath);
             }
 
-            Control control = new Control();
-            control.CreateControl();
-
             using (var countdownEvent = new CountdownEvent(1))
             {
                 // Create the ePub in the background. (Some of the ePub work needs to happen off the main thread)
@@ -193,7 +190,7 @@ namespace Bloom.CLI
                 {
                     try
                     {
-                        CreateEpubArtifact(parameters, control);
+                        CreateEpubArtifact(parameters);
                     }
                     catch (Exception ex)
                     {
@@ -391,8 +388,7 @@ namespace Bloom.CLI
         /// Creates an ePub file at the location specified by parameters
         /// </summary>
         /// <param name="parameters">BookPath and epubOutputPath should be set.</param>
-        /// <param name="control">The epub code needs a control that goes back to the main thread, in order to run some tasks that need to be on the main thread</param>
-        public static void CreateEpubArtifact(CreateArtifactsParameters parameters, Control control)
+        public static void CreateEpubArtifact(CreateArtifactsParameters parameters)
         {
             if (String.IsNullOrEmpty(parameters.EpubOutputPath))
             {
@@ -406,8 +402,6 @@ namespace Bloom.CLI
             BookThumbNailer thumbNailer = s_projectContext.ThumbNailer;
             using (var maker = new EpubMaker(thumbNailer, bookServer))
             {
-                maker.ControlForInvoke = control;
-
                 maker.Book = s_book;
                 // This is the previous default, but probably we should make it configurable, and possibly change the default.
                 // Note that it will end up Fixed if the presence of canvas elements requires it.

--- a/src/BloomExe/Publish/BloomPub/BloomPubMaker.cs
+++ b/src/BloomExe/Publish/BloomPub/BloomPubMaker.cs
@@ -37,7 +37,6 @@ namespace Bloom.Publish.BloomPub
         internal const string kCreatorBloom = "bloom";
         internal const string kCreatorHarvester = "harvester";
         public static string HashOfMostRecentlyCreatedBook { get; private set; }
-        public static Control ControlForInvoke { get; set; }
 
         public static void CreateBloomPub(
             BloomPubPublishSettings settings,
@@ -647,7 +646,6 @@ namespace Bloom.Publish.BloomPub
             HashSet<PublishHelper.FontInfo> fontsUsed = null;
             using (var helper = new PublishHelper())
             {
-                helper.ControlForInvoke = ControlForInvoke;
                 var omittedPages = new Dictionary<string, int>();
                 var modifiedPageMessages = new HashSet<string>();
                 helper.RemoveUnwantedContent(

--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Web;
-using System.Windows.Forms;
 using System.Xml;
 using System.Xml.Linq;
 using Bloom;
@@ -195,19 +194,6 @@ namespace Bloom.Publish.Epub
 
         // image counter for creating id values
         private int _imgCount;
-
-        /// <summary>
-        /// Preparing a book for publication involves displaying it in a browser in order
-        /// to accurately determine which elements are invisible and can be pruned from the
-        /// published book.  This requires being on the UI thread, which may require having
-        /// a Control available for calling Invoke() which will move execution to the UI
-        /// thread.
-        /// </summary>
-        public Control ControlForInvoke
-        {
-            get { return _publishHelper.ControlForInvoke; }
-            set { _publishHelper.ControlForInvoke = value; }
-        }
 
         public bool AbortRequested
         {
@@ -589,6 +575,13 @@ namespace Bloom.Publish.Epub
                 if (Path.GetExtension(filename).ToLowerInvariant() == ".svg")
                     PruneSvgFileOfCruft(filename);
             }
+
+            // Staging is the only thing that uses the off-screen page-checks browser, and it is done now.
+            // Release it so its dedicated thread and WebView2 process don't linger idle after we leave the
+            // publish tab (until this EpubMaker is finally disposed). It is lazily recreated if we stage again.
+            // Safe here: we are on the staging thread and no longer calling into the browser, so this won't
+            // race an in-flight page check (unlike disposing from the UI thread on tab switch).
+            _publishHelper.ReleaseBrowser();
         }
 
         public static void GetPageDimensions(string pageSize, out double width, out double height)

--- a/src/BloomExe/Publish/Epub/PublishEpubApi.cs
+++ b/src/BloomExe/Publish/Epub/PublishEpubApi.cs
@@ -372,12 +372,6 @@ namespace Bloom.Publish.Epub
 
         public string SetupEpubControlContent()
         {
-            // This gets called on a background thread but one step needs to happen on the UI thread,
-            // so the Maker needs a control to Invoke on. An Api class doesn't naturally have one to give it,
-            // so we arrange that this class is given the Bloom main window by the PublishView when the
-            // publish tab is activated. In production, this is roughly equivalent to just using
-            // Form.ActiveForms.Last(), but that fails when debugging; this is more robust.
-            EpubMaker.ControlForInvoke = ControlForInvoke;
             EpubMaker.StageEpub(_progress);
             if (StagingDirectory == null)
                 return null; // aborted, hopefully already reported.

--- a/src/BloomExe/Publish/OffScreenBrowser.cs
+++ b/src/BloomExe/Publish/OffScreenBrowser.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using Bloom.Api;
+using Bloom.Book;
+
+namespace Bloom.Publish
+{
+    /// <summary>
+    /// A WebView2 browser for off-screen work: navigate to a page and run javascript against the real,
+    /// laid-out DOM (so CSS, fonts, and layout are actually resolved) without ever putting the browser on
+    /// screen or letting the user interact with it. Callers drive it with blocking, synchronous calls —
+    /// <see cref="Navigate"/> and <see cref="RunJavascript"/> — that return the result to the calling thread.
+    ///
+    /// The first use is PublishHelper's "page checks" (which elements are visible, what fonts are used), but
+    /// nothing here is specific to that; it suits any task that needs to ask a real browser questions about a
+    /// document off-screen.
+    ///
+    /// How it stays safe: the browser is owned by a private, dedicated STA thread with its own Windows Forms
+    /// message loop, and THAT thread — not the caller — services the browser's callbacks. So a caller can
+    /// simply block for a result. It never has to pump the MAIN UI message loop the way
+    /// Browser.RunJavascriptWithStringResult_Sync_Dangerous does (Application.DoEvents), which lets unrelated
+    /// user commands run in the middle of the call stack — the reentrancy blamed for BL-12614 / BL-13120. And
+    /// it never deadlocks, because the thread that blocks is never the thread that must pump. Async
+    /// continuations for the browser's operations run on the owning thread, so the WebView2 is only ever
+    /// touched by that thread.
+    ///
+    /// The browser is a real <see cref="WebView2Browser"/> (not a bare WebView2 control) so navigation goes
+    /// through Bloom's BloomServer/in-memory-file plumbing and resolves CSS, fonts, and relative paths.
+    /// </summary>
+    public sealed class OffScreenBrowser : IDisposable
+    {
+        private readonly Thread _thread;
+        private WebView2Browser _browser;
+
+        // The message loop we run on the dedicated thread; ExitThread() on it ends the loop at Dispose.
+        private ApplicationContext _appContext;
+
+        // The dedicated thread's Windows Forms synchronization context. Posting to it marshals work onto that
+        // thread; awaits inside that work resume there too.
+        private SynchronizationContext _ctx;
+
+        // Signaled once the dedicated thread has finished (or failed) browser initialization.
+        private readonly ManualResetEventSlim _ready = new ManualResetEventSlim(false);
+        private Exception _startupError;
+
+        private const int kInitTimeoutMs = 20000;
+
+        /// <summary>
+        /// Starts the dedicated thread and blocks until its WebView2 is initialized and ready to navigate.
+        /// </summary>
+        public OffScreenBrowser()
+        {
+            _thread = new Thread(ThreadMain) { IsBackground = true, Name = "OffScreenBrowser" };
+            _thread.SetApartmentState(ApartmentState.STA);
+            _thread.Start();
+            _ready.Wait();
+            if (_startupError != null)
+            {
+                // Initialization failed (e.g. the WebView2 readiness timeout). The dedicated thread may still be
+                // pumping its message loop with a live WebView2 (and its CoreWebView2 process) attached, so tear
+                // that down before we throw; otherwise the thread and the browser process leak.
+                Dispose();
+                throw new ApplicationException(
+                    "OffScreenBrowser failed to initialize",
+                    _startupError
+                );
+            }
+        }
+
+        /// <summary>
+        /// The managed id of the thread that owns the browser. Used by tests to prove the browser runs on a
+        /// different thread than the one that blocks for results.
+        /// </summary>
+        public int BrowserThreadId => _thread.ManagedThreadId;
+
+        // Runs on the dedicated thread: establishes a message loop, creates the browser, then pumps messages
+        // until Dispose() ends the loop via the ApplicationContext.
+        private void ThreadMain()
+        {
+            try
+            {
+                // Give this thread a Windows Forms message loop + synchronization context, so the browser's
+                // async continuations (and cross-thread Posts from callers) run here.
+                var ctx = new WindowsFormsSynchronizationContext();
+                SynchronizationContext.SetSynchronizationContext(ctx);
+                _ctx = ctx;
+
+                // The constructor kicks off CoreWebView2 initialization unawaited; it completes via the message
+                // loop we start below.
+                _browser = new WebView2Browser();
+                // Realize the HWND now; CoreWebView2 initialization can only complete once the control has a
+                // window handle, and nothing else (no parent Form) will create it for us. Same trick as
+                // BookProcessor's off-screen browser.
+                _browser.CreateControl();
+
+                // Poll for readiness once the loop is pumping, then signal the constructor.
+                ctx.Post(_ => WaitUntilReadyThenSignal(), null);
+
+                _appContext = new ApplicationContext();
+                Application.Run(_appContext); // pump until the context's loop is ended in Dispose
+            }
+            catch (Exception e)
+            {
+                _startupError = e;
+                _ready.Set();
+            }
+        }
+
+        private async void WaitUntilReadyThenSignal()
+        {
+            try
+            {
+                var timer = Stopwatch.StartNew();
+                while (!_browser.IsReadyToNavigate)
+                {
+                    if (timer.ElapsedMilliseconds > kInitTimeoutMs)
+                        throw new ApplicationException(
+                            "Timed out initializing the off-screen WebView2."
+                        );
+                    await Task.Delay(20);
+                }
+            }
+            catch (Exception e)
+            {
+                _startupError = e;
+            }
+            finally
+            {
+                _ready.Set();
+            }
+        }
+
+        /// <summary>
+        /// Navigates the browser to the given DOM (served via BloomServer) and blocks the calling thread until
+        /// navigation completes, times out, or is cancelled. Returns true on successful navigation, false on
+        /// timeout or cancellation — matching NavigateAndWaitTillDone's contract for the caller.
+        /// </summary>
+        public bool Navigate(HtmlDom htmlDom, int timeoutMs, Func<bool> cancelCheck)
+        {
+            return RunAndBlock(() => NavigateAsync(htmlDom, timeoutMs, cancelCheck));
+        }
+
+        // Async navigation using only the public Browser API (DocumentCompleted is raised on the WebView2's
+        // NavigationCompleted). No Application.DoEvents: we await the completion event, polling for timeout and
+        // caller-requested cancellation. Runs on the dedicated thread.
+        private async Task<bool> NavigateAsync(
+            HtmlDom htmlDom,
+            int timeoutMs,
+            Func<bool> cancelCheck
+        )
+        {
+            var navigated = new TaskCompletionSource<bool>();
+            void Handler(object sender, EventArgs e) => navigated.TrySetResult(true);
+            _browser.DocumentCompleted += Handler;
+            try
+            {
+                _browser.Navigate(htmlDom, source: InMemoryHtmlFileSource.JustCheckingPage);
+                var timer = Stopwatch.StartNew();
+                while (!navigated.Task.IsCompleted)
+                {
+                    if (cancelCheck != null && cancelCheck())
+                        return false;
+                    if (timer.ElapsedMilliseconds > timeoutMs)
+                        return false;
+                    await Task.WhenAny(navigated.Task, Task.Delay(50));
+                }
+                return true;
+            }
+            finally
+            {
+                _browser.DocumentCompleted -= Handler;
+            }
+        }
+
+        /// <summary>
+        /// Runs the given script and blocks the calling thread until it returns the result (already JSON-decoded
+        /// to a plain string by GetStringFromJavascriptAsync). This is the safe replacement for
+        /// RunJavascriptWithStringResult_Sync_Dangerous: it blocks the caller instead of pumping the main loop.
+        /// </summary>
+        public string RunJavascript(string script)
+        {
+            return RunAndBlock(() => _browser.GetStringFromJavascriptAsync(script));
+        }
+
+        // Marshals an async function onto the dedicated thread and BLOCKS the calling thread for its result.
+        // Blocking is safe here precisely because the dedicated thread — not the caller — pumps the messages
+        // that let the awaited WebView2 operations complete.
+        private T RunAndBlock<T>(Func<Task<T>> asyncFunc)
+        {
+            var tcs = new TaskCompletionSource<T>();
+            _ctx.Post(
+                async _ =>
+                {
+                    try
+                    {
+                        tcs.SetResult(await asyncFunc());
+                    }
+                    catch (Exception e)
+                    {
+                        tcs.SetException(e);
+                    }
+                },
+                null
+            );
+            return tcs.Task.GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Disposes the WebView2 (on its owning thread) and shuts down the dedicated thread's message loop.
+        /// </summary>
+        public void Dispose()
+        {
+            var ctx = _ctx;
+            if (ctx != null)
+            {
+                ctx.Post(
+                    _ =>
+                    {
+                        // Always end the loop, even if disposing the browser throws — otherwise the loop keeps
+                        // running and Join below only returns after its 5s timeout, with the thread still alive.
+                        try
+                        {
+                            _browser?.Dispose();
+                        }
+                        finally
+                        {
+                            _appContext?.ExitThread();
+                        }
+                    },
+                    null
+                );
+            }
+            _thread.Join(5000);
+        }
+    }
+}

--- a/src/BloomExe/Publish/PublishHelper.cs
+++ b/src/BloomExe/Publish/PublishHelper.cs
@@ -43,8 +43,6 @@ namespace Bloom.Publish
             _latestInstance = this;
         }
 
-        public Control ControlForInvoke { get; set; }
-
         public static void Cancel()
         {
             _latestInstance = null;
@@ -52,88 +50,22 @@ namespace Bloom.Publish
 
         public static bool InPublishTab { get; set; }
 
-        private Browser _browser;
-        public Browser BrowserForPageChecks
+        private OffScreenBrowser _pageChecksBrowser;
+
+        /// <summary>
+        /// The browser we use for the "page checks" (element visibility and font info). It is an off-screen
+        /// browser on its own dedicated thread, so we can drive it with blocking calls that never pump the main
+        /// UI message loop — avoiding the reentrancy that made RunJavascriptWithStringResult_Sync_Dangerous
+        /// dangerous (BL-12614 / BL-13120) — and never deadlock. Created lazily. See <see cref="OffScreenBrowser"/>.
+        /// </summary>
+        private OffScreenBrowser GetOrCreatePageChecksBrowser()
         {
-            get
-            {
-                if (_browser == null)
-                {
-                    Debug.Assert(
-                        ControlForInvoke != null
-                            || Program.RunningUnitTests
-                            || Program.RunningOnUiThread
-                    );
-                    if (ControlForInvoke != null && ControlForInvoke.InvokeRequired)
-                    {
-                        ControlForInvoke.Invoke(
-                            (Action)(() => _browser = BrowserMaker.MakeBrowser())
-                        );
-                    }
-                    else
-                    {
-                        _browser = BrowserMaker.MakeBrowser();
-                    }
-                }
-                return _browser;
-            }
+            return _pageChecksBrowser ??= new OffScreenBrowser();
         }
 
         // The only reason this isn't just ../* is performance. We could change it.  It comes from the need to actually
         // remove any elements that the style rules would hide, because epub readers ignore visibility settings.
         private const string kSelectThingsThatCanBeHidden = ".//div | .//img";
-
-        /// <summary>
-        /// Remove unwanted content from the XHTML of this book.  As a side-effect, store the fonts used in the remaining
-        /// content of the book.
-        /// </summary>
-        public void RemoveUnwantedContent(
-            HtmlDom dom,
-            Book.Book book,
-            bool removeInactiveLanguages,
-            Dictionary<string, int> omittedPages,
-            ISet<string> modifiedPageMessages,
-            PublishingMediums medium, // should normally only be one of them
-            EpubMaker epubMaker = null,
-            bool keepPageLabels = false
-        )
-        {
-            FontsUsed.Clear();
-            FontsAndLangsUsed.Clear();
-            // Removing unwanted content involves a real browser really navigating. I'm not sure exactly why,
-            // but things freeze up if we don't do it on the UI thread.
-            if (ControlForInvoke != null)
-            {
-                ControlForInvoke.Invoke(
-                    (Action)(
-                        delegate
-                        {
-                            RemoveUnwantedContentInternal(
-                                dom,
-                                book,
-                                removeInactiveLanguages,
-                                epubMaker,
-                                omittedPages,
-                                modifiedPageMessages,
-                                medium,
-                                keepPageLabels
-                            );
-                        }
-                    )
-                );
-            }
-            else
-                RemoveUnwantedContentInternal(
-                    dom,
-                    book,
-                    removeInactiveLanguages,
-                    epubMaker,
-                    omittedPages,
-                    modifiedPageMessages,
-                    medium,
-                    keepPageLabels
-                );
-        }
 
         /// <summary>
         /// This javascript function is run in the browser to get the display and font information
@@ -299,20 +231,29 @@ namespace Bloom.Publish
         protected Dictionary<string, FontInfo> _mapIdToFontInfo =
             new Dictionary<string, FontInfo>();
 
-        private void RemoveUnwantedContentInternal(
+        /// <summary>
+        /// Remove unwanted content from the XHTML of this book.  As a side-effect, store the fonts used in the remaining
+        /// content of the book.
+        /// </summary>
+        /// <remarks>
+        /// This no longer needs to run on the UI thread: the browser it uses lives on its own dedicated thread
+        /// (see GetOrCreatePageChecksBrowser) and is driven by blocking calls that marshal onto that thread, so the DOM work
+        /// here is thread-agnostic and can run on whatever thread the caller is on.
+        /// </remarks>
+        public void RemoveUnwantedContent(
             HtmlDom dom,
             Book.Book book,
             bool removeInactiveLanguages,
-            EpubMaker epubMaker,
             Dictionary<string, int> omittedPages,
             ISet<string> modifiedPageMessages,
             PublishingMediums medium, // should normally only be one of them
+            EpubMaker epubMaker = null,
             bool keepPageLabels = false
         )
         {
+            FontsUsed.Clear();
+            FontsAndLangsUsed.Clear();
             var startRemoveTime = DateTime.Now;
-            // The ControlForInvoke can be null for tests.  If it's not null, we better not need an Invoke!
-            Debug.Assert(ControlForInvoke == null || !ControlForInvoke.InvokeRequired); // should be called on UI thread.
             Debug.Assert(dom != null && dom.Body != null);
 
             // Collect all the page divs.
@@ -474,13 +415,8 @@ namespace Bloom.Publish
             if (this != _latestInstance)
                 return;
             if (
-                !BrowserForPageChecks.NavigateAndWaitTillDone(
-                    displayDom,
-                    10000,
-                    InMemoryHtmlFileSource.JustCheckingPage,
-                    () => this != _latestInstance,
-                    false
-                )
+                !GetOrCreatePageChecksBrowser()
+                    .Navigate(displayDom, 10000, () => this != _latestInstance)
             )
             {
                 // We started having problems with timeouts here (BL-7892).
@@ -495,9 +431,8 @@ namespace Bloom.Publish
                 return;
 
             // Get and store the display and font information for each element in the DOM.
-            var elementsInfo = BrowserForPageChecks.RunJavascriptWithStringResult_Sync_Dangerous(
-                GetElementDisplayAndFontInfoJavascript
-            );
+            var elementsInfo = GetOrCreatePageChecksBrowser()
+                .RunJavascript(GetElementDisplayAndFontInfoJavascript);
             var rawInfo = Newtonsoft.Json.JsonConvert.DeserializeObject<ElementInfoArray>(
                 elementsInfo
             );
@@ -1514,39 +1449,29 @@ namespace Bloom.Publish
         // This code added to correctly implement the disposable pattern.
         private bool _isDisposed = false; // To detect redundant calls
 
+        /// <summary>
+        /// Shut down the off-screen page-checks browser (its thread and WebView2 process) if we made one, so
+        /// it stops consuming resources once we are done with it. It will be lazily recreated if page checks
+        /// are needed again. Callers that finish a batch of page checks (e.g. EpubMaker at the end of staging)
+        /// should call this so the browser does not linger idle after the work is done. Must be called from a
+        /// thread that is not currently mid-call into the browser; OffScreenBrowser.Dispose posts teardown to
+        /// the browser's own thread and joins it.
+        /// </summary>
+        public void ReleaseBrowser()
+        {
+            // Don't use GetOrCreatePageChecksBrowser here — if we never created one, we don't want to make
+            // one now just to dispose it.
+            _pageChecksBrowser?.Dispose();
+            _pageChecksBrowser = null;
+        }
+
         protected virtual void Dispose(bool disposing)
         {
             if (!_isDisposed)
             {
                 if (disposing)
                 {
-                    if (_browser != null) // Don't use BrowserForPageChecks here...if we don't have one we don't want to make it now!
-                    {
-                        if (
-                            ControlForInvoke != null
-                            && ControlForInvoke.IsHandleCreated
-                            && !ControlForInvoke.IsDisposed
-                        )
-                        {
-                            // Seems safest of all to invoke using the thing we use for all other invokes.
-                            // Also, seems our WebView2Browser may not actually get a handle, yet its
-                            // embedded WebView2 still needs to be disposed on the right thread.
-                            ControlForInvoke.Invoke((Action)(() => _browser.Dispose()));
-                        }
-                        else if (_browser.IsHandleCreated)
-                        {
-                            _browser.Invoke((Action)(() => _browser.Dispose()));
-                        }
-                        else
-                        {
-                            // We can't invoke if it doesn't have a handle...and we certainly don't want
-                            // to waste time getting it one...hopefully we can just dispose it on this
-                            // thread.
-                            _browser.Dispose();
-                        }
-                    }
-
-                    _browser = null;
+                    ReleaseBrowser();
                 }
                 _isDisposed = true;
             }

--- a/src/BloomExe/Publish/PublishView.cs
+++ b/src/BloomExe/Publish/PublishView.cs
@@ -106,7 +106,6 @@ namespace Bloom.Publish
             WorkspaceView?.SetTabsEnabled(true);
             PublishHelper.InPublishTab = true;
             var hostForm = GetHostControlForInvoke() as Form;
-            BloomPubMaker.ControlForInvoke = hostForm;
             PublishEpubApi.ControlForInvoke = hostForm;
             LibraryPublishApi.Model = new BloomLibraryPublishModel(
                 _bookTransferrer,

--- a/src/BloomTests/Publish/OffScreenBrowserTests.cs
+++ b/src/BloomTests/Publish/OffScreenBrowserTests.cs
@@ -1,0 +1,129 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Bloom.Api;
+using Bloom.Book;
+using Bloom.Publish;
+using NUnit.Framework;
+
+namespace BloomTests.Publish
+{
+    /// <summary>
+    /// Mechanics test for OffScreenBrowser: proves a real WebView2Browser initializes on its own dedicated
+    /// thread and runs javascript when driven by blocking synchronous calls from THIS thread — the pattern
+    /// that retires RunJavascriptWithStringResult_Sync_Dangerous in PublishHelper.
+    ///
+    /// Full navigation against real books (which needs a running BloomServer to resolve CSS/fonts/relative
+    /// paths) is covered by the existing epub/bloompub publish suites, which drive RemoveUnwantedContent
+    /// against real books. That is also where the BL-15292 "real fonts, not empty/garbage" risk is
+    /// validated. This file uses a minimal BloomServer (no book folder needed) just to prove several
+    /// OffScreenBrowser instances can navigate concurrently without interfering with each other.
+    /// </summary>
+    [TestFixture]
+    public class OffScreenBrowserTests
+    {
+        private static BloomServer s_bloomServer;
+
+        /// <summary>
+        /// A running BloomServer is required for Navigate() (it serves the in-memory HTML). No book/file
+        /// locator setup is needed here since the test pages don't reference any files.
+        /// </summary>
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            s_bloomServer = new BloomServer(new BookSelection());
+            s_bloomServer.EnsureListening();
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            s_bloomServer.Dispose();
+        }
+
+        [Test]
+        public void CanRunJavascriptOnDedicatedThread_WithoutPumpingCallingThread()
+        {
+            var callingThreadId = Thread.CurrentThread.ManagedThreadId;
+
+            using (var host = new OffScreenBrowser())
+            {
+                // SANITY: the browser must be on a DIFFERENT thread than the one we block on, otherwise the
+                // whole premise (block safely because someone else pumps) is void.
+                Assert.That(
+                    host.BrowserThreadId,
+                    Is.Not.EqualTo(callingThreadId),
+                    "browser should run on its own thread, not the calling thread"
+                );
+
+                // This blocking call is the crux: the calling thread does NOT pump a message loop, yet the
+                // script completes because the dedicated thread services the WebView2 callbacks. If the
+                // premise were wrong this would deadlock (and the test would time out) rather than fail.
+                var result = host.RunJavascript("(1 + 2).toString()");
+
+                Assert.That(
+                    result,
+                    Is.EqualTo("3"),
+                    "javascript executed on the dedicated-thread browser should return its result"
+                );
+            }
+        }
+
+        [Test]
+        public void MultipleInstances_CanNavigateConcurrently_WithoutCrossContamination()
+        {
+            const int kBrowserCount = 3;
+            var browsers = Enumerable
+                .Range(0, kBrowserCount)
+                .Select(_ => new OffScreenBrowser())
+                .ToArray();
+            try
+            {
+                var results = new string[kBrowserCount];
+
+                // Drive each browser's Navigate+RunJavascript round-trip from its own task, all started
+                // together, so the dedicated threads/WebView2s are genuinely active at the same time rather
+                // than one finishing before the next starts.
+                var tasks = Enumerable
+                    .Range(0, kBrowserCount)
+                    .Select(i =>
+                        Task.Run(() =>
+                        {
+                            var dom = new HtmlDom(
+                                $"<html><head></head><body><div id='marker'>browser-{i}</div></body></html>"
+                            );
+                            var navigated = browsers[i].Navigate(dom, 10000, null);
+                            Assert.That(
+                                navigated,
+                                Is.True,
+                                $"browser {i} should have navigated successfully"
+                            );
+                            results[i] = browsers[i]
+                                .RunJavascript("document.getElementById('marker').textContent");
+                        })
+                    )
+                    .ToArray();
+
+                Assert.That(
+                    Task.WaitAll(tasks, 20000),
+                    Is.True,
+                    "all browsers should finish navigating within the timeout"
+                );
+
+                for (var i = 0; i < kBrowserCount; i++)
+                {
+                    Assert.That(
+                        results[i],
+                        Is.EqualTo($"browser-{i}"),
+                        $"browser {i} should see only the content it was navigated to, not another browser's"
+                    );
+                }
+            }
+            finally
+            {
+                foreach (var browser in browsers)
+                    browser.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
PublishHelper.RemoveUnwantedContent (the epub/bloompub "which elements are
visible, what fonts are used" pass) got its element/font info via
Browser.RunJavascriptWithStringResult_Sync_Dangerous, and navigated via
NavigateAndWaitTillDone. Both wait by pumping the MAIN UI message loop
(Application.DoEvents), which lets unrelated user commands run in the middle of
our call stack -- the reentrancy blamed for BL-12614 / BL-13120.

Introduce OffScreenBrowser: a WebView2 browser for off-screen work (navigate to
a page and run javascript against a real, laid-out DOM -- CSS, fonts, and layout
actually resolved -- without putting the browser on screen or letting the user
interact with it). It owns a real WebView2Browser on its own private, dedicated
STA thread with its own Windows Forms message loop. Because THAT thread services
the browser's callbacks, a caller can simply BLOCK for a result: it never pumps
the main loop (no reentrancy) and never deadlocks (the thread that blocks is
never the thread that must pump). Navigation is async (awaits the completion
event; no DoEvents). Nothing about it is specific to page checks -- it suits any
task that needs to ask a real browser questions about a document off-screen.

PublishHelper now drives this browser through blocking Navigate/RunJavascript
calls, so the sync-dangerous script call and the DoEvents-pumping navigation are
both gone from that path. Since the browser owns its own thread, the work no
longer needs to run on the UI thread, so:

- The ControlForInvoke.Invoke wrapper and UI-thread Debug assert are removed, and
  RemoveUnwantedContent is merged with its former *Internal helper into one method.
- The whole vestigial ControlForInvoke plumbing that existed only to hand the page
  checks a control to Invoke on is deleted: the properties on PublishHelper and
  EpubMaker, the propagation in PublishEpubApi.SetupEpubControlContent and
  PublishView, the static on BloomPubMaker, and the control the CLI created solely
  to pass down. PublishEpubApi.ControlForInvoke is kept -- it is independently used
  to run the save-as dialog on the UI thread.

Validated against the existing epub and bloompub publish suites (which drive
RemoveUnwantedContent against real books with real fonts -- also the BL-15292 risk
area): they pass with no test changes, so no behavior change slipped through. A
small mechanics test (OffScreenBrowserTests) covers the dedicated-thread pattern.

BookProcessor still uses RunJavascriptWithStringResult_Sync_Dangerous (for polling
window globals during its off-screen per-page fix-up); migrating it to
OffScreenBrowser and then deleting the obsolete base-class method is a follow-up.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8030)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8030)
<!-- Reviewable:end -->
