### PR TITLE
Fix ProjectContext.Dispose crash when app container disposed first

### DIFF
--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -859,9 +859,17 @@ namespace Bloom
             // We now keep BloomApiHandler alive for the application lifetime, but many endpoints are project-scoped.
             // Disposing the ProjectContext should fully shut down the project (including webviews) before we clear
             // those project-scoped endpoints.
-            var server = _scope.Resolve<BloomServer>();
             try
             {
+                // During application shutdown, WinForms can fire Application.ApplicationExit (for example as a
+                // worker thread's message context is torn down while publish artifacts are being created, as in
+                // the harvester's CreateArtifacts flow). That disposes the ApplicationContainer, which is the
+                // parent of _scope, before this Dispose runs. When that has happened, BloomServer (an
+                // application-level singleton) and all its API handlers are already gone, so resolving it throws
+                // ObjectDisposedException and there is nothing project-scoped left to clean up. In that case we
+                // just fall through to disposing our own scope.
+                var server = _scope.Resolve<BloomServer>();
+
                 // The order of these is tricky. The problem is that browsers could still be
                 // running and trying to call APIs while we are shutting down.
                 // Disposing the scope disposes the browsers, after which they shouldn't be able
@@ -877,10 +885,15 @@ namespace Bloom
                 // project is closed. A reload disposes this context before creating the next one, which
                 // sets it again, so clearing here is safe.
                 web.controllers.CommonApi.CurrentCollectionSettings = null;
-                _scope.Dispose();
+            }
+            catch (ObjectDisposedException)
+            {
+                // The application container was already disposed (see above); nothing project-scoped
+                // remains to clean up, so proceed to dispose our own scope below.
             }
             finally
             {
+                _scope.Dispose();
                 _scope = null;
             }
 


### PR DESCRIPTION
CreateArtifactsCommandTests.CreateArtifacts_LegacyBookWithInvalidXmatter_
HarvesterAllowedToConvert_ConvertsToDefaultTheme was failing with an
UnhandledException. The artifacts were created fine; the failure was in
ProjectContext.Dispose().

During the harvester CreateArtifacts flow, creating publish artifacts does
WinForms/browser work. As a worker thread message context tears down,
WinForms fires Application.ApplicationExit, which calls
ApplicationContainer.OnApplicationExit -> Dispose(), disposing the
application container. That container is the parent of ProjectContext._scope.
When the using block in CreateArtifactsCommand.HandleInternal then runs
ProjectContext.Dispose(), the _scope.Resolve<BloomServer>() call (added in
BL-15716 to clear project-level API handlers) throws ObjectDisposedException
because the parent scope is already gone.

Before BL-15716 this race was harmless because Dispose only called
_scope.Dispose(), which is safe even with a disposed parent.

Fix: tolerate the parent container already being disposed. When it is,
BloomServer and all its API handlers are already gone, so there is nothing
project-scoped left to clear; we skip the handler cleanup and just dispose
our own scope. Normal project-switch reloads do not dispose the container,
so handlers are still cleared as before.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8040)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8040)
<!-- Reviewable:end -->
