### PR TITLE
Improve starting Reading App Builder from inside Bloom

### DIFF
--- a/src/BloomExe/Publish/Rab/RabProjectService.cs
+++ b/src/BloomExe/Publish/Rab/RabProjectService.cs
@@ -2684,6 +2684,9 @@ namespace Bloom.Publish.Rab
                     if (process.MainWindowHandle == IntPtr.Zero)
                         continue;
 
+                    if (process.ProcessName != "java")
+                        continue; // Don't match browser tabs, for instance.
+
                     if (
                         process.MainWindowTitle.IndexOf(
                             "Reading App Builder",
@@ -2697,6 +2700,11 @@ namespace Bloom.Publish.Rab
                 catch
                 {
                     // Ignore processes that cannot be inspected.
+                }
+                finally
+                {
+                    // close the process handle to avoid leaking resources, but don't kill the process
+                    process.Dispose();
                 }
             }
 

--- a/src/BloomExe/Publish/Rab/RabProjectService.cs
+++ b/src/BloomExe/Publish/Rab/RabProjectService.cs
@@ -2677,53 +2677,60 @@ namespace Bloom.Publish.Rab
 
         internal virtual bool TryBringRunningRabToFront()
         {
-            foreach (var process in Process.GetProcesses())
+            var processes = Process.GetProcesses();
+            try
             {
-                try
+                foreach (var process in processes)
                 {
-                    if (process.MainWindowHandle == IntPtr.Zero)
-                        continue;
+                    try
+                    {
+                        if (process.MainWindowHandle == IntPtr.Zero)
+                            continue;
 
-                    // RAB is a Java (Eclipse) app. Depending on how it is launched, its
-                    // window may belong to either java.exe or the console-less javaw.exe, so
-                    // accept both. This keeps us from matching, e.g., a browser tab whose
-                    // title happens to contain "Reading App Builder".
-                    if (
-                        !string.Equals(
-                            process.ProcessName,
-                            "java",
-                            StringComparison.OrdinalIgnoreCase
+                        // RAB is a Java (Eclipse) app. Depending on how it is launched, its
+                        // window may belong to either java.exe or the console-less javaw.exe, so
+                        // accept both. This keeps us from matching, e.g., a browser tab whose
+                        // title happens to contain "Reading App Builder".
+                        if (
+                            !string.Equals(
+                                process.ProcessName,
+                                "java",
+                                StringComparison.OrdinalIgnoreCase
+                            )
+                            && !string.Equals(
+                                process.ProcessName,
+                                "javaw",
+                                StringComparison.OrdinalIgnoreCase
+                            )
                         )
-                        && !string.Equals(
-                            process.ProcessName,
-                            "javaw",
-                            StringComparison.OrdinalIgnoreCase
+                            continue;
+
+                        if (
+                            process.MainWindowTitle.IndexOf(
+                                "Reading App Builder",
+                                StringComparison.OrdinalIgnoreCase
+                            ) < 0
                         )
-                    )
-                        continue;
+                            continue;
 
-                    if (
-                        process.MainWindowTitle.IndexOf(
-                            "Reading App Builder",
-                            StringComparison.OrdinalIgnoreCase
-                        ) < 0
-                    )
-                        continue;
+                        return ProcessExtra.SetForegroundWindow(process.MainWindowHandle);
+                    }
+                    catch
+                    {
+                        // Ignore processes that cannot be inspected.
+                    }
+                }
 
-                    return ProcessExtra.SetForegroundWindow(process.MainWindowHandle);
-                }
-                catch
-                {
-                    // Ignore processes that cannot be inspected.
-                }
-                finally
-                {
-                    // close the process handle to avoid leaking resources, but don't kill the process
-                    process.Dispose();
-                }
+                return false;
             }
-
-            return false;
+            finally
+            {
+                // Close every process handle we obtained to avoid leaking resources, but
+                // don't kill the processes. This includes any processes we never got to
+                // inspect because a match was found and we returned early.
+                foreach (var process in processes)
+                    process.Dispose();
+            }
         }
 
         internal virtual string GetRabSettingsFilePath()

--- a/src/BloomExe/Publish/Rab/RabProjectService.cs
+++ b/src/BloomExe/Publish/Rab/RabProjectService.cs
@@ -2684,8 +2684,23 @@ namespace Bloom.Publish.Rab
                     if (process.MainWindowHandle == IntPtr.Zero)
                         continue;
 
-                    if (process.ProcessName != "java")
-                        continue; // Don't match browser tabs, for instance.
+                    // RAB is a Java (Eclipse) app. Depending on how it is launched, its
+                    // window may belong to either java.exe or the console-less javaw.exe, so
+                    // accept both. This keeps us from matching, e.g., a browser tab whose
+                    // title happens to contain "Reading App Builder".
+                    if (
+                        !string.Equals(
+                            process.ProcessName,
+                            "java",
+                            StringComparison.OrdinalIgnoreCase
+                        )
+                        && !string.Equals(
+                            process.ProcessName,
+                            "javaw",
+                            StringComparison.OrdinalIgnoreCase
+                        )
+                    )
+                        continue;
 
                     if (
                         process.MainWindowTitle.IndexOf(


### PR DESCRIPTION
## What

Improves how Bloom brings an already-running Reading App Builder (RAB) window to the front instead of launching a duplicate instance.

### Changes
- **Only match real RAB windows.** `TryBringRunningRabToFront()` now skips any process whose name is not `java`/`javaw` before checking the window title, so a browser tab (or other window) whose title happens to contain "Reading App Builder" is never mistaken for RAB.
- **Match both `java` and `javaw`.** RAB is a Java (Eclipse) app; depending on how it is launched its window may belong to `java.exe` or the console-less `javaw.exe`. Both are now accepted (case-insensitive) so the "bring to front" behavior isn't silently skipped.
- **Dispose process handles.** The enumeration loop now disposes each `Process` in a `finally`, avoiding leaked handles (without killing the process).

## Testing
- `Publish.Rab` unit suite: 91/91 passing.
- BloomExe builds clean.

_Note: `TryBringRunningRabToFront()` enumerates OS processes, so it isn't directly unit-tested; the `java`/`javaw` name is worth a quick confirmation against a live RAB._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8041)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8041)
<!-- Reviewable:end -->
