### PR TITLE
Unify TopBar control colors to black at 80% opacity

### DIFF
--- a/src/BloomBrowserUI/react_components/TopBar/CollectionTopBarControls/CollectionTopBarControls.tsx
+++ b/src/BloomBrowserUI/react_components/TopBar/CollectionTopBarControls/CollectionTopBarControls.tsx
@@ -16,11 +16,9 @@ const kOpenCreateCollectionIcon = `${bloomApiPrefix}images/OpenCreateCollection2
 const kSettingsIcon = `${bloomApiPrefix}images/settings24x24.png`;
 
 const mainButtonBackground = kBloomBlue;
-// Review: this doesn't seem to match anything else in our UI.
-// But it is what the original WinForms button had, so I've kept it for now.
-// Likely we'll need JH to make a full pass through the TopBar controls once
-// they are all in React to decide what we want everything to be.
-const mainButtonTextColor = "rgb(60, 60, 60)";
+// Black at 80% opacity, matching the controls in WorkspaceTopRightControls
+// (language menu, help, zoom) so the whole TopBar reads as one group.
+const mainButtonTextColor = "rgba(0, 0, 0, 0.8)";
 
 export const CollectionTopBarControls: React.FunctionComponent = () => {
     const teamCollectionStatus = useWatchApiData<TeamCollectionStatus>(
@@ -62,6 +60,15 @@ export const CollectionTopBarControls: React.FunctionComponent = () => {
                         display: flex;
                         gap: 10px;
                         align-items: center;
+
+                        // The button icons are flat gray (#404040) PNG silhouettes.
+                        // Recolor them to black at 80% opacity so they match this
+                        // group's text and the WorkspaceTopRightControls to the right.
+                        // brightness(0) blackens the flat shape (no internal detail to lose);
+                        // opacity(0.8) composites it at 80%.
+                        img {
+                            filter: brightness(0) opacity(0.8);
+                        }
                     `}
                 >
                     <TopBarButton

--- a/src/BloomBrowserUI/react_components/TopBar/workspaceTopRightControls/WorkspaceTopRightControls.tsx
+++ b/src/BloomBrowserUI/react_components/TopBar/workspaceTopRightControls/WorkspaceTopRightControls.tsx
@@ -5,24 +5,26 @@ import { createTheme, ThemeProvider } from "@mui/material/styles";
 import { ZoomControl } from "./ZoomControl";
 import { UiLanguageMenu } from "./UiLanguageMenu";
 import { HelpMenu } from "./HelpMenu";
-import { kTextOnPurple } from "../../../bloomMaterialUITheme";
+
+// Every affordance in this group -- text, menu-button labels, the help icon, and the
+// dropdown arrows -- is drawn in black at 80% opacity. The tab-bar background these sit
+// on isn't always the same color, and black-at-80% reads well across those backgrounds.
+const kTopRightControlColor = "rgba(0, 0, 0, 0.8)";
 
 export const WorkspaceTopRightControls: React.FunctionComponent = () => {
     const lightThemeOverride = React.useMemo(
         () =>
             createTheme(lightTheme, {
                 components: {
-                    // kTextOnPurple: The background isn't always purple,
-                    // but this matches what the original winforms control was doing.
-                    // Without the override, we get Bloom blue.
+                    // Without this override, MUI buttons in this group would be Bloom blue.
                     MuiButton: {
                         styleOverrides: {
                             root: {
-                                color: kTextOnPurple,
+                                color: kTopRightControlColor,
                                 fontWeight: "normal",
                             },
                             text: {
-                                color: kTextOnPurple,
+                                color: kTopRightControlColor,
                                 fontWeight: "normal",
                             },
                         },
@@ -42,10 +44,14 @@ export const WorkspaceTopRightControls: React.FunctionComponent = () => {
                     align-items: end;
                     font-size: 12px;
 
-                    // kTextOnPurple: see comment above
-                    color: ${kTextOnPurple};
+                    // See comment on kTopRightControlColor above.
+                    color: ${kTopRightControlColor};
                     button {
-                        color: ${kTextOnPurple};
+                        color: ${kTopRightControlColor};
+                    }
+                    // Make SVG icons (help icon, dropdown arrows) match the text color.
+                    svg {
+                        fill: currentColor;
                     }
                 `}
             >


### PR DESCRIPTION
[Claude Opus 4.8]

## What

The TopBar's control groups were two different colors:

- **Collection tab buttons** (Settings, Other Collection) — text in `rgb(60, 60, 60)` medium gray.
- **Right-hand controls** (language menu, help, zoom) — `kTextOnPurple` (`#31202e`, a dark purple).

Side by side they read as two mismatched groups. This unifies everything to **black at 80% opacity** so the whole TopBar reads as one group.

## Changes

- **CollectionTopBarControls**: main-button text color → `rgba(0, 0, 0, 0.8)`; recolor the flat-gray PNG icons to match with `filter: brightness(0) opacity(0.8)`. (The icons are detail-free `#404040` silhouettes, so blackening them loses nothing.)
- **WorkspaceTopRightControls**: replace `kTextOnPurple` with the same `rgba(0, 0, 0, 0.8)`, and add `svg { fill: currentColor }` so the help icon and dropdown arrows follow the text color.

No layout or behavior changes — color only.

## Testing

Verified live in a running Bloom (collection tab): the wrench/collection icons, their labels, the language menu, help icon, and dropdown arrows all render as uniform black-80% on the teal tab bar. `eslint` and the type check pass via the pre-commit hook.

[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8043)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8043)
<!-- Reviewable:end -->
