### PR TITLE
Strip orphaned CKEditor filling chars to fix Decodable Reader ZWSP bug (BL-16490)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
+++ b/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
@@ -335,7 +335,9 @@ export class EditableDivUtils {
 
     // Get the cleaned up data (getData()) from ckeditor, rather than just the raw html.
     // Specifically, we want it to remove the zero-width space characters that ckeditor inserts.
-    // See BL-12391.
+    // See BL-12391. Note that getData() only removes the filling char ckeditor is actively
+    // tracking; an orphaned one survives it, so we also strip stray filling chars explicitly
+    // (see removeCkEditorFillingChars and BL-16490).
     // Return the bookmarks for each editable div, so that we can restore the selection after
     // modifying the divs.
     // Changes to this logic may need to be reflected in audioRecording.ts' cleanUpCkEditorHtml.
@@ -364,7 +366,13 @@ export class EditableDivUtils {
                     }
                 }
 
-                const ckEditorData = ckeditorOfThisBox.getData();
+                // Strip stray filling chars before comparing: if the live DOM has an
+                // orphaned filling char that getData() didn't remove, the stripped data
+                // will differ from div.innerHTML and trigger the replacement that removes it.
+                const ckEditorData =
+                    EditableDivUtils.removeCkEditorFillingChars(
+                        ckeditorOfThisBox.getData(),
+                    );
                 if (ckEditorData !== div.innerHTML) {
                     this.safelyReplaceContentWithCkEditorData(
                         div,
@@ -385,6 +393,12 @@ export class EditableDivUtils {
         div: HTMLDivElement,
         ckEditorData: string,
     ) {
+        // Belt-and-suspenders for callers that pass getData() directly (e.g.
+        // audioRecording.cleanUpCkEditorHtml): make sure we never write an
+        // orphaned ckeditor filling char into the DOM. See BL-16490.
+        ckEditorData =
+            EditableDivUtils.removeCkEditorFillingChars(ckEditorData);
+
         let needToRemoveInitialParagraph = false;
         let divChildNodes = Array.from(div.childNodes);
         if (
@@ -434,6 +448,20 @@ export class EditableDivUtils {
 
     private static isNodeCkEditorBookmark(node: Node): boolean {
         return node.nodeName === "SPAN" && node["id"].startsWith("cke_bm_");
+    }
+
+    // CKEditor 4 inserts a "filling char" (U+200B ZERO WIDTH SPACE) at the caret on
+    // WebKit/Blink to keep the cursor navigable near inline-element boundaries and
+    // before <br>. It removes the one it is tracking, but when the decodable/leveled
+    // reader rewrites a box's innerHTML out from under ckeditor, that filling char is
+    // orphaned: getData() no longer strips it, so it gets saved and corrupts reader
+    // word matching (the analyzer treats U+200B as a word split while the highlighter
+    // does not). Strip any such stray filling chars. See BL-16490.
+    // We deliberately remove only U+200B; U+200C (ZWNJ) and U+200D (ZWJ) are legitimate
+    // in some scripts and must be preserved.
+    public static removeCkEditorFillingChars(html: string): string {
+        const fillingChar = String.fromCharCode(0x200b); // U+200B ZERO WIDTH SPACE
+        return html.split(fillingChar).join("");
     }
 
     // I don't know why cdEditor's getData() converts paragraphs with only a <br>

--- a/src/BloomBrowserUI/bookEdit/js/editableDivUtilsSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/editableDivUtilsSpec.ts
@@ -213,14 +213,14 @@ describe("EditableDivUtils Tests", () => {
 
     it("safelyReplaceContentWithCkEditorData strips orphaned filling chars", () => {
         const zwsp = String.fromCharCode(0x200b);
-        const div = document.createElement("div");
-        // sanity check: the filling char really is present before we call the method.
-        div.innerHTML = `<p>before</p>`;
-        expect(div.innerHTML.indexOf(zwsp)).toEqual(-1);
+        const ckEditorData = `<p>ca${zwsp}t${zwsp}</p>`;
+        // sanity check: our input really does contain the filling char we expect to be stripped.
+        expect(ckEditorData.indexOf(zwsp)).toBeGreaterThan(-1);
 
+        const div = document.createElement("div");
         EditableDivUtils.safelyReplaceContentWithCkEditorData(
             div,
-            `<p>ca${zwsp}t${zwsp}</p>`,
+            ckEditorData,
         );
 
         expect(div.innerHTML.indexOf(zwsp)).toEqual(-1);

--- a/src/BloomBrowserUI/bookEdit/js/editableDivUtilsSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/editableDivUtilsSpec.ts
@@ -194,4 +194,36 @@ describe("EditableDivUtils Tests", () => {
             expect(div.innerHTML).toEqual(testCase[2]);
         }
     });
+
+    it("removeCkEditorFillingChars removes U+200B but preserves U+200C and U+200D", () => {
+        const zwsp = String.fromCharCode(0x200b); // filling char we want gone
+        const zwnj = String.fromCharCode(0x200c); // legitimate; must be kept
+        const zwj = String.fromCharCode(0x200d); // legitimate; must be kept
+
+        // sanity check the test data
+        expect(zwsp).not.toEqual(zwnj);
+        const input = `a${zwsp}b${zwnj}c${zwj}d${zwsp}`;
+        expect(input.indexOf(zwsp)).toBeGreaterThan(-1);
+
+        const result = EditableDivUtils.removeCkEditorFillingChars(input);
+
+        expect(result.indexOf(zwsp)).toEqual(-1);
+        expect(result).toEqual(`ab${zwnj}c${zwj}d`);
+    });
+
+    it("safelyReplaceContentWithCkEditorData strips orphaned filling chars", () => {
+        const zwsp = String.fromCharCode(0x200b);
+        const div = document.createElement("div");
+        // sanity check: the filling char really is present before we call the method.
+        div.innerHTML = `<p>before</p>`;
+        expect(div.innerHTML.indexOf(zwsp)).toEqual(-1);
+
+        EditableDivUtils.safelyReplaceContentWithCkEditorData(
+            div,
+            `<p>ca${zwsp}t${zwsp}</p>`,
+        );
+
+        expect(div.innerHTML.indexOf(zwsp)).toEqual(-1);
+        expect(div.innerHTML).toEqual("<p>cat</p>");
+    });
 });

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -3603,7 +3603,15 @@ export default class AudioRecording implements IAudioRecorder {
         const ckeditorOfThisBox = (<any>editableDiv).bloomCkEditor;
         if (!ckeditorOfThisBox) return;
 
-        if (editableDiv.innerHTML !== ckeditorOfThisBox.getData()) {
+        // Strip stray ckeditor filling chars before comparing: an orphaned one that
+        // getData() didn't remove would otherwise make both sides equal, skip the
+        // cleanup below, and leave the zero-width space in the copy we analyze. See BL-16490.
+        if (
+            editableDiv.innerHTML !==
+            EditableDivUtils.removeCkEditorFillingChars(
+                ckeditorOfThisBox.getData(),
+            )
+        ) {
             // Flag the element we are processing so we can find it in the version we make from ckeditor's getData().
             element.setAttribute("data-element-we-are-processing", "this-one");
 


### PR DESCRIPTION
Fixes the Decodable Reader zero-width-space problem.

## Problem
CKEditor 4 inserts a U+200B ZERO WIDTH SPACE "filling char" at the caret on WebKit/Blink to keep the cursor navigable. It removes the one it is actively tracking, but when the decodable/leveled reader rewrites a box's `innerHTML` out from under CKEditor (word-wrapping spans), that filling char is **orphaned** — `getData()` no longer strips it, so it gets persisted on save/refresh/duplicate and corrupts reader word matching. (The Synphony analyzer treats U+200B as a word split, while `wrap_words_extra`'s `\p{Z}`/`\p{P}` boundaries do not — so a perfectly good word gets flagged as not-decodable.)

## Fix
- Add `EditableDivUtils.removeCkEditorFillingChars(html)` — removes only U+200B; U+200C (ZWNJ) and U+200D (ZWJ) are legitimate in some scripts and preserved.
- Apply it in `doCkEditorCleanup` **before** comparing `getData()` to `div.innerHTML`, so an orphaned char in the live DOM triggers the replacement that removes it.
- Apply it at the top of `safelyReplaceContentWithCkEditorData` (covers `audioRecording`'s direct-call path).

Both markup (`doMarkup`) and save (`getBodyContentForSavePage`) flow through `doCkEditorCleanup`. Adds unit tests.

Note: this stops *new* ZWSPs from being persisted and cleans them on the next save/markup pass; books that already contain saved ZWSPs are cleaned the next time their page is edited and saved.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16490

[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8044)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8044)
<!-- Reviewable:end -->
