### PR TITLE
Fix BL-16525 `vp test` cannot resolve jsdom under vite-plus bundled runner

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -62,6 +62,8 @@ These are now being run using Vitest in the BloomBrowserUI folder (where all our
 
 For now, all tests are being run using Node and JsDom. This approach has limitations; JsDom's emulation of the browser DOM is imperfect. In particular, you can't do much with a Canvas, and you can't get layout measurements. The file vitest.setup.ts contains various mocks to make jsdom work a little better. Eventually, we hope to be able to run a subset of tests using a real browser.
 
+`pnpm test` is the canonical way to run the tests. Bare `vp test` also works, but only because `vite-plus` is a local devDependency: `vp` prefers a project-local vite-plus over its own bundled toolchain, and pnpm links our `jsdom` into the local install's vitest, whereas vp's bundled vitest cannot resolve `jsdom` at all (BL-16525). Note that `vp test` runs vite-plus's own vitest version, which may differ from the vitest pinned in package.json that `pnpm test` uses.
+
 # Other Info
 
 ### Run more than one copy of Bloom

--- a/src/BloomBrowserUI/package.json
+++ b/src/BloomBrowserUI/package.json
@@ -266,6 +266,7 @@
         "vite": "7.1.5",
         "vite-plugin-pug": "0.4.1",
         "vite-plugin-static-copy": "3.1.3",
+        "vite-plus": "0.2.2",
         "vitest": "4.0.8"
     },
     "lint-staged": {

--- a/src/BloomBrowserUI/pnpm-lock.yaml
+++ b/src/BloomBrowserUI/pnpm-lock.yaml
@@ -255,7 +255,7 @@ importers:
                 version: 7.17.12(@babel/core@7.18.5(supports-color@5.5.0))
             "@chromatic-com/storybook":
                 specifier: 4.1.2
-                version: 4.1.2(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)))
+                version: 4.1.2(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)))
             "@eslint/js":
                 specifier: 9.21.0
                 version: 9.21.0
@@ -264,13 +264,13 @@ importers:
                 version: 7.2.24(@types/react@18.3.31)
             "@storybook/addon-a11y":
                 specifier: 10.0.2
-                version: 10.0.2(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)))
+                version: 10.0.2(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)))
             "@storybook/addon-docs":
                 specifier: 10.0.2
-                version: 10.0.2(@types/react@18.3.31)(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)))(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))
+                version: 10.0.2(@types/react@18.3.31)(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)))(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
             "@storybook/react-vite":
                 specifier: 10.0.2
-                version: 10.0.2(esbuild@0.25.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.62.2)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)))(typescript@6.0.3)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))
+                version: 10.0.2(esbuild@0.25.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.62.2)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)))(typescript@6.0.3)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
             "@testing-library/jest-dom":
                 specifier: 6.8.0
                 version: 6.8.0
@@ -336,10 +336,10 @@ importers:
                 version: 7.0.0-dev.20260619.1
             "@vitejs/plugin-react":
                 specifier: 5.0.4
-                version: 5.0.4(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))
+                version: 5.0.4(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
             "@vitest/browser-playwright":
                 specifier: 4.0.8
-                version: 4.0.8(playwright@1.56.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))(vitest@4.0.8)
+                version: 4.0.8(playwright@1.56.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))(vitest@4.0.8)
             "@vitest/ui":
                 specifier: 4.0.8
                 version: 4.0.8(vitest@4.0.8)
@@ -369,7 +369,7 @@ importers:
                 version: 5.2.0(eslint@9.33.0(supports-color@5.5.0))
             eslint-plugin-storybook:
                 specifier: 10.0.2
-                version: 10.0.2(eslint@9.33.0(supports-color@5.5.0))(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)))(supports-color@5.5.0)(typescript@6.0.3)
+                version: 10.0.2(eslint@9.33.0(supports-color@5.5.0))(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)))(supports-color@5.5.0)(typescript@6.0.3)
             glob:
                 specifier: 11.0.3
                 version: 11.0.3
@@ -435,7 +435,7 @@ importers:
                 version: 7.3.5
             storybook:
                 specifier: 10.0.2
-                version: 10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))
+                version: 10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
             typescript:
                 specifier: 6.0.3
                 version: 6.0.3
@@ -447,16 +447,19 @@ importers:
                 version: 1.0.0
             vite:
                 specifier: 7.1.5
-                version: 7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)
+                version: 7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)
             vite-plugin-pug:
                 specifier: 0.4.1
                 version: 0.4.1
             vite-plugin-static-copy:
                 specifier: 3.1.3
-                version: 3.1.3(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))
+                version: 3.1.3(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
+            vite-plus:
+                specifier: 0.2.2
+                version: 0.2.2(@types/node@22.9.0)(@vitest/browser-playwright@4.0.8)(@vitest/ui@4.0.8)(jsdom@26.1.0(supports-color@5.5.0))(less@3.13.1)(typescript@6.0.3)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)
             vitest:
                 specifier: 4.0.8
-                version: 4.0.8(@types/node@22.9.0)(@vitest/browser-playwright@4.0.8)(@vitest/ui@4.0.8)(jsdom@26.1.0(supports-color@5.5.0))(less@3.13.1)(supports-color@5.5.0)(yaml@2.9.0)
+                version: 4.0.8(@types/node@22.9.0)(@vitest/browser-playwright@4.0.8)(@vitest/browser-preview@4.1.9)(@vitest/ui@4.0.8)(jsdom@26.1.0(supports-color@5.5.0))(less@3.13.1)(lightningcss@1.32.0)(supports-color@5.5.0)(yaml@2.9.0)
 
 packages:
     "@adobe/css-tools@4.5.0":
@@ -1407,6 +1410,12 @@ packages:
                 integrity: sha512-w/63nURdkRPpg3AXbNr7lPv6HgOuVDyefTumiXsbXxtIwcuk5EXayWR5OpSwDjsQPgaYsfUSedMduaNOjAYY8A==,
             }
 
+    "@blazediff/core@1.9.1":
+        resolution:
+            {
+                integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==,
+            }
+
     "@chromatic-com/storybook@4.1.2":
         resolution:
             {
@@ -2354,6 +2363,432 @@ packages:
                 integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==,
             }
         engines: { node: ">= 8" }
+
+    "@oxc-project/runtime@0.138.0":
+        resolution:
+            {
+                integrity: sha512-yHhoXsN8tYxgdJCdD91PbySNjEEaBX/tH2OQRDXJpsQv5b184oC4/qVbU7qlblvfil/JP15Lh2HW7+HN5DS90Q==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+
+    "@oxc-project/types@0.138.0":
+        resolution:
+            {
+                integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==,
+            }
+
+    "@oxfmt/binding-android-arm-eabi@0.57.0":
+        resolution:
+            {
+                integrity: sha512-qVBsEO+KugOsCmUHcO8iqNnqc65p7PCKpCs8M66mPZ+Ri+CWbcpoQOEJBg2OTu03+0qu++NK1jj6IzvQVs0Sig==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [arm]
+        os: [android]
+
+    "@oxfmt/binding-android-arm64@0.57.0":
+        resolution:
+            {
+                integrity: sha512-mp6PibWbao3aizijcheOeHQaYEhcUAt8pwLniYbtLfHxL/psFF0BykAwCj+s3c6qIpa8yN8keZICWrqtZ70w8g==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [arm64]
+        os: [android]
+
+    "@oxfmt/binding-darwin-arm64@0.57.0":
+        resolution:
+            {
+                integrity: sha512-T+0stuCBqmUVY+aMIvrgXhzGhHO3sD5tNiiEcYqgSdPsnukskQqn2u5qOVD0sv1l7RLdFS5Z/f5Wi9Ktyjr3Eg==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [arm64]
+        os: [darwin]
+
+    "@oxfmt/binding-darwin-x64@0.57.0":
+        resolution:
+            {
+                integrity: sha512-O+3JbqWs/mCI2oi4xfhRO2IVPFJNDDEBV8Odo+ZpmsUOeKJfjXoNH7nDmBEQcDgK7NfjDIyE7kRgYSZcTLDO0A==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [x64]
+        os: [darwin]
+
+    "@oxfmt/binding-freebsd-x64@0.57.0":
+        resolution:
+            {
+                integrity: sha512-pxwhxVC+JkLX9twOQ/8C/vbuOQcMZyKIDmiRDZfO7yITuVcIdZCiLRqqf4QOxb2+8FWrRXzQpm+1DBKcMpHSSQ==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [x64]
+        os: [freebsd]
+
+    "@oxfmt/binding-linux-arm-gnueabihf@0.57.0":
+        resolution:
+            {
+                integrity: sha512-pxBU4zH2imB/MDBfth2rOMeVxXUMjRQLCazagwLARIFH3hVlxZJBlM4nSnHXaIHJK4/qezoFCIORN6AY8Mra4A==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [arm]
+        os: [linux]
+
+    "@oxfmt/binding-linux-arm-musleabihf@0.57.0":
+        resolution:
+            {
+                integrity: sha512-JAprOzt8tycYou36ZgEw14DlRHTiN8qdtKANdV3VZIRIvTI/lh/cX13c9pJ/EnDk2GT3FASH7KvCgQ2AufAifQ==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [arm]
+        os: [linux]
+
+    "@oxfmt/binding-linux-arm64-gnu@0.57.0":
+        resolution:
+            {
+                integrity: sha512-ajtjaxSaj9xl4BW7REt+Cef/ttzbAq00Bq4z7JUDZEfgFXdwSjH8K9bF+IcIJzZB9lKqMfQ4eHuSFOvvlvtqOg==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [arm64]
+        os: [linux]
+        libc: [glibc]
+
+    "@oxfmt/binding-linux-arm64-musl@0.57.0":
+        resolution:
+            {
+                integrity: sha512-p4Y/+RYk9Bk5WO+zHSUXAClRmZ2fbJCejMuCAsU2HhyME4jqf6Ftt/mJYEwIah1wGCBDYOB7wEGV1x5bCEZ6hA==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [arm64]
+        os: [linux]
+        libc: [musl]
+
+    "@oxfmt/binding-linux-ppc64-gnu@0.57.0":
+        resolution:
+            {
+                integrity: sha512-By6tRALAZsno0F4zedmtG+wdMvJiJmJoXM4d3+A9zHE4HRXLqXITwRH8mgrlcXc5yJM2g2W3riRPwTYdgemZLQ==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [ppc64]
+        os: [linux]
+        libc: [glibc]
+
+    "@oxfmt/binding-linux-riscv64-gnu@0.57.0":
+        resolution:
+            {
+                integrity: sha512-skYeG+RgvyzspqVEBsEprL90OYYZfoVNqB3HcCNR6QDJyXKOzfDRT3zncnHmUaFluIlBHuY23mU1b5WGgR98hA==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [riscv64]
+        os: [linux]
+        libc: [glibc]
+
+    "@oxfmt/binding-linux-riscv64-musl@0.57.0":
+        resolution:
+            {
+                integrity: sha512-FFgACrZOXAXUh5KQh2mt1CDOVOZmn+QzHP71wM9QobNwyQvoFfyAeefVUltW83g3sm7LTiH3yfFqLLVUpA5ZFQ==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [riscv64]
+        os: [linux]
+        libc: [musl]
+
+    "@oxfmt/binding-linux-s390x-gnu@0.57.0":
+        resolution:
+            {
+                integrity: sha512-Nm/BAOfQeFiiKd502mZn/GAVKJwtd0RdCg17G3Wz/WSOIQmDi3+7/SZH4BHn1Ye5KvTVH3ua8WvfwLLycNIuvA==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [s390x]
+        os: [linux]
+        libc: [glibc]
+
+    "@oxfmt/binding-linux-x64-gnu@0.57.0":
+        resolution:
+            {
+                integrity: sha512-BiSy5Ku3mQqyxS6YIqAJgd403wEUWvI7kerfzPxc2l/txZVmZM0pSj7oDM+4bGBExowxOi7o73jEam1W0EDTZg==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [x64]
+        os: [linux]
+        libc: [glibc]
+
+    "@oxfmt/binding-linux-x64-musl@0.57.0":
+        resolution:
+            {
+                integrity: sha512-BCRkJiotz5s9afLYD2LuMvzAoDYx9H17E/YbDyu4xK7l4zHDPeny9ErSXL//i/nJyaOwRk08x4b8cgJC00+JDg==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [x64]
+        os: [linux]
+        libc: [musl]
+
+    "@oxfmt/binding-openharmony-arm64@0.57.0":
+        resolution:
+            {
+                integrity: sha512-4Oaxe1qrGgXfpCJ1C/ERJ2iCtV2rN1R79ga9fsfyVHfSQRu/hVW780u2KDqZWFZ/iGTHODJji0JemxqFZ63eIQ==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [arm64]
+        os: [openharmony]
+
+    "@oxfmt/binding-win32-arm64-msvc@0.57.0":
+        resolution:
+            {
+                integrity: sha512-MYLAsDnhdNsSGheLYhWgbk0vfIrlS84iQYun/y21fX6u0jj8iBtYtbpZMdiqYeuf8U12eVPUjVY2xE2NrCfJ0g==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [arm64]
+        os: [win32]
+
+    "@oxfmt/binding-win32-ia32-msvc@0.57.0":
+        resolution:
+            {
+                integrity: sha512-PBwdzZALJY/jcCx2E6is0yu+cuVXeySTDmwuseD+9j0mHqlRNxwlKgsyRTBed/woPeqfVfuXfWjoq4Cx2Zt3Eg==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [ia32]
+        os: [win32]
+
+    "@oxfmt/binding-win32-x64-msvc@0.57.0":
+        resolution:
+            {
+                integrity: sha512-bQJdH9i4RRfw55jm7+8/xS7GzHLLTbHx4huhrrDxQJaJtbSDbsyOnODvP1ftT7EG0KFKAYO2S+q6AcioXODx8w==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [x64]
+        os: [win32]
+
+    "@oxlint-tsgolint/darwin-arm64@0.24.0":
+        resolution:
+            {
+                integrity: sha512-C2uMmwK5Bc4ri4ysZ6sA8Rcu+A5zBQTp6ml2u0CLLbRZp4kMFPV3yWk8B5DK9Aw7y9bbjogIm75tUwGLFzlsYQ==,
+            }
+        cpu: [arm64]
+        os: [darwin]
+
+    "@oxlint-tsgolint/darwin-x64@0.24.0":
+        resolution:
+            {
+                integrity: sha512-Wgvt/1lRbDxmoNqWQKKcL+UIiqLmdJ+EWLpQa1qzoNVAfNB0PJpa82/8dH1twT/3rSs4zrP5TXPWl4juB71WuQ==,
+            }
+        cpu: [x64]
+        os: [darwin]
+
+    "@oxlint-tsgolint/linux-arm64@0.24.0":
+        resolution:
+            {
+                integrity: sha512-PB1rxII7KV83+ASY4sSkXtqvpij6ME66+QCRL49uksi/ofs2Rf/UVboYr095n0Rkbl2wgvlsHGl6DHC361jQUQ==,
+            }
+        cpu: [arm64]
+        os: [linux]
+
+    "@oxlint-tsgolint/linux-x64@0.24.0":
+        resolution:
+            {
+                integrity: sha512-xcz3CxKmjTQLREtE/UShh+ruWmm9nAb7UM9zKcD65BStiuYgOakAKkPHl4YS5DztpVcDrE0+HqbOolTlRKYWmw==,
+            }
+        cpu: [x64]
+        os: [linux]
+
+    "@oxlint-tsgolint/win32-arm64@0.24.0":
+        resolution:
+            {
+                integrity: sha512-A2i6ZGBec3i20S7RaxkgHc6r3HYtD5Mn7j/mb22NkTz14u0JuudvTu6JggAnbGMcv8+dBKQI//EasxSPJLD8pw==,
+            }
+        cpu: [arm64]
+        os: [win32]
+
+    "@oxlint-tsgolint/win32-x64@0.24.0":
+        resolution:
+            {
+                integrity: sha512-0ZbGd9qRB6zs82moekaKdEvncRANq49EAwfNX62JpTS46feXUhKAuoyVDvZMj6Rywejylrmmu79Wo6faYCo4Ew==,
+            }
+        cpu: [x64]
+        os: [win32]
+
+    "@oxlint/binding-android-arm-eabi@1.72.0":
+        resolution:
+            {
+                integrity: sha512-zhCmvn+1Mj3UchAc/90i99S0t7jJUsHmFVSPg4UWrjO8b8eaSGwscgO6QAUtvHBstkjQwBttQNswEnAF1mIQdA==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [arm]
+        os: [android]
+
+    "@oxlint/binding-android-arm64@1.72.0":
+        resolution:
+            {
+                integrity: sha512-mtH+aY/ozv1eZoCUC2owjFAtyNBKHpJHygKeEu9zXXnQGW1Q2/qOpvx+I+Lf23+TvTz66F4iiXUbl2cGvoLPCQ==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [arm64]
+        os: [android]
+
+    "@oxlint/binding-darwin-arm64@1.72.0":
+        resolution:
+            {
+                integrity: sha512-EvnajNPDtfknB3ZieeOOyDTwJn9QXDiwfnF4ZDQqART6RG6hjY4WigQcZdGoK2dkB3e1vrmEzN9aYbQCUkh/gQ==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [arm64]
+        os: [darwin]
+
+    "@oxlint/binding-darwin-x64@1.72.0":
+        resolution:
+            {
+                integrity: sha512-ZkCdEa/G80A7vEHfeCDz/+L3m33DE73v32mDKhgOIgz8Uwf0DFcK7+uu6qC+7LEhmz5fpOe1osWKyjSNMydFIQ==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [x64]
+        os: [darwin]
+
+    "@oxlint/binding-freebsd-x64@1.72.0":
+        resolution:
+            {
+                integrity: sha512-NroXv2vh+sxVY1uya/rM5pjhx1hm8BzlYpx9q67QP0Xhw5MH2bf5GJylpvLEC+781p1Xli/317EoV9AlGwViag==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [x64]
+        os: [freebsd]
+
+    "@oxlint/binding-linux-arm-gnueabihf@1.72.0":
+        resolution:
+            {
+                integrity: sha512-0NDywYgfj279Ou/BcQuCYSj7NJwBfmWn5qc5uGO/Ny7fUWmXyIpvawqX/8acQlWG6IXelJsJhj+JAy6sjsKj0A==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [arm]
+        os: [linux]
+
+    "@oxlint/binding-linux-arm-musleabihf@1.72.0":
+        resolution:
+            {
+                integrity: sha512-4vpXB06h65Ezsy4hRyrGjGrfa1SkVPii09yaajiYhmVpgsFiLD+KNxIx/BNAY+XiO+i1yqp9HHdwqM8VTqa5XQ==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [arm]
+        os: [linux]
+
+    "@oxlint/binding-linux-arm64-gnu@1.72.0":
+        resolution:
+            {
+                integrity: sha512-immaN4g2ZGFiOkKrvRX9LvzZdd2GkQM5wR+UyzYyUuyhUTXGQ4HKUJH18xp4G8OfhCVaVAJfKZxwE1r8+4hhaQ==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [arm64]
+        os: [linux]
+        libc: [glibc]
+
+    "@oxlint/binding-linux-arm64-musl@1.72.0":
+        resolution:
+            {
+                integrity: sha512-JGHS9Mnr7iWyyLDxgCv1MhzVpAckgptg00F2gnxt/GD7lQ2SW1BRcxHqhSTaSdDpjWRrBkBxMMh4+Hn3aVtExg==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [arm64]
+        os: [linux]
+        libc: [musl]
+
+    "@oxlint/binding-linux-ppc64-gnu@1.72.0":
+        resolution:
+            {
+                integrity: sha512-AOYgBZqxNshrg83P9v0RYv+m8s10Cqkj4/PxXFDhcS3k7FqsIG5+CxErshZCIN7G8iy4Y+VGfAsuEdar8AcbBg==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [ppc64]
+        os: [linux]
+        libc: [glibc]
+
+    "@oxlint/binding-linux-riscv64-gnu@1.72.0":
+        resolution:
+            {
+                integrity: sha512-QMybPS5ij3/vrKG67mqzHwW++91sYxK/PPUVi6SBtNCEzW4niS52fVBdXbQ6nou0wWbUPEpx8Sl/ZjtgE3clXA==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [riscv64]
+        os: [linux]
+        libc: [glibc]
+
+    "@oxlint/binding-linux-riscv64-musl@1.72.0":
+        resolution:
+            {
+                integrity: sha512-gOc3W7JV0PXRpIL7stUlLe3Wa9Gp0Kdlup87IT3gHDvPKck2xNgMIl/Gs2lldYY2lyXZDC4rWi3hmoLUobkgbQ==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [riscv64]
+        os: [linux]
+        libc: [musl]
+
+    "@oxlint/binding-linux-s390x-gnu@1.72.0":
+        resolution:
+            {
+                integrity: sha512-rpGxph+FjjHcYI5q6uxB3Az+tnfmEnDbSA8+PK9ZE/VzyUAkvBOMeuY7ZQMhu5mpZH7YQDsTdW6Cx4kV/msc6w==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [s390x]
+        os: [linux]
+        libc: [glibc]
+
+    "@oxlint/binding-linux-x64-gnu@1.72.0":
+        resolution:
+            {
+                integrity: sha512-WND+uhf/Ko13SLqQMWQUgsZuLvYYEvL0ZKgg0tgGYfLqxG7l8Ju123fHDMJyYSDl5E3bUbpFUuii/OvMreFQzw==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [x64]
+        os: [linux]
+        libc: [glibc]
+
+    "@oxlint/binding-linux-x64-musl@1.72.0":
+        resolution:
+            {
+                integrity: sha512-SrpbrUL70nG9vh6zP4/oKHWgLuHquwsr7MW9XOn0olBVgh10Uqr8qscKhQoBGEn6olK/IUpn5GSKcdQ5AjUhGA==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [x64]
+        os: [linux]
+        libc: [musl]
+
+    "@oxlint/binding-openharmony-arm64@1.72.0":
+        resolution:
+            {
+                integrity: sha512-qkrsEn6NmgFKr7U/QnezQMb+q/vzAy0Dd9Y95gQGQTyjzDLN+HRZMuM5u70iyH4nBLCfKBzhjMsYCehKay2jyg==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [arm64]
+        os: [openharmony]
+
+    "@oxlint/binding-win32-arm64-msvc@1.72.0":
+        resolution:
+            {
+                integrity: sha512-LWR6ZlFZph+KPjXv8opgZsXRDCdrdQe8VL8Cg9zxCoBS73h6znzZpydVgmdnwj8mB9AuSM5jxEgDJDpQkjboeg==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [arm64]
+        os: [win32]
+
+    "@oxlint/binding-win32-ia32-msvc@1.72.0":
+        resolution:
+            {
+                integrity: sha512-yt6HEh7IsHvtjRWtmeZRX134eaXKHq5Gnqlf1xBJdJl1JtdoRUEJw3nAxpZoUDS860cX/foKbztO441anVBtVQ==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [ia32]
+        os: [win32]
+
+    "@oxlint/binding-win32-x64-msvc@1.72.0":
+        resolution:
+            {
+                integrity: sha512-b2eKFD2hX7tIwmo/cyH6TDq8vzWRZ2qNHrzoGntUTmq0h3zQh/uX3eTSHCwI8OB/ADQfJCRelLItK8BsxuucDA==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        cpu: [x64]
+        os: [win32]
+
+    "@oxlint/plugins@1.68.0":
+        resolution:
+            {
+                integrity: sha512-titLmukUt/h8ho7Svlf0xSBjoy2ccZKrXjpXpZCj+v6V4CJccC2KyP45BLSCMx8YIpifMyiDyUptM4+5sruKbQ==,
+            }
+        engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
 
     "@pkgjs/parseargs@0.11.0":
         resolution:
@@ -3324,6 +3759,14 @@ packages:
             playwright: "*"
             vitest: 4.0.8
 
+    "@vitest/browser-preview@4.1.9":
+        resolution:
+            {
+                integrity: sha512-a4/OrkMDb/WUnE4OOB/4FJbK3rYVO7YykqtUgcTKG4p2a0R3XcjPVu7SLRHFBs2+NIYhv5yxp1Lz3dbdGBjIow==,
+            }
+        peerDependencies:
+            vitest: 4.1.9
+
     "@vitest/browser@4.0.8":
         resolution:
             {
@@ -3331,6 +3774,14 @@ packages:
             }
         peerDependencies:
             vitest: 4.0.8
+
+    "@vitest/browser@4.1.9":
+        resolution:
+            {
+                integrity: sha512-j1BKtWmPcqpMhmx/L9EPLgAJpCb0zKfwoWLmqBbxaogCXHjOwHFSEoHCBfnGtx93xKQwilZ26m+UOsHqHMkRNg==,
+            }
+        peerDependencies:
+            vitest: 4.1.9
 
     "@vitest/expect@3.2.4":
         resolution:
@@ -3342,6 +3793,12 @@ packages:
         resolution:
             {
                 integrity: sha512-Rv0eabdP/xjAHQGr8cjBm+NnLHNoL268lMDK85w2aAGLFoVKLd8QGnVon5lLtkXQCoYaNL0wg04EGnyKkkKhPA==,
+            }
+
+    "@vitest/expect@4.1.9":
+        resolution:
+            {
+                integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==,
             }
 
     "@vitest/mocker@3.2.4":
@@ -3372,6 +3829,20 @@ packages:
             vite:
                 optional: true
 
+    "@vitest/mocker@4.1.9":
+        resolution:
+            {
+                integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==,
+            }
+        peerDependencies:
+            msw: ^2.4.9
+            vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+        peerDependenciesMeta:
+            msw:
+                optional: true
+            vite:
+                optional: true
+
     "@vitest/pretty-format@3.2.4":
         resolution:
             {
@@ -3384,16 +3855,34 @@ packages:
                 integrity: sha512-qRrjdRkINi9DaZHAimV+8ia9Gq6LeGz2CgIEmMLz3sBDYV53EsnLZbJMR1q84z1HZCMsf7s0orDgZn7ScXsZKg==,
             }
 
+    "@vitest/pretty-format@4.1.9":
+        resolution:
+            {
+                integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==,
+            }
+
     "@vitest/runner@4.0.8":
         resolution:
             {
                 integrity: sha512-mdY8Sf1gsM8hKJUQfiPT3pn1n8RF4QBcJYFslgWh41JTfrK1cbqY8whpGCFzBl45LN028g0njLCYm0d7XxSaQQ==,
             }
 
+    "@vitest/runner@4.1.9":
+        resolution:
+            {
+                integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==,
+            }
+
     "@vitest/snapshot@4.0.8":
         resolution:
             {
                 integrity: sha512-Nar9OTU03KGiubrIOFhcfHg8FYaRaNT+bh5VUlNz8stFhCZPNrJvmZkhsr1jtaYvuefYFwK2Hwrq026u4uPWCw==,
+            }
+
+    "@vitest/snapshot@4.1.9":
+        resolution:
+            {
+                integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==,
             }
 
     "@vitest/spy@3.2.4":
@@ -3406,6 +3895,12 @@ packages:
         resolution:
             {
                 integrity: sha512-nvGVqUunyCgZH7kmo+Ord4WgZ7lN0sOULYXUOYuHr55dvg9YvMz3izfB189Pgp28w0vWFbEEfNc/c3VTrqrXeA==,
+            }
+
+    "@vitest/spy@4.1.9":
+        resolution:
+            {
+                integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==,
             }
 
     "@vitest/ui@4.0.8":
@@ -3427,6 +3922,148 @@ packages:
             {
                 integrity: sha512-pdk2phO5NDvEFfUTxcTP8RFYjVj/kfLSPIN5ebP2Mu9kcIMeAQTbknqcFEyBcC4z2pJlJI9aS5UQjcYfhmKAow==,
             }
+
+    "@vitest/utils@4.1.9":
+        resolution:
+            {
+                integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==,
+            }
+
+    "@voidzero-dev/vite-plus-core@0.2.2":
+        resolution:
+            {
+                integrity: sha512-yAbKexF3npOGjg1N5EtXxun+7vdM/0x6QE5jucO/dv0LFhCAIzSN3UvLVCeamJt/Bz3jt7DLqQHEgXXrjy8drA==,
+            }
+        engines: { node: ^20.19.0 || ^22.18.0 || >=24.11.0 }
+        peerDependencies:
+            "@arethetypeswrong/core": ^0.18.1
+            "@types/node": ^20.19.0 || >=22.12.0
+            "@vitejs/devtools": ^0.3.0
+            esbuild: ^0.27.0 || ^0.28.0
+            jiti: ">=1.21.0"
+            less: ^4.0.0
+            publint: ^0.3.8
+            sass: ^1.70.0
+            sass-embedded: ^1.70.0
+            stylus: ">=0.54.8"
+            sugarss: ^5.0.0
+            terser: ^5.16.0
+            tsx: ^4.8.1
+            typescript: ^5.0.0 || ^6.0.0
+            unplugin-unused: ^0.5.0
+            unrun: "*"
+            yaml: ^2.4.2
+        peerDependenciesMeta:
+            "@arethetypeswrong/core":
+                optional: true
+            "@types/node":
+                optional: true
+            "@vitejs/devtools":
+                optional: true
+            esbuild:
+                optional: true
+            jiti:
+                optional: true
+            less:
+                optional: true
+            publint:
+                optional: true
+            sass:
+                optional: true
+            sass-embedded:
+                optional: true
+            stylus:
+                optional: true
+            sugarss:
+                optional: true
+            terser:
+                optional: true
+            tsx:
+                optional: true
+            typescript:
+                optional: true
+            unplugin-unused:
+                optional: true
+            unrun:
+                optional: true
+            yaml:
+                optional: true
+
+    "@voidzero-dev/vite-plus-darwin-arm64@0.2.2":
+        resolution:
+            {
+                integrity: sha512-Wy0Shx3Waa2cQZGSrPm0cpO1Y5oNyKyC1jarv12bBcgV+4uoEBKX+ep2Nh7zwjfd8Ja4QMiePE7wciOSXxu8oQ==,
+            }
+        engines: { node: ">=20.0.0" }
+        cpu: [arm64]
+        os: [darwin]
+
+    "@voidzero-dev/vite-plus-darwin-x64@0.2.2":
+        resolution:
+            {
+                integrity: sha512-09xcW67OvsQItVPzmF8UckI+glM3DzyQO3A98deNQ4QtUF7Mt+4/cYKKcLKg2ExRWWXGNDnVG/j7/hiLjZzynw==,
+            }
+        engines: { node: ">=20.0.0" }
+        cpu: [x64]
+        os: [darwin]
+
+    "@voidzero-dev/vite-plus-linux-arm64-gnu@0.2.2":
+        resolution:
+            {
+                integrity: sha512-bR6287UFNwulMiQRhbtXF8GYs9a8EjvefXf+Glm7AzbePUXnamW9cwYIj2j4Dgoje0yC4gA52UePEFjXZnJcjA==,
+            }
+        engines: { node: ">=20.0.0" }
+        cpu: [arm64]
+        os: [linux]
+        libc: [glibc]
+
+    "@voidzero-dev/vite-plus-linux-arm64-musl@0.2.2":
+        resolution:
+            {
+                integrity: sha512-YGtvTHT7qP4c5pZmM4kLL78/d8hj2NS150R92cR2SVOW/l9Ilq5R5WrEiMA4k5Ea3B++IJWZT5MRFI0tW9qlcg==,
+            }
+        engines: { node: ">=20.0.0" }
+        cpu: [arm64]
+        os: [linux]
+        libc: [musl]
+
+    "@voidzero-dev/vite-plus-linux-x64-gnu@0.2.2":
+        resolution:
+            {
+                integrity: sha512-FvaMI/vsy4PVM+Qd73K+KM8blfCAfaoZaGaGWNrrlMryhyPThXPnHoB1AQcrKbEAWb+z2fc4zLS4sH+8uI65fw==,
+            }
+        engines: { node: ">=20.0.0" }
+        cpu: [x64]
+        os: [linux]
+        libc: [glibc]
+
+    "@voidzero-dev/vite-plus-linux-x64-musl@0.2.2":
+        resolution:
+            {
+                integrity: sha512-ZsMochHqXqxj2sGTJNJzz3vabppbe4BFgZAjJfsnVzkwR7jv6c5p1BM71LFWxP4qd5LL0TJT7lbeRhALlI44RQ==,
+            }
+        engines: { node: ">=20.0.0" }
+        cpu: [x64]
+        os: [linux]
+        libc: [musl]
+
+    "@voidzero-dev/vite-plus-win32-arm64-msvc@0.2.2":
+        resolution:
+            {
+                integrity: sha512-noBNyJufux0cf18eDpQLOQUZ1Kybfx9zlr+yQ6gAnxMEsQXSvYqZgWymfRDesBE3G/0XB5bg+AUtWijp3TwVcw==,
+            }
+        engines: { node: ">=20.0.0" }
+        cpu: [arm64]
+        os: [win32]
+
+    "@voidzero-dev/vite-plus-win32-x64-msvc@0.2.2":
+        resolution:
+            {
+                integrity: sha512-+VUui1OIaFX0tqdUAXjmoKVlujEtWVdcsFDw2Jff+D6b4LUTQaOMAaaic8nNdfZL6wEjweRREQLZi/icZAXtNQ==,
+            }
+        engines: { node: ">=20.0.0" }
+        cpu: [x64]
+        os: [win32]
 
     accepts@1.3.8:
         resolution:
@@ -4994,6 +5631,13 @@ packages:
             }
         engines: { node: ">= 0.8", npm: 1.2.8000 || >= 1.4.16 }
 
+    detect-libc@2.1.2:
+        resolution:
+            {
+                integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==,
+            }
+        engines: { node: ">=8" }
+
     dir-glob@3.0.1:
         resolution:
             {
@@ -5199,6 +5843,12 @@ packages:
         resolution:
             {
                 integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==,
+            }
+
+    es-module-lexer@2.3.0:
+        resolution:
+            {
+                integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==,
             }
 
     es-object-atoms@1.1.2:
@@ -7162,6 +7812,116 @@ packages:
             }
         engines: { node: ">= 0.8.0" }
 
+    lightningcss-android-arm64@1.32.0:
+        resolution:
+            {
+                integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==,
+            }
+        engines: { node: ">= 12.0.0" }
+        cpu: [arm64]
+        os: [android]
+
+    lightningcss-darwin-arm64@1.32.0:
+        resolution:
+            {
+                integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==,
+            }
+        engines: { node: ">= 12.0.0" }
+        cpu: [arm64]
+        os: [darwin]
+
+    lightningcss-darwin-x64@1.32.0:
+        resolution:
+            {
+                integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==,
+            }
+        engines: { node: ">= 12.0.0" }
+        cpu: [x64]
+        os: [darwin]
+
+    lightningcss-freebsd-x64@1.32.0:
+        resolution:
+            {
+                integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==,
+            }
+        engines: { node: ">= 12.0.0" }
+        cpu: [x64]
+        os: [freebsd]
+
+    lightningcss-linux-arm-gnueabihf@1.32.0:
+        resolution:
+            {
+                integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==,
+            }
+        engines: { node: ">= 12.0.0" }
+        cpu: [arm]
+        os: [linux]
+
+    lightningcss-linux-arm64-gnu@1.32.0:
+        resolution:
+            {
+                integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==,
+            }
+        engines: { node: ">= 12.0.0" }
+        cpu: [arm64]
+        os: [linux]
+        libc: [glibc]
+
+    lightningcss-linux-arm64-musl@1.32.0:
+        resolution:
+            {
+                integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==,
+            }
+        engines: { node: ">= 12.0.0" }
+        cpu: [arm64]
+        os: [linux]
+        libc: [musl]
+
+    lightningcss-linux-x64-gnu@1.32.0:
+        resolution:
+            {
+                integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==,
+            }
+        engines: { node: ">= 12.0.0" }
+        cpu: [x64]
+        os: [linux]
+        libc: [glibc]
+
+    lightningcss-linux-x64-musl@1.32.0:
+        resolution:
+            {
+                integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==,
+            }
+        engines: { node: ">= 12.0.0" }
+        cpu: [x64]
+        os: [linux]
+        libc: [musl]
+
+    lightningcss-win32-arm64-msvc@1.32.0:
+        resolution:
+            {
+                integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==,
+            }
+        engines: { node: ">= 12.0.0" }
+        cpu: [arm64]
+        os: [win32]
+
+    lightningcss-win32-x64-msvc@1.32.0:
+        resolution:
+            {
+                integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==,
+            }
+        engines: { node: ">= 12.0.0" }
+        cpu: [x64]
+        os: [win32]
+
+    lightningcss@1.32.0:
+        resolution:
+            {
+                integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==,
+            }
+        engines: { node: ">= 12.0.0" }
+
     lilconfig@3.1.3:
         resolution:
             {
@@ -7895,6 +8655,13 @@ packages:
             }
         engines: { node: ">= 0.4" }
 
+    obug@2.1.3:
+        resolution:
+            {
+                integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==,
+            }
+        engines: { node: ">=12.20.0" }
+
     on-finished@2.4.1:
         resolution:
             {
@@ -7963,6 +8730,45 @@ packages:
                 integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==,
             }
         engines: { node: ">= 0.4" }
+
+    oxfmt@0.57.0:
+        resolution:
+            {
+                integrity: sha512-ZB7Bi+rGDSqmVIo9jwcLyFgjxXvQhDdU+jx+ZrVy6VRiVXK2+CHc4hO3J4dUQjHe7V0ymHB+MDuv5z+NhK07HA==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        hasBin: true
+        peerDependencies:
+            svelte: ^5.0.0
+            vite-plus: "*"
+        peerDependenciesMeta:
+            svelte:
+                optional: true
+            vite-plus:
+                optional: true
+
+    oxlint-tsgolint@0.24.0:
+        resolution:
+            {
+                integrity: sha512-giCk5sEvG02d5tzPmFMX3hem8ndzEEu1xvGYS5OwNfO2WGl6ZVxt5LjE0yiMDoz94INI7XkXwgFAQiydPvVHDw==,
+            }
+        hasBin: true
+
+    oxlint@1.72.0:
+        resolution:
+            {
+                integrity: sha512-1rhdZIP/EvoI91ABIwNU5Q8+bWf8mjrS5UzIOZld4d4bXxJvtlUhlQvaoTogIGin/qdErMOrwaIJvCSIAKTLhA==,
+            }
+        engines: { node: ^20.19.0 || >=22.12.0 }
+        hasBin: true
+        peerDependencies:
+            oxlint-tsgolint: ">=0.22.1"
+            vite-plus: "*"
+        peerDependenciesMeta:
+            oxlint-tsgolint:
+                optional: true
+            vite-plus:
+                optional: true
 
     p-limit@3.1.0:
         resolution:
@@ -9698,6 +10504,12 @@ packages:
                 integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==,
             }
 
+    std-env@4.1.0:
+        resolution:
+            {
+                integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==,
+            }
+
     stop-iteration-iterator@1.1.0:
         resolution:
             {
@@ -10002,12 +10814,26 @@ packages:
                 integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==,
             }
 
+    tinyexec@1.2.4:
+        resolution:
+            {
+                integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==,
+            }
+        engines: { node: ">=18" }
+
     tinyglobby@0.2.17:
         resolution:
             {
                 integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==,
             }
         engines: { node: ">=12.0.0" }
+
+    tinypool@2.1.0:
+        resolution:
+            {
+                integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==,
+            }
+        engines: { node: ^20.0.0 || >=22.0.0 }
 
     tinyrainbow@2.0.0:
         resolution:
@@ -10497,6 +11323,22 @@ packages:
         peerDependencies:
             vite: ^5.0.0 || ^6.0.0 || ^7.0.0
 
+    vite-plus@0.2.2:
+        resolution:
+            {
+                integrity: sha512-bXO3O0F2/uxtvX9Ck0o67stTErH/Zh0GEcCMd9pAh22tTHABCNTDPrRMWVo733e7Ux3h0Y7HanJ7neOV/nid4g==,
+            }
+        engines: { node: ^20.19.0 || ^22.18.0 || >=24.11.0 }
+        hasBin: true
+        peerDependencies:
+            "@vitest/browser-playwright": 4.1.9
+            "@vitest/browser-webdriverio": 4.1.9
+        peerDependenciesMeta:
+            "@vitest/browser-playwright":
+                optional: true
+            "@vitest/browser-webdriverio":
+                optional: true
+
     vite@7.1.5:
         resolution:
             {
@@ -10569,6 +11411,50 @@ packages:
             "@vitest/browser-preview":
                 optional: true
             "@vitest/browser-webdriverio":
+                optional: true
+            "@vitest/ui":
+                optional: true
+            happy-dom:
+                optional: true
+            jsdom:
+                optional: true
+
+    vitest@4.1.9:
+        resolution:
+            {
+                integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==,
+            }
+        engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
+        hasBin: true
+        peerDependencies:
+            "@edge-runtime/vm": "*"
+            "@opentelemetry/api": ^1.9.0
+            "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
+            "@vitest/browser-playwright": 4.1.9
+            "@vitest/browser-preview": 4.1.9
+            "@vitest/browser-webdriverio": 4.1.9
+            "@vitest/coverage-istanbul": 4.1.9
+            "@vitest/coverage-v8": 4.1.9
+            "@vitest/ui": 4.1.9
+            happy-dom: "*"
+            jsdom: "*"
+            vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+        peerDependenciesMeta:
+            "@edge-runtime/vm":
+                optional: true
+            "@opentelemetry/api":
+                optional: true
+            "@types/node":
+                optional: true
+            "@vitest/browser-playwright":
+                optional: true
+            "@vitest/browser-preview":
+                optional: true
+            "@vitest/browser-webdriverio":
+                optional: true
+            "@vitest/coverage-istanbul":
+                optional: true
+            "@vitest/coverage-v8":
                 optional: true
             "@vitest/ui":
                 optional: true
@@ -11684,13 +12570,15 @@ snapshots:
 
     "@blakeembrey/template@1.2.0": {}
 
-    "@chromatic-com/storybook@4.1.2(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)))":
+    "@blazediff/core@1.9.1": {}
+
+    "@chromatic-com/storybook@4.1.2(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)))":
         dependencies:
             "@neoconfetti/react": 1.0.0
             chromatic: 12.2.0
             filesize: 10.1.6
             jsonfile: 6.2.1
-            storybook: 10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))
+            storybook: 10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
             strip-ansi: 7.2.0
         transitivePeerDependencies:
             - "@chromatic-com/cypress"
@@ -12034,12 +12922,12 @@ snapshots:
 
     "@isaacs/cliui@9.0.0": {}
 
-    "@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@6.0.3)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))":
+    "@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@6.0.3)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))":
         dependencies:
             glob: 10.5.0
             magic-string: 0.30.21
             react-docgen-typescript: 2.4.0(typescript@6.0.3)
-            vite: 7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)
+            vite: 7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)
         optionalDependencies:
             typescript: 6.0.3
 
@@ -12309,6 +13197,144 @@ snapshots:
             "@nodelib/fs.scandir": 2.1.5
             fastq: 1.20.1
 
+    "@oxc-project/runtime@0.138.0": {}
+
+    "@oxc-project/types@0.138.0": {}
+
+    "@oxfmt/binding-android-arm-eabi@0.57.0":
+        optional: true
+
+    "@oxfmt/binding-android-arm64@0.57.0":
+        optional: true
+
+    "@oxfmt/binding-darwin-arm64@0.57.0":
+        optional: true
+
+    "@oxfmt/binding-darwin-x64@0.57.0":
+        optional: true
+
+    "@oxfmt/binding-freebsd-x64@0.57.0":
+        optional: true
+
+    "@oxfmt/binding-linux-arm-gnueabihf@0.57.0":
+        optional: true
+
+    "@oxfmt/binding-linux-arm-musleabihf@0.57.0":
+        optional: true
+
+    "@oxfmt/binding-linux-arm64-gnu@0.57.0":
+        optional: true
+
+    "@oxfmt/binding-linux-arm64-musl@0.57.0":
+        optional: true
+
+    "@oxfmt/binding-linux-ppc64-gnu@0.57.0":
+        optional: true
+
+    "@oxfmt/binding-linux-riscv64-gnu@0.57.0":
+        optional: true
+
+    "@oxfmt/binding-linux-riscv64-musl@0.57.0":
+        optional: true
+
+    "@oxfmt/binding-linux-s390x-gnu@0.57.0":
+        optional: true
+
+    "@oxfmt/binding-linux-x64-gnu@0.57.0":
+        optional: true
+
+    "@oxfmt/binding-linux-x64-musl@0.57.0":
+        optional: true
+
+    "@oxfmt/binding-openharmony-arm64@0.57.0":
+        optional: true
+
+    "@oxfmt/binding-win32-arm64-msvc@0.57.0":
+        optional: true
+
+    "@oxfmt/binding-win32-ia32-msvc@0.57.0":
+        optional: true
+
+    "@oxfmt/binding-win32-x64-msvc@0.57.0":
+        optional: true
+
+    "@oxlint-tsgolint/darwin-arm64@0.24.0":
+        optional: true
+
+    "@oxlint-tsgolint/darwin-x64@0.24.0":
+        optional: true
+
+    "@oxlint-tsgolint/linux-arm64@0.24.0":
+        optional: true
+
+    "@oxlint-tsgolint/linux-x64@0.24.0":
+        optional: true
+
+    "@oxlint-tsgolint/win32-arm64@0.24.0":
+        optional: true
+
+    "@oxlint-tsgolint/win32-x64@0.24.0":
+        optional: true
+
+    "@oxlint/binding-android-arm-eabi@1.72.0":
+        optional: true
+
+    "@oxlint/binding-android-arm64@1.72.0":
+        optional: true
+
+    "@oxlint/binding-darwin-arm64@1.72.0":
+        optional: true
+
+    "@oxlint/binding-darwin-x64@1.72.0":
+        optional: true
+
+    "@oxlint/binding-freebsd-x64@1.72.0":
+        optional: true
+
+    "@oxlint/binding-linux-arm-gnueabihf@1.72.0":
+        optional: true
+
+    "@oxlint/binding-linux-arm-musleabihf@1.72.0":
+        optional: true
+
+    "@oxlint/binding-linux-arm64-gnu@1.72.0":
+        optional: true
+
+    "@oxlint/binding-linux-arm64-musl@1.72.0":
+        optional: true
+
+    "@oxlint/binding-linux-ppc64-gnu@1.72.0":
+        optional: true
+
+    "@oxlint/binding-linux-riscv64-gnu@1.72.0":
+        optional: true
+
+    "@oxlint/binding-linux-riscv64-musl@1.72.0":
+        optional: true
+
+    "@oxlint/binding-linux-s390x-gnu@1.72.0":
+        optional: true
+
+    "@oxlint/binding-linux-x64-gnu@1.72.0":
+        optional: true
+
+    "@oxlint/binding-linux-x64-musl@1.72.0":
+        optional: true
+
+    "@oxlint/binding-openharmony-arm64@1.72.0":
+        optional: true
+
+    "@oxlint/binding-win32-arm64-msvc@1.72.0":
+        optional: true
+
+    "@oxlint/binding-win32-ia32-msvc@1.72.0":
+        optional: true
+
+    "@oxlint/binding-win32-x64-msvc@1.72.0":
+        optional: true
+
+    "@oxlint/plugins@1.68.0": {}
+
     "@pkgjs/parseargs@0.11.0":
         optional: true
 
@@ -12479,21 +13505,21 @@ snapshots:
 
     "@standard-schema/spec@1.1.0": {}
 
-    "@storybook/addon-a11y@10.0.2(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)))":
+    "@storybook/addon-a11y@10.0.2(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)))":
         dependencies:
             "@storybook/global": 5.0.0
             axe-core: 4.12.1
-            storybook: 10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))
+            storybook: 10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
 
-    "@storybook/addon-docs@10.0.2(@types/react@18.3.31)(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)))(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))":
+    "@storybook/addon-docs@10.0.2(@types/react@18.3.31)(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)))(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))":
         dependencies:
             "@mdx-js/react": 3.1.1(@types/react@18.3.31)(react@18.3.1)
-            "@storybook/csf-plugin": 10.0.2(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)))(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))
+            "@storybook/csf-plugin": 10.0.2(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)))(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
             "@storybook/icons": 1.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-            "@storybook/react-dom-shim": 10.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)))
+            "@storybook/react-dom-shim": 10.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)))
             react: 18.3.1
             react-dom: 18.3.1(react@18.3.1)
-            storybook: 10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))
+            storybook: 10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
             ts-dedent: 2.3.0
         transitivePeerDependencies:
             - "@types/react"
@@ -12502,25 +13528,25 @@ snapshots:
             - vite
             - webpack
 
-    "@storybook/builder-vite@10.0.2(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)))(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))":
+    "@storybook/builder-vite@10.0.2(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)))(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))":
         dependencies:
-            "@storybook/csf-plugin": 10.0.2(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)))(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))
-            storybook: 10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))
+            "@storybook/csf-plugin": 10.0.2(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)))(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
+            storybook: 10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
             ts-dedent: 2.3.0
-            vite: 7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)
+            vite: 7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)
         transitivePeerDependencies:
             - esbuild
             - rollup
             - webpack
 
-    "@storybook/csf-plugin@10.0.2(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)))(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))":
+    "@storybook/csf-plugin@10.0.2(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)))(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))":
         dependencies:
-            storybook: 10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))
+            storybook: 10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
             unplugin: 2.3.11
         optionalDependencies:
             esbuild: 0.25.12
             rollup: 4.62.2
-            vite: 7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)
+            vite: 7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)
 
     "@storybook/global@5.0.0": {}
 
@@ -12529,27 +13555,27 @@ snapshots:
             react: 18.3.1
             react-dom: 18.3.1(react@18.3.1)
 
-    "@storybook/react-dom-shim@10.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)))":
+    "@storybook/react-dom-shim@10.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)))":
         dependencies:
             react: 18.3.1
             react-dom: 18.3.1(react@18.3.1)
-            storybook: 10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))
+            storybook: 10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
 
-    "@storybook/react-vite@10.0.2(esbuild@0.25.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.62.2)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)))(typescript@6.0.3)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))":
+    "@storybook/react-vite@10.0.2(esbuild@0.25.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.62.2)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)))(typescript@6.0.3)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))":
         dependencies:
-            "@joshwooding/vite-plugin-react-docgen-typescript": 0.6.1(typescript@6.0.3)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))
+            "@joshwooding/vite-plugin-react-docgen-typescript": 0.6.1(typescript@6.0.3)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
             "@rollup/pluginutils": 5.4.0(rollup@4.62.2)
-            "@storybook/builder-vite": 10.0.2(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)))(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))
-            "@storybook/react": 10.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)))(typescript@6.0.3)
+            "@storybook/builder-vite": 10.0.2(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)))(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
+            "@storybook/react": 10.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)))(typescript@6.0.3)
             empathic: 2.0.1
             magic-string: 0.30.21
             react: 18.3.1
             react-docgen: 8.0.3
             react-dom: 18.3.1(react@18.3.1)
             resolve: 1.22.12
-            storybook: 10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))
+            storybook: 10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
             tsconfig-paths: 4.2.0
-            vite: 7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)
+            vite: 7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)
         transitivePeerDependencies:
             - esbuild
             - rollup
@@ -12557,13 +13583,13 @@ snapshots:
             - typescript
             - webpack
 
-    "@storybook/react@10.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)))(typescript@6.0.3)":
+    "@storybook/react@10.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)))(typescript@6.0.3)":
         dependencies:
             "@storybook/global": 5.0.0
-            "@storybook/react-dom-shim": 10.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)))
+            "@storybook/react-dom-shim": 10.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)))
             react: 18.3.1
             react-dom: 18.3.1(react@18.3.1)
-            storybook: 10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))
+            storybook: 10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
         optionalDependencies:
             typescript: 6.0.3
 
@@ -12918,7 +13944,7 @@ snapshots:
         dependencies:
             react: 18.3.1
 
-    "@vitejs/plugin-react@5.0.4(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))":
+    "@vitejs/plugin-react@5.0.4(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))":
         dependencies:
             "@babel/core": 7.29.7
             "@babel/plugin-transform-react-jsx-self": 7.29.7(@babel/core@7.29.7)
@@ -12926,33 +13952,79 @@ snapshots:
             "@rolldown/pluginutils": 1.0.0-beta.38
             "@types/babel__core": 7.20.5
             react-refresh: 0.17.0
-            vite: 7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)
+            vite: 7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)
         transitivePeerDependencies:
             - supports-color
 
-    "@vitest/browser-playwright@4.0.8(playwright@1.56.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))(vitest@4.0.8)":
+    "@vitest/browser-playwright@4.0.8(playwright@1.56.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))(vitest@4.0.8)":
         dependencies:
-            "@vitest/browser": 4.0.8(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))(vitest@4.0.8)
-            "@vitest/mocker": 4.0.8(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))
+            "@vitest/browser": 4.0.8(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))(vitest@4.0.8)
+            "@vitest/mocker": 4.0.8(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
             playwright: 1.56.1
             tinyrainbow: 3.1.0
-            vitest: 4.0.8(@types/node@22.9.0)(@vitest/browser-playwright@4.0.8)(@vitest/ui@4.0.8)(jsdom@26.1.0(supports-color@5.5.0))(less@3.13.1)(supports-color@5.5.0)(yaml@2.9.0)
+            vitest: 4.0.8(@types/node@22.9.0)(@vitest/browser-playwright@4.0.8)(@vitest/browser-preview@4.1.9)(@vitest/ui@4.0.8)(jsdom@26.1.0(supports-color@5.5.0))(less@3.13.1)(lightningcss@1.32.0)(supports-color@5.5.0)(yaml@2.9.0)
         transitivePeerDependencies:
             - bufferutil
             - msw
             - utf-8-validate
             - vite
 
-    "@vitest/browser@4.0.8(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))(vitest@4.0.8)":
+    "@vitest/browser-preview@4.1.9(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))(vitest@4.0.8)":
         dependencies:
-            "@vitest/mocker": 4.0.8(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))
+            "@testing-library/dom": 10.4.1
+            "@testing-library/user-event": 14.6.1(@testing-library/dom@10.4.1)
+            "@vitest/browser": 4.1.9(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))(vitest@4.0.8)
+            vitest: 4.0.8(@types/node@22.9.0)(@vitest/browser-playwright@4.0.8)(@vitest/browser-preview@4.1.9)(@vitest/ui@4.0.8)(jsdom@26.1.0(supports-color@5.5.0))(less@3.13.1)(lightningcss@1.32.0)(supports-color@5.5.0)(yaml@2.9.0)
+        transitivePeerDependencies:
+            - bufferutil
+            - msw
+            - utf-8-validate
+            - vite
+
+    "@vitest/browser@4.0.8(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))(vitest@4.0.8)":
+        dependencies:
+            "@vitest/mocker": 4.0.8(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
             "@vitest/utils": 4.0.8
             magic-string: 0.30.21
             pixelmatch: 7.1.0
             pngjs: 7.0.0
             sirv: 3.0.2
             tinyrainbow: 3.1.0
-            vitest: 4.0.8(@types/node@22.9.0)(@vitest/browser-playwright@4.0.8)(@vitest/ui@4.0.8)(jsdom@26.1.0(supports-color@5.5.0))(less@3.13.1)(supports-color@5.5.0)(yaml@2.9.0)
+            vitest: 4.0.8(@types/node@22.9.0)(@vitest/browser-playwright@4.0.8)(@vitest/browser-preview@4.1.9)(@vitest/ui@4.0.8)(jsdom@26.1.0(supports-color@5.5.0))(less@3.13.1)(lightningcss@1.32.0)(supports-color@5.5.0)(yaml@2.9.0)
+            ws: 8.21.0
+        transitivePeerDependencies:
+            - bufferutil
+            - msw
+            - utf-8-validate
+            - vite
+
+    "@vitest/browser@4.1.9(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))(vitest@4.0.8)":
+        dependencies:
+            "@blazediff/core": 1.9.1
+            "@vitest/mocker": 4.1.9(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
+            "@vitest/utils": 4.1.9
+            magic-string: 0.30.21
+            pngjs: 7.0.0
+            sirv: 3.0.2
+            tinyrainbow: 3.1.0
+            vitest: 4.0.8(@types/node@22.9.0)(@vitest/browser-playwright@4.0.8)(@vitest/browser-preview@4.1.9)(@vitest/ui@4.0.8)(jsdom@26.1.0(supports-color@5.5.0))(less@3.13.1)(lightningcss@1.32.0)(supports-color@5.5.0)(yaml@2.9.0)
+            ws: 8.21.0
+        transitivePeerDependencies:
+            - bufferutil
+            - msw
+            - utf-8-validate
+            - vite
+
+    "@vitest/browser@4.1.9(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))(vitest@4.1.9)":
+        dependencies:
+            "@blazediff/core": 1.9.1
+            "@vitest/mocker": 4.1.9(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
+            "@vitest/utils": 4.1.9
+            magic-string: 0.30.21
+            pngjs: 7.0.0
+            sirv: 3.0.2
+            tinyrainbow: 3.1.0
+            vitest: 4.1.9(@types/node@22.9.0)(@vitest/browser-playwright@4.0.8)(@vitest/browser-preview@4.1.9)(@vitest/ui@4.0.8)(jsdom@26.1.0(supports-color@5.5.0))(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
             ws: 8.21.0
         transitivePeerDependencies:
             - bufferutil
@@ -12977,21 +14049,38 @@ snapshots:
             chai: 6.2.2
             tinyrainbow: 3.1.0
 
-    "@vitest/mocker@3.2.4(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))":
+    "@vitest/expect@4.1.9":
+        dependencies:
+            "@standard-schema/spec": 1.1.0
+            "@types/chai": 5.2.3
+            "@vitest/spy": 4.1.9
+            "@vitest/utils": 4.1.9
+            chai: 6.2.2
+            tinyrainbow: 3.1.0
+
+    "@vitest/mocker@3.2.4(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))":
         dependencies:
             "@vitest/spy": 3.2.4
             estree-walker: 3.0.3
             magic-string: 0.30.21
         optionalDependencies:
-            vite: 7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)
+            vite: 7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)
 
-    "@vitest/mocker@4.0.8(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))":
+    "@vitest/mocker@4.0.8(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))":
         dependencies:
             "@vitest/spy": 4.0.8
             estree-walker: 3.0.3
             magic-string: 0.30.21
         optionalDependencies:
-            vite: 7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)
+            vite: 7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)
+
+    "@vitest/mocker@4.1.9(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))":
+        dependencies:
+            "@vitest/spy": 4.1.9
+            estree-walker: 3.0.3
+            magic-string: 0.30.21
+        optionalDependencies:
+            vite: 7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)
 
     "@vitest/pretty-format@3.2.4":
         dependencies:
@@ -13001,9 +14090,18 @@ snapshots:
         dependencies:
             tinyrainbow: 3.1.0
 
+    "@vitest/pretty-format@4.1.9":
+        dependencies:
+            tinyrainbow: 3.1.0
+
     "@vitest/runner@4.0.8":
         dependencies:
             "@vitest/utils": 4.0.8
+            pathe: 2.0.3
+
+    "@vitest/runner@4.1.9":
+        dependencies:
+            "@vitest/utils": 4.1.9
             pathe: 2.0.3
 
     "@vitest/snapshot@4.0.8":
@@ -13012,11 +14110,20 @@ snapshots:
             magic-string: 0.30.21
             pathe: 2.0.3
 
+    "@vitest/snapshot@4.1.9":
+        dependencies:
+            "@vitest/pretty-format": 4.1.9
+            "@vitest/utils": 4.1.9
+            magic-string: 0.30.21
+            pathe: 2.0.3
+
     "@vitest/spy@3.2.4":
         dependencies:
             tinyspy: 4.0.4
 
     "@vitest/spy@4.0.8": {}
+
+    "@vitest/spy@4.1.9": {}
 
     "@vitest/ui@4.0.8(vitest@4.0.8)":
         dependencies:
@@ -13027,7 +14134,7 @@ snapshots:
             sirv: 3.0.2
             tinyglobby: 0.2.17
             tinyrainbow: 3.1.0
-            vitest: 4.0.8(@types/node@22.9.0)(@vitest/browser-playwright@4.0.8)(@vitest/ui@4.0.8)(jsdom@26.1.0(supports-color@5.5.0))(less@3.13.1)(supports-color@5.5.0)(yaml@2.9.0)
+            vitest: 4.0.8(@types/node@22.9.0)(@vitest/browser-playwright@4.0.8)(@vitest/browser-preview@4.1.9)(@vitest/ui@4.0.8)(jsdom@26.1.0(supports-color@5.5.0))(less@3.13.1)(lightningcss@1.32.0)(supports-color@5.5.0)(yaml@2.9.0)
 
     "@vitest/utils@3.2.4":
         dependencies:
@@ -13039,6 +14146,49 @@ snapshots:
         dependencies:
             "@vitest/pretty-format": 4.0.8
             tinyrainbow: 3.1.0
+
+    "@vitest/utils@4.1.9":
+        dependencies:
+            "@vitest/pretty-format": 4.1.9
+            convert-source-map: 2.0.0
+            tinyrainbow: 3.1.0
+
+    "@voidzero-dev/vite-plus-core@0.2.2(@types/node@22.9.0)(less@3.13.1)(typescript@6.0.3)(yaml@2.9.0)":
+        dependencies:
+            "@oxc-project/runtime": 0.138.0
+            "@oxc-project/types": 0.138.0
+            lightningcss: 1.32.0
+            postcss: 8.5.15
+        optionalDependencies:
+            "@types/node": 22.9.0
+            fsevents: 2.3.3
+            less: 3.13.1
+            typescript: 6.0.3
+            yaml: 2.9.0
+
+    "@voidzero-dev/vite-plus-darwin-arm64@0.2.2":
+        optional: true
+
+    "@voidzero-dev/vite-plus-darwin-x64@0.2.2":
+        optional: true
+
+    "@voidzero-dev/vite-plus-linux-arm64-gnu@0.2.2":
+        optional: true
+
+    "@voidzero-dev/vite-plus-linux-arm64-musl@0.2.2":
+        optional: true
+
+    "@voidzero-dev/vite-plus-linux-x64-gnu@0.2.2":
+        optional: true
+
+    "@voidzero-dev/vite-plus-linux-x64-musl@0.2.2":
+        optional: true
+
+    "@voidzero-dev/vite-plus-win32-arm64-msvc@0.2.2":
+        optional: true
+
+    "@voidzero-dev/vite-plus-win32-x64-msvc@0.2.2":
+        optional: true
 
     accepts@1.3.8:
         dependencies:
@@ -14018,6 +15168,8 @@ snapshots:
 
     destroy@1.2.0: {}
 
+    detect-libc@2.1.2: {}
+
     dir-glob@3.0.1:
         dependencies:
             path-type: 4.0.0
@@ -14183,6 +15335,8 @@ snapshots:
 
     es-module-lexer@1.7.0: {}
 
+    es-module-lexer@2.3.0: {}
+
     es-object-atoms@1.1.2:
         dependencies:
             es-errors: 1.3.0
@@ -14282,11 +15436,11 @@ snapshots:
             string.prototype.matchall: 4.0.12
             string.prototype.repeat: 1.0.0
 
-    eslint-plugin-storybook@10.0.2(eslint@9.33.0(supports-color@5.5.0))(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)))(supports-color@5.5.0)(typescript@6.0.3):
+    eslint-plugin-storybook@10.0.2(eslint@9.33.0(supports-color@5.5.0))(storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)))(supports-color@5.5.0)(typescript@6.0.3):
         dependencies:
             "@typescript-eslint/utils": 8.61.1(eslint@9.33.0(supports-color@5.5.0))(supports-color@5.5.0)(typescript@6.0.3)
             eslint: 9.33.0(supports-color@5.5.0)
-            storybook: 10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))
+            storybook: 10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
         transitivePeerDependencies:
             - supports-color
             - typescript
@@ -15484,6 +16638,55 @@ snapshots:
             prelude-ls: 1.2.1
             type-check: 0.4.0
 
+    lightningcss-android-arm64@1.32.0:
+        optional: true
+
+    lightningcss-darwin-arm64@1.32.0:
+        optional: true
+
+    lightningcss-darwin-x64@1.32.0:
+        optional: true
+
+    lightningcss-freebsd-x64@1.32.0:
+        optional: true
+
+    lightningcss-linux-arm-gnueabihf@1.32.0:
+        optional: true
+
+    lightningcss-linux-arm64-gnu@1.32.0:
+        optional: true
+
+    lightningcss-linux-arm64-musl@1.32.0:
+        optional: true
+
+    lightningcss-linux-x64-gnu@1.32.0:
+        optional: true
+
+    lightningcss-linux-x64-musl@1.32.0:
+        optional: true
+
+    lightningcss-win32-arm64-msvc@1.32.0:
+        optional: true
+
+    lightningcss-win32-x64-msvc@1.32.0:
+        optional: true
+
+    lightningcss@1.32.0:
+        dependencies:
+            detect-libc: 2.1.2
+        optionalDependencies:
+            lightningcss-android-arm64: 1.32.0
+            lightningcss-darwin-arm64: 1.32.0
+            lightningcss-darwin-x64: 1.32.0
+            lightningcss-freebsd-x64: 1.32.0
+            lightningcss-linux-arm-gnueabihf: 1.32.0
+            lightningcss-linux-arm64-gnu: 1.32.0
+            lightningcss-linux-arm64-musl: 1.32.0
+            lightningcss-linux-x64-gnu: 1.32.0
+            lightningcss-linux-x64-musl: 1.32.0
+            lightningcss-win32-arm64-msvc: 1.32.0
+            lightningcss-win32-x64-msvc: 1.32.0
+
     lilconfig@3.1.3: {}
 
     line-height@0.3.1:
@@ -15911,6 +17114,8 @@ snapshots:
             define-properties: 1.2.1
             es-object-atoms: 1.1.2
 
+    obug@2.1.3: {}
+
     on-finished@2.4.1:
         dependencies:
             ee-first: 1.1.1
@@ -15959,6 +17164,64 @@ snapshots:
             get-intrinsic: 1.3.0
             object-keys: 1.1.1
             safe-push-apply: 1.0.0
+
+    oxfmt@0.57.0(vite-plus@0.2.2(@types/node@22.9.0)(@vitest/browser-playwright@4.0.8)(@vitest/ui@4.0.8)(jsdom@26.1.0(supports-color@5.5.0))(less@3.13.1)(typescript@6.0.3)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)):
+        dependencies:
+            tinypool: 2.1.0
+        optionalDependencies:
+            "@oxfmt/binding-android-arm-eabi": 0.57.0
+            "@oxfmt/binding-android-arm64": 0.57.0
+            "@oxfmt/binding-darwin-arm64": 0.57.0
+            "@oxfmt/binding-darwin-x64": 0.57.0
+            "@oxfmt/binding-freebsd-x64": 0.57.0
+            "@oxfmt/binding-linux-arm-gnueabihf": 0.57.0
+            "@oxfmt/binding-linux-arm-musleabihf": 0.57.0
+            "@oxfmt/binding-linux-arm64-gnu": 0.57.0
+            "@oxfmt/binding-linux-arm64-musl": 0.57.0
+            "@oxfmt/binding-linux-ppc64-gnu": 0.57.0
+            "@oxfmt/binding-linux-riscv64-gnu": 0.57.0
+            "@oxfmt/binding-linux-riscv64-musl": 0.57.0
+            "@oxfmt/binding-linux-s390x-gnu": 0.57.0
+            "@oxfmt/binding-linux-x64-gnu": 0.57.0
+            "@oxfmt/binding-linux-x64-musl": 0.57.0
+            "@oxfmt/binding-openharmony-arm64": 0.57.0
+            "@oxfmt/binding-win32-arm64-msvc": 0.57.0
+            "@oxfmt/binding-win32-ia32-msvc": 0.57.0
+            "@oxfmt/binding-win32-x64-msvc": 0.57.0
+            vite-plus: 0.2.2(@types/node@22.9.0)(@vitest/browser-playwright@4.0.8)(@vitest/ui@4.0.8)(jsdom@26.1.0(supports-color@5.5.0))(less@3.13.1)(typescript@6.0.3)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)
+
+    oxlint-tsgolint@0.24.0:
+        optionalDependencies:
+            "@oxlint-tsgolint/darwin-arm64": 0.24.0
+            "@oxlint-tsgolint/darwin-x64": 0.24.0
+            "@oxlint-tsgolint/linux-arm64": 0.24.0
+            "@oxlint-tsgolint/linux-x64": 0.24.0
+            "@oxlint-tsgolint/win32-arm64": 0.24.0
+            "@oxlint-tsgolint/win32-x64": 0.24.0
+
+    oxlint@1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.2(@types/node@22.9.0)(@vitest/browser-playwright@4.0.8)(@vitest/ui@4.0.8)(jsdom@26.1.0(supports-color@5.5.0))(less@3.13.1)(typescript@6.0.3)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)):
+        optionalDependencies:
+            "@oxlint/binding-android-arm-eabi": 1.72.0
+            "@oxlint/binding-android-arm64": 1.72.0
+            "@oxlint/binding-darwin-arm64": 1.72.0
+            "@oxlint/binding-darwin-x64": 1.72.0
+            "@oxlint/binding-freebsd-x64": 1.72.0
+            "@oxlint/binding-linux-arm-gnueabihf": 1.72.0
+            "@oxlint/binding-linux-arm-musleabihf": 1.72.0
+            "@oxlint/binding-linux-arm64-gnu": 1.72.0
+            "@oxlint/binding-linux-arm64-musl": 1.72.0
+            "@oxlint/binding-linux-ppc64-gnu": 1.72.0
+            "@oxlint/binding-linux-riscv64-gnu": 1.72.0
+            "@oxlint/binding-linux-riscv64-musl": 1.72.0
+            "@oxlint/binding-linux-s390x-gnu": 1.72.0
+            "@oxlint/binding-linux-x64-gnu": 1.72.0
+            "@oxlint/binding-linux-x64-musl": 1.72.0
+            "@oxlint/binding-openharmony-arm64": 1.72.0
+            "@oxlint/binding-win32-arm64-msvc": 1.72.0
+            "@oxlint/binding-win32-ia32-msvc": 1.72.0
+            "@oxlint/binding-win32-x64-msvc": 1.72.0
+            oxlint-tsgolint: 0.24.0
+            vite-plus: 0.2.2(@types/node@22.9.0)(@vitest/browser-playwright@4.0.8)(@vitest/ui@4.0.8)(jsdom@26.1.0(supports-color@5.5.0))(less@3.13.1)(typescript@6.0.3)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0)
 
     p-limit@3.1.0:
         dependencies:
@@ -17174,19 +18437,21 @@ snapshots:
 
     std-env@3.10.0: {}
 
+    std-env@4.1.0: {}
+
     stop-iteration-iterator@1.1.0:
         dependencies:
             es-errors: 1.3.0
             internal-slot: 1.1.0
 
-    storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)):
+    storybook@10.0.2(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)):
         dependencies:
             "@storybook/global": 5.0.0
             "@storybook/icons": 1.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
             "@testing-library/jest-dom": 6.8.0
             "@testing-library/user-event": 14.6.1(@testing-library/dom@10.4.1)
             "@vitest/expect": 3.2.4
-            "@vitest/mocker": 3.2.4(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))
+            "@vitest/mocker": 3.2.4(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
             "@vitest/spy": 3.2.4
             esbuild: 0.25.12
             recast: 0.23.11
@@ -17381,10 +18646,14 @@ snapshots:
 
     tinyexec@0.3.2: {}
 
+    tinyexec@1.2.4: {}
+
     tinyglobby@0.2.17:
         dependencies:
             fdir: 6.5.0(picomatch@4.0.4)
             picomatch: 4.0.4
+
+    tinypool@2.1.0: {}
 
     tinyrainbow@2.0.0: {}
 
@@ -17655,16 +18924,75 @@ snapshots:
             picocolors: 1.1.1
             pug: 3.0.4
 
-    vite-plugin-static-copy@3.1.3(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)):
+    vite-plugin-static-copy@3.1.3(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)):
         dependencies:
             chokidar: 3.6.0
             fs-extra: 11.3.5
             p-map: 7.0.4
             picocolors: 1.1.1
             tinyglobby: 0.2.17
-            vite: 7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)
+            vite: 7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)
 
-    vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0):
+    vite-plus@0.2.2(@types/node@22.9.0)(@vitest/browser-playwright@4.0.8)(@vitest/ui@4.0.8)(jsdom@26.1.0(supports-color@5.5.0))(less@3.13.1)(typescript@6.0.3)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0):
+        dependencies:
+            "@oxc-project/types": 0.138.0
+            "@oxlint/plugins": 1.68.0
+            "@vitest/browser": 4.1.9(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))(vitest@4.1.9)
+            "@vitest/browser-preview": 4.1.9(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))(vitest@4.0.8)
+            "@vitest/expect": 4.1.9
+            "@vitest/mocker": 4.1.9(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
+            "@vitest/pretty-format": 4.1.9
+            "@vitest/runner": 4.1.9
+            "@vitest/snapshot": 4.1.9
+            "@vitest/spy": 4.1.9
+            "@vitest/utils": 4.1.9
+            "@voidzero-dev/vite-plus-core": 0.2.2(@types/node@22.9.0)(less@3.13.1)(typescript@6.0.3)(yaml@2.9.0)
+            oxfmt: 0.57.0(vite-plus@0.2.2(@types/node@22.9.0)(@vitest/browser-playwright@4.0.8)(@vitest/ui@4.0.8)(jsdom@26.1.0(supports-color@5.5.0))(less@3.13.1)(typescript@6.0.3)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0))
+            oxlint: 1.72.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.2(@types/node@22.9.0)(@vitest/browser-playwright@4.0.8)(@vitest/ui@4.0.8)(jsdom@26.1.0(supports-color@5.5.0))(less@3.13.1)(typescript@6.0.3)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))(yaml@2.9.0))
+            oxlint-tsgolint: 0.24.0
+            vitest: 4.1.9(@types/node@22.9.0)(@vitest/browser-playwright@4.0.8)(@vitest/browser-preview@4.1.9)(@vitest/ui@4.0.8)(jsdom@26.1.0(supports-color@5.5.0))(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
+        optionalDependencies:
+            "@vitest/browser-playwright": 4.0.8(playwright@1.56.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))(vitest@4.0.8)
+            "@voidzero-dev/vite-plus-darwin-arm64": 0.2.2
+            "@voidzero-dev/vite-plus-darwin-x64": 0.2.2
+            "@voidzero-dev/vite-plus-linux-arm64-gnu": 0.2.2
+            "@voidzero-dev/vite-plus-linux-arm64-musl": 0.2.2
+            "@voidzero-dev/vite-plus-linux-x64-gnu": 0.2.2
+            "@voidzero-dev/vite-plus-linux-x64-musl": 0.2.2
+            "@voidzero-dev/vite-plus-win32-arm64-msvc": 0.2.2
+            "@voidzero-dev/vite-plus-win32-x64-msvc": 0.2.2
+        transitivePeerDependencies:
+            - "@arethetypeswrong/core"
+            - "@edge-runtime/vm"
+            - "@opentelemetry/api"
+            - "@types/node"
+            - "@vitejs/devtools"
+            - "@vitest/coverage-istanbul"
+            - "@vitest/coverage-v8"
+            - "@vitest/ui"
+            - bufferutil
+            - esbuild
+            - happy-dom
+            - jiti
+            - jsdom
+            - less
+            - msw
+            - publint
+            - sass
+            - sass-embedded
+            - stylus
+            - sugarss
+            - svelte
+            - terser
+            - tsx
+            - typescript
+            - unplugin-unused
+            - unrun
+            - utf-8-validate
+            - vite
+            - yaml
+
+    vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0):
         dependencies:
             esbuild: 0.25.12
             fdir: 6.5.0(picomatch@4.0.4)
@@ -17676,12 +19004,13 @@ snapshots:
             "@types/node": 22.9.0
             fsevents: 2.3.3
             less: 3.13.1
+            lightningcss: 1.32.0
             yaml: 2.9.0
 
-    vitest@4.0.8(@types/node@22.9.0)(@vitest/browser-playwright@4.0.8)(@vitest/ui@4.0.8)(jsdom@26.1.0(supports-color@5.5.0))(less@3.13.1)(supports-color@5.5.0)(yaml@2.9.0):
+    vitest@4.0.8(@types/node@22.9.0)(@vitest/browser-playwright@4.0.8)(@vitest/browser-preview@4.1.9)(@vitest/ui@4.0.8)(jsdom@26.1.0(supports-color@5.5.0))(less@3.13.1)(lightningcss@1.32.0)(supports-color@5.5.0)(yaml@2.9.0):
         dependencies:
             "@vitest/expect": 4.0.8
-            "@vitest/mocker": 4.0.8(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))
+            "@vitest/mocker": 4.0.8(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
             "@vitest/pretty-format": 4.0.8
             "@vitest/runner": 4.0.8
             "@vitest/snapshot": 4.0.8
@@ -17698,11 +19027,12 @@ snapshots:
             tinyexec: 0.3.2
             tinyglobby: 0.2.17
             tinyrainbow: 3.1.0
-            vite: 7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0)
+            vite: 7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)
             why-is-node-running: 2.3.0
         optionalDependencies:
             "@types/node": 22.9.0
-            "@vitest/browser-playwright": 4.0.8(playwright@1.56.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(yaml@2.9.0))(vitest@4.0.8)
+            "@vitest/browser-playwright": 4.0.8(playwright@1.56.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))(vitest@4.0.8)
+            "@vitest/browser-preview": 4.1.9(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))(vitest@4.0.8)
             "@vitest/ui": 4.0.8(vitest@4.0.8)
             jsdom: 26.1.0(supports-color@5.5.0)
         transitivePeerDependencies:
@@ -17718,6 +19048,37 @@ snapshots:
             - terser
             - tsx
             - yaml
+
+    vitest@4.1.9(@types/node@22.9.0)(@vitest/browser-playwright@4.0.8)(@vitest/browser-preview@4.1.9)(@vitest/ui@4.0.8)(jsdom@26.1.0(supports-color@5.5.0))(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)):
+        dependencies:
+            "@vitest/expect": 4.1.9
+            "@vitest/mocker": 4.1.9(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))
+            "@vitest/pretty-format": 4.1.9
+            "@vitest/runner": 4.1.9
+            "@vitest/snapshot": 4.1.9
+            "@vitest/spy": 4.1.9
+            "@vitest/utils": 4.1.9
+            es-module-lexer: 2.3.0
+            expect-type: 1.3.0
+            magic-string: 0.30.21
+            obug: 2.1.3
+            pathe: 2.0.3
+            picomatch: 4.0.4
+            std-env: 4.1.0
+            tinybench: 2.9.0
+            tinyexec: 1.2.4
+            tinyglobby: 0.2.17
+            tinyrainbow: 3.1.0
+            vite: 7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0)
+            why-is-node-running: 2.3.0
+        optionalDependencies:
+            "@types/node": 22.9.0
+            "@vitest/browser-playwright": 4.0.8(playwright@1.56.1)(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))(vitest@4.0.8)
+            "@vitest/browser-preview": 4.1.9(vite@7.1.5(@types/node@22.9.0)(less@3.13.1)(lightningcss@1.32.0)(yaml@2.9.0))(vitest@4.0.8)
+            "@vitest/ui": 4.0.8(vitest@4.0.8)
+            jsdom: 26.1.0(supports-color@5.5.0)
+        transitivePeerDependencies:
+            - msw
 
     void-elements@2.0.1: {}
 


### PR DESCRIPTION
Fixes [BL-16525](https://issues.bloomlibrary.org/youtrack/issue/BL-16525): bare `vp test` in `src/BloomBrowserUI` failed with `Cannot find package 'jsdom'` (47 errors, no tests run) because vite-plus's bundled vitest in `~/.vite-plus` is installed without jsdom, and vitest only gets jsdom via an optional peer dependency that pnpm links when vitest lives in the project.

## Fix

- Add `vite-plus: 0.2.2` as an exact devDependency in `src/BloomBrowserUI`. The global `vp` binary prefers a project-local vite-plus install over its bundled toolchain, and pnpm peer-links our `jsdom@26.1.0` into that install's vitest, so `vp test` now loads the jsdom environment.
- Document in ReadMe.md that `pnpm test` is the canonical test command and why `vp test` works.

## Notes

- Pinned at 0.2.2 because the repo's 7-day `minimumReleaseAge` policy blocks 0.2.4 (published 2026-07-08).
- `vp test` runs vite-plus's vitest 4.1.9 while `pnpm test` runs the pinned 4.0.8; both pass the full suite (498 passed / 5 skipped).
- `pnpm peers check` gains a few `@vitest/browser-*` version-skew warnings; browser mode is disabled in vite.config.mts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8049)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8049)
<!-- Reviewable:end -->
