### PR TITLE
Add papercut log: capture small improvement ideas without derailing work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,14 @@ All public methods should have a comment. So should most private ones!
 # Git Committing
 Always include a good description when creating a git commit.
 
+# Papercuts
+When you hit tooling/process friction, have to work around something, or learn something these
+docs should have told you — and now isn't the time to fix it — append a short entry to
+`PAPERCUTS.md` at the repo root (format in that file's header). Don't make a separate commit
+for it (it rides along in your next commit), don't derail your current task, and mention the
+logged cut in your final report. Cuts about the environment or team workflow (not this repo)
+go in your local bloom-team-skills clone's `PAPERCUTS.md` instead, if you have one.
+
 # Skills
 Reusable, task-specific procedures for this repo live in `.github/skills/<name>/SKILL.md`.
 When a request matches one of these, READ the matching `SKILL.md` and follow it as the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ Always include a good description when creating a git commit.
 
 # Papercuts
 When you hit tooling/process friction, have to work around something, or learn something these
-docs should have told you — and now isn't the time to fix it — append a short entry to
+docs should have told you — and now isn't the time to fix it — prepend a short entry to
 `PAPERCUTS.md` at the repo root (format in that file's header). Don't make a separate commit
 for it (it rides along in your next commit), don't derail your current task, and mention the
 logged cut in your final report. Cuts about the environment or team workflow (not this repo)

--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -1,0 +1,31 @@
+# Papercuts
+
+Small dev/agent/tooling friction points and improvement ideas — captured in the moment,
+fixed later. This file holds cuts about **this repo** (its docs, scripts, build, tests,
+agent experience); cuts about the environment, machine, or team workflow go in
+bloom-team-skills' `PAPERCUTS.md`. The full procedure is the `papercut` skill in
+https://github.com/BloomBooks/bloom-team-skills.
+
+House rules:
+
+- Add new entries at the **top**, directly under this header block.
+- Entry format: `## YYYY-MM-DD — Title`, then `- **Cut:**` / `- **Idea:**` / optional
+  `- **Context:**` lines. 2–5 lines total.
+- Hit the same cut again? Add a dated `seen again: ...` line to the existing entry instead of
+  duplicating it.
+- On a merge conflict here, keep both sides' entries.
+- Product bugs/features go to YouTrack instead.
+- To work through the backlog, run the `papercut` skill in trim mode ("trim the papercuts").
+  Fixed, promoted, or stale entries get **deleted** — the log only contains open cuts.
+
+---
+
+## 2026-07-10 — Pre-commit hook fails confusingly when node_modules is empty
+
+- **Cut:** With `src/BloomBrowserUI/node_modules` empty (e.g. a fresh checkout/worktree after
+  the pnpm migration, before `pnpm install`), `git commit` fails with
+  `pretty-quick: command not found` — and since the hook runs mid-command, the failed commit
+  is easy to miss.
+- **Idea:** Have `.vite-hooks/pre-commit` check for `node_modules/.bin/pretty-quick` first and
+  fail with "front-end dependencies not installed — run `pnpm install` in src/BloomBrowserUI".
+- **Context:** Hit while committing this very file.


### PR DESCRIPTION
[Claude Fable 5]

## What

Adds the **papercut** system to this repo:

- **`PAPERCUTS.md`** — a lightweight, committed log where agents and devs jot down small dev/agent/tooling friction (stale docs, script quirks, workflow snags) in the moment, without derailing whatever they were doing. Entries are triaged later ("trim the papercuts") and deleted once fixed, promoted (e.g. to YouTrack), or dropped — the log only holds open cuts.
- **`AGENTS.md`** — a short rule telling agents to log such cuts proactively as they hit them.

The full procedure (entry format, routing between this repo's log and the environment/team-workflow log, add vs. trim modes) is the new [`papercut` skill in bloom-team-skills](https://github.com/BloomBooks/bloom-team-skills/tree/main/papercut), which also carries a new `TEAM-AGENTS.md` so the proactive rule reaches Claude sessions in every repo.

The log is seeded with a first real cut hit while committing this very change: the pre-commit hook fails with a confusing `pretty-quick: command not found` when `node_modules` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8050)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8050)
<!-- Reviewable:end -->
