### PR TITLE
Fix the easy C# build warnings (BL-16526)

### DIFF
--- a/src/BloomExe/ImageProcessing/ImageUtils.cs
+++ b/src/BloomExe/ImageProcessing/ImageUtils.cs
@@ -88,13 +88,6 @@ namespace Bloom.ImageProcessing
             return false;
         }
 
-        private class ColorInfo
-        {
-            public Color color;
-            public bool isGrayish;
-            public bool isNearWhite;
-        }
-
         // Thresholds for the in-process dominant-color line-art check.
         // To be a line-art background, a color must have a perceptual brightness
         // of at least LineArtBackgroundMinBrightness and a chroma (max-min channel) of at

--- a/src/BloomExe/TempFiles.cs
+++ b/src/BloomExe/TempFiles.cs
@@ -53,11 +53,9 @@ namespace BloomTemp
             return f;
         }
 
-        [Obsolete(
-            "Go ahead and give it a name related to the test.  Makes it easier to track down problems."
-        )]
-        public TemporaryFolder()
-            : this("unnamedTestFolder") { }
+        // Used only by TrackExisting; unlike the public constructors, this must not create
+        // (or delete) any folder on disk.
+        private TemporaryFolder() { }
 
         public TemporaryFolder(string name)
         {

--- a/src/BloomTests/ErrorReporter/HtmlErrorReporterTests.cs
+++ b/src/BloomTests/ErrorReporter/HtmlErrorReporterTests.cs
@@ -209,12 +209,15 @@ namespace BloomTests.ErrorReporter
                 .Build();
 
             // System Under Test
+            // This deliberately exercises the obsolete legacy overload.
+#pragma warning disable 618
             reporter.NotifyUserOfProblem(
                 new ShowAlwaysPolicy(),
                 "Details",
                 ErrorResult.Yes,
                 "message"
             );
+#pragma warning restore 618
 
             mockFactory.Verify(x =>
                 x.CreateReactDialog(

--- a/src/BloomTests/Publish/Epub/ExportEpubWithVideoTests.cs
+++ b/src/BloomTests/Publish/Epub/ExportEpubWithVideoTests.cs
@@ -221,8 +221,6 @@ namespace BloomTests.Publish.Epub
             );
             MakeImageFiles(book, "DevilsSlide");
             MakeVideoFiles(book, "a0c5c8dd-d84b-4bf6-9f53-c4bb5caf38d0", "importedvideo");
-            // Without a branding, Bloom Enterprise-only features are removed
-            var branding = "Test";
             // May need to try more than once on Linux to make the epub without an exception for failing to complete loading the document.
             MakeEpubWithRetries(
                 kMakeEpubTrials,

--- a/src/BloomTests/Spreadsheet/SpreadsheetFormattingTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetFormattingTests.cs
@@ -731,7 +731,7 @@ namespace BloomTests.Spreadsheet
             string supRegex =
                 "<p>Head.*<sup>.* shoulders.*</sup>.*<sup> knees</sup><span style=\"color:#ABCABC;\"> and toes</span></p>";
             string colorRegex =
-                "<p>Head.*<span  style=\"color:#DEF123;\">.* shoulders.*</span>.*<sup> knees</sup><span style=\"color:#ABCABC;\"> and toes</span></p>";
+                "<p>Head.*<span style=\"color:#DEF123;\">.* shoulders.*</span>.*<sup> knees</sup><span style=\"color:#ABCABC;\"> and toes</span></p>";
             ExcelRange fifthCell = _worksheet.Cells[5, 5];
             string xmlString = SpreadsheetIO.BuildXmlString(fifthCell);
             Assert.That(xmlString.Length, Is.EqualTo(possibleExpected.Length));

--- a/src/BloomTests/Spreadsheet/SpreadsheetFormattingTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetFormattingTests.cs
@@ -735,7 +735,13 @@ namespace BloomTests.Spreadsheet
             ExcelRange fifthCell = _worksheet.Cells[5, 5];
             string xmlString = SpreadsheetIO.BuildXmlString(fifthCell);
             Assert.That(xmlString.Length, Is.EqualTo(possibleExpected.Length));
-            Assert.That(Regex.IsMatch(xmlString, supRegex));
+            // The tag nesting order can vary, so accept either <sup><span>...
+            // or <span><sup>... for the colored superscript run.
+            Assert.That(
+                Regex.IsMatch(xmlString, supRegex) || Regex.IsMatch(xmlString, colorRegex),
+                Is.True,
+                "BuildXmlString result did not match either expected nesting order: " + xmlString
+            );
         }
 
         [Test]

--- a/src/BloomTests/web/AvatarApiTests.cs
+++ b/src/BloomTests/web/AvatarApiTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Bloom.Api;
@@ -99,9 +100,9 @@ namespace BloomTests.web
             _server.EnsureListening();
 
             byte[] data;
-            using (var client = new WebClient())
+            using (var client = new HttpClient())
             {
-                data = client.DownloadData(AvatarUrl("user@example.com"));
+                data = client.GetByteArrayAsync(AvatarUrl("user@example.com")).Result;
             }
 
             Assert.That(data, Is.EqualTo(new byte[] { 10, 20, 30 }));
@@ -113,16 +114,11 @@ namespace BloomTests.web
             _cache.BytesToReturn = null; // simulate no known photo, no Gravatar, offline
             _server.EnsureListening();
 
-            using (var client = new WebClient())
+            using (var client = new HttpClient())
+            using (var response = client.GetAsync(AvatarUrl("nobody@example.com")).Result)
             {
-                var ex = Assert.Throws<WebException>(() =>
-                    client.DownloadData(AvatarUrl("nobody@example.com"))
-                );
                 // 404 is the contract that makes react-avatar fall back to generated initials.
-                Assert.That(
-                    ((HttpWebResponse)ex.Response).StatusCode,
-                    Is.EqualTo(HttpStatusCode.NotFound)
-                );
+                Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
             }
         }
 


### PR DESCRIPTION
Fixes all 9 code-level C# compiler warnings so the build output only contains package/infrastructure warnings.

- **ImageUtils.cs**: remove the unused private `ColorInfo` class (CS0649 ×3, fields never assigned).
- **TempFiles.cs**: the obsolete parameterless `TemporaryFolder()` constructor's only caller was `TrackExisting`, and it created an orphaned `unnamedTestFolder` in the temp directory as a side effect. Replaced with a private no-op constructor (CS0618, plus fixes that small bug).
- **ExportEpubWithVideoTests.cs**: remove the unused `branding` variable (CS0219).
- **SpreadsheetFormattingTests.cs**: the unused `colorRegex` (CS0219) was clearly intended as the alternate tag-nesting order for `BuildsXmlWithColors`, so the assertion now accepts either regex (and a follow-up commit fixes a two-space typo that made the alternate regex unmatchable).
- **AvatarApiTests.cs**: replace obsolete `WebClient` with `HttpClient` (SYSLIB0014 ×2).
- **HtmlErrorReporterTests.cs**: suppress CS0618 around the call that deliberately tests the obsolete legacy `NotifyUserOfProblem` overload.

Remaining warnings are all package/infrastructure level (NU1701, NU1903, MSB3243/3245/3884) and are intentionally not addressed here.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16526

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8051)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8051)
<!-- Reviewable:end -->
