### PR TITLE
Briefly show newly-enabled toolbox tool's checkbox before collapsing "More..." (BL-16501)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.tsx
@@ -1012,8 +1012,7 @@ export const ToolboxRoot: React.FunctionComponent = () => {
                                         // alone, hovering an opened reader tool paints its whole
                                         // body the jQuery-UI "hover" lightcoral (#f08080).
                                         // Neutralize the stray header theming. (BL-16501)
-                                        div[data-toolid].ui-accordion-header,
-                                        div[data-toolId].ui-accordion-header {
+                                        div[data-toolid].ui-accordion-header {
                                             &,
                                             &.ui-state-hover,
                                             &.ui-state-focus,

--- a/src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.tsx
@@ -1002,6 +1002,27 @@ export const ToolboxRoot: React.FunctionComponent = () => {
                                             margin-right: 0 !important;
                                             padding-right: 0 !important;
                                         }
+
+                                        // The Decodable/Leveled reader tool bodies are
+                                        // adopted from the old jQuery-UI accordion and
+                                        // still wear its header classes (ui-accordion-header,
+                                        // ui-state-default) plus jQuery hover/focus handlers
+                                        // that add ui-state-hover/-focus. Here they are tool
+                                        // *bodies*, not headers, so that theming is wrong: left
+                                        // alone, hovering an opened reader tool paints its whole
+                                        // body the jQuery-UI "hover" lightcoral (#f08080).
+                                        // Neutralize the stray header theming. (BL-16501)
+                                        div[data-toolid].ui-accordion-header,
+                                        div[data-toolId].ui-accordion-header {
+                                            &,
+                                            &.ui-state-hover,
+                                            &.ui-state-focus,
+                                            &.ui-state-active {
+                                                background: transparent !important;
+                                                border: none !important;
+                                                font-weight: normal;
+                                            }
+                                        }
                                     `}
                                 >
                                     {section.liveToolBodyElement ? (

--- a/src/BloomBrowserUI/bookEdit/toolbox/settings/SettingsToolControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/settings/SettingsToolControls.tsx
@@ -40,7 +40,10 @@ const ToolboxCheckbox: FunctionComponent<{
                 l10nKey={`EditTab.Toolbox.${props.l10nKeySuffix}`}
                 checked={checked}
                 onCheckChanged={(checked) => {
-                    setToolEnabledFromSettings(props.tool, checked!);
+                    // Pass true so that, when enabling, the tool opens after a
+                    // brief delay letting the user see this checkbox tick before
+                    // the "More..." section collapses to reveal the tool. (BL-16501)
+                    setToolEnabledFromSettings(props.tool, checked!, true);
                     setChecked(checked!);
                 }}
             />

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -724,6 +724,18 @@ export function getActiveToolId(): string | undefined {
     return newToolId ? newToolId : currentTool?.id();
 }
 
+// How long, after a tool is turned on in the "More..." settings section, we wait
+// before adding/opening it. The open collapses the "More..." section, so we delay
+// it just long enough for the user to see the checkbox they ticked. (BL-16501)
+const kShowToolAfterEnableDelayMs = 300;
+
+// Pending deferred "open this tool" timers, keyed by tool name, so a later toggle
+// of the same tool can cancel an open that hasn't fired yet.
+const pendingShowToolTimeouts = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+>();
+
 // modifies the enabledToolIds set, the saved active
 // state of the tool in question, and the presence of
 // the tool in the toolbox, whenever the tool is checked
@@ -747,7 +759,34 @@ export function setToolEnabledFromSettings(
         "editView/saveToolboxSetting",
         "active\t" + toolName + "Check\t" + (turnOn ? "1" : "0"),
     );
-    showOrHideTool(toolId, turnOn);
+
+    // A pending deferred open (below) reflects an earlier state; this call
+    // supersedes it, so cancel it. Without this, ticking a tool on and then off
+    // again within the delay would let the stale timer re-add the disabled tool
+    // (the disable runs synchronously and would otherwise be overtaken).
+    const pendingTimeout = pendingShowToolTimeouts.get(toolName);
+    if (pendingTimeout !== undefined) {
+        clearTimeout(pendingTimeout);
+        pendingShowToolTimeouts.delete(toolName);
+    }
+
+    if (turnOn) {
+        // Turning a tool on adds it to the accordion and makes it the active
+        // section, which collapses the "More..." settings section. If we do that
+        // immediately, the "More..." section closes before the user perceives the
+        // checkbox they just ticked. Briefly delay so the checkmark is visible
+        // before the section collapses to reveal the newly-enabled tool. (BL-16501)
+        const timeout = setTimeout(() => {
+            pendingShowToolTimeouts.delete(toolName);
+            // Guard against the tool having been turned off again during the delay.
+            if (enabledToolIds.has(toolName)) {
+                showOrHideTool(toolId, true);
+            }
+        }, kShowToolAfterEnableDelayMs);
+        pendingShowToolTimeouts.set(toolName, timeout);
+    } else {
+        showOrHideTool(toolId, turnOn);
+    }
 }
 
 function showOrHideTool(

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -731,6 +731,9 @@ const kShowToolAfterEnableDelayMs = 300;
 
 // Pending deferred "open this tool" timers, keyed by tool name, so a later toggle
 // of the same tool can cancel an open that hasn't fired yet.
+// We deliberately don't clear this map on toolbox teardown/navigation: each timer
+// is ~300ms and removes its own entry when it fires, so at most a couple of very
+// short-lived entries ever exist and nothing can accumulate. (BL-16501)
 const pendingShowToolTimeouts = new Map<
     string,
     ReturnType<typeof setTimeout>
@@ -739,10 +742,16 @@ const pendingShowToolTimeouts = new Map<
 // modifies the enabledToolIds set, the saved active
 // state of the tool in question, and the presence of
 // the tool in the toolbox, whenever the tool is checked
-// or unchecked in the toolbox settings
+// or unchecked in the toolbox settings.
+// deferShowToRevealCheckbox is set only by the "More..." settings checkboxes:
+// when turning a tool on from there, opening it collapses the settings section,
+// so we briefly delay the open (see below) to let the user see the checkbox they
+// ticked. Other callers (e.g. activating a tool from an in-page action) leave it
+// false so the tool opens immediately. (BL-16501)
 export function setToolEnabledFromSettings(
     toolName: string,
     turnOn: boolean,
+    deferShowToRevealCheckbox: boolean = false,
 ): void {
     if (turnOn) {
         enabledToolIds.add(toolName);
@@ -770,7 +779,7 @@ export function setToolEnabledFromSettings(
         pendingShowToolTimeouts.delete(toolName);
     }
 
-    if (turnOn) {
+    if (turnOn && deferShowToRevealCheckbox) {
         // Turning a tool on adds it to the accordion and makes it the active
         // section, which collapses the "More..." settings section. If we do that
         // immediately, the "More..." section closes before the user perceives the


### PR DESCRIPTION
When you enable a tool from the toolbox's **More...** settings section, the newly-enabled tool used to open and collapse **More...** so fast that you never saw the checkbox you just ticked. This delays the open briefly so the checkmark is visible first, then **More...** collapses to reveal the tool.

While verifying this, a pre-existing stray-theming bug surfaced: opening a Decodable/Leveled reader tool under the resting pointer painted its whole body **lightcoral** (`#f08080`). Those reader tool bodies are adopted into the React accordion still wearing legacy jQuery-UI accordion-*header* classes (plus jQuery hover/focus handlers), so jQuery-UI's hover theme applied. This neutralizes that stray theming for tool bodies hosted in the React accordion.

### Changes
- `toolbox.ts` — defer opening a just-enabled tool by `kShowToolAfterEnableDelayMs`; cancel/guard the deferred open if the tool is toggled off again within the delay.
- `ToolboxRoot.tsx` — neutralize jQuery-UI `ui-state-*` header theming on reader-tool bodies.

### Verified
- Enabling a tool from **More...**: checkbox ticks, then the section collapses to reveal the tool (driven live over CDP).
- After enabling + hovering the opened reader tool body: `ui-state-hover` may still be added, but computed background is transparent (dark panel), not lightcoral.
- Typecheck, lint, and full TS test suite (498 passed / 5 skipped) green.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16501

[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8057)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8057)
<!-- Reviewable:end -->
