### PR TITLE
Keep talking-book highlight when clicking CKEditor toolbar/popups (BL-16534)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -2713,7 +2713,23 @@ export default class AudioRecording implements IAudioRecorder {
     // Declared in this unusual way so we can use it as an event handler without messing with bind
     // and still get the right 'this'.
     private moveRecordingHighlightToClick = async (event: MouseEvent) => {
-        await this.moveRecordingHighlightToElement(event.target as HTMLElement);
+        const target = event.target as HTMLElement;
+        // Ignore clicks on CKEditor's floating UI. Its formatting toolbar (.cke_float) and its
+        // popups -- combo/dropdown panels (.cke_panel), the color picker (.cke_colorpanel), and
+        // the context menu (.cke_menu) -- all float inside the page's document body, so this
+        // capture-phase mousedown listener catches them. None of them is (or contains) an audio
+        // element, so moveRecordingHighlightToElement would treat such a click as "clicked outside
+        // everything" and remove the current talking-book highlight (also disabling the recording
+        // controls via changeStateAndSetExpectedAsync("")). These widgets act on the text box that
+        // is already highlighted, so we must leave the highlight alone. The inline-editable content
+        // is not inside any of these containers, so real content clicks still move the highlight.
+        // (Keyboard formatting shortcuts such as Ctrl+B don't fire mousedown, which is why they
+        // were unaffected.)
+        if (
+            target.closest(".cke_float, .cke_panel, .cke_colorpanel, .cke_menu")
+        )
+            return;
+        await this.moveRecordingHighlightToElement(target);
     };
 
     // If we can somehow set audio recording to something associated with the argumennt, do so


### PR DESCRIPTION
Fixes BL-16534 — https://issues.bloomlibrary.org/youtrack/issue/BL-16534

## Problem

In the Talking Book tool, selecting a range of text and then clicking a button in the CKEditor **format toolbar** made the recording highlight (`ui-audioCurrent`) disappear and disabled the recording controls. Using a keyboard formatting shortcut (Ctrl+B, or Ctrl+Space) did **not** trigger it.

This is a pre-existing bug (not related to any current feature work); it was found while testing the Ctrl+Space "clear formatting" feature on a separate branch.

## Cause

`AudioRecording` installs a capture-phase `mousedown` listener on the page document body (`moveRecordingHighlightToClick`) to move the highlight to whatever audio element the user clicks. The CKEditor formatting toolbar floats inside that same document body (a `.cke_float` container), so clicking a toolbar button was caught by the listener. A toolbar button is not (and does not contain) an audio element, so the handler took its "clicked outside everything" branch and called `removeAudioCurrent()` + `changeStateAndSetExpectedAsync("")`, removing the highlight and disabling controls.

Keyboard shortcuts don't fire `mousedown`, which is exactly why they were unaffected.

## Fix

Ignore `mousedown`s whose target is inside a `.cke_float` toolbar. The toolbar acts on the text box that is already highlighted, so the highlight is left alone. Inline-editable content is not inside a `.cke_float`, so real content clicks still move the highlight as before.

## Testing

Verified the diagnosis by tracing the handler; typecheck and lint pass (0 errors). Should be exercised in a running Bloom: with the Talking Book tool open, select text in a highlighted box and click a format-toolbar button — the highlight should remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8058)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8058)
<!-- Reviewable:end -->
