### PR TITLE
Integrate restyled Image Chooser (bloom-image-gallery)

### DIFF
--- a/DistFiles/localization/en/BloomMediumPriority.xlf
+++ b/DistFiles/localization/en/BloomMediumPriority.xlf
@@ -1596,6 +1596,26 @@
         <note>ID: ImageLibrary.ThisPage</note>
         <note>Short link text used in setup instructions (e.g., as in "go to this page"). Should be lowercase as it appears mid-sentence.</note>
       </trans-unit>
+      <trans-unit id="ImageLibrary.SelectImagePrompt" translate="no">
+        <source xml:lang="en">Select an image to see its details and license.</source>
+        <note>ID: ImageLibrary.SelectImagePrompt</note>
+        <note>Hint shown in the right-hand pane of the Image Chooser dialog before the user has selected any image; it prompts them to pick a thumbnail to reveal that image's attribution details.</note>
+      </trans-unit>
+      <trans-unit id="ImageLibrary.Dimensions" translate="no">
+        <source xml:lang="en">Dimensions</source>
+        <note>ID: ImageLibrary.Dimensions</note>
+        <note>Label in the Image Chooser detail pane. Its value is the selected image's pixel size, e.g. "1024 × 768".</note>
+      </trans-unit>
+      <trans-unit id="ImageLibrary.FileSize" translate="no">
+        <source xml:lang="en">File size</source>
+        <note>ID: ImageLibrary.FileSize</note>
+        <note>Label in the Image Chooser detail pane. Its value is the selected image's file size, e.g. "2.3M".</note>
+      </trans-unit>
+      <trans-unit id="ImageLibrary.License" translate="no">
+        <source xml:lang="en">License</source>
+        <note>ID: ImageLibrary.License</note>
+        <note>Label in the Image Chooser detail pane. Its value is the image's license, shown as a link, e.g. "CC-BY-SA".</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/BloomBrowserUI/package.json
+++ b/src/BloomBrowserUI/package.json
@@ -141,7 +141,7 @@
         "@types/react-transition-group": "4.4.1",
         "@use-it/event-listener": "0.1.7",
         "axios": "0.21.1",
-        "bloom-image-gallery": "github:BloomBooks/bloom-image-gallery",
+        "bloom-image-gallery": "github:BloomBooks/bloom-image-gallery#0b4ae4e253d7d5b93f089f43f9a7752452c1cf9a",
         "bloom-player": "2.20.1",
         "calculate-aspect-ratio": "0.1.3",
         "clsx": "1.2.1",

--- a/src/BloomBrowserUI/pnpm-lock.yaml
+++ b/src/BloomBrowserUI/pnpm-lock.yaml
@@ -86,7 +86,7 @@ importers:
                 version: 0.21.1
             bloom-image-gallery:
                 specifier: github:BloomBooks/bloom-image-gallery
-                version: https://codeload.github.com/BloomBooks/bloom-image-gallery/tar.gz/51c5a75bb611c51dd24b40c9162929c6e75473eb(@types/react@18.3.31)(supports-color@5.5.0)
+                version: https://codeload.github.com/BloomBooks/bloom-image-gallery/tar.gz/0b4ae4e253d7d5b93f089f43f9a7752452c1cf9a(@types/react@18.3.31)(supports-color@5.5.0)
             bloom-player:
                 specifier: 2.20.1
                 version: 2.20.1
@@ -4040,12 +4040,12 @@ packages:
                 integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==,
             }
 
-    bloom-image-gallery@https://codeload.github.com/BloomBooks/bloom-image-gallery/tar.gz/51c5a75bb611c51dd24b40c9162929c6e75473eb:
+    bloom-image-gallery@https://codeload.github.com/BloomBooks/bloom-image-gallery/tar.gz/0b4ae4e253d7d5b93f089f43f9a7752452c1cf9a:
         resolution:
             {
                 gitHosted: true,
-                integrity: sha512-UDY38GPb9jUq4iC1IWPhNyJZOvSF+YYrgHUUJNFNDLymFwqt/YPu6kplT+Y+O9kZYhOJzUtha4ImKcHqnxhmsQ==,
-                tarball: https://codeload.github.com/BloomBooks/bloom-image-gallery/tar.gz/51c5a75bb611c51dd24b40c9162929c6e75473eb,
+                integrity: sha512-yQCSWNiY8/8TNKS9IbYLJqK4qt4yZ2++kjXCfW+CE82zT2qyopk46FIfwddgAxHH+9Ud5UdbJAUM3djuuylB0Q==,
+                tarball: https://codeload.github.com/BloomBooks/bloom-image-gallery/tar.gz/0b4ae4e253d7d5b93f089f43f9a7752452c1cf9a,
             }
         version: 0.0.2
 
@@ -13393,7 +13393,7 @@ snapshots:
             file-uri-to-path: 1.0.0
         optional: true
 
-    bloom-image-gallery@https://codeload.github.com/BloomBooks/bloom-image-gallery/tar.gz/51c5a75bb611c51dd24b40c9162929c6e75473eb(@types/react@18.3.31)(supports-color@5.5.0):
+    bloom-image-gallery@https://codeload.github.com/BloomBooks/bloom-image-gallery/tar.gz/0b4ae4e253d7d5b93f089f43f9a7752452c1cf9a(@types/react@18.3.31)(supports-color@5.5.0):
         dependencies:
             "@emotion/react": 11.14.0(@types/react@18.3.31)(react@18.3.1)
             "@emotion/styled": 11.14.1(@emotion/react@11.14.0(@types/react@18.3.31)(react@18.3.1))(@types/react@18.3.31)(react@18.3.1)


### PR DESCRIPTION
Bumps the `bloom-image-gallery` dependency to the restyled Image Chooser and adds the localizable strings its detail pane needs.

**bloom-image-gallery side:** [PR #18](https://github.com/BloomBooks/bloom-image-gallery/pull/18) — justified-rows grid, sidebar pills, structured attribution, plus review follow-ups (stale local-file image cleared on provider-clear; SearchBar lint tidy). This BloomDesktop PR pins that repo at `0b4ae4e`.

**Changes here (integration only):**
- `package.json` / `pnpm-lock.yaml`: `bloom-image-gallery` → `0b4ae4e`. The lock change is a minimal in-place hash+integrity swap, keeping the repo's existing lockfile serialization format (a full `pnpm install` reformats the whole lock because the committed lock predates the local pnpm's serialization style — out of scope for this PR).
- `BloomMediumPriority.xlf`: adds `ImageLibrary.SelectImagePrompt`, `ImageLibrary.Dimensions`, `ImageLibrary.FileSize`, `ImageLibrary.License`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8059)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8059)
<!-- Reviewable:end -->
