### PR TITLE
Build pageSizes.ts via Node native type-stripping instead of ts-node

### DIFF
--- a/src/BloomBrowserUI/scripts/build.js
+++ b/src/BloomBrowserUI/scripts/build.js
@@ -108,13 +108,27 @@ const run = async () => {
     console.log("Building content assets...");
     await runCommand("node", ["checkForNodeModules.js"], { cwd: contentRoot });
 
-    const tsNodeBin = resolvePackageBin(contentRoot, "ts-node", "ts-node");
     const cpxBin = resolvePackageBin(contentRoot, "cpx", "cpx");
     const rimrafBin = resolvePackageBin(contentRoot, "rimraf", "rimraf");
 
-    await runCommand("node", [tsNodeBin, "pageSizes.ts"], {
-        cwd: contentRoot,
-    });
+    // Run pageSizes.ts through Node's native TypeScript type stripping rather
+    // than ts-node: the pinned TypeScript 6.0 + ts-node combo fails on Node 22
+    // (ERR_UNKNOWN_FILE_EXTENSION and a TS5107 deprecation error).
+    // --experimental-strip-types is required on the Volta-pinned Node 22.14
+    // (stripping is on by default only from 22.18); the disable-warning flags
+    // silence the harmless experimental and typeless-package.json notices.
+    await runCommand(
+        "node",
+        [
+            "--experimental-strip-types",
+            "--disable-warning=ExperimentalWarning",
+            "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
+            "pageSizes.ts",
+        ],
+        {
+            cwd: contentRoot,
+        },
+    );
 
     // Type-check before bundling. Vite/esbuild strips types without checking them,
     // so this is our only build-time guard against type errors (it fails on the

--- a/src/content/package.json
+++ b/src/content/package.json
@@ -15,7 +15,8 @@
         "The -a option says to run them all before watching": "",
         "watch:pug": "onchange -j 9 -a \"**/*.pug\" -- pug {{file}} --pretty --out ../../output/browser/{{fileDir}}",
         "//": "______________________________________________________________________________________________________",
-        "build:pageSizes": "ts-node pageSizes.ts",
+        "// build:pageSizes runs the .ts directly via Node's native type stripping (no ts-node). --experimental-strip-types is required on the Volta-pinned Node 22.14 (default only from 22.18); the disable-warning flags silence the harmless experimental and typeless-package.json notices": "",
+        "build:pageSizes": "node --experimental-strip-types --disable-warning=ExperimentalWarning --disable-warning=MODULE_TYPELESS_PACKAGE_JSON pageSizes.ts",
         "build:less": "npm-run-all build:pageSizes build:less-inner",
         "build:less-inner": "node ../BloomBrowserUI/scripts/watchLess.mjs --scope=content --once",
         "// there is no current way to exclude node_modules, so we can't just do the whole directory.": "https://github.com/jonycheung/deadsimple-less-watch-compiler/issues/72",
@@ -54,8 +55,7 @@
         "prettier": "3.6.2",
         "pug": "3.0.2",
         "pug-cli": "1.0.0-alpha6",
-        "rimraf": "5.0.5",
-        "ts-node": "10.9.2"
+        "rimraf": "5.0.5"
     },
     "dependencies": {
         "@types/node": "22.17.0",

--- a/src/content/pnpm-lock.yaml
+++ b/src/content/pnpm-lock.yaml
@@ -47,9 +47,6 @@ importers:
             rimraf:
                 specifier: 5.0.5
                 version: 5.0.5
-            ts-node:
-                specifier: 10.9.2
-                version: 10.9.2(@types/node@22.17.0)(typescript@6.0.3)
 
 packages:
     "@babel/helper-string-parser@7.29.7":
@@ -93,38 +90,12 @@ packages:
                 integrity: sha512-w/63nURdkRPpg3AXbNr7lPv6HgOuVDyefTumiXsbXxtIwcuk5EXayWR5OpSwDjsQPgaYsfUSedMduaNOjAYY8A==,
             }
 
-    "@cspotcode/source-map-support@0.8.1":
-        resolution:
-            {
-                integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==,
-            }
-        engines: { node: ">=12" }
-
     "@isaacs/cliui@8.0.2":
         resolution:
             {
                 integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==,
             }
         engines: { node: ">=12" }
-
-    "@jridgewell/resolve-uri@3.1.2":
-        resolution:
-            {
-                integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==,
-            }
-        engines: { node: ">=6.0.0" }
-
-    "@jridgewell/sourcemap-codec@1.5.5":
-        resolution:
-            {
-                integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==,
-            }
-
-    "@jridgewell/trace-mapping@0.3.9":
-        resolution:
-            {
-                integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==,
-            }
 
     "@nodelib/fs.scandir@2.1.5":
         resolution:
@@ -154,30 +125,6 @@ packages:
             }
         engines: { node: ">=14" }
 
-    "@tsconfig/node10@1.0.12":
-        resolution:
-            {
-                integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==,
-            }
-
-    "@tsconfig/node12@1.0.11":
-        resolution:
-            {
-                integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==,
-            }
-
-    "@tsconfig/node14@1.0.3":
-        resolution:
-            {
-                integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==,
-            }
-
-    "@tsconfig/node16@1.0.4":
-        resolution:
-            {
-                integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==,
-            }
-
     "@types/babel-types@7.0.16":
         resolution:
             {
@@ -202,13 +149,6 @@ packages:
                 integrity: sha512-uWttZCk96+7itPxK8xCzY86PnxKTMrReKDqrHzv42VQY0K30PUO8WY13WMOuI+cOdX4EIdzdvQ8k6jkuGRFMYw==,
             }
 
-    acorn-walk@8.3.5:
-        resolution:
-            {
-                integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==,
-            }
-        engines: { node: ">=0.4.0" }
-
     acorn@3.3.0:
         resolution:
             {
@@ -229,14 +169,6 @@ packages:
         resolution:
             {
                 integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==,
-            }
-        engines: { node: ">=0.4.0" }
-        hasBin: true
-
-    acorn@8.17.0:
-        resolution:
-            {
-                integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==,
             }
         engines: { node: ">=0.4.0" }
         hasBin: true
@@ -806,12 +738,6 @@ packages:
             }
         hasBin: true
 
-    create-require@1.1.1:
-        resolution:
-            {
-                integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==,
-            }
-
     cross-spawn@6.0.6:
         resolution:
             {
@@ -928,13 +854,6 @@ packages:
                 integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==,
             }
         engines: { node: ">=0.4.0" }
-
-    diff@4.0.4:
-        resolution:
-            {
-                integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==,
-            }
-        engines: { node: ">=0.3.1" }
 
     doctypes@1.1.0:
         resolution:
@@ -2167,12 +2086,6 @@ packages:
                 integrity: sha512-IfpFq6UM39dUNiphpA6uDezNx/AvWyhwfICWPR3t1VspkgkMZrL+Rk1RbN1bx+aeNYwOrqGJgEgV3yotk+ZUVw==,
             }
         engines: { node: ">=18" }
-
-    make-error@1.3.6:
-        resolution:
-            {
-                integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==,
-            }
 
     map-cache@0.2.2:
         resolution:
@@ -3423,23 +3336,6 @@ packages:
             }
         hasBin: true
 
-    ts-node@10.9.2:
-        resolution:
-            {
-                integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==,
-            }
-        hasBin: true
-        peerDependencies:
-            "@swc/core": ">=1.2.50"
-            "@swc/wasm": ">=1.2.50"
-            "@types/node": "*"
-            typescript: ">=2.7"
-        peerDependenciesMeta:
-            "@swc/core":
-                optional: true
-            "@swc/wasm":
-                optional: true
-
     tslib@1.14.1:
         resolution:
             {
@@ -3562,12 +3458,6 @@ packages:
             }
         deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
         hasBin: true
-
-    v8-compile-cache-lib@3.0.1:
-        resolution:
-            {
-                integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==,
-            }
 
     validate-npm-package-license@3.0.4:
         resolution:
@@ -3692,13 +3582,6 @@ packages:
                 integrity: sha512-QFzUah88GAGy9lyDKGBqZdkYApt63rCXYBGYnEP4xDJPXNqXXnBDACnbrXnViV6jRSqAePwrATi2i8mfYm4L1A==,
             }
 
-    yn@3.1.1:
-        resolution:
-            {
-                integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==,
-            }
-        engines: { node: ">=6" }
-
 snapshots:
     "@babel/helper-string-parser@7.29.7": {}
 
@@ -3717,10 +3600,6 @@ snapshots:
 
     "@blakeembrey/template@1.2.0": {}
 
-    "@cspotcode/source-map-support@0.8.1":
-        dependencies:
-            "@jridgewell/trace-mapping": 0.3.9
-
     "@isaacs/cliui@8.0.2":
         dependencies:
             string-width: 5.1.2
@@ -3729,15 +3608,6 @@ snapshots:
             strip-ansi-cjs: strip-ansi@6.0.1
             wrap-ansi: 8.1.0
             wrap-ansi-cjs: wrap-ansi@7.0.0
-
-    "@jridgewell/resolve-uri@3.1.2": {}
-
-    "@jridgewell/sourcemap-codec@1.5.5": {}
-
-    "@jridgewell/trace-mapping@0.3.9":
-        dependencies:
-            "@jridgewell/resolve-uri": 3.1.2
-            "@jridgewell/sourcemap-codec": 1.5.5
 
     "@nodelib/fs.scandir@2.1.5":
         dependencies:
@@ -3754,14 +3624,6 @@ snapshots:
     "@pkgjs/parseargs@0.11.0":
         optional: true
 
-    "@tsconfig/node10@1.0.12": {}
-
-    "@tsconfig/node12@1.0.11": {}
-
-    "@tsconfig/node14@1.0.3": {}
-
-    "@tsconfig/node16@1.0.4": {}
-
     "@types/babel-types@7.0.16": {}
 
     "@types/babylon@6.16.9":
@@ -3776,17 +3638,11 @@ snapshots:
         dependencies:
             acorn: 4.0.13
 
-    acorn-walk@8.3.5:
-        dependencies:
-            acorn: 8.17.0
-
     acorn@3.3.0: {}
 
     acorn@4.0.13: {}
 
     acorn@7.4.1: {}
-
-    acorn@8.17.0: {}
 
     ajv@4.11.8:
         dependencies:
@@ -4159,8 +4015,6 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    create-require@1.1.1: {}
-
     cross-spawn@6.0.6:
         dependencies:
             nice-try: 1.0.5
@@ -4238,8 +4092,6 @@ snapshots:
 
     delayed-stream@1.0.0:
         optional: true
-
-    diff@4.0.4: {}
 
     doctypes@1.1.0: {}
 
@@ -5066,8 +4918,6 @@ snapshots:
 
     make-dir@5.1.0:
         optional: true
-
-    make-error@1.3.6: {}
 
     map-cache@0.2.2: {}
 
@@ -5934,24 +5784,6 @@ snapshots:
 
     tree-kill@1.2.2: {}
 
-    ts-node@10.9.2(@types/node@22.17.0)(typescript@6.0.3):
-        dependencies:
-            "@cspotcode/source-map-support": 0.8.1
-            "@tsconfig/node10": 1.0.12
-            "@tsconfig/node12": 1.0.11
-            "@tsconfig/node14": 1.0.3
-            "@tsconfig/node16": 1.0.4
-            "@types/node": 22.17.0
-            acorn: 8.17.0
-            acorn-walk: 8.3.5
-            arg: 4.1.3
-            create-require: 1.1.1
-            diff: 4.0.4
-            make-error: 1.3.6
-            typescript: 6.0.3
-            v8-compile-cache-lib: 3.0.1
-            yn: 3.1.1
-
     tslib@1.14.1: {}
 
     tunnel-agent@0.6.0:
@@ -6036,8 +5868,6 @@ snapshots:
 
     uuid@3.4.0:
         optional: true
-
-    v8-compile-cache-lib@3.0.1: {}
 
     validate-npm-package-license@3.0.4:
         dependencies:
@@ -6140,5 +5970,3 @@ snapshots:
             cliui: 2.1.0
             decamelize: 1.2.0
             window-size: 0.1.0
-
-    yn@3.1.1: {}


### PR DESCRIPTION
_(Filed by Claude Opus 4.8 (1M context) via /preflight.)_

## What
Removes the `ts-node` dev dependency from `src/content` and runs the tiny build-time script `src/content/pageSizes.ts` through **Node's built-in TypeScript type-stripping** instead.

## Why
On the Volta-pinned **Node 22.14.0**, the pinned **TypeScript 6.0.3 + ts-node 10.9.2** combination fails at the `build:pageSizes` step, breaking `pnpm run build` and `./init.sh`:
- ts-node lets Node reparse the `import`-using `.ts` as ESM → `ERR_UNKNOWN_FILE_EXTENSION` ("Unknown file extension .ts").
- TypeScript 6.0 hard-errors `TS5107` on ts-node's default `moduleResolution=node10`.

## How
`build:pageSizes` (in `src/content/package.json`) and `src/BloomBrowserUI/scripts/build.js` now invoke:
```
node --experimental-strip-types --disable-warning=ExperimentalWarning --disable-warning=MODULE_TYPELESS_PACKAGE_JSON pageSizes.ts
```
`--experimental-strip-types` is required on Node 22.14 (stripping is on by default only from 22.18) and is a no-op on later versions. `pageSizes.ts` itself is unchanged (still TypeScript). `ts-node` is dropped from devDependencies and its subtree pruned from `pnpm-lock.yaml`.

## Verification
`pnpm run build` in `src/BloomBrowserUI` runs green end-to-end (exit 0) on the Volta Node 22.14.0 with no env override — pageSizes → LESS (181 compiled), Vite bundles, typecheck, and markdown all pass.

Note: no product/runtime or test source changed — only build tooling — so the C#/TS test suites were not run (they exercise unchanged code); the build itself, the only affected artifact, was verified.

[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8060)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8060)
<!-- Reviewable:end -->

Ref: BL-16546 — https://issues.bloomlibrary.org/youtrack/issue/BL-16546
