### PR TITLE
Restyle Open/Create Collections dialog cards (BL-16548)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -345,9 +345,14 @@
         <note>{0} is the number of books checked out to the current user in a team collection.</note>
       </trans-unit>
       <trans-unit id="CollectionChooser.UnpublishedToBloomLibrary" translate="no">
-        <source xml:lang="en">{0} unpublished to bloomlibrary.org</source>
+        <source xml:lang="en">Books not yet published to BloomLibrary.org</source>
         <note>ID: CollectionChooser.UnpublishedToBloomLibrary</note>
-        <note>{0} is the number of books in the collection not yet published to bloomlibrary.org.</note>
+        <note>Hover tooltip on the unpublished-count label of a collection card in the Open/Create Collections dialog. "BloomLibrary.org" is a product name and must not be translated.</note>
+      </trans-unit>
+      <trans-unit id="CollectionChooser.UnpublishedShort" translate="no">
+        <source xml:lang="en">{0} unpublished</source>
+        <note>ID: CollectionChooser.UnpublishedShort</note>
+        <note>Short label shown on a status chip on a collection card in the Open/Create Collections dialog. {0} is the number of books not yet published to BloomLibrary.org. The phrase "Books not yet published to BloomLibrary.org" appears as the chip's hover tooltip.</note>
       </trans-unit>
       <trans-unit id="CollectionSettingsDialog.AboutBloomSubscriptions">
         <source xml:lang="en">About Bloom Subscriptions</source>
@@ -3748,6 +3753,11 @@
         <source xml:lang="en">Browse for another collection on this computer</source>
         <note>ID: OpenCreateNewCollectionsDialog.BrowseForOtherCollections</note>
       </trans-unit>
+      <trans-unit id="OpenCreateNewCollectionsDialog.BrowseOnThisComputer" translate="no">
+        <source xml:lang="en">Browse on this computer</source>
+        <note>ID: OpenCreateNewCollectionsDialog.BrowseOnThisComputer</note>
+        <note>Text button at the bottom-left of the Open/Create Collections dialog. Clicking it opens a file browser so the user can find a Bloom collection stored elsewhere on their computer.</note>
+      </trans-unit>
       <trans-unit id="OpenCreateNewCollectionsDialog.CopyFromChorusHub">
         <source xml:lang="en">Copy From Chorus Hub on Local Network</source>
         <note>ID: OpenCreateNewCollectionsDialog.CopyFromChorusHub</note>
@@ -3765,7 +3775,7 @@
         <note>ID: OpenCreateNewCollectionsDialog.CreateNewCollection</note>
       </trans-unit>
       <trans-unit id="OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle">
-        <source xml:lang="en">Open/Create Collections</source>
+        <source xml:lang="en">Open / Create Collections</source>
         <note>ID: OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle</note>
       </trans-unit>
       <trans-unit id="OpenCreateNewCollectionsDialog.ReadMoreLink">

--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -1,0 +1,39 @@
+# Papercuts
+
+Small dev/agent/tooling friction points and improvement ideas — captured in the moment,
+fixed later. This file holds cuts about **this repo** (its docs, scripts, build, tests, and
+skills); cuts about the environment, machine setup, or team workflow go in bloom-team-skills'
+`PAPERCUTS.md`. The full procedure is the `papercut` skill.
+
+House rules:
+
+- Add new entries at the **top**, directly under this header block.
+- Entry format: `## YYYY-MM-DD — Title`, then `- **Cut:**` / `- **Idea:**` / optional
+  `- **Context:**` lines. 2–5 lines total.
+- Hit the same cut again? Add a dated `seen again: ...` line to the existing entry instead of
+  duplicating it.
+- On a merge conflict here, keep both sides' entries.
+- Product bugs/features go to YouTrack instead.
+- To work through the backlog, run the `papercut` skill in trim mode ("trim the papercuts").
+  Fixed, promoted, or stale entries get **deleted** — the log only contains open cuts.
+
+---
+
+## 2026-07-13 — pnpm-lock.yaml reformats wholesale on any install (format drift)
+- **Cut:** The committed `src/BloomBrowserUI/pnpm-lock.yaml` (on master too) is in an
+  older pnpm serialization style (double-quoted `lockfileVersion`, 4-space indent, and it
+  resolves some deps with a `(supports-color@5.5.0)` peer suffix). But the pinned + active
+  pnpm (11.5.2, per `packageManager`) writes a *different* style (single-quoted, 2-space,
+  no supports-color suffix). So **any** `pnpm install` rewrites the entire lockfile,
+  producing a spurious ~30k-line diff that has nothing to do with your actual change. To
+  bump a single `github:` dependency's commit hash I had to hand-patch the lock (swap the
+  4 hash occurrences + the integrity line) to keep the diff minimal and mergeable.
+- **Idea:** Regenerate/commit the lockfile once with the pinned pnpm so committed state
+  matches `packageManager` output, or document the exact pnpm invocation the team uses so
+  installs are format-stable. Until then, hash bumps need a manual lock edit.
+- **Context:** BL image-chooser integration PR (BloomDesktop #8059); local pnpm 11.5.2.
+
+## 2026-07-11 — Can't screenshot Bloom's WinForms modal dialogs via CDP
+- **Cut:** Verifying a `WireUpForWinforms` modal (e.g. `CollectionChooserDialog`) is painful. The modal opens in a separate WebView2 that is NOT exposed on the main CDP endpoint (`/json/list` shows only the main workspace page), so `screenshotBloom.mjs` can't capture it. Vite React Fast Refresh also closes any open modal on HMR. I fell back to OS-level screen capture, which needed the `AttachThreadInput` foregrounding trick because the ORCA host window covers the screen and `SetForegroundWindow` from a background process is blocked.
+- **Idea:** Have the `run-bloom` / `bloom-automation` skill document a supported way to screenshot modal dialogs — e.g. expose the dialog's WebView2 on a discoverable CDP port, or ship a helper that does the force-foreground + region capture.
+- **Context:** ImproveVisuals branch, restyling the Open/Create Collections dialog to the 2A design.

--- a/src/BloomBrowserUI/collection/CollectionCard.tsx
+++ b/src/BloomBrowserUI/collection/CollectionCard.tsx
@@ -8,11 +8,12 @@ import {
     IconButton,
     Menu,
     MenuItem,
+    Chip,
 } from "@mui/material";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import { LocalizableMenuItem } from "../react_components/localizableMenuItem";
 import { get, postString } from "../utils/bloomApi";
-import { kBloomRed } from "../bloomMaterialUITheme";
+import { kBloomBlue, kBloomRed } from "../bloomMaterialUITheme";
 import { useL10n } from "../react_components/l10nHooks";
 import { TeamCollectionIcon } from "../teamCollection/TeamCollectionIcon";
 
@@ -23,6 +24,8 @@ export interface ICollectionInfo {
     checkedOutCount?: number;
     unpublishedCount?: number;
     isTeamCollection?: boolean;
+    // True for the collection currently open in Bloom; that card is highlighted.
+    isCurrentCollection?: boolean;
 }
 
 const moreButtonStyle = css`
@@ -34,12 +37,39 @@ const moreButtonStyle = css`
     transition: opacity 0.3s;
 `;
 
+// Outlined cards with a very subtle resting shadow; on hover the border tints to
+// Bloom blue and the shadow lifts a little to signal the whole card is clickable.
 const cardStyle = css`
     position: relative;
-    box-shadow: #b5b5b5 0px 3px 5px;
+    border-radius: 8px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+    transition:
+        box-shadow 0.15s,
+        border-color 0.15s;
+    &:hover {
+        border-color: ${kBloomBlue};
+        box-shadow:
+            0 2px 4px -1px rgba(0, 0, 0, 0.16),
+            0 4px 10px 0 rgba(0, 0, 0, 0.1);
+    }
     &:hover .more-button {
         opacity: 1;
     }
+`;
+
+// Applied in addition to cardStyle for the collection currently open in Bloom:
+// a faint tinted background.
+const currentCardStyle = css`
+    background-color: ${kBloomBlue}0d;
+`;
+
+// The unpublished count is now plain gray text pushed to the right edge of the
+// metadata row (margin-left:auto), rather than a chip.
+const unpublishedTextStyle = css`
+    margin-left: auto;
+    font-size: 13px;
+    color: #6b6b6b;
+    white-space: nowrap;
 `;
 
 const cardContentStyle = css`
@@ -47,9 +77,57 @@ const cardContentStyle = css`
     display: flex;
     flex-direction: row;
     justify-content: space-between;
-    padding: 6px 10px;
+    padding: 16px 18px;
     &:last-child {
-        padding-bottom: 6px;
+        padding-bottom: 16px;
+    }
+`;
+
+const cardTitleStyle = css`
+    font-size: 16px;
+    font-weight: 500;
+    letter-spacing: 0.1px;
+    color: #262626;
+    line-height: 1.3;
+    margin: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    // Grow to fill the row so the team icon is pushed to the right edge,
+    // vertically in line with the right-aligned unpublished text below.
+    min-width: 0;
+    flex: 1 1 auto;
+`;
+
+// The book count, an optional checked-out chip, and the right-aligned unpublished
+// text share a single row beneath the title.
+const metadataRowStyle = css`
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+`;
+
+const bookCountStyle = css`
+    font-size: 13px;
+    color: #6b6b6b;
+    line-height: 1.1;
+    white-space: nowrap;
+`;
+
+// Pill-shaped status "tag" chips. The unpublished chip is a tinted teal fill; the
+// checked-out chip is outlined red (see the variant/border override where used).
+// Keep the label at a normal weight; the design's teal reads as a light tag, and
+// Bloom's font fallback renders 500 heavier than the mockup's Roboto.
+const chipBaseStyle = css`
+    height: 24px;
+    border-radius: 12px;
+    letter-spacing: 0.2px;
+    .MuiChip-label {
+        padding-left: 10px;
+        padding-right: 10px;
+        font-size: 12px;
+        font-weight: 400;
     }
 `;
 
@@ -92,13 +170,18 @@ export const CollectionCard: React.FunctionComponent<ICollectionInfo> = (
         undefined,
         String(props.checkedOutCount ?? 0),
     );
+    // Full phrase, used as the chip's hover tooltip so the short label stays clear.
     const unpublishedText = useL10n(
-        "{0} unpublished to bloomlibrary.org",
+        "Books not yet published to BloomLibrary.org",
         "CollectionChooser.UnpublishedToBloomLibrary",
+    );
+    // Short label shown on the right of the metadata row.
+    const unpublishedShortText = useL10n(
+        "{0} unpublished",
+        "CollectionChooser.UnpublishedShort",
         undefined,
         String(unpublishedCount ?? 0),
     );
-
     const handleClick = (event: React.MouseEvent<HTMLElement>) => {
         event.stopPropagation();
         setMoreMenuAnchorEl(event.currentTarget);
@@ -111,10 +194,14 @@ export const CollectionCard: React.FunctionComponent<ICollectionInfo> = (
         handleMenuClose();
     };
 
-    const additionalCardTexts: JSX.Element[] = getAdditionalCardTexts();
+    const bookCountText =
+        props.bookCount === 1 ? bookCountSingular : bookCountPlural;
 
     return (
-        <Card variant="outlined" css={cardStyle}>
+        <Card
+            variant="outlined"
+            css={[cardStyle, props.isCurrentCollection && currentCardStyle]}
+        >
             <CardActionArea
                 onClick={() => {
                     if (!moreMenuAnchorEl)
@@ -126,47 +213,53 @@ export const CollectionCard: React.FunctionComponent<ICollectionInfo> = (
                         css={css`
                             display: flex;
                             flex-direction: column;
-                            gap: 3px;
                             width: 100%;
                         `}
                     >
                         <div
                             css={css`
                                 display: flex;
-                                justify-content: space-between;
                                 align-items: center;
+                                gap: 8px;
                                 width: 100%;
+                                margin-bottom: 10px;
                             `}
                         >
-                            <Typography
-                                variant="h5"
-                                css={css`
-                                    color: #263238;
-                                    line-height: 1.2;
-                                    margin: 0;
-                                    white-space: nowrap;
-                                    overflow: hidden;
-                                    text-overflow: ellipsis;
-                                    flex-grow: 1;
-                                `}
-                            >
+                            <Typography variant="body1" css={cardTitleStyle}>
                                 {props.title}
                             </Typography>
                             {props.isTeamCollection && (
                                 <TeamCollectionIcon
                                     css={css`
-                                        margin-left: 6px;
+                                        flex: none;
                                     `}
                                 />
                             )}
                         </div>
-                        {additionalCardTexts}
-                        {/* Guarantee we always have 3 AdditionalCardTexts, but that blanks are last */}
-                        {Array.from({
-                            length: 3 - additionalCardTexts.length,
-                        }).map((_, index) => (
-                            <AdditionalCardText key={`blank${index}`} />
-                        ))}
+                        <div css={metadataRowStyle}>
+                            <span css={bookCountStyle}>{bookCountText}</span>
+                            {props.checkedOutCount ? (
+                                <Chip
+                                    size="small"
+                                    variant="outlined"
+                                    label={checkedOutText}
+                                    css={css`
+                                        ${chipBaseStyle};
+                                        color: ${kBloomRed};
+                                        border-color: ${kBloomRed}73;
+                                        background-color: transparent;
+                                    `}
+                                />
+                            ) : null}
+                            {unpublishedCount ? (
+                                <span
+                                    css={unpublishedTextStyle}
+                                    title={unpublishedText}
+                                >
+                                    {unpublishedShortText}
+                                </span>
+                            ) : null}
+                        </div>
                     </div>
                 </CardContent>
             </CardActionArea>
@@ -214,51 +307,4 @@ export const CollectionCard: React.FunctionComponent<ICollectionInfo> = (
             </Menu>
         </Card>
     );
-
-    function getAdditionalCardTexts() {
-        const additionalCardTexts: JSX.Element[] = [];
-        additionalCardTexts.push(
-            <AdditionalCardText
-                key="bookCount"
-                text={
-                    props.bookCount === 1 ? bookCountSingular : bookCountPlural
-                }
-            />,
-        );
-        if (props.checkedOutCount) {
-            additionalCardTexts.push(
-                <AdditionalCardText
-                    key="checkedOutCount"
-                    text={checkedOutText}
-                    color={kBloomRed}
-                />,
-            );
-        }
-        if (unpublishedCount) {
-            additionalCardTexts.push(
-                <AdditionalCardText
-                    key="unpublishedCount"
-                    text={unpublishedText}
-                />,
-            );
-        }
-        return additionalCardTexts;
-    }
 };
-
-const AdditionalCardText: React.FunctionComponent<{
-    text?: string;
-    color?: string;
-}> = (props) => (
-    <Typography
-        variant="body2"
-        css={css`
-            color: ${props.color ?? "#606060"};
-            line-height: 1.1;
-            margin-block-end: 2px !important;
-            ${props.text ? "" : "visibility: hidden;"}
-        `}
-    >
-        {props.text || "invisible"}
-    </Typography>
-);

--- a/src/BloomBrowserUI/collection/CollectionCard.tsx
+++ b/src/BloomBrowserUI/collection/CollectionCard.tsx
@@ -28,9 +28,13 @@ export interface ICollectionInfo {
     isCurrentCollection?: boolean;
 }
 
+// The "..." menu button sits in the top-right corner of the card. The title row
+// reserves matching space on its right (kMoreButtonReservedSpace) so a long
+// collection name truncates with an ellipsis instead of sliding under the button.
+const kMoreButtonReservedSpace = "34px";
 const moreButtonStyle = css`
     position: absolute;
-    bottom: 8px;
+    top: 8px;
     right: 8px;
     color: #979797;
     opacity: 0;
@@ -93,8 +97,9 @@ const cardTitleStyle = css`
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    // Grow to fill the row so the team icon is pushed to the right edge,
-    // vertically in line with the right-aligned unpublished text below.
+    // Grow to fill the row so the team icon is pushed to the right (up to the
+    // space reserved for the "..." button), and truncate a long name with an
+    // ellipsis before it reaches that button.
     min-width: 0;
     flex: 1 1 auto;
 `;
@@ -115,10 +120,10 @@ const bookCountStyle = css`
     white-space: nowrap;
 `;
 
-// Pill-shaped status "tag" chips. The unpublished chip is a tinted teal fill; the
-// checked-out chip is outlined red (see the variant/border override where used).
-// Keep the label at a normal weight; the design's teal reads as a light tag, and
-// Bloom's font fallback renders 500 heavier than the mockup's Roboto.
+// Pill-shaped status "tag" chip, currently used only for the outlined-red
+// checked-out chip (see the color/border override where used). Keep the label at
+// a normal weight; Bloom's font fallback renders 500 heavier than the mockup's
+// Roboto.
 const chipBaseStyle = css`
     height: 24px;
     border-radius: 12px;
@@ -223,6 +228,9 @@ export const CollectionCard: React.FunctionComponent<ICollectionInfo> = (
                                 gap: 8px;
                                 width: 100%;
                                 margin-bottom: 10px;
+                                // Keep the title (and team icon) clear of the
+                                // top-right "..." button.
+                                padding-right: ${kMoreButtonReservedSpace};
                             `}
                         >
                             <Typography variant="body1" css={cardTitleStyle}>

--- a/src/BloomBrowserUI/collection/CollectionChooserDialog.tsx
+++ b/src/BloomBrowserUI/collection/CollectionChooserDialog.tsx
@@ -1,5 +1,8 @@
 import { css } from "@emotion/react";
-import FileFindIcon from "@mui/icons-material/FindInPage";
+import SearchIcon from "@mui/icons-material/Search";
+import AddIcon from "@mui/icons-material/Add";
+import CloseIcon from "@mui/icons-material/Close";
+import { IconButton } from "@mui/material";
 import BloomButton from "../react_components/bloomButton";
 import {
     BloomDialog,
@@ -27,6 +30,49 @@ interface IProps {
     dialogEnvironment?: IBloomDialogEnvironmentParams;
 }
 
+// A light footer band that spans the full width of the dialog. The negative
+// margins bleed out over the dialog's side (24px) and bottom (10px) padding so
+// the band reaches the edges; the padding then re-insets the buttons. We zero
+// the inner DialogBottomButtons top padding so our own 14px sets the spacing.
+const footerBandStyle = css`
+    margin-top: auto;
+    margin-left: -24px;
+    margin-right: -24px;
+    margin-bottom: -10px;
+    padding: 14px 24px;
+    background-color: #fafafa;
+    border-top: 1px solid #eee;
+    & > div {
+        padding-top: 0;
+    }
+`;
+
+// The language menu and close button form one right-aligned group in the title
+// bar, matching the design (rather than the language menu drifting toward the
+// middle). We render our own close button and suppress DialogTitle's built-in
+// one via preventCloseButton so the two controls sit together.
+const titleRightGroupStyle = css`
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    // The language button sets text-transform:none on itself; override it here
+    // (only in this dialog) so the label reads uppercase per the design.
+    & button {
+        text-transform: uppercase !important;
+        font-size: 14px;
+    }
+    // DialogTitle forces font-weight:bold on all its descendants; the design
+    // shows the language label at a normal weight, so override it here.
+    & * {
+        font-weight: 400 !important;
+    }
+`;
+
+const closeButtonStyle = css`
+    color: #8a8a8a;
+`;
+
 export const CollectionChooserDialog: React.FunctionComponent<IProps> = (
     props,
 ) => {
@@ -34,9 +80,11 @@ export const CollectionChooserDialog: React.FunctionComponent<IProps> = (
         props.dialogEnvironment,
     );
     const dialogTitle = useL10n(
-        "Open/Create Collections",
+        "Open / Create Collections",
         "OpenCreateNewCollectionsDialog.OpenAndCreateWindowTitle",
     );
+    const closeText = useL10n("Close", "Common.Close");
+    const handleClose = props.onClose ?? propsForBloomDialog.onClose;
     return (
         <BloomDialog
             {...propsForBloomDialog}
@@ -54,6 +102,7 @@ export const CollectionChooserDialog: React.FunctionComponent<IProps> = (
             >
                 <DialogTitle
                     title={dialogTitle}
+                    preventCloseButton={true}
                     icon={
                         <img
                             css={css`
@@ -67,53 +116,59 @@ export const CollectionChooserDialog: React.FunctionComponent<IProps> = (
                         />
                     }
                 >
-                    <div
-                        css={css`
-                            margin-left: auto;
-                            margin-right: 8px;
-                            display: flex;
-                            align-items: center;
-                        `}
-                    >
+                    <div css={titleRightGroupStyle}>
                         <UiLanguageMenu />
+                        <IconButton
+                            aria-label={closeText}
+                            title={closeText}
+                            css={closeButtonStyle}
+                            onClick={() => handleClose?.()}
+                        >
+                            <CloseIcon />
+                        </IconButton>
                     </div>
                 </DialogTitle>
                 <DialogMiddle
                     css={css`
-                        height: 340px;
+                        height: 420px;
                     `}
                 >
                     <CollectionChooser collections={props.collections} />
                 </DialogMiddle>
-                <DialogBottomButtons>
-                    <DialogBottomLeftButtons>
+                <div css={footerBandStyle}>
+                    <DialogBottomButtons>
+                        <DialogBottomLeftButtons>
+                            <BloomButton
+                                variant="text"
+                                color="primary"
+                                enabled={true}
+                                l10nKey={
+                                    "OpenCreateNewCollectionsDialog.BrowseOnThisComputer"
+                                }
+                                startIcon={<SearchIcon />}
+                                onClick={() =>
+                                    post("workspace/browseForCollection")
+                                }
+                            >
+                                Browse on this computer
+                            </BloomButton>
+                        </DialogBottomLeftButtons>
                         <BloomButton
-                            variant="text"
+                            variant="contained"
                             color="primary"
                             enabled={true}
                             l10nKey={
-                                "OpenCreateNewCollectionsDialog.BrowseForOtherCollections"
+                                "OpenCreateNewCollectionsDialog.CreateNewCollection"
                             }
-                            startIcon={<FileFindIcon />}
+                            startIcon={<AddIcon />}
                             onClick={() =>
-                                post("workspace/browseForCollection")
+                                post("workspace/createNewCollection")
                             }
                         >
-                            Browse for another collection on this computer
+                            Create New Collection
                         </BloomButton>
-                    </DialogBottomLeftButtons>
-                    <BloomButton
-                        variant="contained"
-                        color="primary"
-                        enabled={true}
-                        l10nKey={
-                            "OpenCreateNewCollectionsDialog.CreateNewCollection"
-                        }
-                        onClick={() => post("workspace/createNewCollection")}
-                    >
-                        Create New Collection
-                    </BloomButton>
-                </DialogBottomButtons>
+                    </DialogBottomButtons>
+                </div>
             </BloomDialogContext.Provider>
         </BloomDialog>
     );

--- a/src/BloomExe/web/controllers/CollectionChooserApi.cs
+++ b/src/BloomExe/web/controllers/CollectionChooserApi.cs
@@ -168,6 +168,16 @@ namespace Bloom.web.controllers
             var checkedOutCount = isTeamCollection
                 ? CountCheckedOutToCurrentUser(folderPath)
                 : (int?)null;
+            // The collection currently open in Bloom (if any). Null at startup, when no
+            // project is loaded, so nothing is highlighted in that case.
+            var currentCollectionPath = CommonApi.CurrentCollectionSettings?.SettingsFilePath;
+            var isCurrentCollection =
+                !string.IsNullOrEmpty(currentCollectionPath)
+                && string.Equals(
+                    collectionFilePath,
+                    currentCollectionPath,
+                    StringComparison.OrdinalIgnoreCase
+                );
             return new
             {
                 path = collectionFilePath,
@@ -175,6 +185,7 @@ namespace Bloom.web.controllers
                 bookCount = CountBooksInCollection(folderPath),
                 isTeamCollection,
                 checkedOutCount,
+                isCurrentCollection,
             };
         }
 


### PR DESCRIPTION
Restyles the collection cards in the Open/Create Collections dialog toward the new design:

- Outlined cards with a subtle resting shadow and a hover lift (border tints to Bloom blue).
- Compact metadata row: book count, an outlined red "checked out to you" chip for team collections, and a right-aligned "N unpublished" label whose full phrase ("Books not yet published to BloomLibrary.org") shows as a hover tooltip.
- A faint tinted background marks the collection currently open in Bloom (no separate "CURRENT" badge).
- Adds an `isCurrentCollection` flag to the collection-info API to drive that highlight.
- Custom localized Close button on the dialog.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16548

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8062)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8062)
<!-- Reviewable:end -->
