### PR TITLE
Grow canvas text elements to fit content during process-book (BL-16537)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -1467,7 +1467,9 @@ export function getBodyContentForSavePage() {
 }
 
 // Grow each text canvas element (bloom-canvas-element) to fit its content, matching what the editor
-// does automatically when a page is opened.
+// does automatically when a page is opened. (Despite the "grow" in the name, this fits to content in
+// BOTH directions -- it will also shrink a box that was authored taller than its text -- which is
+// exactly what the editor's auto-grow does; "grow" just names the case that motivated the fix.)
 //
 // On page load the editor schedules this same auto-height adjustment for every editable
 // (OverflowChecker.AddOverflowHandlers -> AdjustSizeOrMarkOverflowSoon), but that runs on a 1000ms
@@ -1497,6 +1499,14 @@ function growTextCanvasElementsToFitContent(): void {
         for (const editable of canvasEditables) {
             const [, overflowY] =
                 OverflowChecker.getSelfOverflowAmounts(editable);
+            // Calling this off-screen is DOM-safe. adjustSizeOfContainingCanvasElementToMatchContent
+            // ends by calling adjustTarget()/alignControlFrameWithActiveElement() (CanvasElementManager
+            // ~514-515), which in the live editor can add drag-game target arrows or the selection
+            // frame. Neither happens here: adjustTarget runs only AFTER the bloom-noAutoHeight
+            // early-return, so drag-game text (which is bloom-noAutoHeight) never reaches it, and a
+            // normal canvas box has no drag target to build one for; alignControlFrame no-ops when
+            // there is no active element (there isn't, off-screen). This is the same resize path the
+            // live editor already runs on auto-grow, and capture strips editing debris afterward.
             theOneCanvasElementManager.adjustSizeOfContainingCanvasElementToMatchContent(
                 editable,
                 overflowY,

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -1484,17 +1484,26 @@ export function getBodyContentForSavePage() {
 // overflow markup or qtip debris to the captured DOM. Callers run this on the fully settled layout
 // (after the activeDelays wait), so text measurements reflect the final image sizing and fonts.
 function growTextCanvasElementsToFitContent(): void {
-    const canvasEditables = Array.from(
-        document.querySelectorAll<HTMLElement>(
-            `${kCanvasElementSelector} .bloom-editable.bloom-visibility-code-on`,
-        ),
-    );
-    for (const editable of canvasEditables) {
-        const [, overflowY] = OverflowChecker.getSelfOverflowAmounts(editable);
-        theOneCanvasElementManager.adjustSizeOfContainingCanvasElementToMatchContent(
-            editable,
-            overflowY,
+    // Never throws out: this runs inside finish()'s try/catch, and a failure to grow must not
+    // block capturing/saving the page (same contract as the fitImageTextSplits block). If it
+    // threw, the whole page capture would be abandoned -- strictly worse than falling back to the
+    // authored height. So we self-guard and degrade to "capture without the resize" on any error.
+    try {
+        const canvasEditables = Array.from(
+            document.querySelectorAll<HTMLElement>(
+                `${kCanvasElementSelector} .bloom-editable.bloom-visibility-code-on`,
+            ),
         );
+        for (const editable of canvasEditables) {
+            const [, overflowY] =
+                OverflowChecker.getSelfOverflowAmounts(editable);
+            theOneCanvasElementManager.adjustSizeOfContainingCanvasElementToMatchContent(
+                editable,
+                overflowY,
+            );
+        }
+    } catch (e) {
+        console.error("growTextCanvasElementsToFitContent failed: ", e);
     }
 }
 

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -1466,6 +1466,38 @@ export function getBodyContentForSavePage() {
     return result;
 }
 
+// Grow each text canvas element (bloom-canvas-element) to fit its content, matching what the editor
+// does automatically when a page is opened.
+//
+// On page load the editor schedules this same auto-height adjustment for every editable
+// (OverflowChecker.AddOverflowHandlers -> AdjustSizeOrMarkOverflowSoon), but that runs on a 1000ms
+// setTimeout that is NOT registered as a requestPageContent delay, so the off-screen capture's
+// wait-for-delays loop does not wait for it. Off-screen, C# captures as soon as the (image-sizing,
+// etc.) delays clear, which is usually well under a second, so without this we would save the box at
+// its authored height. When that height is too short for how Bloom actually renders the text (e.g. a
+// caption that wraps to two lines), the result is a scrollbar-clipped box that only fixes itself once
+// a human opens the page in the Edit tab (letting the timer fire) and saves. Doing it synchronously
+// here bakes the corrected height into the processed HTML.
+//
+// We call adjustSizeOfContainingCanvasElementToMatchContent directly (rather than the full
+// OverflowChecker.AdjustSizeOrMarkOverflow) so we only resize the box and don't add page-level
+// overflow markup or qtip debris to the captured DOM. Callers run this on the fully settled layout
+// (after the activeDelays wait), so text measurements reflect the final image sizing and fonts.
+function growTextCanvasElementsToFitContent(): void {
+    const canvasEditables = Array.from(
+        document.querySelectorAll<HTMLElement>(
+            `${kCanvasElementSelector} .bloom-editable.bloom-visibility-code-on`,
+        ),
+    );
+    for (const editable of canvasEditables) {
+        const [, overflowY] = OverflowChecker.getSelfOverflowAmounts(editable);
+        theOneCanvasElementManager.adjustSizeOfContainingCanvasElementToMatchContent(
+            editable,
+            overflowY,
+        );
+    }
+}
+
 // Used by the off-screen "process whole book" path (C# BookProcessor, driven by the
 // external/process-book API). It gathers the same page content that requestPageContent() would save
 // (via the shared extractAndStripPageContentForSave()), but instead of posting it to the editView/pageContent
@@ -1473,7 +1505,9 @@ export function getBodyContentForSavePage() {
 // combined result on window.__bloomExternalPageContent for the C# caller to poll. Like
 // requestPageContent(), it first waits for any in-flight async DOM work (activeDelays) to finish, up to
 // kMaxWaitTimeMs, so browser-based measurements (image sizing, canvas-element layout, etc.) are complete
-// before we capture the page.
+// before we capture the page. It also grows text canvas elements to fit their content (see
+// growTextCanvasElementsToFitContent), since that auto-height adjustment is otherwise deferred on a
+// timer the wait loop does not track.
 export function captureContentForExternalProcessing(
     fitImageTextSplits?: boolean,
 ): void {
@@ -1506,6 +1540,7 @@ export function captureContentForExternalProcessing(
     const start = Date.now();
     const finish = () => {
         try {
+            growTextCanvasElementsToFitContent();
             window.__bloomExternalPageContent =
                 extractAndStripPageContentForSave();
         } catch (e) {

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -1466,10 +1466,8 @@ export function getBodyContentForSavePage() {
     return result;
 }
 
-// Grow each text canvas element (bloom-canvas-element) to fit its content, matching what the editor
-// does automatically when a page is opened. (Despite the "grow" in the name, this fits to content in
-// BOTH directions -- it will also shrink a box that was authored taller than its text -- which is
-// exactly what the editor's auto-grow does; "grow" just names the case that motivated the fix.)
+// Resize each text canvas element (bloom-canvas-element) to fit its content -- growing or shrinking
+// the box -- matching what the editor does automatically when a page is opened.
 //
 // On page load the editor schedules this same auto-height adjustment for every editable
 // (OverflowChecker.AddOverflowHandlers -> AdjustSizeOrMarkOverflowSoon), but that runs on a 1000ms
@@ -1485,8 +1483,8 @@ export function getBodyContentForSavePage() {
 // OverflowChecker.AdjustSizeOrMarkOverflow) so we only resize the box and don't add page-level
 // overflow markup or qtip debris to the captured DOM. Callers run this on the fully settled layout
 // (after the activeDelays wait), so text measurements reflect the final image sizing and fonts.
-function growTextCanvasElementsToFitContent(): void {
-    // Never throws out: this runs inside finish()'s try/catch, and a failure to grow must not
+function resizeCanvasElementsToFitContent(): void {
+    // Never throws out: this runs inside finish()'s try/catch, and a failure to resize must not
     // block capturing/saving the page (same contract as the fitImageTextSplits block). If it
     // threw, the whole page capture would be abandoned -- strictly worse than falling back to the
     // authored height. So we self-guard and degrade to "capture without the resize" on any error.
@@ -1513,7 +1511,7 @@ function growTextCanvasElementsToFitContent(): void {
             );
         }
     } catch (e) {
-        console.error("growTextCanvasElementsToFitContent failed: ", e);
+        console.error("resizeCanvasElementsToFitContent failed: ", e);
     }
 }
 
@@ -1524,8 +1522,8 @@ function growTextCanvasElementsToFitContent(): void {
 // combined result on window.__bloomExternalPageContent for the C# caller to poll. Like
 // requestPageContent(), it first waits for any in-flight async DOM work (activeDelays) to finish, up to
 // kMaxWaitTimeMs, so browser-based measurements (image sizing, canvas-element layout, etc.) are complete
-// before we capture the page. It also grows text canvas elements to fit their content (see
-// growTextCanvasElementsToFitContent), since that auto-height adjustment is otherwise deferred on a
+// before we capture the page. It also resizes text canvas elements to fit their content (see
+// resizeCanvasElementsToFitContent), since that auto-height adjustment is otherwise deferred on a
 // timer the wait loop does not track.
 export function captureContentForExternalProcessing(
     fitImageTextSplits?: boolean,
@@ -1559,7 +1557,7 @@ export function captureContentForExternalProcessing(
     const start = Date.now();
     const finish = () => {
         try {
-            growTextCanvasElementsToFitContent();
+            resizeCanvasElementsToFitContent();
             window.__bloomExternalPageContent =
                 extractAndStripPageContentForSave();
         } catch (e) {


### PR DESCRIPTION
### Problem
Canvas text overlays authored by BloomBridge (from EPUB/PDF) are sized to the source text geometry, which is often too short for how Bloom actually renders the text (line-height, padding, re-wrapping). The result is a scrollbar-clipped text box in BloomPUB Viewer that only corrects itself once a human opens the page in the Edit tab and saves. See BL-16537 (Blocker).

### Root cause
Bloom already auto-grows such boxes to fit, but on page load that adjustment is deferred via `AdjustSizeOrMarkOverflowSoon` on a 1000ms `setTimeout` that is **not** registered as a `requestPageContent` delay. The off-screen `process-book` capture (`captureContentForExternalProcessing`) only waits for `activeDelays`, so it snapshots the page before the timer fires and bakes in the too-short height.

### Fix
`captureContentForExternalProcessing` now grows each text canvas element to fit its content synchronously inside `finish()` — after the `activeDelays` wait, so measurements reflect the settled image sizing and fonts — before extracting the page. It calls `adjustSizeOfContainingCanvasElementToMatchContent` directly (not the full `OverflowChecker.AdjustSizeOrMarkOverflow`), so it only resizes the box and does not add page-level overflow markup or qtip debris to the captured DOM.

Only affects the off-screen `process-book` path; live editing is unchanged.

### Testing
Verified interactively: a BloomBridge EPUB conversion (which invokes `process-book`) now produces canvas text boxes at the grown height with no scrollbar, without ever opening the page in the Edit tab.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16537

[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8063)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8063)
<!-- Reviewable:end -->
