### PR TITLE
Fix BL-16536 "Culture is not supported" error

### DIFF
--- a/src/BloomExe/BloomWebView2.cs
+++ b/src/BloomExe/BloomWebView2.cs
@@ -1,0 +1,55 @@
+using System.Globalization;
+using System.Windows.Forms;
+using Microsoft.Web.WebView2.WinForms;
+using SIL.Reporting;
+
+namespace Bloom
+{
+    /// <summary>
+    /// A WebView2 control that guards against a WinForms/.NET crash (BL-16536) that happens when the
+    /// user switches to a keyboard whose input language reports a BCP-47 tag that .NET does not
+    /// recognize as a culture. For example, the Keyman IPA keyboard reports "und-Latn" (undetermined
+    /// language, Latin script). When the input language changes, Windows sends WM_INPUTLANGCHANGE to
+    /// the focused window (which, while the user is typing, is this WebView2 control). WinForms' handler
+    /// for that message builds a CultureInfo from the keyboard's tag and throws
+    /// CultureNotFoundException. Because that runs inside WndProc during message dispatch, it is
+    /// otherwise a fatal, unhandled exception on the UI thread.
+    ///
+    /// Bloom does all its text editing inside WebView2, which tracks its own input language
+    /// independently of WinForms, so we can safely ignore WinForms' inability to represent the
+    /// keyboard and just perform the default window processing.
+    /// </summary>
+    public class BloomWebView2 : WebView2
+    {
+        private const int WM_INPUTLANGCHANGEREQUEST = 0x0050;
+        private const int WM_INPUTLANGCHANGE = 0x0051;
+
+        /// <summary>
+        /// Intercepts the input-language-change messages so that an unrecognized keyboard culture
+        /// cannot crash Bloom. See the class comment for the full explanation (BL-16536).
+        /// </summary>
+        protected override void WndProc(ref Message m)
+        {
+            if (m.Msg == WM_INPUTLANGCHANGE || m.Msg == WM_INPUTLANGCHANGEREQUEST)
+            {
+                try
+                {
+                    base.WndProc(ref m);
+                }
+                catch (CultureNotFoundException e)
+                {
+                    Logger.WriteMinorEvent(
+                        "Ignoring unsupported input-language culture from keyboard (BL-16536): "
+                            + e.Message
+                    );
+                    // WinForms' own handler for these messages ends by calling DefWndProc; since its
+                    // handler threw before reaching that point, we do the default processing here so
+                    // Windows still handles the language change normally.
+                    DefWndProc(ref m);
+                }
+                return;
+            }
+            base.WndProc(ref m);
+        }
+    }
+}

--- a/src/BloomExe/WebView2Browser.Designer.cs
+++ b/src/BloomExe/WebView2Browser.Designer.cs
@@ -18,7 +18,7 @@ namespace Bloom
 		/// </summary>
 		private void InitializeComponent()
 		{
-            this._webview = new Microsoft.Web.WebView2.WinForms.WebView2();
+            this._webview = new Bloom.BloomWebView2();
             ((System.ComponentModel.ISupportInitialize)(this._webview)).BeginInit();
             this.SuspendLayout();
             // 
@@ -49,6 +49,6 @@ namespace Bloom
 
 		#endregion
 
-		private Microsoft.Web.WebView2.WinForms.WebView2 _webview;
+		private Bloom.BloomWebView2 _webview;
 	}
 }


### PR DESCRIPTION
Switching to a keyboard whose input language reports a BCP-47 tag that .NET does not recognize as a culture (e.g. the Keyman IPA keyboard, which reports `und-Latn`) crashed Bloom. When the input language changes, Windows sends `WM_INPUTLANGCHANGE` to the focused window (the WebView2 control while the user is typing), and WinForms' handler builds a `CultureInfo` from the keyboard's tag, throwing `CultureNotFoundException`. Because that runs inside `WndProc` during message dispatch, it was a fatal, unhandled exception.

Fix: introduce `BloomWebView2`, a subclass of the WinForms `WebView2` control that overrides `WndProc` to run the input-language-change messages (`WM_INPUTLANGCHANGE` / `WM_INPUTLANGCHANGEREQUEST`) inside a try/catch. On `CultureNotFoundException` it logs a minor event and calls `DefWndProc` (the default processing WinForms' own handler ends with) instead of crashing. Bloom does all text editing in WebView2, which tracks its own input language independently of WinForms, so ignoring WinForms' inability to represent the keyboard is safe.

Because every browser in Bloom (the edit view in Shell, every ReactDialog, print preview, thumbnails, etc.) hosts a single WebView2 control via `WebView2Browser`, changing that control fixes the crash in all contexts.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16536

[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8066)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8066)
<!-- Reviewable:end -->
