### PR TITLE
Speed up the C# test suite (full run ~8m30s -> ~7m) (BL-16556)

### DIFF
--- a/src/BloomExe/Publish/PublishHelper.cs
+++ b/src/BloomExe/Publish/PublishHelper.cs
@@ -53,13 +53,27 @@ namespace Bloom.Publish
         private OffScreenBrowser _pageChecksBrowser;
 
         /// <summary>
+        /// Test hook: an externally-owned browser every PublishHelper uses for its page checks instead of
+        /// lazily creating its own. The owner retains ownership: ReleaseBrowser and Dispose leave it alone,
+        /// and the owner must dispose it. This lets one browser — with its expensive-to-start WebView2
+        /// environment and dedicated thread — be shared across the many PublishHelper instances created when
+        /// tests export dozens of epubs/bloompubs in a row (booting a browser per export dominated those
+        /// suites' time). Never set in production, where helpers deliberately release their browser as soon
+        /// as a batch of page checks is done (see ReleaseBrowser) rather than keep one idle.
+        /// </summary>
+        internal static OffScreenBrowser ExternalPageChecksBrowserForTests;
+
+        /// <summary>
         /// The browser we use for the "page checks" (element visibility and font info). It is an off-screen
         /// browser on its own dedicated thread, so we can drive it with blocking calls that never pump the main
         /// UI message loop — avoiding the reentrancy that made RunJavascriptWithStringResult_Sync_Dangerous
-        /// dangerous (BL-12614 / BL-13120) — and never deadlock. Created lazily. See <see cref="OffScreenBrowser"/>.
+        /// dangerous (BL-12614 / BL-13120) — and never deadlock. Created lazily, unless the tests supplied
+        /// a shared one via <see cref="ExternalPageChecksBrowserForTests"/>. See <see cref="OffScreenBrowser"/>.
         /// </summary>
         private OffScreenBrowser GetOrCreatePageChecksBrowser()
         {
+            if (ExternalPageChecksBrowserForTests != null)
+                return ExternalPageChecksBrowserForTests;
             return _pageChecksBrowser ??= new OffScreenBrowser();
         }
 
@@ -1460,7 +1474,8 @@ namespace Bloom.Publish
         public void ReleaseBrowser()
         {
             // Don't use GetOrCreatePageChecksBrowser here — if we never created one, we don't want to make
-            // one now just to dispose it.
+            // one now just to dispose it. An external browser (ExternalPageChecksBrowserForTests) belongs
+            // to its owner, so we never dispose it.
             _pageChecksBrowser?.Dispose();
             _pageChecksBrowser = null;
         }

--- a/src/BloomTests/Publish/BloomPub/BloomPubMakerTests.cs
+++ b/src/BloomTests/Publish/BloomPub/BloomPubMakerTests.cs
@@ -34,6 +34,14 @@ namespace BloomTests.Publish.BloomPub
         private BookServer _bookServer;
         protected BloomServer s_bloomServer;
 
+        // One off-screen page-checks browser shared by every bloompub creation in the fixture (via
+        // PublishHelper.ExternalPageChecksBrowserForTests). BloomPubMaker.PrepareBookForBloomReader
+        // creates a PublishHelper per call, and starting a WebView2 environment (browser process +
+        // dedicated thread) per bloompub dominates the time of these tests; sharing one keeps each
+        // test running the real browser-based visibility checks while paying the startup cost only
+        // once per fixture.
+        private static OffScreenBrowser s_pageChecksBrowser;
+
         [OneTimeSetUp]
         public virtual void OneTimeSetup()
         {
@@ -51,11 +59,16 @@ namespace BloomTests.Publish.BloomPub
                 locator
             );
             s_bloomServer.EnsureListening();
+            s_pageChecksBrowser = new OffScreenBrowser();
+            PublishHelper.ExternalPageChecksBrowserForTests = s_pageChecksBrowser;
         }
 
         [OneTimeTearDown]
         public virtual void OneTimeTearDown()
         {
+            PublishHelper.ExternalPageChecksBrowserForTests = null;
+            s_pageChecksBrowser.Dispose();
+            s_pageChecksBrowser = null;
             s_bloomServer.Dispose();
         }
 
@@ -2290,11 +2303,16 @@ namespace BloomTests.Publish.BloomPub
                     isTemplateBook: false,
                     creator: creator
                 );
-                var zip = new ZipFile(bloompubTempFile.Path);
-                var newHtml = GetEntryContents(zip, "index.htm");
-                var paramObj = new ZipHtmlObj(zip, newHtml);
-                assertionsOnZipArchive?.Invoke(paramObj); // send in html in case we need to compare it with the zip contents
-                assertionsOnResultingHtmlString?.Invoke(newHtml);
+                // The ZipFiles must be disposed before the enclosing TempFiles are: an open
+                // ZipFile locks the .bloompub, and the TempFile's Dispose then spends seconds
+                // in robust-delete retry loops trying to remove its temp folder.
+                using (var zip = new ZipFile(bloompubTempFile.Path))
+                {
+                    var newHtml = GetEntryContents(zip, "index.htm");
+                    var paramObj = new ZipHtmlObj(zip, newHtml);
+                    assertionsOnZipArchive?.Invoke(paramObj); // send in html in case we need to compare it with the zip contents
+                    assertionsOnResultingHtmlString?.Invoke(newHtml);
+                }
                 if (assertionsOnRepeat != null)
                 {
                     // compress it again! Used for checking important repeatable results
@@ -2311,8 +2329,10 @@ namespace BloomTests.Publish.BloomPub
                             _bookServer,
                             new NullWebSocketProgress()
                         );
-                        zip = new ZipFile(extraTempFile.Path);
-                        assertionsOnRepeat(zip);
+                        using (var zipOfRepeat = new ZipFile(extraTempFile.Path))
+                        {
+                            assertionsOnRepeat(zipOfRepeat);
+                        }
                     }
                 }
             }

--- a/src/BloomTests/Publish/Epub/ExportEpubTestsBaseClass.cs
+++ b/src/BloomTests/Publish/Epub/ExportEpubTestsBaseClass.cs
@@ -9,6 +9,7 @@ using Bloom.Api;
 using Bloom.Book;
 using Bloom.Collection;
 using Bloom.ImageProcessing;
+using Bloom.Publish;
 using Bloom.Publish.Epub;
 using Bloom.SafeXml;
 using Bloom.SubscriptionAndFeatures;
@@ -41,6 +42,13 @@ namespace BloomTests.Publish.Epub
         protected static BloomServer s_testServer;
         protected static BookSelection s_bookSelection;
         protected static CollectionSettings s_collectionSettings;
+
+        // One off-screen page-checks browser shared by every epub export in the fixture (via
+        // PublishHelper.ExternalPageChecksBrowserForTests). Starting a WebView2 environment (browser
+        // process + dedicated thread) per export dominates the time of these tests; sharing one keeps
+        // each test running the real browser-based visibility checks while paying the startup cost
+        // only once per fixture.
+        protected static OffScreenBrowser s_pageChecksBrowser;
         protected BookServer _bookServer;
         protected string _defaultSourceValue;
 
@@ -61,11 +69,16 @@ namespace BloomTests.Publish.Epub
         {
             s_collectionSettings = new CollectionSettings();
             s_testServer = GetTestServer();
+            s_pageChecksBrowser = new OffScreenBrowser();
+            PublishHelper.ExternalPageChecksBrowserForTests = s_pageChecksBrowser;
         }
 
         [OneTimeTearDown]
         public virtual void OneTimeTearDown()
         {
+            PublishHelper.ExternalPageChecksBrowserForTests = null;
+            s_pageChecksBrowser.Dispose();
+            s_pageChecksBrowser = null;
             s_testServer.Dispose();
         }
 

--- a/src/BloomTests/Publish/Rab/RabRealBuildTests.cs
+++ b/src/BloomTests/Publish/Rab/RabRealBuildTests.cs
@@ -73,6 +73,9 @@ namespace BloomTests.Publish.Rab
             var rabLauncherPath = RealRabProjectService.FindInstalledRabLauncherPath(paths);
             var rabKeytoolPath = RealRabProjectService.FindInstalledRabKeytoolPath(paths);
 
+            // The user opted in with the env var, so an incomplete toolchain is a failure — but a
+            // fast one, checked up front, rather than letting the build churn for ~10 seconds
+            // before reporting a confusing error.
             Assert.That(
                 !string.IsNullOrWhiteSpace(rabLauncherPath) && RobustFile.Exists(rabLauncherPath),
                 Is.True,
@@ -82,6 +85,14 @@ namespace BloomTests.Publish.Rab
                 !string.IsNullOrWhiteSpace(rabKeytoolPath) && RobustFile.Exists(rabKeytoolPath),
                 Is.True,
                 $"Reading App Builder runtime keytool is missing. Expected keytool discovered by Bloom's RAB path logic."
+            );
+            // RAB itself shells out to buildapp.bat, which comes from its separate build-tools
+            // component and must be on the PATH. Without it, the build churns for ~10 seconds and
+            // then reports "'buildapp.bat' is not recognized...", so check up front.
+            Assert.That(
+                CanFindOnPath("buildapp.bat"),
+                Is.True,
+                "Reading App Builder's build tools are not installed (buildapp.bat is not on the PATH). Install them before running this test."
             );
 
             var sourceBloomPubPath = GetRepoBloomPubPath();
@@ -143,6 +154,18 @@ namespace BloomTests.Publish.Rab
                     "The generated APK should contain AndroidManifest.xml."
                 );
             }
+        }
+
+        /// <summary>
+        /// True if the given file name resolves via the PATH environment variable, the way
+        /// cmd.exe will resolve it when Reading App Builder invokes it.
+        /// </summary>
+        private static bool CanFindOnPath(string fileName)
+        {
+            var path = Environment.GetEnvironmentVariable("PATH") ?? "";
+            return path.Split(Path.PathSeparator)
+                .Where(dir => !string.IsNullOrWhiteSpace(dir))
+                .Any(dir => File.Exists(Path.Combine(dir.Trim(), fileName)));
         }
 
         private string[] CreateLauncherIcons(string launcherIconRoot)

--- a/src/BloomTests/WebLibraryIntegration/BloomS3ClientTests.cs
+++ b/src/BloomTests/WebLibraryIntegration/BloomS3ClientTests.cs
@@ -12,7 +12,10 @@ namespace BloomTests.WebLibraryIntegration
     /// This file now contains only edge cases. For a more efficient upload/download test,
     /// the more standard tests have been separated out into BloomS3StandardUpDownloadTests.
     /// </summary>
+    // Integration tests: these talk to the live unit-test S3 bucket, so they need internet
+    // access. Exclude them from a quick local run with --filter TestCategory!=Integration
     [TestFixture]
+    [Category("Integration")]
     public class BloomS3ClientTests
     {
         private BloomS3Client _client;

--- a/src/BloomTests/WebLibraryIntegration/BloomS3StandardUpDownloadTests.cs
+++ b/src/BloomTests/WebLibraryIntegration/BloomS3StandardUpDownloadTests.cs
@@ -8,6 +8,10 @@ using SIL.Progress;
 
 namespace BloomTests.WebLibraryIntegration
 {
+    // Integration tests: the fixture setup uploads (and later downloads) a real book to the
+    // live unit-test S3 bucket, so these need internet access. Exclude them from a quick local
+    // run with --filter TestCategory!=Integration
+    [Category("Integration")]
     class BloomS3StandardUpDownloadTests
     {
         private BloomS3ClientTestDouble _client;

--- a/src/BloomTests/WebLibraryIntegration/BookUploadAndDownloadTests.cs
+++ b/src/BloomTests/WebLibraryIntegration/BookUploadAndDownloadTests.cs
@@ -50,7 +50,12 @@ namespace BloomTests.WebLibraryIntegration
         }
     }
 
+    // Integration tests: these upload/download real books against the live unit-test S3 buckets
+    // and the live bloomlibrary API (and one test downloads from the production site), so they
+    // need internet access and take minutes. Exclude them from a quick local run with
+    // --filter TestCategory!=Integration
     [TestFixture]
+    [Category("Integration")]
     public class BookUploadAndDownloadTests
     {
         private TemporaryFolder _workFolder;

--- a/src/BloomTests/WebLibraryIntegration/ProblemBookUploaderTests.cs
+++ b/src/BloomTests/WebLibraryIntegration/ProblemBookUploaderTests.cs
@@ -8,7 +8,10 @@ using SIL.Progress;
 
 namespace BloomTests.WebLibraryIntegration
 {
+    // Integration test: uploads a real zip to the live unit-test S3 bucket, so it needs
+    // internet access. Exclude it from a quick local run with --filter TestCategory!=Integration
     [TestFixture]
+    [Category("Integration")]
     public class ProblemBookUploaderTests
     {
         [Test]

--- a/src/BloomTests/web/BloomServerTests.cs
+++ b/src/BloomTests/web/BloomServerTests.cs
@@ -492,13 +492,15 @@ namespace BloomTests.web
             var directory = Path.Combine(testRootDir, "resources");
             Directory.CreateDirectory(directory);
             var tempFileRelativePath = Path.Combine(directory, "image.png");
-            RobustFile.Create(tempFileRelativePath);
-            var file = TempFile.TrackExisting(tempFileRelativePath);
-
-            // No need to create the file contents right now.
-            // Better (for unit tests) to do the minimum IO needed to make the test pass.
-
-            return file;
+            // This must be a real image, and the file must be closed once written. It used to be
+            // RobustFile.Create(path), which left the returned stream open (so the file was locked)
+            // and the file empty (not a valid PNG); the server's image processing then burned
+            // ~20 seconds in RetryUtility retry loops before giving up on the unreadable image.
+            using (var x = new Bitmap(100, 100))
+            {
+                x.Save(tempFileRelativePath, ImageFormat.Png);
+            }
+            return TempFile.TrackExisting(tempFileRelativePath);
         }
 
         [Test]


### PR DESCRIPTION
Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16556

Speeds up the C# test suite: full run ~8m30s → ~7m, and a run that skips network-dependent fixtures (`--filter TestCategory!=Integration`) finishes in ~3m25s. Every test still exercises the same real code paths as before.

- **Share one off-screen page-checks browser across the epub and bloompub test fixtures** via a new test hook, `PublishHelper.ExternalPageChecksBrowserForTests`. Each epub export / bloompub creation previously booted and tore down its own WebView2 environment (browser process + dedicated STA thread). The fixtures create one browser per fixture and clear the hook on teardown; the real browser-based visibility/font checks still run for every book. Production is unaffected (the hook is never set outside tests). Epub suite: 1m32s → 1m9s.
- **Dispose the `ZipFile`s in `BloomPubMakerTests.TestHtmlAfterCompression`.** The undisposed `ZipFile` kept each .bloompub locked, so each `TempFile` Dispose sat in `RobustIO`/`RetryUtility` sleep-retry loops (~80% of the fixture's wall time). Fixture: 1m41s → 19s.
- **Fix `BloomServerTests.CanGetActivityImage`**, which used `RobustFile.Create` to make its test image: that left the stream open (file locked) and the file empty (invalid PNG), sending the server's image pipeline into ~20s of `PalasoImage.FromFileRobustly` retries. It now writes a real small PNG and closes it. Test: 23s → <1s; fixture: 27s → 4s.
- **Mark the four WebLibraryIntegration fixtures that talk to live web services** (unit-test S3 buckets, bloomlibrary API, production site) with `[Category("Integration")]`. They still run by default; the category just makes their ~3.5 minutes of network tests skippable when a quick local iteration doesn't need them.
- **Make the opt-in manual RAB build test check its whole toolchain up front** (launcher, keytool, buildapp.bat on the PATH) and fail fast (~200ms) with an actionable message, instead of letting RAB churn for ~10s before failing with "'buildapp.bat' is not recognized".

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8067)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8067)
<!-- Reviewable:end -->

