### PR TITLE
Fix PNG file resizing for new image gallery dialog (BL-16424)

### DIFF
--- a/src/BloomExe/Edit/PageEditingModel.cs
+++ b/src/BloomExe/Edit/PageEditingModel.cs
@@ -42,8 +42,7 @@ namespace Bloom.Edit
             var imageFileName = ImageUtils.ProcessAndSaveImageIntoFolder(
                 imageInfo,
                 bookFolderPath,
-                isSameFile,
-                resizeFileIfNeeded: false // resizing will happen later in a callback from javascript
+                isSameFile
             );
             try
             {

--- a/src/BloomExe/ImageProcessing/ImageUtils.cs
+++ b/src/BloomExe/ImageProcessing/ImageUtils.cs
@@ -932,9 +932,13 @@ namespace Bloom.ImageProcessing
         /// Create a display-ready processed version of an image in <paramref name="destDir"/>:
         /// resize if too large, convert format if beneficial (JPEG→PNG for transparent line art,
         /// PNG→JPEG for photographic content), and optionally make backgrounds transparent.
-        /// This contains the processing that was formerly done at import time by
-        /// <see cref="ProcessAndSaveImageIntoFolder"/>; it is now applied at display time so that
-        /// the book folder always stores something as close as we think reasonable to the original/unmodified file.
+        /// This may duplicate some processing that is done at import time by
+        /// <see cref="ProcessAndSaveImageIntoFolder"/>, but this method is also called when
+        /// publishing to possibly adjust the images even further.
+        /// After import processing, the book folder always stores something as close as we think
+        /// reasonable to the original/unmodified file and that is suitable for good quality print
+        /// publication.  The result of this method is not stored in the book folder, but is used
+        /// for display in the Bloom UI or for ebook publication.
         /// </summary>
         /// <param name="sourcePath">Path to the image file in the book folder.</param>
         /// <param name="destDir">Directory in which to write the processed copy.</param>
@@ -946,6 +950,12 @@ namespace Bloom.ImageProcessing
         /// Path of the processed image inside <paramref name="destDir"/>, or <c>null</c> if the
         /// original can be served as-is or if processing failed.
         /// </returns>
+        /// <remarks>
+        /// Care must be taken that any processing here that duplicates what is done at import time does not
+        /// slow down the UI.  For example, if the image is already a web format and small enough, we should
+        /// use it as-is.  Methods that may process the image with GraphicsMagick should avoid processing if
+        /// the result would be the same as the original. (BL-16424)
+        /// </remarks>
         public static string AdjustImageForDisplay(
             string sourcePath,
             string destDir,


### PR DESCRIPTION
## What

Restores image resizing for the new image gallery dialog.

`PageEditingModel.ChangePicture` was passing `resizeFileIfNeeded: false` to `ImageUtils.ProcessAndSaveImageIntoFolder`, on the assumption that resizing would happen later in a JavaScript callback. That assumption holds for the legacy edit-page path (paste / image toolbox), but **not** for the new image gallery dialog (`ImageGalleryApi`), which has no such callback. As a result, images chosen from the gallery were never downscaled.

This removes the `resizeFileIfNeeded: false` argument so the parameter takes its `true` default, restoring resizing for all callers.

## Why this is safe

The expensive "shrink-attempted-twice on indexed-color PNGs" slowdown that originally motivated `resizeFileIfNeeded: false` (commit `9cba7a96f`) is already prevented by the `IsIndexedColorPngFile` guard added to `TryResizeImageWithGraphicsMagick` in that same commit. That guard remains, so indexed PNGs still short-circuit out of the resize attempt cheaply. Re-enabling resizing on the C# side therefore does not reintroduce the slowdown, and resizing an already-small image is a no-op.

## Testing

`PageEditingModelTests` and `ImageUtilsTests` pass (73/73).

Ref: https://issues.bloomlibrary.org/issue/BL-16424


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8069)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8069)
<!-- Reviewable:end -->
