### PR TITLE
Fix gray spaces lost between sections of closed toolbox menu items (BL-16532)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.tsx
@@ -730,6 +730,9 @@ export const ToolboxRoot: React.FunctionComponent = () => {
                         background-color: ${kBloomPanelBackground};
                         display: flex;
                         flex-direction: column;
+                        // Lets the darker panel background show through between the
+                        // collapsed section headers, as it did in 6.3 and earlier (BL-16532).
+                        gap: 1px;
                         height: 100%;
                         min-height: 0;
 


### PR DESCRIPTION
Restores the thin darker-gray separators between collapsed toolbox sections in the Edit tab, lost in the 6.4 rewrite of the toolbox sidebar from a jQuery UI accordion to MUI Accordions (BL-15894). The old jQuery UI stylesheet gave each accordion header `margin-top: 1px`, letting the darker panel background show through between the lighter collapsed headers.

The fix adds `gap: 1px` to the flex column that holds the Accordion sections in `ToolboxRoot.tsx`. The container's background is the darker panel color (`#2e2e2e`), so each gap renders as a thin separator line between the `#404040` collapsed headers, and it is invisible adjacent to the expanded section, whose background is that same panel color.

Verified visually by launching Bloom from this branch, enabling seven tools, and confirming over CDP that each collapsed accordion header is separated by a 1px gap showing the darker background, matching the 6.3 screenshots on the issue.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16532

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8070)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8070)
<!-- Reviewable:end -->
