### PR TITLE
go.sh launcher: make 3 parallel worktrees viable (reap orphans, patient health check, cap esbuild CPU)

### DIFF
--- a/src/BloomBrowserUI/scripts/go.mjs
+++ b/src/BloomBrowserUI/scripts/go.mjs
@@ -2,12 +2,10 @@
 /* global AbortSignal, clearTimeout, console, fetch, process, setTimeout */
 import { spawn } from "node:child_process";
 import net from "node:net";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import {
-    killProcessTree,
-    sweepStaleWorktreeNodeProcesses,
-} from "./processTree.mjs";
+import { killProcessTree, reapOrphanedBloomDevStacks } from "./processTree.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -17,21 +15,26 @@ const devScriptPath = path.join(browserUIRoot, "scripts", "dev.mjs");
 const exeScriptPath = path.join(repoRoot, "scripts", "watchBloomExe.mjs");
 process.env.feedback = "off";
 const startupQuietMs = 1500;
-const viteHealthTimeoutMs = 30000;
+// Overall window to get a healthy /@vite/client response before giving up.
+const viteHealthTimeoutMs = 60000;
 const viteHealthPollMs = 250;
 // Per-request timeout for a single /@vite/client probe. This must comfortably
 // exceed Vite's real cold-start response latency, NOT just its steady-state
 // latency (a few ms). We probe at the most CPU-contended moment of startup:
 // Vite is still pre-bundling deps (optimizeDeps for jquery/comicaljs), the 7
 // file watchers are doing their initial scans, and LESS is compiling ~180
-// stylesheets, so Vite's event loop stalls in bursts. Measured latency under
-// that load reaches ~2.9s (p99), while steady state is <10ms. A 500ms timeout
-// (the previous value) spuriously aborted every probe during this window, so
-// waitForViteClient never got its 2 consecutive successes and the whole launch
-// failed. A slow-but-listening server is healthy, not broken; a genuinely dead
-// server still fails fast via ECONNREFUSED, so this longer timeout only affects
-// the busy-but-fine case.
-const viteHealthRequestTimeoutMs = 3000;
+// stylesheets, so Vite's event loop stalls in bursts. That contention multiplies
+// when several worktrees run at once (the supported case), so we allow generous
+// slack: a slow-but-listening server is healthy, not broken, and a genuinely
+// dead server still fails fast via ECONNREFUSED, so a long timeout only affects
+// the busy-but-fine case. Measured latency for a single stack reaches ~2.9s
+// (p99); 10s leaves headroom for a loaded machine.
+const viteHealthRequestTimeoutMs = 10000;
+// How many reachable probes (250ms apart) we require before declaring Vite up.
+// We probe only AFTER the dev output has already gone quiescent, so a single
+// success is enough evidence the server is serving; requiring more just adds
+// wall-clock and, under load, risks never stringing successes together at all.
+const requiredHealthProbeSuccesses = 1;
 const maxRandomVitePortAttempts = 10;
 const gracefulShutdownMs = 1500;
 // Probe both loopback families: Vite may bind only IPv6 (::1) on some machines,
@@ -48,6 +51,26 @@ const parsePositiveInteger = (value) => {
 
     return undefined;
 };
+
+// How many CPU cores each dev stack's esbuild (used by Vite for dep pre-bundling
+// and transforms) is allowed to use. esbuild is written in Go and honors the
+// GOMAXPROCS environment variable, which propagates from here through dev.mjs and
+// Vite to the esbuild service child. By default we cap each stack at roughly a
+// third of the machine's logical cores so up to ~3 worktrees can start in
+// parallel without oversubscribing the CPU (which is what inflates cold-start
+// latency past the health-check window and, at the extreme, thrashes the whole
+// machine). This trades some single-stack speed for parallel-run reliability;
+// override with BLOOM_GO_MAX_PROCS to widen or narrow the cap.
+const logicalCpuCount = (() => {
+    try {
+        return os.availableParallelism();
+    } catch {
+        return os.cpus().length;
+    }
+})();
+const esbuildMaxProcs =
+    parsePositiveInteger(process.env.BLOOM_GO_MAX_PROCS) ??
+    Math.max(2, Math.floor(logicalCpuCount / 3));
 
 const requireOptionValue = (args, index, optionName) => {
     const value = args[index + 1];
@@ -263,7 +286,7 @@ const waitForViteClient = async (port, timeoutMs) => {
     while (!isShuttingDown && Date.now() < deadline) {
         if (await isViteClientReachable(port)) {
             consecutiveSuccesses++;
-            if (consecutiveSuccesses >= 2) {
+            if (consecutiveSuccesses >= requiredHealthProbeSuccesses) {
                 return true;
             }
         } else {
@@ -374,6 +397,8 @@ const startDevServerOnPort = (port) =>
                 env: {
                     ...process.env,
                     PORT: String(port),
+                    // Cap this stack's esbuild (Go) parallelism; see esbuildMaxProcs.
+                    GOMAXPROCS: String(esbuildMaxProcs),
                 },
             },
         );
@@ -575,16 +600,16 @@ const startBloomExe = (vitePort) => {
 };
 
 const main = async () => {
-    // Defensive sweep: a prior launcher that was hard-killed (terminal closed,
+    // Defensive reap: a prior launcher that was hard-killed (terminal closed,
     // SIGKILL, timeout) cannot run its shutdown handlers, so its Vite + watcher
-    // node processes orphan. Reap any such leftovers from THIS worktree before we
-    // start, so a previous leak can't starve the machine and wreck this run. We
-    // match on this worktree's repo-root path (which appears in the command lines
-    // of dev.mjs, watchBloomExe.mjs, and the Vite/onchange bins) and exclude our
-    // own pid. Killing a tree root takes its relative-path descendants
-    // (watchLess, onchange's command children) with it.
-    await sweepStaleWorktreeNodeProcesses({
-        commandLineMarker: repoRoot,
+    // node processes orphan. Left uncleaned, these accumulate across worktrees and
+    // sessions until the machine is starved and launches fail their Vite health
+    // check. Reap orphans from EVERY worktree before we start (not just this one):
+    // it is safe because only dead-parented processes are targeted, so a live
+    // go.sh session -- whose processes still have a living parent chain up to its
+    // go.mjs -- is never touched. Killing a tree root takes its descendants
+    // (Vite, watchLess, onchange's command children) with it.
+    await reapOrphanedBloomDevStacks({
         excludePids: [process.pid],
         log: (message) => console.log(`[go] ${message}`),
     });

--- a/src/BloomBrowserUI/scripts/processTree.mjs
+++ b/src/BloomBrowserUI/scripts/processTree.mjs
@@ -62,7 +62,7 @@ export const killProcessTree = (pid, signal = "SIGTERM") =>
 const BLOOM_DEV_STACK_SIGNATURE =
     "watchBloomExe\\.mjs" +
     "|BloomBrowserUI[\\\\/](scripts[\\\\/](dev|watchLess)\\.mjs|node_modules[\\\\/](vite|onchange)[\\\\/])" +
-    "|(compilePug|copyStaticFile|copyContentFile)\\.mjs";
+    "|scripts[\\\\/](compilePug|copyStaticFile|copyContentFile)\\.mjs";
 
 /**
  * Find the process ids of ORPHANED Bloom dev-stack `node.exe` processes across

--- a/src/BloomBrowserUI/scripts/processTree.mjs
+++ b/src/BloomBrowserUI/scripts/processTree.mjs
@@ -51,56 +51,56 @@ export const killProcessTree = (pid, signal = "SIGTERM") =>
         resolve();
     });
 
-/**
- * Quote a string as a single PowerShell single-quoted literal (doubling any
- * embedded single quotes), so an arbitrary worktree path can be embedded safely.
- *
- * @param {string} value - The raw string to quote.
- * @returns {string} A PowerShell-safe single-quoted literal.
- */
-const toPowerShellLiteral = (value) => `'${value.replace(/'/g, "''")}'`;
+// Regex (matched against a process's full command line) identifying a node
+// process that belongs to a Bloom dev stack, in ANY worktree. These are the
+// processes `go.mjs` launches, directly or transitively: the dev.mjs launcher
+// and the watchBloomExe controller (direct children of go.mjs), plus Vite, the
+// LESS watcher, the onchange watchers, and the content-copy scripts they spawn.
+// go.mjs itself is deliberately NOT matched, so a live launcher is never a
+// target. Kept Bloom-specific (paths/script names) so we never touch an
+// unrelated orphaned node server that happens to be on the machine.
+const BLOOM_DEV_STACK_SIGNATURE =
+    "watchBloomExe\\.mjs" +
+    "|BloomBrowserUI[\\\\/](scripts[\\\\/](dev|watchLess)\\.mjs|node_modules[\\\\/](vite|onchange)[\\\\/])" +
+    "|(compilePug|copyStaticFile|copyContentFile)\\.mjs";
 
 /**
- * Find the process ids of stale, ORPHANED `node.exe` processes whose command line
- * contains the given marker (typically this worktree's repo-root path), excluding
- * the supplied pids (e.g. our own process). Windows only; returns an empty array on
- * other platforms because the orphaning bug this guards against is Windows-specific.
+ * Find the process ids of ORPHANED Bloom dev-stack `node.exe` processes across
+ * ALL worktrees, excluding the supplied pids (e.g. our own). Windows only;
+ * returns an empty array elsewhere because the orphaning bug this guards against
+ * is Windows-specific.
  *
- * "Orphaned" means the process's parent is no longer running -- exactly the state a
- * dev-server tree is left in after the launcher is hard-killed without running its
- * shutdown handlers. Requiring a dead parent is what keeps the sweep from killing a
- * legitimate concurrent run from the same worktree (e.g. another terminal's
- * `pnpm dev` or tests), whose processes still have a living parent. We only need to
- * find the orphaned tree roots; their still-parented descendants (Vite, onchange's
- * command children) are taken down when the root's tree is killed.
+ * "Orphaned" means the process's parent is no longer running. This is the key
+ * safety property: a LIVE go.sh session's processes always have a living parent
+ * chain up to their `go.mjs` controller, so they never match — we can therefore
+ * reap orphans from every worktree without any risk of killing a running session
+ * (this worktree's or another's). When a launcher is hard-killed (terminal
+ * closed, SIGKILL, timeout) its shutdown handler never runs, leaving exactly
+ * these dead-parented orphans behind. We only need the orphaned tree roots; their
+ * still-parented descendants are taken down when the root's tree is killed.
  *
- * @param {string} commandLineMarker - Substring that identifies this worktree's processes.
  * @param {number[]} [excludePids] - Process ids to exclude from the result.
  * @returns {Promise<number[]>} The matching, orphaned, non-excluded process ids.
  */
-export const findStaleWorktreeNodeProcesses = (
-    commandLineMarker,
-    excludePids = [],
-) =>
+export const findOrphanedBloomDevStackRoots = (excludePids = []) =>
     new Promise((resolve) => {
-        if (!isWindows || !commandLineMarker) {
+        if (!isWindows) {
             resolve([]);
             return;
         }
 
         const excluded = new Set(excludePids.filter(Number.isInteger));
-        const markerLiteral = toPowerShellLiteral(commandLineMarker);
-        // List node.exe processes whose command line mentions this worktree AND
-        // whose parent process is no longer alive (true orphans), printing just
-        // their pids, one per line. We build a lookup of every live pid so the
+        // List node.exe processes whose command line matches a Bloom dev-stack
+        // process AND whose parent is no longer alive (true orphans), printing
+        // just their pids. We build a lookup of every live pid so the
         // parent-alive test is a cheap hash check.
         const script = [
-            `$marker = ${markerLiteral};`,
+            `$sig = '${BLOOM_DEV_STACK_SIGNATURE}';`,
             "$all = Get-CimInstance Win32_Process;",
             "$alive = @{};",
             "foreach ($p in $all) { $alive[[int]$p.ProcessId] = $true }",
             "$all",
-            "| Where-Object { $_.Name -eq 'node.exe' -and $_.CommandLine -and $_.CommandLine.Contains($marker) -and -not $alive.ContainsKey([int]$_.ParentProcessId) }",
+            "| Where-Object { $_.Name -eq 'node.exe' -and $_.CommandLine -and ($_.CommandLine -match $sig) -and -not $alive.ContainsKey([int]$_.ParentProcessId) }",
             "| ForEach-Object { $_.ProcessId }",
         ].join(" ");
 
@@ -127,35 +127,33 @@ export const findStaleWorktreeNodeProcesses = (
     });
 
 /**
- * Detect and force-kill stale dev-server `node.exe` processes left over from a
- * previous run of THIS worktree (e.g. after the launcher was hard-killed and its
- * signal handlers never ran). This keeps a prior leak from silently starving the
- * machine and wrecking the next `go.sh`. Windows only; a no-op elsewhere.
+ * Detect and force-kill orphaned Bloom dev-stack `node.exe` processes left over
+ * from hard-killed launchers, in ANY worktree. Running this at `go.sh` startup
+ * keeps prior leaks from accumulating across worktrees and sessions and starving
+ * the machine (which otherwise ratchets up until launches start failing their
+ * Vite health check). Safe because only dead-parented orphans are targeted, never
+ * a live session. Windows only; a no-op elsewhere.
  *
- * @param {object} params
- * @param {string} params.commandLineMarker - Substring identifying this worktree's processes.
+ * @param {object} [params]
  * @param {number[]} [params.excludePids] - Process ids to leave alone (e.g. our own).
- * @param {(message: string) => void} [params.log] - Logger for what was swept.
- * @returns {Promise<number>} The number of stale processes that were killed.
+ * @param {(message: string) => void} [params.log] - Logger for what was reaped.
+ * @returns {Promise<number>} The number of orphaned processes that were killed.
  */
-export const sweepStaleWorktreeNodeProcesses = async (params) => {
+export const reapOrphanedBloomDevStacks = async (params = {}) => {
     if (!isWindows) {
         return 0;
     }
 
-    const stalePids = await findStaleWorktreeNodeProcesses(
-        params.commandLineMarker,
-        params.excludePids,
-    );
+    const orphanPids = await findOrphanedBloomDevStackRoots(params.excludePids);
 
-    if (stalePids.length === 0) {
+    if (orphanPids.length === 0) {
         return 0;
     }
 
     params.log?.(
-        `Found ${stalePids.length} orphaned dev-server node process(es) from a hard-killed previous run of this worktree (pids: ${stalePids.join(", ")}). Cleaning them up before starting.`,
+        `Found ${orphanPids.length} orphaned Bloom dev-server node process(es) left by a hard-killed launcher (pids: ${orphanPids.join(", ")}). Cleaning them up before starting.`,
     );
 
-    await Promise.all(stalePids.map((pid) => killProcessTree(pid)));
-    return stalePids.length;
+    await Promise.all(orphanPids.map((pid) => killProcessTree(pid)));
+    return orphanPids.length;
 };


### PR DESCRIPTION
[Claude Opus 4.8]

## Problem

Running Bloom dev stacks (`./go.sh`) in several worktrees at once could snowball into a state where **no** worktree could launch: `go.sh` kept reporting `Vite … never became reachable at /@vite/client` even though Vite had actually started fine.

Two things combined:
- **Resource contention** — several dev stacks each parallelize to all cores, so CPU gets oversubscribed (and at the extreme RAM spills to the pagefile). That inflates Vite's cold-start latency past `go.mjs`'s health-check window, so a *healthy* server gets declared dead and the launch is aborted.
- **Orphan pileup** — on Windows a hard-killed launcher (terminal closed, SIGKILL, timeout) can't run its shutdown handlers, so its Vite + ~7 watcher processes orphan. The old sweep only cleaned *this* worktree's leftovers, so orphans from other worktrees accumulated across runs until the machine was starved — and each failed launch left more behind (a vicious cycle).

Goal: **make ~3 parallel worktrees reliable, accepting slower builds as the trade.**

## Changes

1. **Reap orphaned dev stacks across ALL worktrees on startup** (`processTree.mjs`). Replaces the this-worktree-only sweep with a reaper keyed on *controller liveness*: any Bloom dev-stack node process (`dev.mjs`, Vite, `watchLess`, `onchange`, `watchBloomExe`, content-copy scripts) whose **parent is dead** is an orphan and gets its tree killed. A live `go.sh` session always has a living parent chain up to its `go.mjs`, so it is **never** touched — which is exactly why it's safe to clean every worktree's leftovers, not just this one's.

2. **Patient Vite health gate instead of fail-fast** (`go.mjs`). A slow-but-listening server is healthy, not broken: accept a single reachable probe (was 2 consecutive), raise the per-request timeout 3s→10s and the overall window 30s→60s. A genuinely dead server still fails fast via `ECONNREFUSED`, so the extra slack only affects the busy-but-fine case.

3. **Cap each stack's esbuild CPU via `GOMAXPROCS`** (`go.mjs`). esbuild is written in Go and honors `GOMAXPROCS`, which propagates from `go.mjs` → `dev.mjs` → Vite → the esbuild child. Default it to ~`cores/3` so up to ~3 worktrees can start in parallel without each grabbing all cores. Override with `BLOOM_GO_MAX_PROCS`.

Deliberately **not** included: cross-worktree serialization of cold starts. We don't expect multiple worktrees to start at the same instant, so it wasn't worth the complexity.

## Testing

- `pnpm exec eslint` clean on both files; pre-commit hooks (prettier, lint-staged, tsgo typecheck) pass.
- `node --check` on both files.
- Reaper's signature regex validated against real command lines: matches `dev.mjs` / Vite / `watchLess` / `onchange` / `watchBloomExe` / content-copy children; does **not** match `go.mjs` itself or unrelated node servers.
- Dry-run of the finder against the live machine (3 real worktree stacks running) correctly returned **zero** orphans — confirming live sessions are never flagged.
- `esbuildMaxProcs` computes to 6 on a 20-core machine as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8071)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8071)
<!-- Reviewable:end -->
