### PR TITLE
Bound reader words at zero-width/directional chars in the highlighter (BL-16490)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markupSpec.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markupSpec.js
@@ -279,4 +279,74 @@ describe("jquery.text-markup", function () {
             '<p> <span class="word-not-found" data-segment="word">This</span><em> <span class="word-not-found" data-segment="word">is</span> </em>a test.</p>',
         );
     });
+
+    // The following three tests lock in that the analyzer (getWordsFromHtmlString) and the
+    // highlighter (wrap_words_extra) agree about ZERO WIDTH SPACE (U+200B) being a word
+    // boundary. They previously disagreed: the analyzer split words on U+200B while the
+    // highlighter's \p{Z}/\p{P} boundaries did not match it (U+200B is Unicode category Cf,
+    // not Zs), so a decodable word touching a ZWSP was left unmarked or mis-marked. See
+    // BL-16490. We build the invisible characters with String.fromCharCode so this source
+    // file stays free of them.
+    it("getWordsFromHtmlString splits on ZERO WIDTH SPACE but not ZERO WIDTH JOINER (BL-16490)", function () {
+        const zwsp = String.fromCharCode(0x200b);
+        const zwj = String.fromCharCode(0x200d);
+
+        // sanity check the test data really contains an invisible ZWSP in the middle
+        const input = `cat${zwsp}dog`;
+        expect(input.length).toBe(7);
+        expect(input.indexOf(zwsp)).toBe(3);
+
+        expect(theOneLibSynphony.getWordsFromHtmlString(input)).toEqual([
+            "cat",
+            "dog",
+        ]);
+
+        // ...but ZERO WIDTH JOINER is legitimate within a word and must NOT split it.
+        expect(
+            theOneLibSynphony.getWordsFromHtmlString(`ca${zwj}t`),
+        ).toEqual([`ca${zwj}t`]);
+    });
+
+    it("wrap_words_extra matches words bounded by a ZERO WIDTH SPACE (BL-16490)", function () {
+        const zwsp = String.fromCharCode(0x200b);
+        // A stray ZWSP sits between two words. Because the analyzer splits on it, both
+        // "cat" and "dog" end up in the word list, and the highlighter must wrap both,
+        // leaving the ZWSP in place between them.
+        const html = `<p>cat${zwsp}dog</p>`;
+        // sanity check: the invisible ZWSP really is present in the input
+        expect(html.indexOf(zwsp)).toBeGreaterThan(-1);
+
+        const newHtml = theOneLibSynphony.wrap_words_extra(
+            html,
+            ["cat", "dog"],
+            "word-not-found",
+            ' data-segment="word"',
+        );
+
+        expect(newHtml).toBe(
+            `<p><span class="word-not-found" data-segment="word">cat</span>${zwsp}` +
+                `<span class="word-not-found" data-segment="word">dog</span></p>`,
+        );
+        // the ZWSP must be preserved, not swallowed
+        expect(newHtml.indexOf(zwsp)).toBeGreaterThan(-1);
+    });
+
+    it("wrap_words_extra matches a word immediately followed by a ZERO WIDTH SPACE (BL-16490)", function () {
+        const zwsp = String.fromCharCode(0x200b);
+        // "cat" is decodable; a stray ZWSP sits right after it, before a normal space.
+        // Previously the afterWord boundary (\p{Z}/\p{P} only) did not see the ZWSP, so
+        // "cat" was left unmarked.
+        const html = `<p>cat${zwsp} sat</p>`;
+
+        const newHtml = theOneLibSynphony.wrap_words_extra(
+            html,
+            ["cat"],
+            "word-not-found",
+            ' data-segment="word"',
+        );
+
+        expect(newHtml).toBe(
+            `<p><span class="word-not-found" data-segment="word">cat</span>${zwsp} sat</p>`,
+        );
+    });
 });

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/synphony_lib.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/synphony_lib.ts
@@ -228,6 +228,31 @@ export function setLangData(data) {
     theOneLibSynphony.processVocabularyGroups();
 }
 
+// The zero-width and directional format characters that we treat as word boundaries.
+// U+200B ZERO WIDTH SPACE is the notable one: despite its name it is Unicode category
+// Cf (Format), NOT Zs (Space Separator), so it is NOT matched by \p{Z} or \s. Along with
+// the LTR/RTL marks (U+200E/U+200F), the directional embedding/override markers
+// (U+202A-U+202E), and the directional isolates (U+2066-U+2069), these can appear between
+// (or stray inside) words without being visible.
+// This is the body of a regex character class (no enclosing brackets). It MUST be kept in
+// sync between getWordsFromHtmlString (which splits story text into words on these) and
+// wrap_words_extra (which highlights those words in the HTML): if the two disagree about
+// where a word ends, a decodable word next to one of these characters gets left unmarked
+// or mis-marked. See BL-3933, BL-7081, and BL-16490.
+// NOTE: U+200C (ZWNJ) and U+200D (ZWJ) are deliberately excluded; they are legitimate
+// within words in some scripts and must NOT split or bound a word (BL-13428).
+// Built with String.fromCharCode (not string escapes) so this source file itself stays
+// free of the very invisible characters it describes.
+const zeroWidthAndDirectionalSplitters =
+    String.fromCharCode(0x200b) + // ZERO WIDTH SPACE
+    String.fromCharCode(0x200e, 0x200f) + // LEFT-TO-RIGHT / RIGHT-TO-LEFT MARK
+    String.fromCharCode(0x202a) +
+    "-" +
+    String.fromCharCode(0x202e) + // directional embedding/override markers
+    String.fromCharCode(0x2066) +
+    "-" +
+    String.fromCharCode(0x2069); // directional "isolate" markers
+
 /**
  * Class that holds Synphony-related functions
  * @returns {LibSynphony}
@@ -635,24 +660,20 @@ export class LibSynphony {
         // Originally the code had p{C} (all Control characters), but this was too all-encompassing.
         const whitespace = "\\p{Z}";
         const controlChars = "\\p{Cc}"; // "real" Control characters
-        // The following constants are Control(format) [p{Cf}] characters that should split words.
-        // e.g. ZERO WIDTH SPACE is a Control(format) charactor
+        // We also split on some Control(format) [p{Cf}] characters (ZERO WIDTH SPACE and the
+        // LTR/RTL/directional markers). e.g. ZERO WIDTH SPACE is a Control(format) character
         // (See http://issues.bloomlibrary.org/youtrack/issue/BL-3933),
-        // but so are ZERO WIDTH JOINER and NON JOINER (See https://issues.bloomlibrary.org/youtrack/issue/BL-7081).
+        // as are ZERO WIDTH JOINER and NON JOINER (See https://issues.bloomlibrary.org/youtrack/issue/BL-7081).
         // See list at: https://www.compart.com/en/unicode/category/Cf
-        const zeroWidthSplitters = "\u200b"; // ZERO WIDTH SPACE
-        const ltrrtl = "\u200e\u200f"; // LEFT-TO-RIGHT MARK / RIGHT-TO-LEFT MARK
-        const directional = "\u202A-\u202E"; // more LTR/RTL/directional markers
-        const isolates = "\u2066-\u2069"; // directional "isolate" markers
+        // These live in the shared zeroWidthAndDirectionalSplitters constant so that
+        // wrap_words_extra bounds words at exactly the same characters we split on here
+        // (See BL-16490).
         // split on whitespace, Control(control) and some Control(format) characters
         regex = XRegExp(
             "[" +
                 whitespace +
                 controlChars +
-                zeroWidthSplitters +
-                ltrrtl +
-                directional +
-                isolates +
+                zeroWidthAndDirectionalSplitters +
                 "]+",
             "xg",
         );
@@ -1445,9 +1466,20 @@ export class LibSynphony {
         if (extra.length > 0 && extra.substring(0, 1) !== " ")
             extra = " " + extra;
 
-        var beforeWord = "(^\\s*|>\\s*|[\\s\\p{Z}]|\\p{P}|&nbsp;)"; // word beginning delimiter
+        // Bound words at the same zero-width / directional splitters that
+        // getWordsFromHtmlString splits on (via zeroWidthAndDirectionalSplitters), in
+        // addition to ordinary whitespace/separators. Without this, a decodable word that
+        // touches (or is split by) an invisible character such as U+200B ZERO WIDTH SPACE
+        // is not matched here and so shows up unmarked or as not-decodable, even though the
+        // analyzer counted it. U+200B et al. are Unicode category Cf, so \p{Z} does NOT
+        // include them; they must be listed explicitly. See BL-16490.
+        const wordBoundaryChars =
+            "\\s\\p{Z}" + zeroWidthAndDirectionalSplitters;
+        var beforeWord = "(^\\s*|>\\s*|[" + wordBoundaryChars + "]|\\p{P}|&nbsp;)"; // word beginning delimiter
         var afterWord =
-            "(?=(\\s*$|\\s*<|[\\s\\p{Z}]|\\p{P}+\\s|\\p{P}+<br|[\\s]*&nbsp;|\\p{P}+&nbsp;|\\p{P}+$))"; // word ending delimiter
+            "(?=(\\s*$|\\s*<|[" +
+            wordBoundaryChars +
+            "]|\\p{P}+\\s|\\p{P}+<br|[\\s]*&nbsp;|\\p{P}+&nbsp;|\\p{P}+$))"; // word ending delimiter
 
         // escape special characters
         var escapedWords = aWords.map(RegExp.quote);


### PR DESCRIPTION
## Problem

Zero-width spaces still break the Decodable Reader tool despite the earlier BL-16490 fix (which stripped orphaned CKEditor filling chars). The root cause is a mismatch between two functions in `synphony_lib.ts`:

- **The analyzer** (`getWordsFromHtmlString`) splits story text into words *on* U+200B ZERO WIDTH SPACE and the LTR/RTL/directional format characters.
- **The highlighter** (`wrap_words_extra`) bounded words only with `\s` / `\p{Z}` / `\p{P}` / `&nbsp;`. U+200B and friends are Unicode category **Cf**, not **Zs**, so `\p{Z}` never matched them.

Result: a decodable word touching or split by one of these invisible characters was counted by the analyzer yet left unmatched by the highlighter, so it displayed unmarked or as not-decodable. Blanket-stripping the characters can't fully fix this — it only fires on boxes with a live CKEditor instance, and would be wrong for scripts that use ZWSP as a legitimate word separator.

## Fix

- Extract the splitter set into a shared `zeroWidthAndDirectionalSplitters` constant (built with `String.fromCharCode` so this source file stays free of the invisible characters it describes).
- Use it both in `getWordsFromHtmlString`'s split regex (behavior unchanged — same code points as before) and in `wrap_words_extra`'s `beforeWord`/`afterWord` boundary character classes, so the two can no longer disagree about where a word ends.
- ZWNJ/ZWJ (U+200C/U+200D) remain excluded; they are legitimate within words in some scripts (BL-13428).

## Tests

Added regression tests covering both sides of the mismatch: the analyzer split (splits on ZWSP, not ZWJ) and the highlighter matching for words adjacent to and split by a ZWSP.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16490


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8073)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8073)
<!-- Reviewable:end -->
