### PR TITLE
Test hygiene: no CDP port in unit-test WebView2s; reset Program statics

### DIFF
--- a/src/BloomExe/WebView2Browser.cs
+++ b/src/BloomExe/WebView2Browser.cs
@@ -396,9 +396,13 @@ namespace Bloom
             {
                 additionalBrowserArgs += " --accept-lang=" + _uiLanguageOfThisRun;
             }
-            if (RemoteDebuggingPort.HasValue)
+            if (RemoteDebuggingPort.HasValue && !Program.RunningUnitTests)
             {
                 // Expose a CDP endpoint so Playwright and other automation can attach to the real Bloom WebView2 surface.
+                // NOT in unit tests: nothing attaches to a test-run WebView2, and on a busy CI machine the port
+                // (BloomServer's http port + 2) can already be held by a real Bloom instance running beside the
+                // tests, in which case Chromium's fight over the port breaks WebView2 startup and fails the test
+                // (seen as flaky BookUploadAndDownloadTests upload failures on agents also running Bloom automation).
                 additionalBrowserArgs += $" --remote-debugging-port={RemoteDebuggingPort.Value} "; // allow external inspector connect
             }
             if (featuresToDisable.Count > 0)

--- a/src/BloomTests/ProgramTests.cs
+++ b/src/BloomTests/ProgramTests.cs
@@ -6,6 +6,19 @@ namespace BloomTests
     [TestFixture]
     public class ProgramTests
     {
+        /// <summary>
+        /// ParseStartupPortArguments stores its results in Program statics (StartupAutomation etc.)
+        /// which live for the rest of the test run. Re-parse empty args after each test to restore
+        /// the defaults; the method resets all of them on entry. Without this, the "--automation"
+        /// tests here left StartupAutomation=true for every later fixture, which (among other
+        /// things) made BloomServer print automation banners in unrelated tests' output.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            Program.ParseStartupPortArguments(System.Array.Empty<string>(), out _);
+        }
+
         [Test]
         public void ParseStartupPortArguments_RemovesPortsAndStoresExplicitValues()
         {

--- a/src/BloomTests/ShellTests.cs
+++ b/src/BloomTests/ShellTests.cs
@@ -7,6 +7,17 @@ namespace BloomTests
     [TestFixture]
     public class ShellTests
     {
+        /// <summary>
+        /// ParseStartupPortArguments writes into Program statics that live for the rest of the
+        /// test run; re-parse empty args after each test to restore the defaults (the method
+        /// resets them all on entry). Same rationale as the ProgramTests TearDown.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            Program.ParseStartupPortArguments(Array.Empty<string>(), out _);
+        }
+
         [Test]
         public void ShouldShowPortSummaryInWindowTitle_TracksAutomationFlag()
         {


### PR DESCRIPTION
Two test-hygiene fixes found while investigating CI failures in the upload integration tests. (The actual cause of those CI failures is server-side — `POST https://api.bloomlibrary.org/v1/books/new:upload-start?env=unit-test` currently returns a bare 500, reproducible with curl — so this PR does not fix them; it fixes two real hazards the investigation surfaced.)

1. **Don't request a CDP port for unit-test WebView2s.** `WebView2Browser` passed `--remote-debugging-port=<BloomServer http port + 2>` to every WebView2 whenever a BloomServer was listening in the process — including unit tests. Nothing ever attaches to a test-run WebView2, and on a CI machine that also runs real Bloom instances the port can already be taken, which breaks WebView2 startup and fails whatever test needed the browser. Now skipped when `Program.RunningUnitTests`.

2. **`ProgramTests` no longer leaks `StartupAutomation=true`.** Its `ParseStartupPortArguments("--automation", …)` tests left the Program statics set for every later fixture in the run, which made `BloomServer` print `BLOOM_AUTOMATION_READY` banners in unrelated tests' output (and would defeat fix #1's gate-adjacent reasoning about automation state). A `TearDown` now re-parses empty args, which resets all the startup statics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8076)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8076)
<!-- Reviewable:end -->
