### PR TITLE
Fix BL-16538 Little arrow in Leveled Reader Tool displays after reenable tool on Canvas page

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.tsx
@@ -1025,6 +1025,20 @@ export const ToolboxRoot: React.FunctionComponent = () => {
                                                 font-weight: normal;
                                             }
                                         }
+
+                                        // Those same adopted bodies also keep the
+                                        // header icon jQuery-UI's _createIcons()
+                                        // prepends to every header: a
+                                        // ui-icon-triangle-1-e sprite. As a body
+                                        // (not a header) it renders as a stray
+                                        // right-pointing arrowhead in the top-left
+                                        // corner. The rule above only neutralized the
+                                        // header background/border, not this child
+                                        // icon, so hide it too. (BL-16538)
+                                        div[data-toolid]
+                                            span.ui-accordion-header-icon {
+                                            display: none !important;
+                                        }
                                     `}
                                 >
                                     {section.liveToolBodyElement ? (


### PR DESCRIPTION
Fixes the stray right-pointing arrowhead (►) that intermittently appears in the top-left of the Leveled/Decodable Reader tool body after re-enabling the tool via "More…" on a Canvas page.

### Root cause
The toolbox is mid-migration: a hidden legacy jQuery-UI accordion (`#toolbox`, `display:none`) runs alongside the visible React/MUI accordion (`ToolboxRoot.tsx`). The Leveled/Decodable Reader tool **body** `div`s are adopted out of the legacy accordion into React, but still carry the jQuery-UI `ui-accordion-header` class. jQuery-UI's `_createIcons()` prepends a `span.ui-accordion-header-icon` (a `ui-icon-triangle-1-e` right-triangle sprite, positioned `absolute; left:.5em; top:50%`) to anything with that class — so it renders as the stray arrowhead. `accordion("refresh")` on re-enable re-runs `_createIcons`, which is why it's intermittent after re-enabling a reader tool.

The earlier BL-16501 fix neutralized these divs' header background/border theming but did not hide the prepended icon span. This adds a rule to the same CSS block hiding `span.ui-accordion-header-icon` on adopted `div[data-toolid]` bodies.

### Change
CSS-only, in the emotion `css` block wrapping the adopted reader body in `ToolboxRoot.tsx`.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16538


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8077)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8077)
<!-- Reviewable:end -->
