### PR TITLE
Fix BookOnBlorgBadge refetching on every render (BL-16572)

### DIFF
--- a/src/BloomBrowserUI/react_components/BookOnBlorgBadge.tsx
+++ b/src/BloomBrowserUI/react_components/BookOnBlorgBadge.tsx
@@ -2,7 +2,8 @@ import { css } from "@emotion/react";
 
 import * as React from "react";
 import { get } from "../utils/bloomApi";
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { useMountEffect } from "../utils/useMountEffect";
 import { BloomTooltip } from "./BloomToolTip";
 import { Link } from "../react_components/link";
 import { useSubscribeToWebSocketForStringMessage } from "../utils/WebSocketManager";
@@ -49,6 +50,12 @@ export const BookOnBlorgBadge: React.FunctionComponent<{
                     setBadge(BadgeType.None);
                 }
             },
+            () => {
+                // A transient network failure (e.g. offline, server not ready) should not
+                // throw an unhandled promise rejection to Sentry (BLOOM-DESKTOP-FFG). Silently
+                // leave the badge in its previous state; the websocket subscription above will
+                // refresh it when the server next reports a change.
+            },
         );
     };
 
@@ -62,9 +69,12 @@ export const BookOnBlorgBadge: React.FunctionComponent<{
         },
     );
 
-    useEffect(() => {
-        updateBadge();
-    });
+    // Fetch the badge once when the component mounts. Previously this was a bare
+    // useEffect with no dependency array, so it re-ran on every render; with many badges
+    // visible in a collection, any re-render (websocket broadcast, selection change) refired
+    // every badge's network request, amplifying transient network hiccups into bursts of
+    // errors (BLOOM-DESKTOP-FFG). The websocket subscription above handles later updates.
+    useMountEffect(updateBadge);
 
     return (
         <div


### PR DESCRIPTION
[Claude Opus 4.8]

Fixes the top-frequency Sentry error `System.ApplicationException: Unexpected promise failure: Network Error` (Sentry [BLOOM-DESKTOP-FFG](https://bloom-app.sentry.io/issues/7333896293/): 7,158 events / 58 users in 90 days, on Bloom@6.4.104.0).

## Root cause
`BookOnBlorgBadge`'s effect had no dependency array (`useEffect(() => { updateBadge(); });`), so it re-ran after *every* render. With many badges visible in a collection, any re-render (a websocket broadcast, a selection change) refired every badge's network request. That unbounded redundant refetching amplified any transient network hiccup into bursts of failing axios GETs, which `get()` — lacking an `errorCallback` — turned into unhandled promise rejections reported to Sentry.

## Fix
- Use the repo's `useMountEffect` helper so the badge fetches once on mount. The existing websocket subscription (`bookCollection`/`updateBookBadge`) already refreshes it on server-pushed changes, and each badge is mounted with `key={book.id}`, so book identity is stable per mount.
- Pass an `errorCallback` to `get()` so a transient network failure leaves the badge in its previous state silently instead of throwing to Sentry.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16572


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8078)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8078)
<!-- Reviewable:end -->
