### PR TITLE
Guard and observe RunJavascriptFireAndForget to stop UnobservedTaskException (BL-16571)

### DIFF
--- a/src/BloomExe/WebView2Browser.cs
+++ b/src/BloomExe/WebView2Browser.cs
@@ -788,7 +788,35 @@ namespace Bloom
         /// </summary>
         public override void RunJavascriptFireAndForget(string script)
         {
-            _webview.ExecuteScriptAsync(script);
+            // Guard against running when the browser isn't in a usable state. During app startup
+            // (before CoreWebView2 is initialized) or shutdown (while the control is disposing),
+            // ExecuteScriptAsync throws from inside its async state machine. Because nothing here
+            // awaits or otherwise observes the returned Task, that fault used to reach the GC
+            // finalizer thread and get rethrown as an UnobservedTaskException (Sentry
+            // BLOOM-DESKTOP-D07). This mirrors the readiness check in UpdateDisplay().
+            if (
+                _webview == null
+                || _webview.IsDisposed
+                || _webview.Disposing
+                || _webview.CoreWebView2 == null
+            )
+                return;
+
+            // Even with the guard above there is a tiny race window in which the control can start
+            // disposing between the check and the call, so we still observe the returned Task. On a
+            // fault we just log it: this is an expected startup/shutdown race, not a user-facing
+            // failure, so no MessageBox and no rethrow. Observing the Task is what structurally
+            // eliminates the UnobservedTaskException (BLOOM-DESKTOP-D07).
+            _webview
+                .ExecuteScriptAsync(script)
+                .ContinueWith(
+                    t =>
+                        Logger.WriteEvent(
+                            "WebView2Browser.RunJavascriptFireAndForget: ExecuteScriptAsync faulted (expected during startup/shutdown): "
+                                + t.Exception?.GetBaseException().Message
+                        ),
+                    TaskContinuationOptions.OnlyOnFaulted
+                );
         }
 
         public override async Task<string> GetStringFromJavascriptAsync(string script)

--- a/src/BloomExe/WebView2Browser.cs
+++ b/src/BloomExe/WebView2Browser.cs
@@ -811,10 +811,23 @@ namespace Bloom
                 .ExecuteScriptAsync(script)
                 .ContinueWith(
                     t =>
-                        Logger.WriteEvent(
-                            "WebView2Browser.RunJavascriptFireAndForget: ExecuteScriptAsync faulted (expected during startup/shutdown): "
-                                + t.Exception?.GetBaseException().Message
-                        ),
+                    {
+                        // Read the exception first so it is observed even if logging fails.
+                        var message = t.Exception?.GetBaseException().Message;
+                        try
+                        {
+                            Logger.WriteEvent(
+                                "WebView2Browser.RunJavascriptFireAndForget: ExecuteScriptAsync faulted (expected during startup/shutdown): "
+                                    + message
+                            );
+                        }
+                        catch
+                        {
+                            // Swallow any logging failure: letting it escape would fault this
+                            // continuation's own Task and reintroduce the very
+                            // UnobservedTaskException we are preventing (BLOOM-DESKTOP-D07).
+                        }
+                    },
                     TaskContinuationOptions.OnlyOnFaulted
                 );
         }


### PR DESCRIPTION
[Claude Fable 5]

## What
Fixes Sentry **BLOOM-DESKTOP-D07** — `System.AggregateException: A Task's exception(s) were not observed ... (The instance of CoreWebView2 is uninitialized and unable to complete this operation)`, mechanism `UnobservedTaskException`. ~11,005 events / 0 users in the last 90 days, still recurring through Bloom 6.4.104.0.

## Root cause
`WebView2Browser.RunJavascriptFireAndForget(string script)` was exactly:

```csharp
public override void RunJavascriptFireAndForget(string script)
{
    _webview.ExecuteScriptAsync(script);
}
```

No readiness guard, and the returned `Task` is never awaited or observed. When `CoreWebView2` isn't initialized yet (startup) or the control is disposing (shutdown), `ExecuteScriptAsync`'s `VerifyInitializedGuard` throws inside the async state machine. Nothing observes the faulted `Task`, so the GC finalizer thread later rethrows it as an `UnobservedTaskException`, which Sentry reports. This method is the single choke point; its fire-and-forget callers have no lifecycle guard of their own.

## Fix
In `RunJavascriptFireAndForget`:
1. **Early-return** when the browser isn't usable (`_webview == null || IsDisposed || Disposing || CoreWebView2 == null`), mirroring the guard in `UpdateDisplay()`.
2. **Observe the Task** with an `OnlyOnFaulted` continuation that logs via `Logger.WriteEvent`. This is the structurally-important half: it closes the residual race window between the guard check and the call, so the exception is always observed. This is an expected startup/shutdown race, not a user-facing failure — log only, no MessageBox, no rethrow.

The awaited variants (`RunJavascriptAsync`, `GetStringFromJavascriptAsync`, `GetObjectFromJavascriptAsync`) are intentionally left unchanged: their callers await them, so their exceptions are already observed.

## Testing
No unit test: WebView2 lifecycle can't be driven into the uninitialized/disposing state in a headless unit test, so a test here would be hollow. Verified the change compiles (BloomExe builds clean) and is CSharpier-formatted.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16571
Sentry: https://bloom-app.sentry.io/issues/6252535033/


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8079)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8079)
<!-- Reviewable:end -->
