### PR TITLE
Guard async toolbox/dialog callbacks against torn-down DOM / missing opts (BL-16574)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/TextBoxProperties/TextBoxProperties.ts
+++ b/src/BloomBrowserUI/bookEdit/TextBoxProperties/TextBoxProperties.ts
@@ -152,12 +152,18 @@ export default class TextBoxProperties {
     }
     fillInLanguageNames() {
         get("editView/getBookLangs", (result) => {
-            document.getElementById("tbprop-lang1")!.innerText =
-                "(" + result.data.V + ")";
-            document.getElementById("tbprop-lang2")!.innerText =
-                "(" + result.data.N1 + ")";
-            document.getElementById("tbprop-lang3")!.innerText =
-                "(" + result.data.N2 + ")";
+            // This is an async callback: by the time getBookLangs returns, the dialog may
+            // already have been closed and these elements removed from the DOM. In that case
+            // getElementById returns null; bail rather than throw (Sentry BLOOM-DESKTOP-FFJ).
+            // Guard all three (not just the first): don't rely on an assumption about the
+            // order in which the dialog's elements are torn down.
+            const lang1 = document.getElementById("tbprop-lang1");
+            const lang2 = document.getElementById("tbprop-lang2");
+            const lang3 = document.getElementById("tbprop-lang3");
+            if (!lang1 || !lang2 || !lang3) return;
+            lang1.innerText = "(" + result.data.V + ")";
+            lang2.innerText = "(" + result.data.N1 + ")";
+            lang3.innerText = "(" + result.data.N2 + ")";
         });
     }
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/leveledReaderTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/leveledReaderTool.tsx
@@ -33,9 +33,13 @@ export class LeveledReaderTool extends ToolboxToolReactAdaptor {
     public beginRestoreSettings(opts: string): JQueryPromise<void> {
         return beginInitializeLeveledReaderTool().then(() => {
             const restoreDone = $.Deferred<void>();
+            // opts can be undefined/null when the tool is activated for a book that has no
+            // saved leveled-reader settings. Guard before indexing so we fall through to the
+            // default-level path instead of throwing an unhandled promise rejection that
+            // aborts tool activation (Sentry BLOOM-DESKTOP-FFH).
             const leveledReaderState = (
-                opts as unknown as Record<string, string>
-            )["leveledReaderState"];
+                opts as unknown as Record<string, string> | undefined
+            )?.["leveledReaderState"];
             if (leveledReaderState) {
                 // The true passed here prevents re-saving the state we just read.
                 // One non-obvious implication is that simply opening a level-4 book


### PR DESCRIPTION
[Claude Opus 5] Fix authored by Claude Opus 4.8; preflighted by Claude Sonnet 5 and re-preflighted (rebase onto current master, instrumented verification) by Claude Opus 5.

## Summary

Two small defensive guards for Sentry crash reports on BloomDesktop's front end:

- **`TextBoxProperties.fillInLanguageNames()`** (Sentry `BLOOM-DESKTOP-FFJ`): the
  `editView/getBookLangs` callback is async, so the Text Box Properties dialog can already be
  closed — and its elements removed from the DOM — by the time it resolves. The code used a
  non-null assertion (`document.getElementById(...)!`) and crashed with "Cannot read
  properties of null" when that happened. Now it bails out if the elements are gone.
- **`LeveledReaderTool.beginRestoreSettings(opts)`** (Sentry `BLOOM-DESKTOP-FFH`): the code
  indexed into `opts` unconditionally, throwing "Cannot read properties of undefined (reading
  'leveledReaderState')" when `opts` was nullish. Now it optional-chains the lookup so it falls
  through to the default-level path instead of throwing an unhandled rejection that aborts the
  rest of tool activation.

  Note for the reviewer: on current `master` I could not find a live path that actually delivers
  a nullish `opts`. Both callers pass `toolbox.ts`'s module-level `savedSettings`, which starts
  as `{}` and is only ever reassigned from `get("toolbox/settings")`, and `ToolboxView.HandleSettings`
  always replies with a dictionary containing at least `current` and `visibility`. So the Sentry
  events presumably come from an older or since-removed path. The guard is still correct and
  costs nothing, but it should not be read as "reproducible today by making a book with no saved
  leveled-reader state" — that case yields `{current, visibility}` and takes the default-level
  branch without ever hitting the guard.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors (pre-existing warnings elsewhere untouched)
- [x] `pnpm test:ci` (full vitest suite) at the rebased HEAD — 562 passed, 5 skipped, 0 failed
- [x] `build/agent-dotnet.sh test src/BloomTests` at the rebased HEAD — 2924 passed, 13 skipped,
      9 failed. All 9 failures are artifacts of the agent build wrapper's private output tree,
      not of this branch (which touches no C#), and reproduce identically on two runs:
      4 `PdfMakerTests` need `BloomPdfMaker.exe`, which the wrapper does not produce (no native
      apphost), and 5 xmatter tests resolve their test data with a hardcoded
      `{codeBaseDir}/../../../src/BloomTests/xMatter`, which only lands on the repo root from
      `output/Debug/AnyCPU`, not from `output/agent/<key>/bin`.
- [x] Both new code paths exercised in a running Bloom using temporary instrumentation
      (removed before this push):
  - Text Box Properties: an artificial delay was put on the `editView/getBookLangs` request, the
    dialog was dismissed during the delay, and the callback was confirmed to hit the new
    `if (!lang1 || !lang2 || !lang3) return;` bail-out with all three elements `null` and no
    exception. With the dialog left open, the names still fill in normally.
  - Leveled Reader: the nullish-`opts` condition was forced, and `beginRestoreSettings` was
    confirmed to fall through to `readers/io/defaultLevel`, resolve, and let tool activation
    continue — where the old code threw.
- [ ] Manual QA pass — see the test-ideas comment on BL-16574

Ref: https://bloomlibrary.youtrack.cloud/issue/BL-16574


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8081)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8081)
<!-- Reviewable:end -->
