### PR TITLE
Stop reporting expected startup URL-lookup timeouts to Sentry (BL-16575)

### DIFF
--- a/src/BloomExe/web/UrlLookup.cs
+++ b/src/BloomExe/web/UrlLookup.cs
@@ -248,7 +248,37 @@ namespace Bloom.web
                 _internetAvailable = false;
                 var msg = $"Exception while attempting get URL data from server";
                 Logger.WriteEvent($"{msg}: {e.Message}");
-                NonFatalProblem.ReportSentryOnly(e, msg);
+                // A timeout/cancellation/network failure here is expected on slow or unreliable
+                // connections: this is a deliberately short (2.5s/3s) best-effort lookup, and when
+                // it fails we simply fall back to a cached/default URL. Reporting those to Sentry
+                // just buries real issues under thousands of zero-impact events
+                // (BLOOM-DESKTOP-ERZ, -2H2), so we only log them. Anything unexpected (e.g. a JSON
+                // parse error, which would be a real bug) is still reported.
+                if (!IsExpectedTransientLookupFailure(e))
+                    NonFatalProblem.ReportSentryOnly(e, msg);
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Is this exception one of the expected transient network/timeout failures that the
+        /// best-effort URL lookup in <see cref="TryGetUrlDataFromServer"/> handles gracefully (by
+        /// falling back to a cached/default URL), and so should be logged but not reported to
+        /// Sentry? We walk the whole InnerException chain because the AWS SDK wraps the underlying
+        /// WebException/timeout inside an AmazonServiceException.
+        /// </summary>
+        public static bool IsExpectedTransientLookupFailure(Exception e)
+        {
+            for (var ex = e; ex != null; ex = ex.InnerException)
+            {
+                if (
+                    ex is TimeoutException
+                    || ex is OperationCanceledException // includes TaskCanceledException
+                    || ex is System.Net.WebException
+                    || ex is System.Net.Sockets.SocketException
+                    || ex is System.Net.Http.HttpRequestException
+                )
+                    return true;
             }
             return false;
         }

--- a/src/BloomTests/web/UrlLookupTests.cs
+++ b/src/BloomTests/web/UrlLookupTests.cs
@@ -92,5 +92,53 @@ namespace BloomTests.web
 
             Assert.That(UrlLookup.TestInternetConnection("https://example.com"), Is.False);
         }
+
+        // The best-effort startup URL lookup must NOT report expected transient network/timeout
+        // failures to Sentry (BLOOM-DESKTOP-ERZ, -2H2); it must still report genuinely unexpected
+        // failures. These tests pin the classifier that makes that distinction.
+
+        [Test]
+        public void IsExpectedTransientLookupFailure_Timeout_ReturnsTrue()
+        {
+            Assert.That(
+                UrlLookup.IsExpectedTransientLookupFailure(
+                    new TimeoutException("A task was canceled.")
+                ),
+                Is.True
+            );
+        }
+
+        [Test]
+        public void IsExpectedTransientLookupFailure_Cancellation_ReturnsTrue()
+        {
+            Assert.That(
+                UrlLookup.IsExpectedTransientLookupFailure(new TaskCanceledException()),
+                Is.True
+            );
+        }
+
+        [Test]
+        public void IsExpectedTransientLookupFailure_WrappedWebException_ReturnsTrue()
+        {
+            // The AWS SDK surfaces a timeout as an AmazonServiceException wrapping a WebException,
+            // so the classifier must look down the InnerException chain, not just at the top.
+            var wrapped = new Exception(
+                "A WebException with status Timeout was thrown.",
+                new WebException("timed out", WebExceptionStatus.Timeout)
+            );
+            Assert.That(UrlLookup.IsExpectedTransientLookupFailure(wrapped), Is.True);
+        }
+
+        [Test]
+        public void IsExpectedTransientLookupFailure_UnexpectedError_ReturnsFalse()
+        {
+            // A parse/logic error is a real bug and must still reach Sentry.
+            Assert.That(
+                UrlLookup.IsExpectedTransientLookupFailure(
+                    new InvalidOperationException("bad json")
+                ),
+                Is.False
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `TryGetUrlDataFromServer` (startup URL lookup, `BloomS3Client.DownloadFile`) is a deliberate 2.5s/3s best-effort call that already falls back to a cached/default URL on any failure — the user sees nothing.
- Timeouts/cancellations/network failures there are expected on slow or unreliable connections, so reporting every one to Sentry was pure noise burying real issues: Sentry **BLOOM-DESKTOP-ERZ** (~889 events / 141 users, live 6.3.2) and **-2H2** (older, 6.0.1.0).
- Added `UrlLookup.IsExpectedTransientLookupFailure(Exception)`, which walks the `InnerException` chain looking for `TimeoutException`, `OperationCanceledException` (covers `TaskCanceledException`), `WebException`, `SocketException`, or `HttpRequestException`. Those are now logged locally but no longer sent to Sentry. Anything else (e.g. a JSON parse error) is still reported, since that would be a real bug.
- 4 new NUnit tests pin the classifier's behavior, including the wrapped-exception case.

Fix authored by Claude Opus 4.8; PR opened/landed by Claude Sonnet 5 running the preflight pipeline; rebased and live-verified by Claude Opus 5.

Ref: BL-16575

## Test plan
- [x] `build/agent-dotnet.sh build src/BloomExe/BloomExe.csproj` — succeeds
- [x] `build/agent-dotnet.sh test src/BloomTests/BloomTests.csproj --filter "FullyQualifiedName~UrlLookupTests"` — 8/8 passed (4 existing + 4 new)
- [x] Light correctness review of the diff — clean, no findings
- [x] Rebased onto `master` (2026-07-28). Clean, no conflicts; interdiff empty (rebased patch byte-identical to the original commit). Build + tests re-run on the rebase: 8/8 pass.

## Live verification under the debugger (2026-07-28)

Each branch of the classifier was exercised against a real running Bloom with breakpoints on both `return` statements in `IsExpectedTransientLookupFailure`, and the production exception shape was read off the actual Sentry events. All four cases behave as intended:

| Case | How forced | Actual exception | Result |
| --- | --- | --- | --- |
| Production timeout (ERZ + 2H2) | real events, read from Sentry | `AmazonServiceException` → inner `WebException` (timeout) | suppressed, **matched at depth 1** |
| net8 timeout | overall `DownloadFile` timeout cut to 1 ms | bare `TaskCanceledException` | suppressed, depth 0 |
| net8 network/DNS failure | S3 `ServiceURL` pointed at a non-resolvable host | `HttpRequestException` → inner `SocketException` | suppressed, depth 0 |
| Real bug | corrupted the JSON handed to `DeserializeObject` | `JsonReaderException`, no inner | **reported to Sentry** (correct) |

Two things worth a reviewer's attention:

1. **The `InnerException` walk is load-bearing, not defensive.** The production events are from the .NET Framework build, where `WebExceptionHandler` wraps the timeout in an `AmazonServiceException`; the `WebException` is only reachable one level down. A flat top-level type check would suppress none of the ~889 events. On current net8 builds the SDK does *not* wrap — timeouts and DNS failures arrive bare and match at depth 0 — so the walk is what makes the fix cover both generations. Please don't simplify it away.
2. **Deliberately type-based, not message-based.** The inner message on the real events is localized ("Le délai d'attente de l'opération a expiré"), so any message-string matching would fail for exactly the non-English users generating most of the noise.

BLOOM-DESKTOP-ERZ and -2H2 were confirmed byte-for-byte identical stacks — one root cause split across two Sentry groups. Both are covered.

Devin's single informational note from the earlier consult (a network failure hidden inside a multi-cause `AggregateException` would not be found, since the walk follows only the single `InnerException` link) is now closed empirically as well as by inspection: the real call path uses `GetAwaiter().GetResult()`, and every live repro produced a bare exception, never an `AggregateException`.

[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8082)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8082)
<!-- Reviewable:end -->
