### PR TITLE
Fix split-pane pageXof/pageYof crash on 0-coordinate / native event (BL-16584)

### DIFF
--- a/src/BloomBrowserUI/lib/split-pane/split-pane.ts
+++ b/src/BloomBrowserUI/lib/split-pane/split-pane.ts
@@ -949,12 +949,22 @@ export function splitPane($splitPanes: JQuery): void {
         return [snapped, dividerPositionForDisplay(snapped, true) + "%", false];
     }
 
+    // event.pageX/pageY can legitimately be 0 (dragging to the very edge), so check for
+    // null/undefined rather than falsiness — otherwise a 0 wrongly falls through. And
+    // event.originalEvent is undefined for a native (non-jQuery) event, so guard it before
+    // dereferencing instead of crashing the drag (Sentry BLOOM-DESKTOP-FPW/FJ0/DTS).
     function pageXof(event) {
-        return event.pageX || event.originalEvent.pageX;
+        if (event.pageX != null) return event.pageX;
+        if (event.originalEvent && event.originalEvent.pageX != null)
+            return event.originalEvent.pageX;
+        return 0;
     }
 
     function pageYof(event) {
-        return event.pageY || event.originalEvent.pageY;
+        if (event.pageY != null) return event.pageY;
+        if (event.originalEvent && event.originalEvent.pageY != null)
+            return event.originalEvent.pageY;
+        return 0;
     }
 
     function minHeight(element) {


### PR DESCRIPTION
## Summary

Sentry BLOOM-DESKTOP-FJ0 (pageY, ~3175 events / 17 users, live 6.3.1), -FPW (pageX, ~646/7,
6.3.2), and -DTS (pageY, ~77/9, 6.2.8) are one bug: dragging a pane splitter (origami page
layout) crashed because `pageXof`/`pageYof` used `event.pageX || event.originalEvent.pageX`.
That treats a legitimate `0` coordinate (dragging to the very edge of the page) as missing,
falls through to `event.originalEvent`, and `originalEvent` is `undefined` for a native
(non-jQuery) event — so it crashes dereferencing `.pageX`/`.pageY` on `undefined`.

Fix: check the coordinate for `null`/`undefined` instead of falsiness (so `0` is honored),
guard `event.originalEvent` before dereferencing, and return `0` as a last resort instead of
throwing.

`pageXof`/`pageYof` are module-private inner functions in this legacy jQuery-based split-pane
library with no existing test file or test seam for this module — no unit test was added for
this fix.

Fixed by Claude Opus 4.8; this PR (commit, integration, bot gauntlet) run by Claude Sonnet 5
via the `preflight` skill.

Ref: BL-16584


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8084)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8084)
<!-- Reviewable:end -->
