### PR TITLE
Strip CKEditor markup before decodable-reader checks (BL-16490)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markup.d.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markup.d.ts
@@ -4,6 +4,7 @@ interface JQuery {
     getMaxSentenceLength(): number;
     getTotalWordCount(): number;
     removeSynphonyMarkup(): void;
+    removeCkEditorMarkup(): void;
 }
 
 interface JQueryStatic {

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markup.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markup.ts
@@ -237,6 +237,7 @@ import { ReaderToolsModel } from "../readerToolsModel";
 
         // remove previous synphony markup
         this.removeSynphonyMarkup();
+        this.removeCkEditorMarkup();
 
         // get all text
         this.each(function () {
@@ -380,6 +381,28 @@ import { ReaderToolsModel } from "../readerToolsModel";
             $("body", page.contentWindow.document)
                 .find("div." + cssTooMuchStuffOnPage)
                 .removeClass(cssTooMuchStuffOnPage);
+    };
+
+    $.fn.removeCkEditorMarkup = function () {
+        this.each(function () {
+            // remove CKEditor-specific markup inserted when replacing marked text
+            $(this)
+                .find("span[style]")
+                .filter((_index, element) => {
+                    const style = (element as HTMLElement).getAttribute(
+                        "style",
+                    );
+                    return !!style && /^background-color: rgb\([0-9, ]*\);$/.test(style);
+                })
+                .contents()
+                .unwrap();
+            // remove spans belonging to CKEditor that are hidden.
+            // (Use *= not ~=: ~= matches a whole whitespace-separated token, so it can
+            // never match the multi-word value "display: none;". *= matches the substring.)
+            $(this)
+                .find("span[id^=cke_][style*='display: none;']")
+                .remove();
+        });
     };
 
     $.extend({

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markup.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markup.ts
@@ -392,7 +392,12 @@ import { ReaderToolsModel } from "../readerToolsModel";
                     const style = (element as HTMLElement).getAttribute(
                         "style",
                     );
-                    return !!style && /^background-color: rgb\([0-9, ]*\);$/.test(style);
+                    // rgba? and the optional "." handle highlight colors that carry an
+                    // alpha component (CKEditor serializes those as rgba(r, g, b, a)).
+                    return (
+                        !!style &&
+                        /^background-color: rgba?\([0-9, .]*\);$/.test(style)
+                    );
                 })
                 .contents()
                 .unwrap();

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markup.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markup.ts
@@ -392,18 +392,16 @@ import { ReaderToolsModel } from "../readerToolsModel";
                     const style = (element as HTMLElement).getAttribute(
                         "style",
                     );
-                    // rgba? and the optional "." handle highlight colors that carry an
-                    // alpha component (CKEditor serializes those as rgba(r, g, b, a)).
+                    // CKeditor copies the highlight style as a barebones inline style containing
+                    // only the background-color property.
                     return (
                         !!style &&
-                        /^background-color: rgba?\([0-9, .]*\);$/.test(style)
+                        /^background-color: [^;]*;$/.test(style)
                     );
                 })
                 .contents()
                 .unwrap();
             // remove spans belonging to CKEditor that are hidden.
-            // (Use *= not ~=: ~= matches a whole whitespace-separated token, so it can
-            // never match the multi-word value "display: none;". *= matches the substring.)
             $(this)
                 .find("span[id^=cke_][style*='display: none;']")
                 .remove();

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markupSpec.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markupSpec.js
@@ -257,6 +257,15 @@ describe("jquery.text-markup", function () {
         expect($("#text_entry1").html()).toBe("<p>pre new text post</p>");
     });
 
+    it("removeCkEditorMarkup unwraps spans with rgba() background-color", function () {
+        const input =
+            '<p>pre <span style="background-color: rgba(255, 255, 155, 0.5);">new text</span> post</p>';
+
+        $("#text_entry1").html(input).removeCkEditorMarkup();
+
+        expect($("#text_entry1").html()).toBe("<p>pre new text post</p>");
+    });
+
     it("removeCkEditorMarkup removes hidden cke_ spans", function () {
         const input =
             '<p>pre <span id="cke_1" style="display: none;">hidden</span> post</p>';

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markupSpec.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markupSpec.js
@@ -248,6 +248,24 @@ describe("jquery.text-markup", function () {
         expect(out5).toBe(" This is a test, this is only a test. ");
     });
 
+    it("removeCkEditorMarkup unwraps spans with background-color in style", function () {
+        const input =
+            '<p>pre <span style="background-color: rgb(255, 255, 155);">new text</span> post</p>';
+
+        $("#text_entry1").html(input).removeCkEditorMarkup();
+
+        expect($("#text_entry1").html()).toBe("<p>pre new text post</p>");
+    });
+
+    it("removeCkEditorMarkup removes hidden cke_ spans", function () {
+        const input =
+            '<p>pre <span id="cke_1" style="display: none;">hidden</span> post</p>';
+
+        $("#text_entry1").html(input).removeCkEditorMarkup();
+
+        expect($("#text_entry1").html()).toBe("<p>pre  post</p>");
+    });
+
     it("checkWrapWordsExtraIgnoresEmptyItems", function () {
         const cssWordNotFound = "word-not-found";
         const cssPossibleWord = "possible-word";


### PR DESCRIPTION
Strip leftover CKEditor markup before the decodable-reader check runs.

Adds a `removeCkEditorMarkup()` jQuery plugin, invoked at the start of `checkDecodableReader()`. It:

- unwraps CKEditor's inline highlight spans (spans whose `style` is a bare `background-color: rgb(...);`), keeping their text content, and
- removes CKEditor's hidden `cke_*` helper spans.

Without this, editor-inserted markup skewed the decodable-reader word markup (BL-16490).

Also declares the new method in `jquery.text-markup.d.ts` and adds unit tests for both the unwrap and hidden-span-removal paths.

Ref: https://issues.bloomlibrary.org/issue/BL-16490


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8085)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8085)
<!-- Reviewable:end -->
