### PR TITLE
Improve Leveled Reader tool UI (BL-16585)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -2642,6 +2642,17 @@
       <trans-unit id="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport" sil:dynamic="true">
         <source xml:lang="en">Generate a letter and word list report</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport</note>
+        <note>Obsolete as of 6.5 — shortened to "Generate Report" (DecodableReaderTool.GenerateReport) and moved into an outline button at the bottom of the tool.</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.GenerateReport" translate="no">
+        <source xml:lang="en">Generate Report</source>
+        <note>ID: EditTab.Toolbox.DecodableReaderTool.GenerateReport</note>
+        <note>Label on a button at the bottom of the Decodable Reader tool. Clicking it generates and opens a text-file report of the letters and words available at each decodable stage.</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.GenerateReport.ToolTip" translate="no">
+        <source xml:lang="en">Create and open a text file listing the letters and words available at each decodable stage.</source>
+        <note>ID: EditTab.Toolbox.DecodableReaderTool.GenerateReport.ToolTip</note>
+        <note>Tooltip for the "Generate Report" button at the bottom of the Decodable Reader tool. ".ToolTip" is a required suffix that Bloom's button code appends to the button's own id to find its tooltip; do not translate or remove it.</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage" sil:dynamic="true">
         <source xml:lang="en">Sample words in this stage</source>

--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -2667,6 +2667,17 @@
         <source xml:lang="en">Stage {0} of {1}</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.StageNofM</note>
         <note>{0} is replaced with the current level, and {1} with the total number of levels</note>
+        <note>Obsolete as of 6.5 — split into DecodableReaderTool.StageNumber + ReaderTools.OfCount so the two parts can be styled separately in the toolbox.</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageNumber" sil:dynamic="true">
+        <source xml:lang="en">Stage {0}</source>
+        <note>ID: EditTab.Toolbox.DecodableReaderTool.StageNumber</note>
+        <note>Large first part of the decodable reader stage indicator, immediately followed by the smaller "of N" (ReaderTools.OfCount). {0} is the current stage number.</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Toolbox.ReaderTools.OfCount" sil:dynamic="true">
+        <source xml:lang="en">of {0}</source>
+        <note>ID: EditTab.Toolbox.ReaderTools.OfCount</note>
+        <note>Second, smaller part of the leveled/decodable reader phase indicator, shown right after the level/stage number (e.g. "Level 3" followed by "of 6"). {0} is the total number of levels or stages. Keep it short; it appears immediately after the number.</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.ImageDescriptionTool" sil:dynamic="true">
         <source xml:lang="en">Image Description Tool</source>
@@ -2775,6 +2786,12 @@
         <source xml:lang="en">Level {0} of {1}</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.LevelNofM</note>
         <note>{0} is replaced with the current level, and {1} with the total number of levels</note>
+        <note>Obsolete as of 6.5 — split into LeveledReaderTool.LevelNumber + ReaderTools.OfCount so the two parts can be styled separately in the toolbox.</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelNumber" sil:dynamic="true">
+        <source xml:lang="en">Level {0}</source>
+        <note>ID: EditTab.Toolbox.LeveledReaderTool.LevelNumber</note>
+        <note>Large first part of the leveled reader level indicator, immediately followed by the smaller "of N" (ReaderTools.OfCount). {0} is the current level number.</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true">
         <source xml:lang="en">Max</source>
@@ -2788,6 +2805,11 @@
         <source xml:lang="en">longest sentence</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.MaxSentenceLength</note>
         <note>length of the longest sentence (in the book)</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Measure" sil:dynamic="true">
+        <source xml:lang="en">Measure</source>
+        <note>ID: EditTab.Toolbox.LeveledReaderTool.Measure</note>
+        <note>Column header over the list of statistic names (e.g. "per page", "total") in the leveled reader stats table. Displayed in all-caps via styling.</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true">
         <source xml:lang="en">per page</source>

--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -2644,12 +2644,12 @@
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport</note>
         <note>Obsolete as of 6.5 — shortened to "Generate Report" (DecodableReaderTool.GenerateReport) and moved into an outline button at the bottom of the tool.</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.GenerateReport" translate="no">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.GenerateReport" sil:dynamic="true">
         <source xml:lang="en">Generate Report</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.GenerateReport</note>
         <note>Label on a button at the bottom of the Decodable Reader tool. Clicking it generates and opens a text-file report of the letters and words available at each decodable stage.</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.GenerateReport.ToolTip" translate="no">
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.GenerateReport.ToolTip" sil:dynamic="true">
         <source xml:lang="en">Create and open a text file listing the letters and words available at each decodable stage.</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.GenerateReport.ToolTip</note>
         <note>Tooltip for the "Generate Report" button at the bottom of the Decodable Reader tool. ".ToolTip" is a required suffix that Bloom's button code appends to the button's own id to find its tooltip; do not translate or remove it.</note>

--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -2644,16 +2644,6 @@
         <note>ID: EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport</note>
         <note>Obsolete as of 6.5 — shortened to "Generate Report" (DecodableReaderTool.GenerateReport) and moved into an outline button at the bottom of the tool.</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.GenerateReport" sil:dynamic="true">
-        <source xml:lang="en">Generate Report</source>
-        <note>ID: EditTab.Toolbox.DecodableReaderTool.GenerateReport</note>
-        <note>Label on a button at the bottom of the Decodable Reader tool. Clicking it generates and opens a text-file report of the letters and words available at each decodable stage.</note>
-      </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.GenerateReport.ToolTip" sil:dynamic="true">
-        <source xml:lang="en">Create and open a text file listing the letters and words available at each decodable stage.</source>
-        <note>ID: EditTab.Toolbox.DecodableReaderTool.GenerateReport.ToolTip</note>
-        <note>Tooltip for the "Generate Report" button at the bottom of the Decodable Reader tool. ".ToolTip" is a required suffix that Bloom's button code appends to the button's own id to find its tooltip; do not translate or remove it.</note>
-      </trans-unit>
       <trans-unit id="EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage" sil:dynamic="true">
         <source xml:lang="en">Sample words in this stage</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage</note>
@@ -2679,16 +2669,6 @@
         <note>ID: EditTab.Toolbox.DecodableReaderTool.StageNofM</note>
         <note>{0} is replaced with the current level, and {1} with the total number of levels</note>
         <note>Obsolete as of 6.5 — split into DecodableReaderTool.StageNumber + ReaderTools.OfCount so the two parts can be styled separately in the toolbox.</note>
-      </trans-unit>
-      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageNumber" sil:dynamic="true">
-        <source xml:lang="en">Stage {0}</source>
-        <note>ID: EditTab.Toolbox.DecodableReaderTool.StageNumber</note>
-        <note>Large first part of the decodable reader stage indicator, immediately followed by the smaller "of N" (ReaderTools.OfCount). {0} is the current stage number.</note>
-      </trans-unit>
-      <trans-unit id="EditTab.Toolbox.ReaderTools.OfCount" sil:dynamic="true">
-        <source xml:lang="en">of {0}</source>
-        <note>ID: EditTab.Toolbox.ReaderTools.OfCount</note>
-        <note>Second, smaller part of the leveled/decodable reader phase indicator, shown right after the level/stage number (e.g. "Level 3" followed by "of 6"). {0} is the total number of levels or stages. Keep it short; it appears immediately after the number.</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.ImageDescriptionTool" sil:dynamic="true">
         <source xml:lang="en">Image Description Tool</source>
@@ -2799,11 +2779,6 @@
         <note>{0} is replaced with the current level, and {1} with the total number of levels</note>
         <note>Obsolete as of 6.5 — split into LeveledReaderTool.LevelNumber + ReaderTools.OfCount so the two parts can be styled separately in the toolbox.</note>
       </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelNumber" sil:dynamic="true">
-        <source xml:lang="en">Level {0}</source>
-        <note>ID: EditTab.Toolbox.LeveledReaderTool.LevelNumber</note>
-        <note>Large first part of the leveled reader level indicator, immediately followed by the smaller "of N" (ReaderTools.OfCount). {0} is the current level number.</note>
-      </trans-unit>
       <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Max" sil:dynamic="true">
         <source xml:lang="en">Max</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.Max</note>
@@ -2816,11 +2791,6 @@
         <source xml:lang="en">longest sentence</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.MaxSentenceLength</note>
         <note>length of the longest sentence (in the book)</note>
-      </trans-unit>
-      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Measure" sil:dynamic="true">
-        <source xml:lang="en">Measure</source>
-        <note>ID: EditTab.Toolbox.LeveledReaderTool.Measure</note>
-        <note>Column header over the list of statistic names (e.g. "per page", "total") in the leveled reader stats table. Displayed in all-caps via styling.</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.LeveledReaderTool.PerPage" sil:dynamic="true">
         <source xml:lang="en">per page</source>

--- a/DistFiles/localization/en/BloomMediumPriority.xlf
+++ b/DistFiles/localization/en/BloomMediumPriority.xlf
@@ -256,6 +256,26 @@
         <source xml:lang="en">Book is not Decodable</source>
         <note>ID: EditTab.Toolbox.DecodableReaderTool.BookIsNotDecodable</note>
       </trans-unit>
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.GenerateReport" sil:dynamic="true">
+        <source xml:lang="en">Generate Report</source>
+        <note>ID: EditTab.Toolbox.DecodableReaderTool.GenerateReport</note>
+        <note>Label on a button at the bottom of the Decodable Reader tool. Clicking it generates and opens a text-file report of the letters and words available at each decodable stage.</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.GenerateReport.ToolTip" sil:dynamic="true">
+        <source xml:lang="en">Create and open a text file listing the letters and words available at each decodable stage.</source>
+        <note>ID: EditTab.Toolbox.DecodableReaderTool.GenerateReport.ToolTip</note>
+        <note>Tooltip for the "Generate Report" button at the bottom of the Decodable Reader tool. ".ToolTip" is a required suffix that Bloom's button code appends to the button's own id to find its tooltip; do not translate or remove it.</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Toolbox.DecodableReaderTool.StageNumber" sil:dynamic="true">
+        <source xml:lang="en">Stage {0}</source>
+        <note>ID: EditTab.Toolbox.DecodableReaderTool.StageNumber</note>
+        <note>Large first part of the decodable reader stage indicator, immediately followed by the smaller "of N" (ReaderTools.OfCount). {0} is the current stage number.</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Toolbox.ReaderTools.OfCount" sil:dynamic="true">
+        <source xml:lang="en">of {0}</source>
+        <note>ID: EditTab.Toolbox.ReaderTools.OfCount</note>
+        <note>Second, smaller part of the leveled/decodable reader phase indicator, shown right after the level/stage number (e.g. "Level 3" followed by "of 6"). {0} is the total number of levels or stages. Keep it short; it appears immediately after the number.</note>
+      </trans-unit>
       <trans-unit id="EditTab.Toolbox.Games.Theme">
         <source xml:lang="en">Theme</source>
         <note>ID: EditTab.Toolbox.Games.Theme</note>
@@ -364,6 +384,16 @@
       <trans-unit id="EditTab.Toolbox.LeveledReaderTool.BookIsNotLeveled" sil:dynamic="true">
         <source xml:lang="en">Book is not Leveled</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.BookIsNotLeveled</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.LevelNumber" sil:dynamic="true">
+        <source xml:lang="en">Level {0}</source>
+        <note>ID: EditTab.Toolbox.LeveledReaderTool.LevelNumber</note>
+        <note>Large first part of the leveled reader level indicator, immediately followed by the smaller "of N" (ReaderTools.OfCount). {0} is the current level number.</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.Measure" sil:dynamic="true">
+        <source xml:lang="en">Measure</source>
+        <note>ID: EditTab.Toolbox.LeveledReaderTool.Measure</note>
+        <note>Column header over the list of statistic names (e.g. "per page", "total") in the leveled reader stats table. Displayed in all-caps via styling.</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.LeveledReaderTool.OverLevel" sil:dynamic="true">
         <source xml:lang="en">Over level</source>

--- a/DistFiles/localization/en/BloomMediumPriority.xlf
+++ b/DistFiles/localization/en/BloomMediumPriority.xlf
@@ -365,6 +365,21 @@
         <source xml:lang="en">Book is not Leveled</source>
         <note>ID: EditTab.Toolbox.LeveledReaderTool.BookIsNotLeveled</note>
       </trans-unit>
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.OverLevel" sil:dynamic="true">
+        <source xml:lang="en">Over level</source>
+        <note>ID: EditTab.Toolbox.LeveledReaderTool.OverLevel</note>
+        <note>Legend label next to an orange dot, explaining that statistics shown in orange exceed the current level's limit.</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.OverLevelWarning" sil:dynamic="true">
+        <source xml:lang="en">This book reads above Level {0}</source>
+        <note>ID: EditTab.Toolbox.LeveledReaderTool.OverLevelWarning</note>
+        <note>Warning banner shown above the statistics when one or more measures exceed the current level's limit. {0} is replaced with the current level number.</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Toolbox.LeveledReaderTool.WithinLevel" sil:dynamic="true">
+        <source xml:lang="en">Within level</source>
+        <note>ID: EditTab.Toolbox.LeveledReaderTool.WithinLevel</note>
+        <note>Legend label next to a green dot, explaining that statistics shown in green are within the current level's limit.</note>
+      </trans-unit>
       <!-- Talking Book Advanced -->
       <trans-unit id="EditTab.Toolbox.TalkingBookTool.ESpeakPreview.Error">
         <source xml:lang="en">eSpeak failed.</source>

--- a/src/BloomBrowserUI/bloomUI.less
+++ b/src/BloomBrowserUI/bloomUI.less
@@ -209,3 +209,87 @@ body.bloom-hidden-for-animation > *:not(div.bloom-animationPreview) {
 body.bloom-hidden-for-animation {
     overflow: hidden; //hide the scrollbar during an animation preview.
 }
+
+// ============================================================================
+// Unified dark scrollbar — "Flush & soft" (BL-16585)
+//
+// Bloom has exactly two scrollbar looks. Light panels (the Publish tab's middle
+// and right panels, and dialogs) keep the browser default. Dark panels
+// (everything in the Edit and Collection tabs except dialogs, and the Publish
+// tab's dark left preview) use the style below.
+//
+// Rather than making the dark style the global default, we define it once here
+// and opt a dark panel in by adding the `bloomDarkScrollbars` class to its root
+// container. The rules then style that element's own scrollbar and the
+// scrollbars of all its scrolling descendants, so one class on a panel root is
+// enough.
+//
+// The track sits flush with the panel background, the thumb is a rounded
+// mid-gray inset by a transparent border, and each end shows one quiet arrow.
+// WebView2 is Chromium, so the non-standard ::-webkit-scrollbar pseudo-elements
+// apply. (The standard css-scrollbars-1 properties, scrollbar-width/-color,
+// can't express the fixed width, rounded/inset thumb, hover-active states, or
+// custom arrow buttons, and only reached Blink in Chromium 121 anyway.)
+.bloom-dark-scrollbar-rules() {
+    &::-webkit-scrollbar {
+        width: 15px;
+        height: 15px;
+    }
+    // Track matches the panel background so it reads as flush with the panel.
+    &::-webkit-scrollbar-track {
+        background: @bloom-panelBackground;
+    }
+    // Rounded mid-gray thumb. The transparent border (revealed by
+    // background-clip: padding-box) keeps the thumb slimmer than the track.
+    &::-webkit-scrollbar-thumb {
+        background: #5c5c5c;
+        border-radius: 4px;
+        border: 3px solid @bloom-panelBackground;
+        background-clip: padding-box;
+    }
+    &::-webkit-scrollbar-thumb:hover {
+        background: #7a7a7a;
+        background-clip: padding-box;
+    }
+    &::-webkit-scrollbar-thumb:active {
+        background: #8f8f8f;
+        background-clip: padding-box;
+    }
+    // Arrow buttons at both ends. ":single-button" shows one arrow per end.
+    &::-webkit-scrollbar-button:single-button {
+        background: @bloom-panelBackground;
+        height: 15px;
+        width: 15px;
+        background-repeat: no-repeat;
+        background-position: center;
+        background-size: 8px;
+    }
+    &::-webkit-scrollbar-button:single-button:hover {
+        background-color: #3a3a3a;
+    }
+    // Vertical arrows (#a6a6a6 triangles).
+    &::-webkit-scrollbar-button:single-button:vertical:decrement {
+        background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="8" height="5" viewBox="0 0 8 5"><path d="M4 0 L8 5 L0 5 Z" fill="%23a6a6a6"/></svg>');
+    }
+    &::-webkit-scrollbar-button:single-button:vertical:increment {
+        background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="8" height="5" viewBox="0 0 8 5"><path d="M0 0 L8 0 L4 5 Z" fill="%23a6a6a6"/></svg>');
+    }
+    // Horizontal arrows.
+    &::-webkit-scrollbar-button:single-button:horizontal:decrement {
+        background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="5" height="8" viewBox="0 0 5 8"><path d="M0 4 L5 0 L5 8 Z" fill="%23a6a6a6"/></svg>');
+    }
+    &::-webkit-scrollbar-button:single-button:horizontal:increment {
+        background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="5" height="8" viewBox="0 0 5 8"><path d="M0 0 L5 4 L0 8 Z" fill="%23a6a6a6"/></svg>');
+    }
+    // Where the vertical and horizontal bars meet.
+    &::-webkit-scrollbar-corner {
+        background: @bloom-panelBackground;
+    }
+}
+
+.bloomDarkScrollbars {
+    .bloom-dark-scrollbar-rules(); // the panel's own scrollbar
+    & * {
+        .bloom-dark-scrollbar-rules(); // and every scrolling descendant's
+    }
+}

--- a/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.mixins.pug
+++ b/src/BloomBrowserUI/bookEdit/pageThumbnailList/pageThumbnailList.mixins.pug
@@ -8,7 +8,7 @@ html
 	head
 		meta(charset='utf-8')
 		block headContent
-	body(data-pageSize='A5Portrait')
+	body.bloomDarkScrollbars(data-pageSize='A5Portrait')
 		#panelFlexContainer
 			div#pageThumbnailListLabel(data-i18n="EditTab.PageList.Heading") Pages
 			#pageGridWrapper

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/ReaderSetupButton.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/ReaderSetupButton.tsx
@@ -1,0 +1,56 @@
+import { FunctionComponent } from "react";
+import { css } from "@emotion/react";
+import BloomButton from "../../../react_components/bloomButton";
+import { readerContainedButtonCss } from "./readerToolStyles";
+
+// Shared "Set Up Stages/Levels" outline button shown along the bottom of both
+// reader tool panels. It opens the corresponding setup dialog, differing only
+// in the stage-vs-level wording. (BL-16585)
+export const ReaderSetupButton: FunctionComponent<{
+    isForLeveled: boolean;
+}> = (props) => {
+    return (
+        <BloomButton
+            href={
+                props.isForLeveled
+                    ? "javascript:window.toolboxBundle.showSetupDialog('levels');"
+                    : "javascript:window.toolboxBundle.showSetupDialog('stages');"
+            }
+            l10nKey={
+                props.isForLeveled
+                    ? "EditTab.Toolbox.LeveledReaderTool.SetUpLevels"
+                    : "EditTab.Toolbox.DecodableReaderTool.SetUpStages"
+            }
+            variant="text"
+            enabled={true}
+            hasText={true}
+            iconBeforeText={
+                // The same white tool icon shown in the accordion header (steps
+                // for Leveled, keys for Decodable), rendered as a background image
+                // so it matches the header exactly. It reads cleanly as white on
+                // the contained button's blue fill. (BL-16585)
+                <span
+                    css={css`
+                        width: 16px;
+                        height: 16px;
+                        display: inline-block;
+                        background-position: center;
+                        background-repeat: no-repeat;
+                        background-size: contain;
+                        flex-shrink: 0;
+                    `}
+                    style={{
+                        backgroundImage: `url(${
+                            props.isForLeveled
+                                ? "/bloom/images/steps-white.png"
+                                : "/bloom/images/keys-white.png"
+                        })`,
+                    }}
+                />
+            }
+            css={readerContainedButtonCss}
+        >
+            {props.isForLeveled ? "Set Up Levels" : "Set Up Stages"}
+        </BloomButton>
+    );
+};

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/ReaderToolNav.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/ReaderToolNav.tsx
@@ -4,6 +4,7 @@ import BloomButton from "../../../react_components/bloomButton";
 import { ArrowLeft, ArrowRight } from "@mui/icons-material";
 import { css } from "@emotion/react";
 import { Span } from "../../../react_components/l10nComponents";
+import { kReaderAccent, kReaderMuted } from "./readerToolStyles";
 
 // This component displays the phase navigation for both the
 // decodable reader tool and the leveled reader tool (the part
@@ -44,9 +45,9 @@ export const ReaderToolNav: FunctionComponent<{
             width: 26px;
             height: 26px;
             padding: 0;
-            border: 1px solid rgba(255, 255, 255, 0.4);
+            border: 1px solid ${kReaderAccent};
             border-radius: 4px;
-            color: white;
+            color: ${kReaderAccent};
         }
         // With no button text, MUI's startIcon margin would shove the arrow
         // off-center; zero it so the arrow sits in the middle of the box.
@@ -98,7 +99,7 @@ export const ReaderToolNav: FunctionComponent<{
                     l10nParam0={numberOfPhases().toString()}
                     css={css`
                         font-size: 11px;
-                        color: rgba(255, 255, 255, 0.55);
+                        color: ${kReaderMuted};
                     `}
                 >
                     {"of {0}"}
@@ -114,7 +115,7 @@ export const ReaderToolNav: FunctionComponent<{
                     iconBeforeText={
                         <ArrowLeft
                             css={css`
-                                color: white;
+                                color: currentColor;
                             `}
                         />
                     }
@@ -130,7 +131,7 @@ export const ReaderToolNav: FunctionComponent<{
                     iconBeforeText={
                         <ArrowRight
                             css={css`
-                                color: white;
+                                color: currentColor;
                             `}
                         />
                     }

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/ReaderToolNav.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/ReaderToolNav.tsx
@@ -33,77 +33,119 @@ export const ReaderToolNav: FunctionComponent<{
         return props.isForLeveled ? model.levelNumber : model.stageNumber;
     }
 
+    // Boxed square buttons at the right, matching the mockup. Unlike before,
+    // the button at an end is shown but disabled (greyed) rather than hidden,
+    // so the pair of boxes is always present.
+    // Boxed square buttons at the right, matching the mockup. Unlike before,
+    // the button at an end is shown but disabled (greyed) rather than hidden,
+    // so the pair of boxes is always present. Kept fairly small so the whole
+    // "Level N of M" line fits on a single row.
+    const arrowButtonCss = css`
+        // && beats MUI's .MuiButton-root sizing so the box stays square.
+        && {
+            min-width: unset;
+            width: 26px;
+            height: 26px;
+            padding: 0;
+            border: 1px solid rgba(255, 255, 255, 0.4);
+            border-radius: 4px;
+            color: white;
+        }
+        // With no button text, MUI's startIcon margin would shove the arrow
+        // off-center; zero it so the arrow sits in the middle of the box.
+        & .MuiButton-startIcon {
+            margin: 0;
+        }
+        &.Mui-disabled {
+            opacity: 0.35;
+        }
+    `;
+
     return (
-        <div>
-            <BloomButton
-                iconBeforeText={
-                    curPhaseNum() > 1 ? (
+        <div
+            css={css`
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                margin-bottom: 8px;
+            `}
+        >
+            {/* The level/stage indicator is two separately-styled localized
+                pieces: the large "Level {0}" and the smaller, muted "of {1}".
+                They were split from a single "Level {0} of {1}" string so each
+                part can be styled; nowrap keeps them on one line. */}
+            <div
+                css={css`
+                    display: flex;
+                    align-items: baseline;
+                    gap: 6px;
+                    white-space: nowrap;
+                `}
+            >
+                <Span
+                    l10nKey={
+                        props.isForLeveled
+                            ? "EditTab.Toolbox.LeveledReaderTool.LevelNumber"
+                            : "EditTab.Toolbox.DecodableReaderTool.StageNumber"
+                    }
+                    l10nParam0={curPhaseNum().toString()}
+                    css={css`
+                        font-size: 17px;
+                        font-weight: bold;
+                    `}
+                >
+                    {props.isForLeveled ? "Level {0}" : "Stage {0}"}
+                </Span>
+                <Span
+                    l10nKey="EditTab.Toolbox.ReaderTools.OfCount"
+                    l10nParam0={numberOfPhases().toString()}
+                    css={css`
+                        font-size: 11px;
+                        color: rgba(255, 255, 255, 0.55);
+                    `}
+                >
+                    {"of {0}"}
+                </Span>
+            </div>
+            <div
+                css={css`
+                    display: flex;
+                    gap: 6px;
+                `}
+            >
+                <BloomButton
+                    iconBeforeText={
                         <ArrowLeft
                             css={css`
                                 color: white;
                             `}
                         />
-                    ) : (
-                        <></>
-                    )
-                }
-                variant="text"
-                disabled={curPhaseNum() <= 1}
-                l10nKey=""
-                hasText={false}
-                enabled={true}
-                onClick={() => props.changeFunction(false)}
-                css={css`
-                    width: 6px;
-                    min-width: unset;
-                    height: 18px;
-                    margin-left: 5px;
-                    margin-bottom: 8px;
-                    padding-left: 10px;
-                    padding-right: 3px;
-                `}
-            />
-            <Span
-                l10nKey={
-                    props.isForLeveled
-                        ? "EditTab.Toolbox.LeveledReaderTool.LevelNofM"
-                        : "EditTab.Toolbox.DecodableReaderTool.StageNofM"
-                }
-                l10nParam0={curPhaseNum().toString()}
-                l10nParam1={numberOfPhases().toString()}
-                css={css`
-                    font-size: 21px;
-                `}
-            >
-                {props.isForLeveled ? "Level {0} of {1}" : "Stage {0} of {1}"}
-            </Span>
-            <BloomButton
-                iconBeforeText={
-                    curPhaseNum() !== numberOfPhases() ? (
+                    }
+                    variant="text"
+                    disabled={curPhaseNum() <= 1}
+                    l10nKey=""
+                    hasText={false}
+                    enabled={true}
+                    onClick={() => props.changeFunction(false)}
+                    css={arrowButtonCss}
+                />
+                <BloomButton
+                    iconBeforeText={
                         <ArrowRight
                             css={css`
                                 color: white;
                             `}
                         />
-                    ) : (
-                        <></>
-                    )
-                }
-                variant="text"
-                disabled={curPhaseNum() === numberOfPhases()}
-                l10nKey=""
-                hasText={false}
-                enabled={true}
-                onClick={() => props.changeFunction(true)}
-                css={css`
-                    width: 16px;
-                    min-width: unset;
-                    height: 18px;
-                    padding-left: 12px;
-                    padding-right: 1px;
-                    margin-bottom: 8px;
-                `}
-            />
+                    }
+                    variant="text"
+                    disabled={curPhaseNum() === numberOfPhases()}
+                    l10nKey=""
+                    hasText={false}
+                    enabled={true}
+                    onClick={() => props.changeFunction(true)}
+                    css={arrowButtonCss}
+                />
+            </div>
         </div>
     );
 };

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/ReaderToolNav.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/ReaderToolNav.tsx
@@ -35,9 +35,6 @@ export const ReaderToolNav: FunctionComponent<{
 
     // Boxed square buttons at the right, matching the mockup. Unlike before,
     // the button at an end is shown but disabled (greyed) rather than hidden,
-    // so the pair of boxes is always present.
-    // Boxed square buttons at the right, matching the mockup. Unlike before,
-    // the button at an end is shown but disabled (greyed) rather than hidden,
     // so the pair of boxes is always present. Kept fairly small so the whole
     // "Level N of M" line fits on a single row.
     const arrowButtonCss = css`

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/ReaderToolNav.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/ReaderToolNav.tsx
@@ -34,10 +34,10 @@ export const ReaderToolNav: FunctionComponent<{
         return props.isForLeveled ? model.levelNumber : model.stageNumber;
     }
 
-    // Boxed square buttons at the right, matching the mockup. Unlike before,
-    // the button at an end is shown but disabled (greyed) rather than hidden,
-    // so the pair of boxes is always present. Kept fairly small so the whole
-    // "Level N of M" line fits on a single row.
+    // Boxed square buttons at the right. The button at an end is shown but
+    // disabled (greyed) rather than hidden, so the pair of boxes is always
+    // present. Kept fairly small so the whole "Level N of M" line fits on a
+    // single row.
     const arrowButtonCss = css`
         // && beats MUI's .MuiButton-root sizing so the box stays square.
         && {

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/ReaderToolSwitch.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/ReaderToolSwitch.tsx
@@ -25,6 +25,10 @@ export const ReaderToolSwitch: React.FunctionComponent<{
                 size="small"
                 css={css`
                     margin-left: 2px; // by experimentation. We have to override the default -11px.
+                    // Uppercase the label to match the uppercase button labels in
+                    // the reader tool panels (Set Up, Copy Book Stats, etc.).
+                    // (BL-16585)
+                    text-transform: uppercase;
                 `}
                 l10nKey={
                     props.isForLeveled

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/decodableReader/DecodableReaderToolControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/decodableReader/DecodableReaderToolControls.tsx
@@ -10,15 +10,21 @@ import {
 import { Span } from "../../../../react_components/l10nComponents";
 import BloomButton from "../../../../react_components/bloomButton";
 import { css, ThemeProvider } from "@emotion/react";
-import { Link } from "../../../../react_components/link";
 import { isReaderToolEnabledOnCurrentPage } from "../readerToolPageState";
 import { DataWord } from "../libSynphony/bloomSynphonyExtensions";
 import { useL10n } from "../../../../react_components/l10nHooks";
 import {
-    kBloomLightBlue,
+    kBloomBlue,
     kBloomDarkestBackground,
 } from "../../../../utils/colorUtils";
 import { ReaderToolNav } from "../ReaderToolNav";
+import { ReaderSetupButton } from "../ReaderSetupButton";
+import {
+    kReaderAccent,
+    readerSectionHeaderCss,
+    readerTextButtonCss,
+} from "../readerToolStyles";
+import { SummarizeOutlined } from "@mui/icons-material";
 import { toolboxTheme } from "../../../../bloomMaterialUITheme";
 import { useMountEffect } from "../../../../utils/useMountEffect";
 import { BloomTooltip } from "../../../../react_components/BloomToolTip";
@@ -99,7 +105,10 @@ const DecodableGrid: FunctionComponent<{
                     min-height: 0;
                     flex: 1 1 auto;
                     overflow: auto;
-                    margin-left: 8px;
+                    // Reserve space for the vertical scrollbar so its appearance
+                    // (when the word list grows tall) doesn't shrink/reflow the
+                    // grid, matching the Leveled Reader stabilization. (BL-16585)
+                    scrollbar-gutter: stable;
                     margin-top: 4px;
                     padding-bottom: 0.6em;
                     font-family: ${getTheOneReaderToolsModel().fontName};
@@ -141,8 +150,10 @@ const StageGraphemes: FunctionComponent = () => {
             <Span
                 l10nKey="EditTab.Toolbox.DecodableReaderTool.LettersInThisStage"
                 css={css`
-                    margin-left: 8px;
-                    color: ${kBloomLightBlue};
+                    ${readerSectionHeaderCss};
+                    // Make the underline rule span the full panel width, matching
+                    // the Leveled Reader's "Word Counts" section header.
+                    display: block;
                 `}
             >
                 Letters in this stage
@@ -212,10 +223,13 @@ const SortButton: FunctionComponent<{
                     height: 20px;
                     margin-top: 1px;
                     border-radius: 0;
-                    color: white;
-                    border: 1px solid white;
+                    border: 1px solid ${kReaderAccent};
+                    // Accent outline when idle; the selected sort fills solid
+                    // kBloomBlue with a white icon so the current choice stands
+                    // out. (BL-16585)
+                    color: ${shouldHighlight ? "white" : kReaderAccent};
                     background-color: ${shouldHighlight
-                        ? "grey"
+                        ? kBloomBlue
                         : "transparent"};
 
                     &&,
@@ -225,7 +239,7 @@ const SortButton: FunctionComponent<{
 
                     &:hover {
                         background-color: ${shouldHighlight
-                            ? "grey"
+                            ? kBloomBlue
                             : "transparent"};
                     }
                 `}
@@ -251,19 +265,23 @@ const SortedStageWords: FunctionComponent<{
                 overflow: hidden;
             `}
         >
+            {/* The section header (styled like the Leveled Reader's "Word Counts")
+                shares its row with the sort buttons; the underline rule spans the
+                whole width beneath both. */}
             <div
                 css={css`
+                    ${readerSectionHeaderCss};
                     display: flex;
+                    align-items: center;
                 `}
             >
                 {model.synphony?.source.useAllowedWords === 1 ? (
                     <Span
                         l10nKey="EditTab.Toolbox.DecodableReaderTool.AllowedWordsInThisStage"
                         css={css`
-                            margin-left: 8px;
-                            color: ${kBloomLightBlue};
-                            display: inline-flex;
-                            width: 110px;
+                            flex: 1;
+                            // Keep the label off the sort buttons on its right.
+                            padding-right: 12px;
                         `}
                     >
                         Allowed words in this stage
@@ -272,10 +290,9 @@ const SortedStageWords: FunctionComponent<{
                     <Span
                         l10nKey="EditTab.Toolbox.DecodableReaderTool.SampleWordsInThisStage"
                         css={css`
-                            margin-left: 8px;
-                            color: ${kBloomLightBlue};
-                            display: inline-flex;
-                            width: 110px;
+                            flex: 1;
+                            // Keep the label off the sort buttons on its right.
+                            padding-right: 12px;
                         `}
                     >
                         Sample words in this stage
@@ -394,50 +411,22 @@ export const DecodableReaderToolControls: FunctionComponent = () => {
                     overflow-x: hidden;
                 `}
             >
-                {showTool && (
-                    <>
-                        <div
-                            css={css`
-                                display: flex;
-                                flex-direction: column;
-                                flex: 1 1 auto;
-                                min-height: 0;
-                                overflow-x: hidden;
-                            `}
-                        >
-                            <div
-                                css={css`
-                                    display: flex;
-                                    margin-left: auto;
-                                    margin-bottom: 10px;
-                                    padding-right: 2px;
-                                `}
-                            >
-                                <BloomButton
-                                    href="javascript:window.toolboxBundle.showSetupDialog('stages');"
-                                    l10nKey="EditTab.Toolbox.DecodableReaderTool.SetUpStages"
-                                    variant="text"
-                                    enabled={true}
-                                    hasText={true}
-                                    enabledImageFile="/bloom/bookEdit/toolbox/readers/edit-white.png"
-                                    css={css`
-                                        font-size: xx-small;
-                                        text-decoration: underline;
-                                        font-weight: normal;
-                                        height: 22px;
-                                        img {
-                                            height: 14px;
-                                            margin-right: 2px;
-                                            margin-bottom: 2px;
-                                        }
-                                        &:hover {
-                                            text-decoration: underline;
-                                        }
-                                    `}
-                                >
-                                    Set Up Stages
-                                </BloomButton>
-                            </div>
+                <div
+                    css={css`
+                        display: flex;
+                        flex-direction: column;
+                        flex: 1 1 auto;
+                        min-height: 0;
+                        overflow-x: hidden;
+                        // A single horizontal padding on the whole panel
+                        // gives every row one shared left edge (matching
+                        // the Leveled Reader), instead of the stage being
+                        // hard against the left edge. (BL-16585)
+                        padding: 8px 12px 0 12px;
+                    `}
+                >
+                    {showTool && (
+                        <>
                             <ReaderToolNav
                                 isForLeveled={false}
                                 changeFunction={changeStage}
@@ -446,22 +435,6 @@ export const DecodableReaderToolControls: FunctionComponent = () => {
                                 <StageGraphemes />
                             )}
                             <SortedStageWords changeSortFunc={changeSortFunc} />
-                        </div>
-                        <>
-                            {model.synphony?.source.useAllowedWords === 0 && (
-                                <Link
-                                    l10nKey="EditTab.Toolbox.DecodableReaderTool.MakeLetterWordReport"
-                                    href="javascript:toolboxBundle.makeLetterWordList();"
-                                    css={css`
-                                        padding: 8px;
-                                        padding-left: 11px;
-                                        background-color: ${kBloomDarkestBackground};
-                                        text-decoration: underline;
-                                    `}
-                                >
-                                    Generate a letter and word list report
-                                </Link>
-                            )}
                             {model.getAllowedWordsAsObjects(model.stageNumber)
                                 .length >= model.maxAllowedWords && (
                                 <Span
@@ -479,13 +452,59 @@ export const DecodableReaderToolControls: FunctionComponent = () => {
                                 </Span>
                             )}
                         </>
-                    </>
-                )}
-                <div>
-                    <ReaderToolSwitch
-                        isForLeveled={false}
-                        changeDisplayFunc={() => setShowTool((prev) => !prev)}
-                    />
+                    )}
+                    {/* Bottom group, top to bottom: Generate Report, the "Book is
+                        Decodable" toggle, then the Set Up Stages button last.
+                        Generate Report only appears when sampling words; allowed-
+                        words mode has no report to generate. margin-top:auto pushes
+                        the group to the bottom while the tool content shows; it
+                        scrolls with the content when the panel overflows. The toggle
+                        stays mounted even when the content is hidden so the user can
+                        turn the book back into a decodable reader. */}
+                    <div
+                        css={css`
+                            display: flex;
+                            flex-direction: column;
+                            align-items: flex-start;
+                            gap: 8px;
+                            margin-bottom: 10px;
+                            ${showTool
+                                ? "margin-top: auto; padding-top: 12px;"
+                                : ""}
+                        `}
+                    >
+                        {showTool &&
+                            model.synphony?.source.useAllowedWords === 0 && (
+                                <BloomButton
+                                    l10nKey="EditTab.Toolbox.DecodableReaderTool.GenerateReport"
+                                    l10nTipEnglishEnabled="Create and open a text file listing the letters and words available at each decodable stage."
+                                    href="javascript:toolboxBundle.makeLetterWordList();"
+                                    variant="text"
+                                    enabled={true}
+                                    hasText={true}
+                                    iconBeforeText={
+                                        <SummarizeOutlined
+                                            css={css`
+                                                // currentColor picks up the
+                                                // button's accent text color.
+                                                color: currentColor;
+                                                font-size: 16px;
+                                            `}
+                                        />
+                                    }
+                                    css={readerTextButtonCss}
+                                >
+                                    Generate Report
+                                </BloomButton>
+                            )}
+                        <ReaderToolSwitch
+                            isForLeveled={false}
+                            changeDisplayFunc={() =>
+                                setShowTool((prev) => !prev)
+                            }
+                        />
+                        {showTool && <ReaderSetupButton isForLeveled={false} />}
+                    </div>
                 </div>
             </div>
         </ThemeProvider>

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.tsx
@@ -320,6 +320,7 @@ function isBookOverLevel(
         [model.maxGlyphsPerWord(), stats["actualLettersPerWord"]],
         [model.maxAverageGlyphsPerWord(), stats["actualAverageGlyphsPerWord"]],
         [model.maxSentencesPerPage(), stats["actualSentencesPerPage"]],
+        [model.maxSentencesPerBook(), stats["actualSentenceCount"]],
         [
             model.maxAverageSentencesPerPage(),
             stats["actualAverageSentencesPerPage"],

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.tsx
@@ -285,7 +285,7 @@ const OverLevelBanner: FunctionComponent<{ levelNumber: number }> = (props) => {
                     font-weight: bold;
                 `}
             >
-                This book reads above Level {0}
+                {"This book reads above Level {0}"}
             </Span>
         </div>
     );
@@ -325,10 +325,18 @@ function isBookOverLevel(
             stats["actualAverageSentencesPerPage"],
         ],
     ];
-    return pairs.some(
-        ([max, actual]) =>
-            max !== 0 && max !== Infinity && Number(actual) > max,
-    );
+    // Compare against the actual value rounded to the same one decimal place
+    // the rows display (see formatAverage), so the banner never disagrees with
+    // the per-row coloring: e.g. a raw 5.04 shows as "5.0" within-level, so it
+    // must not trip the "reads above level" banner either. Rounding is a no-op
+    // for the integer stats.
+    return pairs.some(([max, actual]) => {
+        if (max === 0 || max === Infinity) {
+            return false;
+        }
+        const roundedActual = Number(Number(actual).toFixed(1));
+        return roundedActual > max;
+    });
 }
 
 const LeveledReaderStats: FunctionComponent<{

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.tsx
@@ -6,22 +6,24 @@ import { getTheOneReaderToolsModel } from "../readerToolsModel";
 import { isReaderToolEnabledOnCurrentPage } from "../readerToolPageState";
 import BloomButton from "../../../../react_components/bloomButton";
 import { ReaderToolNav } from "../ReaderToolNav";
+import { ReaderSetupButton } from "../ReaderSetupButton";
+import {
+    kReaderAccent,
+    kReaderMuted,
+    readerSectionHeaderCss,
+    readerTextButtonCss,
+} from "../readerToolStyles";
 import { Div, Span } from "../../../../react_components/l10nComponents";
-import { kBloomLightBlue } from "../../../../utils/colorUtils";
 import { useMountEffect } from "../../../../utils/useMountEffect";
 import { Link } from "../../../../react_components/link";
-import {
-    ContentCopySharp,
-    EditOutlined,
-    ReportProblemOutlined,
-} from "@mui/icons-material";
+import { ContentCopySharp, ReportProblemOutlined } from "@mui/icons-material";
 
 // Colors used to flag a measure as within/over the current level's limit.
 const kWithinLevelColor = "lightgreen";
 const kOverLevelColor = "orange";
 // Quiet grey used for the column headers and the (de-emphasized) Max values,
 // so the eye lands on the colored Actual figures instead of the limits.
-const kMutedColor = "rgba(255, 255, 255, 0.55)";
+const kMutedColor = kReaderMuted;
 
 // Small, quiet uppercase styling shared by the Measure/Max/Actual column headers.
 const kColumnHeaderCss = css`
@@ -175,15 +177,11 @@ const StatsGrid: FunctionComponent<{
                 <Div
                     l10nKey={`EditTab.Toolbox.LeveledReaderTool.${props.header1L10nText.replace(/\s/g, "")}`} // the ending of the l10n key is just the text, but with all spaces removed. So, remove all the spaces from the text to use it in the key.
                     css={css`
-                        color: ${kBloomLightBlue};
-                        text-transform: uppercase;
-                        letter-spacing: 0.08em;
-                        // Span the section header across all three columns and
-                        // underline it, so the section rule carries the structure
-                        // (the individual data rows are intentionally rule-free).
+                        ${readerSectionHeaderCss};
+                        // Span the section header across all three columns, so the
+                        // section rule carries the structure (the individual data
+                        // rows are intentionally rule-free).
                         grid-column: 1 / -1;
-                        border-bottom: 1px solid rgba(255, 255, 255, 0.15);
-                        padding-bottom: 5px;
                         margin-bottom: 2px;
                     `}
                 >
@@ -197,7 +195,7 @@ const StatsGrid: FunctionComponent<{
                         // "This Page" / "This Book" are sub-labels within a
                         // section: quieter, uppercase, spanning the full width.
                         grid-column: 1 / -1;
-                        color: rgba(255, 255, 255, 0.55);
+                        color: ${kMutedColor};
                         font-size: x-small;
                         letter-spacing: 0.1em;
                         text-transform: uppercase;
@@ -238,7 +236,7 @@ const StatsLegend: FunctionComponent = () => {
                 justify-content: flex-end;
                 margin-top: 8px;
                 font-size: x-small;
-                color: rgba(255, 255, 255, 0.55);
+                color: ${kMutedColor};
             `}
         >
             <span css={item}>
@@ -491,15 +489,7 @@ const LeveledReaderList: FunctionComponent<{
         >
             <Div
                 l10nKey={`EditTab.Toolbox.LeveledReaderTool.${props.l10nKeySuffix}`}
-                css={css`
-                    color: ${kBloomLightBlue};
-                    // Match the stats section headers: uppercase with a
-                    // full-width rule beneath.
-                    text-transform: uppercase;
-                    letter-spacing: 0.08em;
-                    border-bottom: 1px solid rgba(255, 255, 255, 0.15);
-                    padding-bottom: 5px;
-                `}
+                css={readerSectionHeaderCss}
             >
                 {props.listHeaderText}
             </Div>
@@ -587,7 +577,7 @@ export const LeveledReaderToolControls: FunctionComponent = () => {
                     l10nKey={`EditTab.Toolbox.LeveledReaderTool.${linkSuffixes[idx]}`}
                     href={`api/externalLink?path=leveledRTInfo/leveledReaderInfo-en.html&fragment=${linkSuffixes[idx]}`}
                     css={css`
-                        color: ${kBloomLightBlue};
+                        color: ${kReaderAccent};
                         text-decoration: underline;
                     `}
                 >
@@ -617,92 +607,71 @@ export const LeveledReaderToolControls: FunctionComponent = () => {
                     overflow-x: hidden;
                 `}
             >
-                {showTool && (
+                <div
+                    css={css`
+                        display: flex;
+                        flex-direction: column;
+                        flex: 1 1 auto;
+                        min-height: 0;
+                        overflow-x: hidden;
+                        // A single horizontal padding on the whole panel keeps
+                        // every row (including "Level x of y") on one left edge,
+                        // instead of each section supplying its own left margin.
+                        padding: 8px 12px 0 12px;
+                    `}
+                >
+                    {showTool && (
+                        <>
+                            <ReaderToolNav
+                                isForLeveled={true}
+                                changeFunction={changeLevel}
+                            />
+                            {/* The over-level warning banner and the within/over
+                                legend only make sense when at least one measure is
+                                actually over the current level's limit. */}
+                            {isBookOverLevel(model, bookStats) && (
+                                <>
+                                    <OverLevelBanner
+                                        levelNumber={model.levelNumber}
+                                    />
+                                    <StatsLegend />
+                                </>
+                            )}
+                            <LeveledReaderStats bookStats={bookStats} />
+                            {levelReminders.length > 0 && (
+                                <LeveledReaderList
+                                    l10nKeySuffix="FoThisLevel"
+                                    listHeaderText="For this Level"
+                                    listItems={levelReminders}
+                                />
+                            )}
+                            <LeveledReaderList
+                                l10nKeySuffix="KeepInMind"
+                                listHeaderText="Keep in mind"
+                                listItems={getKeepInMindLinks()}
+                            />
+                        </>
+                    )}
+                    {/* Bottom group, top to bottom: Copy Book Stats, the "Book is
+                        Leveled" toggle, then the Set Up Levels button last. When
+                        the tool content is showing, margin-top:auto pushes the
+                        group to the bottom; it scrolls with the content when the
+                        panel overflows. The toggle stays mounted even when the
+                        content is hidden so the user can turn the book back into a
+                        leveled reader. */}
                     <div
                         css={css`
                             display: flex;
                             flex-direction: column;
-                            flex: 1 1 auto;
-                            min-height: 0;
-                            overflow-x: hidden;
-                            // A single horizontal padding on the whole panel keeps
-                            // every row (including "Level x of y") on one left edge,
-                            // instead of each section supplying its own left margin.
-                            padding: 8px 12px 0 12px;
+                            align-items: flex-start;
+                            gap: 8px;
+                            margin-bottom: 10px;
+                            ${showTool
+                                ? "margin-top: auto; padding-top: 12px;"
+                                : ""}
                         `}
                     >
-                        <div
-                            css={css`
-                                display: flex;
-                                margin-left: auto;
-                                margin-bottom: 10px;
-                            `}
-                        >
-                            <BloomButton
-                                href="javascript:window.toolboxBundle.showSetupDialog('levels');"
-                                l10nKey="EditTab.Toolbox.LeveledReaderTool.SetUpLevels"
-                                variant="text"
-                                enabled={true}
-                                hasText={true}
-                                iconBeforeText={
-                                    <EditOutlined
-                                        css={css`
-                                            color: ${kBloomLightBlue};
-                                            font-size: 16px;
-                                        `}
-                                    />
-                                }
-                                css={css`
-                                    font-size: 13px;
-                                    text-decoration: underline;
-                                    font-weight: normal;
-                                    height: 22px;
-                                    & .MuiButton-startIcon {
-                                        margin-right: 3px;
-                                    }
-                                    // && beats MUI's .MuiButton-textPrimary so the
-                                    // link text (and the currentColor icon) take
-                                    // the teal accent.
-                                    && {
-                                        color: ${kBloomLightBlue};
-                                    }
-                                    &:hover {
-                                        text-decoration: underline;
-                                    }
-                                `}
-                            >
-                                Set Up Levels
-                            </BloomButton>
-                        </div>
-                        <ReaderToolNav
-                            isForLeveled={true}
-                            changeFunction={changeLevel}
-                        />
-                        {isBookOverLevel(model, bookStats) && (
-                            <OverLevelBanner levelNumber={model.levelNumber} />
-                        )}
-                        <StatsLegend />
-                        <LeveledReaderStats bookStats={bookStats} />
-                        {levelReminders.length > 0 && (
-                            <LeveledReaderList
-                                l10nKeySuffix="FoThisLevel"
-                                listHeaderText="For this Level"
-                                listItems={levelReminders}
-                            />
-                        )}
-                        <LeveledReaderList
-                            l10nKeySuffix="KeepInMind"
-                            listHeaderText="Keep in mind"
-                            listItems={getKeepInMindLinks()}
-                        />
-                        <div
-                            css={css`
-                                display: flex;
-                                margin-right: auto;
-                                margin-top: 8px;
-                                margin-bottom: 10px;
-                            `}
-                        >
+                        {showTool && (
                             <BloomButton
                                 l10nKey="EditTab.Toolbox.LeveledReaderTool.CopyBookStatistics"
                                 variant="text"
@@ -711,48 +680,28 @@ export const LeveledReaderToolControls: FunctionComponent = () => {
                                 iconBeforeText={
                                     <ContentCopySharp
                                         css={css`
-                                            color: white;
+                                            // currentColor picks up the button's
+                                            // accent text color.
+                                            color: currentColor;
                                         `}
                                     />
                                 }
                                 onClick={() =>
                                     model.copyLeveledReaderStatsToClipboard()
                                 }
-                                css={css`
-                                    // && beats MUI's own button styles so the
-                                    // outline, padding and larger text all take.
-                                    && {
-                                        text-transform: uppercase;
-                                        color: white;
-                                        font-weight: normal;
-                                        font-size: 11px;
-                                        border: 1px solid
-                                            rgba(255, 255, 255, 0.4);
-                                        border-radius: 4px;
-                                        padding: 9px 18px;
-                                        line-height: 1.2;
-                                    }
-
-                                    &:hover {
-                                        background-color: black;
-                                    }
-
-                                    &:active {
-                                        background-color: black;
-                                        transform: translateY(2px);
-                                    }
-                                `}
+                                css={readerTextButtonCss}
                             >
                                 Copy Book Stats
                             </BloomButton>
-                        </div>
+                        )}
+                        <ReaderToolSwitch
+                            isForLeveled={true}
+                            changeDisplayFunc={() =>
+                                setShowTool((prev) => !prev)
+                            }
+                        />
+                        {showTool && <ReaderSetupButton isForLeveled={true} />}
                     </div>
-                )}
-                <div>
-                    <ReaderToolSwitch
-                        isForLeveled={true}
-                        changeDisplayFunc={() => setShowTool((prev) => !prev)}
-                    />
                 </div>
             </div>
         </ThemeProvider>

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.tsx
@@ -96,10 +96,10 @@ const StatsRow: FunctionComponent<{
                     min-width: 83px;
                     padding-right: 8px;
                     align-self: center;
-                    // The mockup capitalizes the first letter of each label
-                    // (e.g. "Per page"). Doing it here keeps the localized
-                    // source strings lowercase and avoids capitalizing every
-                    // word, which text-transform: capitalize would do.
+                    // Capitalize the first letter of each label (e.g. "Per
+                    // page"). Doing it here keeps the localized source strings
+                    // lowercase and avoids capitalizing every word, which
+                    // text-transform: capitalize would do.
                     &::first-letter {
                         text-transform: uppercase;
                     }

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.tsx
@@ -295,6 +295,14 @@ function formatAverage(value: number): string {
     return value.toFixed(1);
 }
 
+// A statistic violates the current level when it exceeds the level's maximum.
+// A maximum of 0 means the level does not limit this statistic at all, and
+// Infinity means we don't know the limit yet (no level data loaded); neither
+// counts as a violation.
+function isOverMax(actualNum: number, maxNum: number): boolean {
+    return maxNum != 0 && maxNum != Infinity && actualNum > maxNum;
+}
+
 // True when at least one measured statistic exceeds the current level's
 // limit. Mirrors the per-row orange coloring rule in StatsRow.
 function isBookOverLevel(

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.tsx
@@ -6,31 +6,51 @@ import { getTheOneReaderToolsModel } from "../readerToolsModel";
 import { isReaderToolEnabledOnCurrentPage } from "../readerToolPageState";
 import BloomButton from "../../../../react_components/bloomButton";
 import { ReaderToolNav } from "../ReaderToolNav";
-import { Div } from "../../../../react_components/l10nComponents";
+import { Div, Span } from "../../../../react_components/l10nComponents";
 import { kBloomLightBlue } from "../../../../utils/colorUtils";
 import { useMountEffect } from "../../../../utils/useMountEffect";
 import { Link } from "../../../../react_components/link";
-import { ContentCopySharp } from "@mui/icons-material";
+import {
+    ContentCopySharp,
+    EditOutlined,
+    ReportProblemOutlined,
+} from "@mui/icons-material";
+
+// Colors used to flag a measure as within/over the current level's limit.
+const kWithinLevelColor = "lightgreen";
+const kOverLevelColor = "orange";
+// Quiet grey used for the column headers and the (de-emphasized) Max values,
+// so the eye lands on the colored Actual figures instead of the limits.
+const kMutedColor = "rgba(255, 255, 255, 0.55)";
+
+// Small, quiet uppercase styling shared by the Measure/Max/Actual column headers.
+const kColumnHeaderCss = css`
+    color: ${kMutedColor};
+    font-size: x-small;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    align-self: end;
+`;
 
 const MaxActualRow: FunctionComponent = () => {
     return (
         <>
-            {/* This div is intentionally included here, though empty, to ensure the grid
-             syling works for the header row.*/}
-            <div
+            <Div
+                l10nKey="EditTab.Toolbox.LeveledReaderTool.Measure"
                 css={css`
+                    ${kColumnHeaderCss};
                     grid-column: 1;
                 `}
-            ></div>
+            >
+                Measure
+            </Div>
             <Div
                 l10nKey="EditTab.Toolbox.LeveledReaderTool.Max"
                 css={css`
+                    ${kColumnHeaderCss};
                     max-width: 40px;
                     padding-right: 6px;
-                    word-wrap: break-word;
-                    overflow-wrap: break-word;
-                    text-align: center;
-                    align-self: start;
+                    text-align: right;
                 `}
             >
                 Max
@@ -38,12 +58,10 @@ const MaxActualRow: FunctionComponent = () => {
             <Div
                 l10nKey="EditTab.Toolbox.LeveledReaderTool.Actual"
                 css={css`
+                    ${kColumnHeaderCss};
                     max-width: 40px;
                     padding-right: 3px;
-                    word-wrap: break-word;
-                    overflow-wrap: break-word;
-                    text-align: center;
-                    align-self: start;
+                    text-align: right;
                 `}
             >
                 Actual
@@ -76,6 +94,13 @@ const StatsRow: FunctionComponent<{
                     min-width: 83px;
                     padding-right: 8px;
                     align-self: center;
+                    // The mockup capitalizes the first letter of each label
+                    // (e.g. "Per page"). Doing it here keeps the localized
+                    // source strings lowercase and avoids capitalizing every
+                    // word, which text-transform: capitalize would do.
+                    &::first-letter {
+                        text-transform: uppercase;
+                    }
                 `}
             >
                 {props.children}
@@ -86,15 +111,18 @@ const StatsRow: FunctionComponent<{
                     padding-right: 6px;
                     word-wrap: break-word;
                     overflow-wrap: break-word;
-                    text-align: center;
+                    text-align: right;
                     align-self: start;
+                    // The limit is de-emphasized (quiet grey) so the eye lands
+                    // on the colored Actual figure beside it.
+                    color: ${kMutedColor};
                 `}
             >
                 {props.maxNum !== 0 &&
                 props.maxNum !== Infinity &&
                 !props.hideMaxNum
                     ? props.maxNum
-                    : ""}
+                    : "—"}
             </div>
             <div
                 // Says whether this value violates the level's limit, so that tests
@@ -111,11 +139,12 @@ const StatsRow: FunctionComponent<{
                     padding-right: 3px;
                     word-wrap: break-word;
                     overflow-wrap: break-word;
-                    text-align: center;
+                    text-align: right;
                     align-self: start;
-                    color: ${isOverMax(props.actualNum, props.maxNum)
-                        ? "orange"
-                        : "lightgreen"};
+                    color: ${Number(props.actualNum) > props.maxNum &&
+                    props.maxNum !== 0
+                        ? kOverLevelColor
+                        : kWithinLevelColor};
                 `}
             >
                 {props.isAverage
@@ -147,7 +176,15 @@ const StatsGrid: FunctionComponent<{
                     l10nKey={`EditTab.Toolbox.LeveledReaderTool.${props.header1L10nText.replace(/\s/g, "")}`} // the ending of the l10n key is just the text, but with all spaces removed. So, remove all the spaces from the text to use it in the key.
                     css={css`
                         color: ${kBloomLightBlue};
-                        grid-column: 1;
+                        text-transform: uppercase;
+                        letter-spacing: 0.08em;
+                        // Span the section header across all three columns and
+                        // underline it, so the section rule carries the structure
+                        // (the individual data rows are intentionally rule-free).
+                        grid-column: 1 / -1;
+                        border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+                        padding-bottom: 5px;
+                        margin-bottom: 2px;
                     `}
                 >
                     {props.header1L10nText}
@@ -157,8 +194,17 @@ const StatsGrid: FunctionComponent<{
                 <Div
                     l10nKey={`EditTab.Toolbox.LeveledReaderTool.${props.header2L10nText.replace(/\s/g, "")}`} // same deal here
                     css={css`
-                        color: white;
-                        grid-column: 1;
+                        // "This Page" / "This Book" are sub-labels within a
+                        // section: quieter, uppercase, spanning the full width.
+                        grid-column: 1 / -1;
+                        color: rgba(255, 255, 255, 0.55);
+                        font-size: x-small;
+                        letter-spacing: 0.1em;
+                        text-transform: uppercase;
+                        margin-top: 6px;
+                        // Half-em breathing room before the column headers/rows
+                        // that follow the "This Page"/"This Book" sub-label.
+                        margin-bottom: 0.5em;
                     `}
                 >
                     {props.header2L10nText}
@@ -170,22 +216,122 @@ const StatsGrid: FunctionComponent<{
     );
 };
 
+// Legend explaining the green/orange coloring of the Actual figures.
+const StatsLegend: FunctionComponent = () => {
+    const swatch = (color: string) => css`
+        display: inline-block;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background-color: ${color};
+        margin-right: 6px;
+    `;
+    const item = css`
+        display: inline-flex;
+        align-items: center;
+        margin-left: 16px;
+    `;
+    return (
+        <div
+            css={css`
+                display: flex;
+                justify-content: flex-end;
+                margin-top: 8px;
+                font-size: x-small;
+                color: rgba(255, 255, 255, 0.55);
+            `}
+        >
+            <span css={item}>
+                <span css={swatch(kWithinLevelColor)} />
+                <Div l10nKey="EditTab.Toolbox.LeveledReaderTool.WithinLevel">
+                    Within level
+                </Div>
+            </span>
+            <span css={item}>
+                <span css={swatch(kOverLevelColor)} />
+                <Div l10nKey="EditTab.Toolbox.LeveledReaderTool.OverLevel">
+                    Over level
+                </Div>
+            </span>
+        </div>
+    );
+};
+
+// Warning banner shown at the top of the stats when any measure with a
+// limit exceeds that limit for the current level.
+const OverLevelBanner: FunctionComponent<{ levelNumber: number }> = (props) => {
+    return (
+        <div
+            css={css`
+                display: flex;
+                align-items: center;
+                gap: 8px;
+                margin: 10px 0 0 0;
+                padding: 8px 10px;
+                border-left: 3px solid ${kOverLevelColor};
+                background-color: rgba(255, 165, 0, 0.12);
+            `}
+        >
+            <ReportProblemOutlined
+                css={css`
+                    color: ${kOverLevelColor};
+                    font-size: 18px;
+                `}
+            />
+            <Span
+                l10nKey="EditTab.Toolbox.LeveledReaderTool.OverLevelWarning"
+                l10nParam0={props.levelNumber.toString()}
+                css={css`
+                    font-weight: bold;
+                `}
+            >
+                This book reads above Level {0}
+            </Span>
+        </div>
+    );
+};
+
 // This simple function is used in LeveledReaderStats to cut all
 // of the average values down to one decimal place
 function formatAverage(value: number): string {
     return value.toFixed(1);
 }
 
-// A statistic violates the current level when it exceeds the level's maximum.
-// A maximum of 0 means the level does not limit this statistic at all, and
-// Infinity means we don't know the limit yet (no level data loaded); neither
-// counts as a violation.
-function isOverMax(actualNum: number, maxNum: number): boolean {
-    return maxNum !== 0 && actualNum > maxNum;
+// True when at least one measured statistic exceeds the current level's
+// limit. Mirrors the per-row orange coloring rule in StatsRow.
+function isBookOverLevel(
+    model: ReturnType<typeof getTheOneReaderToolsModel>,
+    stats: { [key: string]: number },
+): boolean {
+    const pairs: Array<[number, number | string]> = [
+        [model.maxWordsPerPage(), stats["actualWordsPerPage"]],
+        [
+            model.maxWordsPerSentenceOnThisPage(),
+            stats["actualWordsPerSentence"],
+        ],
+        [model.maxWordsPerBook(), stats["actualWordCount"]],
+        [model.maxWordsPerPage(), stats["actualWordsPerPageBook"]],
+        [model.maxUniqueWordsPerBook(), stats["actualUniqueWords"]],
+        [
+            model.maxAverageWordsPerSentence(),
+            stats["actualAverageWordsPerSentence"],
+        ],
+        [model.maxAverageWordsPerPage(), stats["actualAverageWordsPerPage"]],
+        [model.maxGlyphsPerWord(), stats["actualLettersPerWord"]],
+        [model.maxAverageGlyphsPerWord(), stats["actualAverageGlyphsPerWord"]],
+        [model.maxSentencesPerPage(), stats["actualSentencesPerPage"]],
+        [
+            model.maxAverageSentencesPerPage(),
+            stats["actualAverageSentencesPerPage"],
+        ],
+    ];
+    return pairs.some(
+        ([max, actual]) =>
+            max !== 0 && max !== Infinity && Number(actual) > max,
+    );
 }
 
-// Exported for testing.
-export const LeveledReaderStats: FunctionComponent<{
+const LeveledReaderStats: FunctionComponent<{
     bookStats: { [key: string]: number };
 }> = (props) => {
     const model = getTheOneReaderToolsModel();
@@ -193,7 +339,6 @@ export const LeveledReaderStats: FunctionComponent<{
     return (
         <div
             css={css`
-                margin-left: 10px;
                 margin-top: 20px;
             `}
         >
@@ -217,8 +362,7 @@ export const LeveledReaderStats: FunctionComponent<{
                 </StatsRow>
             </StatsGrid>
             {/* Here, header2 is used instead of header1 because the header text
-            "This Book" is supposed to have the normal white color, and it is
-            technically part of the "section" with the overall header "Word Counts" */}
+            "This Book" is a sub-label within the "Word Counts" section. */}
             <StatsGrid header2L10nText="This Book">
                 <StatsRow
                     l10nKeySuffix="Total"
@@ -332,7 +476,6 @@ const LeveledReaderList: FunctionComponent<{
     return (
         <div
             css={css`
-                padding-left: 10px;
                 margin-top: 15px;
                 margin-bottom: 5px;
             `}
@@ -341,6 +484,12 @@ const LeveledReaderList: FunctionComponent<{
                 l10nKey={`EditTab.Toolbox.LeveledReaderTool.${props.l10nKeySuffix}`}
                 css={css`
                     color: ${kBloomLightBlue};
+                    // Match the stats section headers: uppercase with a
+                    // full-width rule beneath.
+                    text-transform: uppercase;
+                    letter-spacing: 0.08em;
+                    border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+                    padding-bottom: 5px;
                 `}
             >
                 {props.listHeaderText}
@@ -429,6 +578,7 @@ export const LeveledReaderToolControls: FunctionComponent = () => {
                     l10nKey={`EditTab.Toolbox.LeveledReaderTool.${linkSuffixes[idx]}`}
                     href={`api/externalLink?path=leveledRTInfo/leveledReaderInfo-en.html&fragment=${linkSuffixes[idx]}`}
                     css={css`
+                        color: ${kBloomLightBlue};
                         text-decoration: underline;
                     `}
                 >
@@ -438,6 +588,14 @@ export const LeveledReaderToolControls: FunctionComponent = () => {
         }
         return listOfLinks;
     }
+
+    // "For this Level" holds level-specific reminders the team entered in the
+    // setup dialog. An empty reminders field comes back as [""] (one blank
+    // string), so filter out blank entries; the section is only shown below
+    // when something real remains.
+    const levelReminders = model
+        .getLevelReminders()
+        .filter((reminder) => reminder.trim().length > 0);
 
     return (
         <ThemeProvider theme={toolboxTheme}>
@@ -458,6 +616,10 @@ export const LeveledReaderToolControls: FunctionComponent = () => {
                             flex: 1 1 auto;
                             min-height: 0;
                             overflow-x: hidden;
+                            // A single horizontal padding on the whole panel keeps
+                            // every row (including "Level x of y") on one left edge,
+                            // instead of each section supplying its own left margin.
+                            padding: 8px 12px 0 12px;
                         `}
                     >
                         <div
@@ -465,7 +627,6 @@ export const LeveledReaderToolControls: FunctionComponent = () => {
                                 display: flex;
                                 margin-left: auto;
                                 margin-bottom: 10px;
-                                padding-right: 2px;
                             `}
                         >
                             <BloomButton
@@ -474,16 +635,27 @@ export const LeveledReaderToolControls: FunctionComponent = () => {
                                 variant="text"
                                 enabled={true}
                                 hasText={true}
-                                enabledImageFile="/bloom/bookEdit/toolbox/readers/edit-white.png"
+                                iconBeforeText={
+                                    <EditOutlined
+                                        css={css`
+                                            color: ${kBloomLightBlue};
+                                            font-size: 16px;
+                                        `}
+                                    />
+                                }
                                 css={css`
-                                    font-size: xx-small;
+                                    font-size: 13px;
                                     text-decoration: underline;
                                     font-weight: normal;
                                     height: 22px;
-                                    img {
-                                        height: 14px;
-                                        margin-right: 2px;
-                                        margin-bottom: 2px;
+                                    & .MuiButton-startIcon {
+                                        margin-right: 3px;
+                                    }
+                                    // && beats MUI's .MuiButton-textPrimary so the
+                                    // link text (and the currentColor icon) take
+                                    // the teal accent.
+                                    && {
+                                        color: ${kBloomLightBlue};
                                     }
                                     &:hover {
                                         text-decoration: underline;
@@ -497,12 +669,18 @@ export const LeveledReaderToolControls: FunctionComponent = () => {
                             isForLeveled={true}
                             changeFunction={changeLevel}
                         />
+                        {isBookOverLevel(model, bookStats) && (
+                            <OverLevelBanner levelNumber={model.levelNumber} />
+                        )}
+                        <StatsLegend />
                         <LeveledReaderStats bookStats={bookStats} />
-                        <LeveledReaderList
-                            l10nKeySuffix="FoThisLevel"
-                            listHeaderText="For this Level"
-                            listItems={getTheOneReaderToolsModel().getLevelReminders()}
-                        />
+                        {levelReminders.length > 0 && (
+                            <LeveledReaderList
+                                l10nKeySuffix="FoThisLevel"
+                                listHeaderText="For this Level"
+                                listItems={levelReminders}
+                            />
+                        )}
                         <LeveledReaderList
                             l10nKeySuffix="KeepInMind"
                             listHeaderText="Keep in mind"
@@ -512,7 +690,7 @@ export const LeveledReaderToolControls: FunctionComponent = () => {
                             css={css`
                                 display: flex;
                                 margin-right: auto;
-                                margin-left: 8px;
+                                margin-top: 8px;
                                 margin-bottom: 10px;
                             `}
                         >
@@ -525,7 +703,6 @@ export const LeveledReaderToolControls: FunctionComponent = () => {
                                     <ContentCopySharp
                                         css={css`
                                             color: white;
-                                            margin-right: -4px;
                                         `}
                                     />
                                 }
@@ -533,12 +710,19 @@ export const LeveledReaderToolControls: FunctionComponent = () => {
                                     model.copyLeveledReaderStatsToClipboard()
                                 }
                                 css={css`
-                                    text-transform: uppercase;
-                                    color: white;
-                                    font-weight: normal;
-                                    border-radius: 0;
-                                    text-align: left;
-                                    line-height: 15px;
+                                    // && beats MUI's own button styles so the
+                                    // outline, padding and larger text all take.
+                                    && {
+                                        text-transform: uppercase;
+                                        color: white;
+                                        font-weight: normal;
+                                        font-size: 11px;
+                                        border: 1px solid
+                                            rgba(255, 255, 255, 0.4);
+                                        border-radius: 4px;
+                                        padding: 9px 18px;
+                                        line-height: 1.2;
+                                    }
 
                                     &:hover {
                                         background-color: black;

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolStyles.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolStyles.ts
@@ -3,10 +3,9 @@ import { kBloomBlue } from "../../../utils/colorUtils";
 
 // The reader tools (Decodable + Leveled) share one accent, brighter than
 // kBloomLightBlue, so the section headers, links, and the button/sort outlines
-// all read clearly (AA, ~5.4:1) against the dark toolbox panel and no longer
-// mix two different blues. kBloomBlue (#1d94a4) stays as a *fill* — the
-// accordion header bar and the selected-sort background — with white on top.
-// (BL-16585)
+// all read clearly (AA, ~5.4:1) against the dark toolbox panel. kBloomBlue
+// (#1d94a4) is used as a *fill* — the accordion header bar and the
+// selected-sort background — with white on top. (BL-16585)
 export const kReaderAccent = "#23b4c7";
 // Muted text in the reader tools ("of N", the Max column, the This Page/This
 // Book sub-labels, the within/over legend). (BL-16585)

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolStyles.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolStyles.ts
@@ -1,0 +1,101 @@
+import { css } from "@emotion/react";
+import { kBloomBlue } from "../../../utils/colorUtils";
+
+// The reader tools (Decodable + Leveled) share one accent, brighter than
+// kBloomLightBlue, so the section headers, links, and the button/sort outlines
+// all read clearly (AA, ~5.4:1) against the dark toolbox panel and no longer
+// mix two different blues. kBloomBlue (#1d94a4) stays as a *fill* — the
+// accordion header bar and the selected-sort background — with white on top.
+// (BL-16585)
+export const kReaderAccent = "#23b4c7";
+// Muted text in the reader tools ("of N", the Max column, the This Page/This
+// Book sub-labels, the within/over legend). (BL-16585)
+export const kReaderMuted = "#999999";
+
+// Section header styling shared across the reader tools: an uppercase accent
+// label with a full-width underline rule. This is the look of "Word Counts"
+// et al. in the Leveled Reader; the Decodable Reader's "Letters in this stage"
+// / "Sample words in this stage" headers reuse it so the two tools match.
+// (BL-16585)
+export const readerSectionHeaderCss = css`
+    color: ${kReaderAccent};
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+    padding-bottom: 5px;
+`;
+
+// "Outline" button styling shared by the buttons along the bottom of the
+// reader tool panels (Set Up Stages/Levels, Generate Report, Copy Book Stats):
+// a quiet uppercase accent label inside a thin accent rounded rectangle. Any
+// icon uses currentColor so it takes the same accent. (BL-16585)
+export const readerOutlineButtonCss = css`
+    // && beats MUI's own button styles so the outline, padding and text all take.
+    && {
+        text-transform: uppercase;
+        color: ${kReaderAccent};
+        font-weight: normal;
+        font-size: 11px;
+        border: 1px solid ${kReaderAccent};
+        border-radius: 4px;
+        padding: 9px 18px;
+        line-height: 1.2;
+    }
+    &:hover {
+        background-color: black;
+    }
+    &:active {
+        background-color: black;
+        transform: translateY(2px);
+    }
+`;
+
+// "Contained" button styling for the primary Set Up Stages/Levels action: white
+// text on a kBloomBlue fill (the same fill Bloom uses for the accordion header
+// bar and the selected sort button), so the setup button reads as the main call
+// to action and stands apart from the quieter text actions. (BL-16585)
+export const readerContainedButtonCss = css`
+    && {
+        text-transform: uppercase;
+        color: white;
+        font-weight: normal;
+        font-size: 11px;
+        border: 1px solid ${kBloomBlue};
+        border-radius: 4px;
+        padding: 9px 18px;
+        line-height: 1.2;
+        background-color: ${kBloomBlue};
+    }
+    // Keep the fill on hover/active (only the press nudge changes), so the solid
+    // look is stable rather than flashing to the black used by the text buttons.
+    &:hover {
+        background-color: ${kBloomBlue};
+    }
+    &:active {
+        background-color: ${kBloomBlue};
+        transform: translateY(2px);
+    }
+`;
+
+// "Text" button styling for the secondary actions in the Actions section (Copy
+// Book Stats, Generate Report): the same quiet uppercase accent label as the
+// outline button but with no border, so the outlined/contained Set Up button
+// stays visually dominant. Any icon uses currentColor so it takes the accent.
+// (BL-16585)
+export const readerTextButtonCss = css`
+    && {
+        text-transform: uppercase;
+        color: ${kReaderAccent};
+        font-weight: normal;
+        font-size: 11px;
+        padding: 9px 8px;
+        line-height: 1.2;
+    }
+    &:hover {
+        background-color: black;
+    }
+    &:active {
+        background-color: black;
+        transform: translateY(2px);
+    }
+`;

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolStyles.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolStyles.ts
@@ -25,31 +25,6 @@ export const readerSectionHeaderCss = css`
     padding-bottom: 5px;
 `;
 
-// "Outline" button styling shared by the buttons along the bottom of the
-// reader tool panels (Set Up Stages/Levels, Generate Report, Copy Book Stats):
-// a quiet uppercase accent label inside a thin accent rounded rectangle. Any
-// icon uses currentColor so it takes the same accent. (BL-16585)
-export const readerOutlineButtonCss = css`
-    // && beats MUI's own button styles so the outline, padding and text all take.
-    && {
-        text-transform: uppercase;
-        color: ${kReaderAccent};
-        font-weight: normal;
-        font-size: 11px;
-        border: 1px solid ${kReaderAccent};
-        border-radius: 4px;
-        padding: 9px 18px;
-        line-height: 1.2;
-    }
-    &:hover {
-        background-color: black;
-    }
-    &:active {
-        background-color: black;
-        transform: translateY(2px);
-    }
-`;
-
 // "Contained" button styling for the primary Set Up Stages/Levels action: white
 // text on a kBloomBlue fill (the same fill Bloom uses for the accordion header
 // bar and the selected sort button), so the setup button reads as the main call

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
@@ -100,8 +100,9 @@ export class ReaderToolsModel {
     // (The constructor must return synchronously)
     public async initAsync(): Promise<void> {
         const keys = {
-            "EditTab.Toolbox.DecodableReaderTool.StageNofM": "Stage {0} of {1}",
-            "EditTab.Toolbox.LeveledReaderTool.LevelNofM": "Level {0} of {1}",
+            "EditTab.Toolbox.DecodableReaderTool.StageNumber": "Stage {0}",
+            "EditTab.Toolbox.LeveledReaderTool.LevelNumber": "Level {0}",
+            "EditTab.Toolbox.ReaderTools.OfCount": "of {0}",
         };
 
         // Asynchronously pre-load the localizations (in the UI language) of the specified keys

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.less
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.less
@@ -105,7 +105,9 @@ div.ui-accordion-content:not([data-toolid="leveledReaderTool"]):not(
 }
 // Reserve space for the vertical scrollbar on the reader tools, so that when
 // their content grows tall enough to need one, the scrollbar's appearance
-// doesn't shrink the content width and reflow/crowd everything. (BL-16585)
+// doesn't shrink the content width and reflow/crowd everything. (The dark
+// scrollbar *styling* now comes from the shared `bloomDarkScrollbars` class on
+// the toolbox root — see bloomUI.less — rather than a rule here.) (BL-16585)
 div.ui-accordion-content[data-toolid="leveledReaderTool"],
 div.ui-accordion-content[data-toolid="decodableReaderTool"] {
     scrollbar-gutter: stable;

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.less
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.less
@@ -103,6 +103,13 @@ div.ui-accordion-content:not([data-toolid="leveledReaderTool"]):not(
     margin: 0 !important;
     top: 0 !important;
 }
+// Reserve space for the vertical scrollbar on the reader tools, so that when
+// their content grows tall enough to need one, the scrollbar's appearance
+// doesn't shrink the content width and reflow/crowd everything. (BL-16585)
+div.ui-accordion-content[data-toolid="leveledReaderTool"],
+div.ui-accordion-content[data-toolid="decodableReaderTool"] {
+    scrollbar-gutter: stable;
+}
 
 .h1 {
     padding-top: 20px;

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.mixins.pug
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.mixins.pug
@@ -4,7 +4,7 @@ doctype html
 html
 	head
 		block headContent
-	body
+	body.bloomDarkScrollbars
 		.toolboxRoot
 			#toolbox-react-root
 		block endBodyScripts

--- a/src/BloomBrowserUI/collectionsTab/CollectionsTabPane.tsx
+++ b/src/BloomBrowserUI/collectionsTab/CollectionsTabPane.tsx
@@ -490,6 +490,8 @@ export const CollectionsTabPane: React.FunctionComponent = () => {
 
     return (
         <div
+            // Dark panel: opt into Bloom's shared dark scrollbar style (bloomUI.less).
+            className="bloomDarkScrollbars"
             css={css`
                 height: 100%;
                 background-color: ${kPanelBackground};

--- a/src/BloomBrowserUI/publish/PublishTab/PublishTabPane.tsx
+++ b/src/BloomBrowserUI/publish/PublishTab/PublishTabPane.tsx
@@ -302,7 +302,15 @@ export const PublishTabPane: React.FunctionComponent = () => {
                                 }
                             `}
                         >
-                            <TabList>
+                            {/* Dark panel: the far-left tab strip scrolls and is
+                                dark, so opt it into Bloom's shared dark scrollbar
+                                style (bloomUI.less). The class goes on the tab-list
+                                only, not on BloomTabs, so the light tab panels
+                                (which are siblings, not descendants) are unaffected.
+                                react-tabs supplies "react-tabs__tab-list" only as a
+                                default className, so a custom className replaces it;
+                                we must repeat it here to keep the tab-list styling. */}
+                            <TabList className="react-tabs__tab-list bloomDarkScrollbars">
                                 {publishTabs.map((tab, index) => (
                                     <Tab
                                         key={index}


### PR DESCRIPTION
Redesigns the Leveled Reader toolbox panel to match the approved mockup (BL-16585).

**Highlights**
- Over-level warning banner + within/over-level color legend.
- Section headers uppercased with a consistent underline rule; "This Page"/"This Book" sub-labels get half-em spacing.
- Stats table: MEASURE column header, right-aligned quiet-grey Max values, em dash for no-limit Max cells, first-letter-capitalized row labels.
- Level indicator split into a large "Level N" + a small muted "of M" on one line, with boxed prev/next arrow buttons (shared `ReaderToolNav`, so the Decodable tool's "Stage N of M" gets the same treatment).
- Teal "Set up Levels" link with a colorable edit icon; outlined "Copy Book Stats" button.
- Single horizontal panel padding so every row shares one left edge; `scrollbar-gutter: stable` reserves scrollbar width on the reader panels.
- "For this Level" hides when the level has no real reminders.

**Localization**
- Split the combined `LevelNofM` / `StageNofM` strings into `LevelNumber` / `StageNumber` + a shared `ReaderTools.OfCount` (old strings marked obsolete as of 6.5) so the two parts can be styled separately.
- New strings: banner/legend in `BloomMediumPriority.xlf`; `Measure` and the split level/stage strings in `Bloom.xlf`. English (`DistFiles/localization/en/`) only.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16585


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8087)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8087)
<!-- Reviewable:end -->
