### PR TITLE
Fix BL-16586 talking book text checksum doesn't remove every vertical line character

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBookChecksum.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBookChecksum.ts
@@ -21,6 +21,8 @@ export function getChecksum(message: string): string {
     // However, we don't want the sentence markup to be updated because the checksums differ (since a character was deleted).
     //
     // Thus, our checksum function needs to ignore the vertical line character when computing the checksum.
-    const adjustedMessage = message.replace("|", "");
+    // Use a global replace: a single audio-sentence can contain more than one delimiter
+    // (e.g. "one | two | three."), and every one of them must be stripped (BL-16586).
+    const adjustedMessage = message.replace(/\|/g, "");
     return getMd5(adjustedMessage);
 }

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBookChecksumSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBookChecksumSpec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { getChecksum } from "./talkingBookChecksum";
+import { getMd5 } from "./md5Util";
+
+// BL-16586
+// The vertical-line character ("|") is a temporary phrase delimiter that the user inserts to
+// split a sentence into phrases for recording and then deletes once the audio is made. The
+// checksum has to ignore every "|" so that deleting the delimiters doesn't make the recording
+// look out of date (which would regenerate the markup and lose the phrase-level audio).
+describe("getChecksum", () => {
+    it("ignores EVERY vertical-line character, not just the first (BL-16586)", () => {
+        // A single audio-sentence can contain more than one phrase delimiter.
+        const withDelimiters = "one | two | three.";
+        // What is left after the user deletes only the "|" characters.
+        const withoutDelimiters = "one  two  three.";
+
+        // Sanity check: the two strings really do differ, so matching checksums are meaningful.
+        expect(withDelimiters).not.toBe(withoutDelimiters);
+
+        expect(getChecksum(withDelimiters)).toBe(
+            getChecksum(withoutDelimiters),
+        );
+    });
+
+    it("still removes a single vertical-line character", () => {
+        expect(getChecksum("This is a test,| this is only a test.")).toBe(
+            getChecksum("This is a test, this is only a test."),
+        );
+    });
+
+    it("computes the md5 of the delimiter-stripped text", () => {
+        // Sanity check: the raw (un-stripped) md5 is different, so this asserts stripping happened.
+        expect(getMd5("a|b|c")).not.toBe(getMd5("abc"));
+
+        expect(getChecksum("a|b|c")).toBe(getMd5("abc"));
+    });
+});


### PR DESCRIPTION
To decide whether a recording still matches its text, Talking Book compares the text with the temporary `|` phrase markers removed. The code that removed them used `message.replace("|", "")`, which only removes the **first** `|`. So when a piece of text contains two or more `|`, a leftover `|` can make Bloom think the words changed when they didn't.

**Fix:** strip *every* `|` with `message.replace(/\|/g, "")`, so the comparison is always correct.

**User impact:** none observed. In "record by sentence" mode the `|` acts as a sentence break, so text is split into separate audio chunks and no chunk holds more than one `|` (the bug can't arise). In "record by whole text box" mode the box is one chunk and can contain two `|`, so the faulty comparison does happen — but its only effect is to re-do the audio markup on the box, which preserves the recording, its id, and the phrase timings. So this is a latent correctness bug, not audio loss.

**Tests:** added `talkingBookChecksumSpec.ts` (multiple markers, a single marker, and the md5-of-stripped-text case). The multi-marker tests fail on the old code and pass on the new. Full talkingBook suite (233 tests) still green.

**Note:** the card also flagged the misspelled `"undefind"` return value as a typo. It's deliberate — an intentionally unique, greppable sentinel, purposely different from the `"undefined"` that `isMissingRecordingChecksum` treats as "no recording yet", and that branch is test-only. Left unchanged.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16586


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8090)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8090)
<!-- Reviewable:end -->
