### PR TITLE
Fix three Talking Book audio-highlighting regressions (BL-15300)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -2100,6 +2100,16 @@ export default class AudioRecording implements IAudioRecorder {
         ) {
             await this.setRecordingModeAsync(RecordingMode.Sentence);
         }
+
+        // Re-establish the yellow current highlight (BL-15300). clearAudioSplit() above
+        // removed the blue split (::highlight) paint, but with pseudo-element highlighting
+        // nothing puts the yellow current highlight back the way removing bloom-postAudioSplit
+        // from the .ui-audioCurrent box used to do under the old background-color model. Without
+        // this, clearing a split whole-text-box recording leaves the box with no highlight.
+        // (When we switched to Sentence mode just above, setRecordingModeAsync already selected
+        // and highlighted the first sentence; refreshing again is harmless.)
+        this.refreshAudioTextHighlights();
+
         await this.changeStateAndSetExpectedAsync("record");
         this.updateDisplay();
     }

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -170,7 +170,6 @@ export default class AudioRecording implements IAudioRecorder {
 
     private showingImageDescriptions: boolean;
     public recordingMode: RecordingMode;
-    private previousRecordMode: RecordingMode;
     private haveAudio: boolean;
     private inShowPlaybackOrderMode: boolean = false;
     private wholeTextBoxAudioFeatureStatus: FeatureStatus | undefined;
@@ -2358,9 +2357,16 @@ export default class AudioRecording implements IAudioRecorder {
         recordingMode: RecordingMode,
         forceOverwrite: boolean = false,
     ): Promise<void> {
-        if (this.previousRecordMode === undefined) {
-            this.previousRecordMode = this.recordingMode;
-        }
+        // Which branch we take below depends on the mode the current text box is in *before*
+        // this switch. Use this.recordingMode, which is re-derived from the current box/page
+        // (initializeAudioRecordingMode / updateDisplay). We must NOT use a remembered
+        // "previous mode" field here: this is a session-long singleton and such a field is not
+        // reset when the page or current box changes, so a stale value sends us down the wrong
+        // branch and skips the textbox->sentence markup conversion. That was BL-15300: after
+        // clearing a whole-text-box recording and switching to Record by Sentence, the whole
+        // box was highlighted instead of the first sentence, because the box was never split
+        // into per-sentence spans.
+        const modeBeforeSwitch = this.recordingMode;
         this.recordingMode = recordingMode;
 
         // Check if there are any audio recordings present.
@@ -2383,7 +2389,7 @@ export default class AudioRecording implements IAudioRecorder {
 
         let result;
         // Update the UI after clicking the checkbox
-        if (this.previousRecordMode === RecordingMode.TextBox) {
+        if (modeBeforeSwitch === RecordingMode.TextBox) {
             // This also implies converting the playback mode to Sentence, because we disallow Recording=Sentence,Playback=TextBox.
             // Enhance: Maybe don't bother if the current playback mode is already sentence?
             // Enhance: Maybe it means that you should be less aggressively trying to convert Markup into Playback=TextBox. Or that Clear should be more aggressively attempting ton convert into Playback=Sentence.
@@ -2420,7 +2426,6 @@ export default class AudioRecording implements IAudioRecorder {
                 result = this.changeStateAndSetExpectedAsync("record");
             }
         }
-        this.previousRecordMode = this.recordingMode;
         return result;
     }
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -3285,7 +3285,14 @@ export default class AudioRecording implements IAudioRecorder {
         }
         const activeCanvasElement =
             getCanvasElementManager()?.getActiveElement();
-        if (activeCanvasElement) {
+        // Only defer to the active canvas element if it actually belongs to the current page.
+        // The CanvasElementManager is a page-frame singleton whose activeElement is not reliably
+        // cleared on page navigation, so after paging it can still point at a detached element
+        // from a previous page. If we honored that stale reference we would return without
+        // highlighting any text and never fall through to the first-audio-sentence code below,
+        // leaving the new page with no highlight at all (BL-15300: "after 2 or 3 pages, text
+        // blocks are not highlighted").
+        if (activeCanvasElement && pageDocBody.contains(activeCanvasElement)) {
             // Stop if this appears to be a recursive call. See BL-14898.
             if (activeCanvasElement !== this.canvasElementBeingHighlighted) {
                 this.canvasElementBeingHighlighted = activeCanvasElement;

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
@@ -2538,6 +2538,51 @@ describe("audio recording tests", () => {
                 "Two.",
             );
         });
+
+        // BL-15300 regression (Problem 3): the whole-box-vs-first-sentence decision when
+        // switching to Record by Sentence must be based on the current box's actual mode, not a
+        // mode remembered from an earlier switch elsewhere in the (session-long) recorder. Here
+        // the user first works with a by-sentence box, then navigates to a box recorded By Whole
+        // Text Box, clears it, and switches to by-sentence. Only the FIRST sentence should be
+        // highlighted -- previously the whole box was, because the box was never split into spans.
+        it("highlights only the first sentence when switching a whole-text-box box to by-sentence after an earlier by-sentence switch", async () => {
+            setupDefaultApiResponses();
+            vi.spyOn(axios, "post").mockResolvedValue({});
+
+            const recording = new AudioRecording();
+            (recording as unknown as { isShowing: boolean }).isShowing = true;
+
+            // 1) Earlier in the session: a by-sentence text box; end on Sentence mode.
+            SetupIFrameFromHtml(
+                '<div id="page1"><div class="bloom-translationGroup"><div id="boxA" class="bloom-editable" data-test-preselect="true" data-audiorecordingmode="Sentence"><p><span id="a1" class="audio-sentence">Alpha one.</span></p></div></div></div>',
+            );
+            setHighlightedElementFromDom(recording);
+            recording.recordingMode = RecordingMode.Sentence;
+            await recording.setRecordingModeAsync(RecordingMode.Sentence);
+
+            // 2) Navigate to a page whose box was recorded By Whole Text Box, and let the tool
+            //    (re)derive the mode for the current box the way handleNewPageReady does.
+            SetupIFrameFromHtml(
+                '<div id="page2"><div class="bloom-translationGroup"><div id="boxB" class="bloom-editable audio-sentence" data-test-preselect="true" data-audiorecordingmode="TextBox"><p>First sentence. Second sentence.</p></div></div></div>',
+            );
+            getFrameElementById("page", "boxB")!.setAttribute(
+                "recordingmd5",
+                "fakeMd5",
+            );
+            setHighlightedElementFromDom(recording);
+            recording.initializeAudioRecordingMode();
+            // Sanity: the current box's mode is correctly read as TextBox.
+            expect(recording.recordingMode).toBe(RecordingMode.TextBox);
+
+            // 3) Clear the recording, then switch to Record by Sentence.
+            recording.uiState.buttons.clear = Status.Enabled;
+            await recording.clearRecordingAsync();
+            await recording.setRecordingModeAsync(RecordingMode.Sentence);
+
+            expect(getHighlightTexts(currentHighlightName)).toEqual([
+                "First sentence.",
+            ]);
+        });
     });
 });
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
@@ -2500,6 +2500,44 @@ describe("audio recording tests", () => {
                 [],
             ]);
         });
+
+        // BL-15300 regression (Problem 2): after recording a whole text box and splitting it,
+        // clearing the recording should return the text box to the yellow current highlight.
+        // The split (blue) highlights must be removed AND the yellow current highlight
+        // re-registered. In the old DOM-class model the yellow reappeared automatically once
+        // bloom-postAudioSplit was removed from the .ui-audioCurrent box; with pseudo-element
+        // highlights nothing re-registers it unless clearRecordingAsync asks for a refresh.
+        it("restores the yellow current highlight when a split text-box recording is cleared", async () => {
+            SetupIFrameFromHtml(
+                '<div id="page1"><div class="bloom-translationGroup"><div id="div1" class="bloom-editable audio-sentence bloom-postAudioSplit" data-test-preselect="true" data-audiorecordingmode="TextBox" data-audiorecordingendtimes="1.0 2.0"><p><span id="span1" class="bloom-highlightSegment">One.</span> <span id="span2" class="bloom-highlightSegment">Two.</span></p></div></div></div>',
+            );
+
+            setupDefaultApiResponses();
+            vi.spyOn(axios, "post").mockResolvedValue({});
+
+            const recording = new AudioRecording();
+            setHighlightedElementFromDom(recording);
+            (recording as unknown as { isShowing: boolean }).isShowing = true;
+            recording.recordingMode = RecordingMode.TextBox;
+
+            // Simulate the post-split state: blue segment highlights are showing, no yellow.
+            recording.markAudioSplit();
+            expect(getSplitHighlightTexts()).toEqual([["One."], ["Two."], []]);
+            expect(getHighlightTexts(currentHighlightName)).toEqual([]);
+
+            recording.uiState.buttons.clear = Status.Enabled;
+            await recording.clearRecordingAsync();
+
+            // The blue split highlights should be gone...
+            expect(getSplitHighlightTexts()).toEqual([[], [], []]);
+            // ...and the whole text box should be highlighted yellow again.
+            expect(getHighlightTexts(currentHighlightName).join("")).toContain(
+                "One.",
+            );
+            expect(getHighlightTexts(currentHighlightName).join("")).toContain(
+                "Two.",
+            );
+        });
     });
 });
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
@@ -25,6 +25,55 @@ import {
     splitHighlightNames,
 } from "./audioTextHighlightManager";
 
+// A controllable stand-in for the page-frame CanvasElementManager. By default it is DISABLED,
+// so getCanvasElementManager() returns undefined -- exactly how the real one behaves in tests
+// (there is no editable-page bundle) -- and every existing test is unaffected. A test that
+// needs to exercise the audio code's handling of an active canvas element calls __enable() and
+// __setActiveForTest(...). When enabled it is a Proxy so that any method the production code
+// happens to call (e.g. resumeComicEditing during image-description setup) is a safe no-op,
+// while getActiveElement returns the (possibly stale/detached) element the test supplied.
+const mockCanvasElement = vi.hoisted(() => {
+    let activeElement: HTMLElement | undefined = undefined;
+    let enabled = false;
+    const explicit: Record<string, unknown> = {
+        getActiveElement: () => activeElement,
+        setActiveElement: (element: HTMLElement | undefined) => {
+            activeElement = element;
+        },
+    };
+    const manager = new Proxy(explicit, {
+        get(target, prop: string) {
+            if (prop in target) return target[prop];
+            // Any other method the production code calls is a harmless no-op in tests.
+            return () => undefined;
+        },
+    });
+    return {
+        getManager: () => (enabled ? manager : undefined),
+        __enable: () => {
+            enabled = true;
+        },
+        __setActiveForTest: (element: HTMLElement | undefined) => {
+            activeElement = element;
+        },
+        __reset: () => {
+            activeElement = undefined;
+            enabled = false;
+        },
+    };
+});
+
+vi.mock("../canvas/canvasElementPageBridge", async (importActual) => {
+    const actual =
+        await importActual<
+            typeof import("../canvas/canvasElementPageBridge")
+        >();
+    return {
+        ...actual,
+        getCanvasElementManager: () => mockCanvasElement.getManager(),
+    };
+});
+
 class FakeHighlight {
     public ranges: Range[];
 
@@ -146,6 +195,7 @@ describe("audio recording tests", () => {
         // when tests finish before timers fire
         theOneAudioRecorder?.clearTimeouts();
         getPseudoHighlightsRegistry().clear();
+        mockCanvasElement.__reset();
     });
 
     // In an earlier version of our API, checkForAnyRecording was designed to fail (404) if there was no recording.
@@ -1630,6 +1680,56 @@ describe("audio recording tests", () => {
             // Verification
             const firstDiv = getFrameElementById("page", "div1")!;
             expect(recording.getAudioCurrentElement()).toBe(firstDiv);
+        });
+
+        // BL-15300 regression (Problem 1): in a picture book (e.g. Moon and Cap) the recordable
+        // text lives inside a canvas element (text over picture). Highlighting text makes that
+        // canvas element the CanvasElementManager's "active" element, and that reference is not
+        // cleared when you navigate to another page. When the next page loads,
+        // setCurrentAudioElementToDefaultAsync used to see the (now detached) active canvas
+        // element and return without highlighting anything -- so after a couple of page turns no
+        // text was highlighted at all. The new page's own text must still get highlighted even
+        // though a stale active canvas element from the previous page is still hanging around.
+        it("still highlights text on a new page when a stale canvas element from the previous page is still active", async () => {
+            setupDefaultApiResponses();
+            mockCanvasElement.__enable();
+
+            const canvasTextPage = (n: number) =>
+                `<div id="page${n}"><div class="bloom-canvas"><div class="bloom-canvas-element"><div class="bloom-translationGroup"><div id="box${n}" class="bloom-editable bloom-visibility-code-on" data-audiorecordingmode="Sentence"><p><span id="s${n}" class="audio-sentence">Page ${n} text.</span></p></div></div></div></div></div>`;
+
+            // Page 1: opens fine and highlights its text.
+            SetupIFrameFromHtml(canvasTextPage(1));
+            const recording = new AudioRecording();
+            (recording as unknown as { isShowing: boolean }).isShowing = true;
+            recording.recordingMode = RecordingMode.Sentence;
+            await recording.handleNewPageReady();
+            expect(getHighlightTexts(currentHighlightName)).toEqual([
+                "Page 1 text.",
+            ]);
+
+            // Simulate the CanvasElementManager keeping page 1's canvas element active.
+            const page1CanvasElement = getPageWindow()!.document.querySelector(
+                ".bloom-canvas-element",
+            ) as HTMLElement;
+            mockCanvasElement.__setActiveForTest(page1CanvasElement);
+
+            // Navigate to page 2: replacing the body detaches page 1's nodes, so the still-active
+            // canvas element reference is now stale (not part of the current page).
+            SetupIFrameFromHtml(canvasTextPage(2));
+            getPseudoHighlightsRegistry().clear();
+            // Real navigation nulls the current highlight during teardown.
+            (
+                recording as unknown as {
+                    highlightedElement: HTMLElement | null;
+                }
+            ).highlightedElement = null;
+
+            await recording.handleNewPageReady();
+
+            // The regression: page 2's text should still be highlighted.
+            expect(getHighlightTexts(currentHighlightName)).toEqual([
+                "Page 2 text.",
+            ]);
         });
     });
 


### PR DESCRIPTION
Fixes three regressions in the reworked Talking Book audio-highlighting (Edit tab, CSS Custom Highlight API) reported against BL-15300.

**Problem 1 — text highlight lost after paging through a picture book.** In picture books the recordable text lives inside a canvas element, so highlighting it makes that element the `CanvasElementManager`'s active element — a reference not cleared on page navigation. `setCurrentAudioElementToDefaultAsync` treated any truthy active canvas element as "don't highlight text" and returned early, so once the reference went stale (detached after a page turn) no page highlighted again. Fix: only defer to the active canvas element when it's actually part of the current page (`pageDocBody.contains(...)`).

**Problem 2 — no yellow highlight after clearing a split recording.** `clearRecordingAsync` cleared the blue split `::highlight` paint but never re-registered the yellow current highlight (the old DOM-class model did this automatically). Fix: refresh the highlights at the end of `clearRecordingAsync`.

**Problem 3 — whole box highlighted instead of first sentence on mode switch.** `setRecordingModeAsync` decided whether to convert whole-textbox markup into per-sentence spans based on `previousRecordMode`, a field on the session-long singleton that is never reset when the page/box changes. A stale value sent the switch down the "don't convert" branch, so the box kept its whole-box `audio-sentence` and was painted whole. Fix: decide from `this.recordingMode` captured at entry (re-derived per page) and remove the stale field.

Each fix has a regression test (verified fix-sensitive) in `audioRecordingSpec.ts`. Full talking-book vitest suites pass (233 tests).

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-15300


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8091)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8091)
<!-- Reviewable:end -->
