### PR TITLE
Guard against null CoreWebView2 in UpdateDisplay (BL-16570)

### DIFF
--- a/src/BloomExe/WebView2Browser.cs
+++ b/src/BloomExe/WebView2Browser.cs
@@ -507,7 +507,16 @@ namespace Bloom
 
             // If we are disposed, this will certainly fail. Likely we are shutting down and just
             // trying to navigate to a blank page.
-            if (!_webview.IsDisposed && !_webview.Disposing)
+            // One user reported a crash in this method which indicated that a null reference exception was
+            // thrown on the line with the Navigate method. (BL-16570) I don't know how that could happen.
+            // EnsureBrowserReadyToNavigate() should have prevented it, but it uses a while loop over
+            // Application.DoEvents() which is known to be unsafe.
+            if (
+                !_webview.IsDisposed
+                && !_webview.Disposing
+                && _readyToNavigate
+                && _webview.CoreWebView2 != null
+            )
                 _webview.CoreWebView2.Navigate(newUrl);
         }
 


### PR DESCRIPTION
Fixes a `NullReferenceException` in `WebView2Browser.UpdateDisplay` reported by a user (crash on the `Navigate` line while a freshly-created browser was loading, via `ReactControl_Load`).

### Cause
`CoreWebView2` can be `null` even when the control itself is not disposed/disposing:
- async WebView2 initialization may not have completed yet (the `CoreWebView2` property stays null until `CoreWebView2InitializationCompleted` fires), and/or
- the core was torn down by a re-entrant `Application.DoEvents()` pump inside `EnsureBrowserReadyToNavigate()`.

The old guard only checked `IsDisposed`/`Disposing`, so it dereferenced a null `CoreWebView2` and crashed.

### Fix
Add `_readyToNavigate` and `CoreWebView2 != null` to the guard before calling `Navigate`, matching the existing defensive pattern used elsewhere in this file. When those aren't satisfied we skip navigation (the intended behavior during shutdown/teardown) instead of crashing.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16570

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8092)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8092)
<!-- Reviewable:end -->
