### PR TITLE
Fix image sizes for spreadsheet export to be DPI aware (BL-16529)

### DIFF
--- a/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
@@ -36,18 +36,11 @@ namespace Bloom.Spreadsheet
         private const int languageColumnWidth = 30;
         private const int defaultImageWidth = 150; //width of images in pixels.
 
-        static int _scaleFactor = 100;
-
         static SpreadsheetIO()
         {
             // The package requires us to do this as a way of acknowledging that we
             // accept the terms of the NonCommercial license.
             ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
-
-            // This scaling factor seems to be used by the library for column sizing.
-            // We need to use it for sizing thumbnail images stored inside the spreadsheet.
-            // See BL-16529.
-            _scaleFactor = WindowsMonitorScaling.GetScalingFactorForPrimaryMonitor();
         }
 
         public static void WriteSpreadsheet(
@@ -57,6 +50,12 @@ namespace Bloom.Spreadsheet
             IWebSocketProgress progress = null
         )
         {
+            // The spreadsheet-export library sizes its columns using the primary monitor's scaling factor,
+            // so we read that same factor and use it to size the thumbnail images we store inside the
+            // spreadsheet. We read it here, once per export, so a change to the display configuration during
+            // the session is reflected the next time the user exports. See BL-16529.
+            int scaleFactor = WindowsMonitorScaling.GetScalingFactorForPrimaryMonitor();
+
             using (var package = new ExcelPackage())
             {
                 var worksheet = package.Workbook.Worksheets.Add("BloomBook");
@@ -218,8 +217,8 @@ namespace Bloom.Spreadsheet
                             var origImageHeight = image.Size.Height;
                             var origImageWidth = image.Size.Width;
                             int finalWidth = defaultImageWidth;
-                            if (_scaleFactor > 100)
-                                finalWidth = defaultImageWidth * _scaleFactor / 100;
+                            if (scaleFactor > 100)
+                                finalWidth = defaultImageWidth * scaleFactor / 100;
                             finalHeight = (int)(finalWidth * origImageHeight / origImageWidth);
                             var size = new Size(finalWidth, finalHeight);
                             using (

--- a/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
@@ -36,11 +36,18 @@ namespace Bloom.Spreadsheet
         private const int languageColumnWidth = 30;
         private const int defaultImageWidth = 150; //width of images in pixels.
 
+        static int _scaleFactor = 100;
+
         static SpreadsheetIO()
         {
             // The package requires us to do this as a way of acknowledging that we
             // accept the terms of the NonCommercial license.
             ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
+
+            // This scaling factor seems to be used by the library for column sizing.
+            // We need to use it for sizing thumbnail images stored inside the spreadsheet.
+            // See BL-16529.
+            _scaleFactor = WindowsMonitorScaling.GetScalingFactorForPrimaryMonitor();
         }
 
         public static void WriteSpreadsheet(
@@ -211,6 +218,8 @@ namespace Bloom.Spreadsheet
                             var origImageHeight = image.Size.Height;
                             var origImageWidth = image.Size.Width;
                             int finalWidth = defaultImageWidth;
+                            if (_scaleFactor > 100)
+                                finalWidth = defaultImageWidth * _scaleFactor / 100;
                             finalHeight = (int)(finalWidth * origImageHeight / origImageWidth);
                             var size = new Size(finalWidth, finalHeight);
                             using (

--- a/src/BloomExe/WindowsMonitorScaling.cs
+++ b/src/BloomExe/WindowsMonitorScaling.cs
@@ -10,13 +10,24 @@ namespace Bloom
     /// </summary>
     internal static class WindowsMonitorScaling
     {
+        [StructLayout(LayoutKind.Sequential)]
+        public struct POINT
+        {
+            public int X;
+            public int Y;
+        }
+
         [DllImport("Shcore.dll")]
         private static extern int GetScaleFactorForMonitor(IntPtr hmonitor, out int pScale);
 
         [DllImport("user32.dll")]
         private static extern IntPtr MonitorFromWindow(IntPtr hwnd, uint dwFlags);
 
-        private const int MONITOR_DEFAULTTONEAREST = 0x00000002;
+        [DllImport("user32.dll")]
+        private static extern IntPtr MonitorFromPoint(POINT pt, uint dwFlags);
+
+        private const uint MONITOR_DEFAULTTOPRIMARY = 0x00000001;
+        private const uint MONITOR_DEFAULTTONEAREST = 0x00000002;
 
         [DllImport("Shcore.dll")]
         private static extern int GetDpiForMonitor(
@@ -48,6 +59,15 @@ namespace Bloom
                 out uint dpiX,
                 out uint dpiY
             );
+            GetScaleFactorForMonitor(hmonitor, out int percentScaleFactor);
+            return percentScaleFactor;
+        }
+
+        // Bloom uses this to scale images stored in spreadsheets during spreadsheet export to fit column width.
+        internal static int GetScalingFactorForPrimaryMonitor()
+        {
+            var ptZero = new POINT { X = 0, Y = 0 };
+            var hmonitor = MonitorFromPoint(ptZero, MONITOR_DEFAULTTOPRIMARY);
             GetScaleFactorForMonitor(hmonitor, out int percentScaleFactor);
             return percentScaleFactor;
         }

--- a/src/BloomExe/WindowsMonitorScaling.cs
+++ b/src/BloomExe/WindowsMonitorScaling.cs
@@ -64,6 +64,7 @@ namespace Bloom
         }
 
         // Bloom uses this to scale images stored in spreadsheets during spreadsheet export to fit column width.
+        // The third-party library that does the spreadsheet export apparently uses the primary monitor's scaling factor.
         internal static int GetScalingFactorForPrimaryMonitor()
         {
             var ptZero = new POINT { X = 0, Y = 0 };

--- a/src/BloomExe/WindowsMonitorScaling.cs
+++ b/src/BloomExe/WindowsMonitorScaling.cs
@@ -65,12 +65,31 @@ namespace Bloom
 
         // Bloom uses this to scale images stored in spreadsheets during spreadsheet export to fit column width.
         // The third-party library that does the spreadsheet export apparently uses the primary monitor's scaling factor.
+        // Returns 100 (i.e. no scaling) if the scale factor can't be determined for any reason, so that spreadsheet
+        // export still works even when this Windows API is unavailable or fails. We call this from a static constructor,
+        // so an unhandled failure here would surface as a TypeInitializationException that breaks every export, not just
+        // the image sizing. PublishAudioVideoAPI.TryGetWindowScalePercent guards the same GetScaleFactorForMonitor call.
         internal static int GetScalingFactorForPrimaryMonitor()
         {
-            var ptZero = new POINT { X = 0, Y = 0 };
-            var hmonitor = MonitorFromPoint(ptZero, MONITOR_DEFAULTTOPRIMARY);
-            GetScaleFactorForMonitor(hmonitor, out int percentScaleFactor);
-            return percentScaleFactor;
+            try
+            {
+                var ptZero = new POINT { X = 0, Y = 0 };
+                var hmonitor = MonitorFromPoint(ptZero, MONITOR_DEFAULTTOPRIMARY);
+                if (hmonitor == IntPtr.Zero)
+                    return 100;
+                // GetScaleFactorForMonitor returns S_OK (0) on success; otherwise percentScaleFactor is unreliable.
+                if (GetScaleFactorForMonitor(hmonitor, out int percentScaleFactor) != 0 || percentScaleFactor <= 0)
+                    return 100;
+                return percentScaleFactor;
+            }
+            catch (EntryPointNotFoundException)
+            {
+                return 100;
+            }
+            catch (DllNotFoundException)
+            {
+                return 100;
+            }
         }
 
         // Bloom uses this to scale a Problem Report screenshot if the display resolution is > 100%.

--- a/src/BloomExe/WindowsMonitorScaling.cs
+++ b/src/BloomExe/WindowsMonitorScaling.cs
@@ -66,9 +66,8 @@ namespace Bloom
         // Bloom uses this to scale images stored in spreadsheets during spreadsheet export to fit column width.
         // The third-party library that does the spreadsheet export apparently uses the primary monitor's scaling factor.
         // Returns 100 (i.e. no scaling) if the scale factor can't be determined for any reason, so that spreadsheet
-        // export still works even when this Windows API is unavailable or fails. We call this from a static constructor,
-        // so an unhandled failure here would surface as a TypeInitializationException that breaks every export, not just
-        // the image sizing. PublishAudioVideoAPI.TryGetWindowScalePercent guards the same GetScaleFactorForMonitor call.
+        // export still works — falling back to unscaled images — even when this Windows API is unavailable or fails.
+        // PublishAudioVideoAPI.TryGetWindowScalePercent guards the same GetScaleFactorForMonitor call the same way.
         internal static int GetScalingFactorForPrimaryMonitor()
         {
             try


### PR DESCRIPTION
## Problem

[6.5 regression] Images in spreadsheet export display smaller — they only take up about half the column width in LibreOffice. In 6.4 the images filled almost the whole column width.

## Cause

The third-party spreadsheet-export library (EPPlus) sizes columns using the **primary monitor's** scaling factor. On a high-DPI primary monitor (scaling > 100%) the columns end up wider than the fixed `defaultImageWidth` (150px) thumbnails we generate, so the images look small.

## Fix

- Add `WindowsMonitorScaling.GetScalingFactorForPrimaryMonitor()`, which reads the primary monitor's scale factor via `MonitorFromPoint(0,0, MONITOR_DEFAULTTOPRIMARY)` + `GetScaleFactorForMonitor`.
- In `SpreadsheetIO`, read that factor once in the static constructor and, when it is above 100%, scale the exported thumbnail width by the same factor so images fill the column as they did in 6.4.

When the primary monitor is at 100% scaling, behavior is unchanged.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16529


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8094)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8094)
<!-- Reviewable:end -->
