### PR TITLE
Port BL-16536 input-language crash fixes to Version6.4

### DIFF
--- a/src/BloomExe/BloomWebView2.cs
+++ b/src/BloomExe/BloomWebView2.cs
@@ -1,0 +1,55 @@
+using System.Globalization;
+using System.Windows.Forms;
+using Microsoft.Web.WebView2.WinForms;
+using SIL.Reporting;
+
+namespace Bloom
+{
+    /// <summary>
+    /// A WebView2 control that guards against a WinForms/.NET crash (BL-16536) that happens when the
+    /// user switches to a keyboard whose input language reports a BCP-47 tag that .NET does not
+    /// recognize as a culture. For example, the Keyman IPA keyboard reports "und-Latn" (undetermined
+    /// language, Latin script). When the input language changes, Windows sends WM_INPUTLANGCHANGE to
+    /// the focused window (which, while the user is typing, is this WebView2 control). WinForms' handler
+    /// for that message builds a CultureInfo from the keyboard's tag and throws
+    /// CultureNotFoundException. Because that runs inside WndProc during message dispatch, it is
+    /// otherwise a fatal, unhandled exception on the UI thread.
+    ///
+    /// Bloom does all its text editing inside WebView2, which tracks its own input language
+    /// independently of WinForms, so we can safely ignore WinForms' inability to represent the
+    /// keyboard and just perform the default window processing.
+    /// </summary>
+    public class BloomWebView2 : WebView2
+    {
+        private const int WM_INPUTLANGCHANGEREQUEST = 0x0050;
+        private const int WM_INPUTLANGCHANGE = 0x0051;
+
+        /// <summary>
+        /// Intercepts the input-language-change messages so that an unrecognized keyboard culture
+        /// cannot crash Bloom. See the class comment for the full explanation (BL-16536).
+        /// </summary>
+        protected override void WndProc(ref Message m)
+        {
+            if (m.Msg == WM_INPUTLANGCHANGE || m.Msg == WM_INPUTLANGCHANGEREQUEST)
+            {
+                try
+                {
+                    base.WndProc(ref m);
+                }
+                catch (CultureNotFoundException e)
+                {
+                    Logger.WriteMinorEvent(
+                        "Ignoring unsupported input-language culture from keyboard (BL-16536): "
+                            + e.Message
+                    );
+                    // WinForms' own handler for these messages ends by calling DefWndProc; since its
+                    // handler threw before reaching that point, we do the default processing here so
+                    // Windows still handles the language change normally.
+                    DefWndProc(ref m);
+                }
+                return;
+            }
+            base.WndProc(ref m);
+        }
+    }
+}

--- a/src/BloomExe/FatalExceptionHandler.cs
+++ b/src/BloomExe/FatalExceptionHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Threading;
 using System.Windows.Forms;
 using Bloom.web.controllers;
@@ -66,6 +67,9 @@ namespace Bloom
         /// ------------------------------------------------------------------------------------
         protected void HandleTopLevelError(object sender, ThreadExceptionEventArgs e)
         {
+            if (IsHarmlessInputLanguageCultureException(e.Exception))
+                return;
+
             if (!GetShouldHandleException(sender, e.Exception))
                 return;
 
@@ -96,6 +100,9 @@ namespace Bloom
         /// ------------------------------------------------------------------------------------
         protected new void HandleUnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
+            if (IsHarmlessInputLanguageCultureException(e.ExceptionObject as Exception))
+                return;
+
             if (!GetShouldHandleException(sender, e.ExceptionObject as Exception))
                 return;
 
@@ -112,6 +119,37 @@ namespace Bloom
                 DisplayError(e.ExceptionObject as Exception);
             else
                 DisplayError(new ApplicationException("Got unknown exception"));
+        }
+
+        /// <summary>
+        /// Returns true for the harmless CultureNotFoundException that WinForms throws while
+        /// processing WM_INPUTLANGCHANGE when the user switches to a keyboard whose input language
+        /// reports a BCP-47 tag that .NET cannot turn into a CultureInfo (e.g. the Keyman IPA
+        /// keyboard's "und-Latn"). See BL-16536.
+        ///
+        /// BloomWebView2 already swallows this when the message reaches the WebView2 control itself,
+        /// but Windows delivers WM_INPUTLANGCHANGE to whichever window has focus, so the same
+        /// exception can surface from any of our WinForms controls (the stack shows a bare
+        /// UserControl.WndProc). Rather than subclass every control, we catch it here, at the
+        /// thread-exception level, so it can never take Bloom down. Bloom does all its text editing
+        /// inside WebView2, which tracks its own input language independently of WinForms, so there
+        /// is nothing to lose by ignoring WinForms' inability to represent the keyboard.
+        /// </summary>
+        private static bool IsHarmlessInputLanguageCultureException(Exception exception)
+        {
+            // The distinctive marker is a CultureNotFoundException whose stack runs through the
+            // WM_INPUTLANGCHANGE handling (WmInputLangChange / InputLanguageChangedEventArgs).
+            if (!(exception is CultureNotFoundException))
+                return false;
+            var stack = exception.StackTrace;
+            if (stack == null || !stack.Contains("InputLang"))
+                return false;
+
+            Logger.WriteMinorEvent(
+                "Ignoring unsupported input-language culture from keyboard (BL-16536): "
+                    + exception.Message
+            );
+            return true;
         }
 
         protected override bool ShowUI

--- a/src/BloomExe/FatalExceptionHandler.cs
+++ b/src/BloomExe/FatalExceptionHandler.cs
@@ -100,9 +100,12 @@ namespace Bloom
         /// ------------------------------------------------------------------------------------
         protected new void HandleUnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
-            if (IsHarmlessInputLanguageCultureException(e.ExceptionObject as Exception))
-                return;
-
+            // Note: we do NOT try to suppress the harmless input-language CultureNotFoundException
+            // here (see IsHarmlessInputLanguageCultureException / HandleTopLevelError). That crash
+            // arrives on the UI thread's WndProc and is delivered to Application.ThreadException,
+            // which lets us return and carry on. AppDomain.UnhandledException, by contrast, fires
+            // when the CLR is already terminating; returning early cannot prevent the exit, so
+            // swallowing it here would only hide the crash report without saving the process.
             if (!GetShouldHandleException(sender, e.ExceptionObject as Exception))
                 return;
 

--- a/src/BloomExe/WebView2Browser.Designer.cs
+++ b/src/BloomExe/WebView2Browser.Designer.cs
@@ -18,7 +18,7 @@ namespace Bloom
 		/// </summary>
 		private void InitializeComponent()
 		{
-            this._webview = new Microsoft.Web.WebView2.WinForms.WebView2();
+            this._webview = new Bloom.BloomWebView2();
             ((System.ComponentModel.ISupportInitialize)(this._webview)).BeginInit();
             this.SuspendLayout();
             // 
@@ -49,6 +49,6 @@ namespace Bloom
 
 		#endregion
 
-		private Microsoft.Web.WebView2.WinForms.WebView2 _webview;
+		private Bloom.BloomWebView2 _webview;
 	}
 }


### PR DESCRIPTION
@
Ports the BL-16536 fixes from master (#8066 and #8093) to Version6.4. All three commits cherry-picked cleanly with no conflicts; the resulting files are identical to their master versions.

## What this fixes

Switching to a keyboard whose input language reports a BCP-47 tag that .NET cannot turn into a `CultureInfo` (e.g. the Keyman IPA keyboards `und-Latn`) made WinForms throw a `CultureNotFoundException` while handling `WM_INPUTLANGCHANGE` inside `WndProc`, crashing Bloom.

## Changes (same as master)

- **From #8066:** `BloomWebView2`, a WebView2 subclass whose `WndProc` runs the input-language-change messages inside a try/catch, logging and calling `DefWndProc` on `CultureNotFoundException`. `WebView2Browser` now instantiates it.
- **From #8093:** `FatalExceptionHandler` recognizes this specific harmless exception on the `Application.ThreadException` path (a `CultureNotFoundException` whose stack runs through `InputLang`) and ignores it, since Windows can deliver `WM_INPUTLANGCHANGE` to any focused control, not just the WebView2.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16536

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8097)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8097)
<!-- Reviewable:end -->
