### PR TITLE
BL-14330: fix source tab order not tracking selections mid-session

### DIFF
--- a/src/BloomBrowserUI/bookEdit/sourceBubbles/BloomSourceBubbles.tsx
+++ b/src/BloomBrowserUI/bookEdit/sourceBubbles/BloomSourceBubbles.tsx
@@ -269,19 +269,21 @@ export default class BloomSourceBubbles {
         editableDiv.css("min-height", "");
     }
 
-    // The source languages the user has viewed during this editing session, most-recently-viewed
-    // first. GetSettings().defaultSourceLanguage[2] only reflects the two remembered languages as
-    // of when C# injected them at page load; it is NOT refreshed as the user clicks tabs. So we
-    // mirror the tab selections here (see recordSourceLangViewed) and let them take precedence over
-    // the injected values when ordering tabs. Without this, choosing a tab updated the server-side
-    // Settings but the in-session tab order kept using the stale page-load values, so the second
-    // remembered tab was wrong until the page was reloaded. See BL-14330.
+    // The (up to) two source languages the user has viewed most recently during this editing
+    // session, most-recently-viewed first. GetSettings().defaultSourceLanguage[2] only reflects the
+    // two remembered languages as of when C# injected them at page load; it is NOT refreshed as the
+    // user clicks tabs. So we mirror the tab selections here (see recordSourceLangViewed) and let
+    // them take precedence over the injected values when ordering tabs. Without this, choosing a tab
+    // updated the server-side Settings but the in-session tab order kept using the stale page-load
+    // values, so the second remembered tab was wrong until the page was reloaded. See BL-14330.
+    // We keep only two, exactly mirroring the server's LastSourceLanguageViewed/Viewed2, so the
+    // in-session order matches what a reload would inject.
     private static recentlyViewedSourceLangs: string[] = [];
 
-    // Record that the user just viewed a source language tab, keeping the list most-recently-viewed
-    // first with no duplicates. Mirrors the shift logic in EditingViewApi.HandleSourceTextTab so the
-    // in-session tab ordering matches what the server persists (and will inject on the next load).
-    // 'hint' is ignored to match the server, which does not remember it.
+    // Record that the user just viewed a source language tab, keeping the two most-recently-viewed
+    // (most recent first, no duplicates). Mirrors the shift logic in EditingViewApi.HandleSourceTextTab
+    // so the in-session tab ordering matches what the server persists (and will inject on the next
+    // load). 'hint' is ignored to match the server, which does not remember it.
     public static recordSourceLangViewed(langTag: string): void {
         if (!langTag || langTag === "hint") return;
         BloomSourceBubbles.recentlyViewedSourceLangs = [
@@ -289,7 +291,7 @@ export default class BloomSourceBubbles {
             ...BloomSourceBubbles.recentlyViewedSourceLangs.filter(
                 (lang) => lang !== langTag,
             ),
-        ];
+        ].slice(0, 2);
     }
 
     // 'Smart' orders the tabs putting the latest viewed languages first, followed by others in the collection

--- a/src/BloomBrowserUI/bookEdit/sourceBubbles/BloomSourceBubbles.tsx
+++ b/src/BloomBrowserUI/bookEdit/sourceBubbles/BloomSourceBubbles.tsx
@@ -196,7 +196,12 @@ export default class BloomSourceBubbles {
                     list.get(0) as HTMLElement
                 ).lastElementChild?.firstElementChild?.addEventListener(
                     "click",
-                    () => postString("editView/sourceTextTab", langTag),
+                    () => {
+                        // Keep the in-session order in sync so the next bubble (e.g. on the next
+                        // page, or after choosing a dropdown language) orders this tab correctly.
+                        BloomSourceBubbles.recordSourceLangViewed(langTag);
+                        postString("editView/sourceTextTab", langTag);
+                    },
                 );
                 // BL-8174: Add a tooltip with the language tag to the item
                 // BL-15212: we no longer want the tag here, just on the language-name label
@@ -264,6 +269,29 @@ export default class BloomSourceBubbles {
         editableDiv.css("min-height", "");
     }
 
+    // The source languages the user has viewed during this editing session, most-recently-viewed
+    // first. GetSettings().defaultSourceLanguage[2] only reflects the two remembered languages as
+    // of when C# injected them at page load; it is NOT refreshed as the user clicks tabs. So we
+    // mirror the tab selections here (see recordSourceLangViewed) and let them take precedence over
+    // the injected values when ordering tabs. Without this, choosing a tab updated the server-side
+    // Settings but the in-session tab order kept using the stale page-load values, so the second
+    // remembered tab was wrong until the page was reloaded. See BL-14330.
+    private static recentlyViewedSourceLangs: string[] = [];
+
+    // Record that the user just viewed a source language tab, keeping the list most-recently-viewed
+    // first with no duplicates. Mirrors the shift logic in EditingViewApi.HandleSourceTextTab so the
+    // in-session tab ordering matches what the server persists (and will inject on the next load).
+    // 'hint' is ignored to match the server, which does not remember it.
+    public static recordSourceLangViewed(langTag: string): void {
+        if (!langTag || langTag === "hint") return;
+        BloomSourceBubbles.recentlyViewedSourceLangs = [
+            langTag,
+            ...BloomSourceBubbles.recentlyViewedSourceLangs.filter(
+                (lang) => lang !== langTag,
+            ),
+        ];
+    }
+
     // 'Smart' orders the tabs putting the latest viewed languages first, followed by others in the collection
     // param 'items' is an alphabetical list of all the divs of different languages to be used as tabs
     // optional param 'newLangTag' is defined when the user clicks on a language in the dropdown box
@@ -274,12 +302,15 @@ export default class BloomSourceBubbles {
         const settings = GetSettings();
 
         // Get language preferences in priority order, filtering out any empty/undefined values
-        // and removing duplicates (same language codes) using Set
+        // and removing duplicates (same language codes) using Set.
+        // The in-session recentlyViewedSourceLangs come before the injected defaultSourceLanguage[2]
+        // so that selections made since page load win over the (possibly stale) injected values.
         const preferredLanguages = [
             newLangTag, // Highest priority - explicitly selected
-            settings.defaultSourceLanguage, // Second priority - primary source language
-            settings.defaultSourceLanguage2, // Third priority - secondary source language
-            settings.currentCollectionLanguage2, // Fourth priority - collection languages
+            ...BloomSourceBubbles.recentlyViewedSourceLangs, // languages viewed during this session, most recent first
+            settings.defaultSourceLanguage, // primary source language as of page load
+            settings.defaultSourceLanguage2, // secondary source language as of page load
+            settings.currentCollectionLanguage2, // then collection languages
             settings.currentCollectionLanguage3,
         ].filter((lang) => Boolean(lang?.trim())); // Remove empty/undefined/whitespace-only values
 
@@ -304,7 +335,9 @@ export default class BloomSourceBubbles {
             if (indexA >= 0) return -1;
             if (indexB >= 0) return 1;
             // Neither in preferred list - maintain alphabetical order
-            return langA < langB ? (langA > langB ? 1 : 0) : -1;
+            if (langA < langB) return -1;
+            if (langA > langB) return 1;
+            return 0;
         });
 
         return $(itemArray);
@@ -428,6 +461,10 @@ export default class BloomSourceBubbles {
 
     private static styledSelectChangeHandler(event) {
         const newLangTag = event.target.href.split("#")[1];
+
+        // Record before re-producing the bubble below, so SmartOrderSourceTabs orders against
+        // the updated in-session list rather than the stale injected settings.
+        BloomSourceBubbles.recordSourceLangViewed(newLangTag);
 
         // Figure out which qtip we're in and go find the associated bloom-translationGroup
         const qtip = $(event.target).closest(".qtip").attr("id");

--- a/src/BloomBrowserUI/bookEdit/sourceBubbles/SourceBubblesSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/sourceBubbles/SourceBubblesSpec.ts
@@ -8,6 +8,9 @@ describe("SourceBubbles", () => {
     // reset fixture
     beforeEach(() => {
         $("body").html("");
+        // Clear the in-session most-recently-viewed source languages so tests don't leak
+        // state into each other (see recordSourceLangViewed / BL-14330).
+        (BloomSourceBubbles as any).recentlyViewedSourceLangs = [];
     });
     afterEach(() => {
         $("body").html("");
@@ -115,6 +118,59 @@ describe("SourceBubbles", () => {
         expect(listItems[0].getAttribute("id")).toBe("fr");
         expect(listItems[1].getAttribute("id")).toBe("tpi");
         expect(listItems[2].getAttribute("id")).toBe("es");
+    });
+
+    it("in-session recordSourceLangViewed takes precedence over injected settings (BL-14330)", () => {
+        // Reproduces the BL-14330 regression: choosing tabs during an editing session must reorder
+        // the tabs even though GetSettings() still returns the languages injected at page load.
+        const testHtml = $(
+            [
+                "<div id='testTarget' class='bloom-translationGroup'>",
+                "   <div class='bloom-editable' lang='es'>Spanish text</div>",
+                "   <div class='bloom-editable bloom-content1 bloom-visibility-code-on' lang='en'>English text</div>",
+                "   <div class='bloom-editable' lang='fr'>French text</div>",
+                "   <div class='bloom-editable' lang='tpi'>Tok Pisin text</div>",
+                "</div>",
+            ].join("\n"),
+        );
+        $("body").append(testHtml);
+
+        // Injected (page-load) settings: without any in-session selection this would order fr, tpi, es
+        // (exactly the "including defaultSourceLanguage2" test above).
+        const oldGetSettings = (window as any).GetSettings;
+        (window as any).GetSettings = () => ({
+            defaultSourceLanguage: "en",
+            defaultSourceLanguage2: "fr",
+            currentCollectionLanguage2: "tpi",
+            currentCollectionLanguage3: null,
+        });
+
+        // Sanity check: nothing recorded yet, so the injected-settings order applies.
+        const before = BloomSourceBubbles.MakeSourceTextDivForGroup(
+            $("body").find("#testTarget")[0],
+        );
+        const beforeItems = before.find("nav ul li");
+        expect(beforeItems[0].getAttribute("id")).toBe("fr");
+        expect(beforeItems[1].getAttribute("id")).toBe("tpi");
+
+        // Now simulate the user viewing 'es' then 'tpi' during the session.
+        BloomSourceBubbles.recordSourceLangViewed("es");
+        BloomSourceBubbles.recordSourceLangViewed("tpi");
+
+        const result = BloomSourceBubbles.MakeSourceTextDivForGroup(
+            $("body").find("#testTarget")[0],
+        );
+
+        // Restore original GetSettings
+        (window as any).GetSettings = oldGetSettings;
+
+        // The most-recently-viewed languages (tpi, then es) now come first, ahead of the
+        // injected defaultSourceLanguage2 ('fr'), which drops to last.
+        const listItems = result.find("nav ul li");
+        expect(listItems.length).toBe(3);
+        expect(listItems[0].getAttribute("id")).toBe("tpi");
+        expect(listItems[1].getAttribute("id")).toBe("es");
+        expect(listItems[2].getAttribute("id")).toBe("fr");
     });
 
     it("Run CreateDropdownIfNecessary with pre-defined settings", () => {

--- a/src/BloomBrowserUI/bookEdit/sourceBubbles/SourceBubblesSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/sourceBubbles/SourceBubblesSpec.ts
@@ -173,6 +173,29 @@ describe("SourceBubbles", () => {
         expect(listItems[2].getAttribute("id")).toBe("fr");
     });
 
+    it("recordSourceLangViewed keeps only the two most-recent, mirroring the server (BL-14330)", () => {
+        // The server persists exactly two slots (LastSourceLanguageViewed/Viewed2); the in-session
+        // list must match, so it never grows past two and the oldest is evicted.
+        BloomSourceBubbles.recordSourceLangViewed("es");
+        BloomSourceBubbles.recordSourceLangViewed("fr");
+        expect((BloomSourceBubbles as any).recentlyViewedSourceLangs).toEqual([
+            "fr",
+            "es",
+        ]);
+        // A third distinct selection drops the oldest ('es'), leaving the two most recent.
+        BloomSourceBubbles.recordSourceLangViewed("tpi");
+        expect((BloomSourceBubbles as any).recentlyViewedSourceLangs).toEqual([
+            "tpi",
+            "fr",
+        ]);
+        // Re-viewing the current front is a no-op (no duplicate, no reorder).
+        BloomSourceBubbles.recordSourceLangViewed("tpi");
+        expect((BloomSourceBubbles as any).recentlyViewedSourceLangs).toEqual([
+            "tpi",
+            "fr",
+        ]);
+    });
+
     it("Run CreateDropdownIfNecessary with pre-defined settings", () => {
         const testHtml = $(
             [


### PR DESCRIPTION
## Problem

The "remember two source tabs" feature (BL-14330) ordered source-bubble tabs from the injected `GetSettings().defaultSourceLanguage`/`defaultSourceLanguage2`. Those values are injected by C# **only at page load** and are never refreshed, while every tab click updates the server-side `Settings.LastSourceLanguageViewed`/`Viewed2` (`EditingViewApi.HandleSourceTextTab`). So during an editing session the two desynced and the tab order used the stale page-load snapshot for the second remembered tab.

Reproduction (page loaded with French primary, English secondary):
- Choose English (visible tab) → highlight moves, order stays.
- Choose Tibetan → order became **Tibetan, French, (English)** instead of the correct **Tibetan, English, (French)**.
- Choose English → order became **English, French, (Tibetan)** instead of **English, Tibetan, (French)**.

Changing pages (which reloads the iframe and re-injects fresh settings) made the order correct again — confirming the stale-snapshot root cause.

## Fix

- Added an in-session most-recently-viewed list `BloomSourceBubbles.recentlyViewedSourceLangs` plus `recordSourceLangViewed()`, mirroring the server-side shift logic.
- Called from both selection paths: the visible-tab click handler and the dropdown `styledSelectChangeHandler` (recorded before the bubble is re-produced).
- `SmartOrderSourceTabs` now prioritizes the in-session list ahead of the injected settings, so selections win over the stale snapshot while still falling back to the injected pair before any click.
- Fixed an inconsistent comparator in the alphabetical fallback that mis-sorted the non-preferred (dropdown) tail.

## Testing

- New regression test in `SourceBubblesSpec.ts` reproducing the scenario; the in-session static is reset per test. All 7 spec tests pass.
- Verified live end-to-end in Bloom: the exact reported sequence now yields the correct orders.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-14330


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8099)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8099)
<!-- Reviewable:end -->
