### PR TITLE
Add visual-regression tests to the nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -177,10 +177,39 @@ jobs:
               shell: bash
               run: pnpm test
 
-            # On failure, keep the current + diff images so a human can see what changed. The
-            # committed *-reference.png baselines are already in the repo; *-current.png and
-            # *-diff.png are generated (gitignored). if-no-files-found: ignore avoids a warning
-            # when the failure was not a pixel mismatch (e.g. Bloom failed to launch).
+            # When the visual-regression step fails, the most useful clue is usually Bloom's own
+            # log (it launches a real Bloom.exe and talks to it over HTTP). Bloom writes to
+            # %TEMP%\SIL\Bloom\Log.txt (and, depending on how far it got, %LOCALAPPDATA%\SIL\Bloom);
+            # a crash on startup often leaves a .NET Watson/CLR entry in the Windows Application
+            # event log. Gather whatever exists into a fixed folder so the next step can upload it,
+            # rather than losing the one thing that explains a "Bloom never came up" failure.
+            # Best-effort throughout: never let missing logs turn this diagnostic step red.
+            - name: Collect Bloom diagnostics
+              if: ${{ !cancelled() && steps.visual_regression.outcome == 'failure' }}
+              shell: bash
+              run: |
+                  set +e
+                  dest="bloom-diagnostics"
+                  mkdir -p "$dest"
+                  for src in "$TEMP/SIL/Bloom" "$LOCALAPPDATA/SIL/Bloom" "$LOCALAPPDATA/Temp/SIL/Bloom"; do
+                      if [ -d "$src" ]; then
+                          echo "Found Bloom logs in: $src"
+                          # Flatten the source root into the name so two Log.txt don't collide.
+                          tag=$(echo "$src" | tr '/:\\ ' '____')
+                          cp -r "$src" "$dest/$tag" 2>/dev/null
+                      fi
+                  done
+                  # .NET runtime crashes (e.g. a missing WebView2 runtime) surface here even when
+                  # Bloom wrote no log of its own.
+                  powershell -NoProfile -Command "Get-WinEvent -LogName Application -MaxEvents 40 -ErrorAction SilentlyContinue | Where-Object { \$_.ProviderName -match 'Application Error|.NET Runtime|Windows Error Reporting' } | Format-List TimeCreated, ProviderName, Message" > "$dest/windows-application-events.txt" 2>&1
+                  echo "----- collected diagnostics -----"
+                  ls -R "$dest" || true
+
+            # On failure, keep the current + diff images so a human can see what changed, plus the
+            # Bloom logs / crash events gathered above. The committed *-reference.png baselines are
+            # already in the repo; *-current.png and *-diff.png are generated (gitignored).
+            # if-no-files-found: ignore avoids a warning when the failure was not a pixel mismatch
+            # (e.g. Bloom failed to launch, so no screenshots were produced).
             - name: Upload visual regression diffs
               if: ${{ !cancelled() && steps.visual_regression.outcome == 'failure' }}
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -189,6 +218,7 @@ jobs:
                   path: |
                       src/BloomVisualRegressionTests/collections/**/screenshots/*-current.png
                       src/BloomVisualRegressionTests/collections/**/screenshots/*-diff.png
+                      bloom-diagnostics/**
                   retention-days: 14
                   if-no-files-found: ignore
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,6 +62,7 @@ jobs:
                   cache-dependency-path: |
                       src/BloomBrowserUI/pnpm-lock.yaml
                       src/content/pnpm-lock.yaml
+                      src/BloomVisualRegressionTests/pnpm-lock.yaml
 
             # ----- Dependencies (mirrors init.sh) -----
 
@@ -146,6 +147,50 @@ jobs:
                   msbuild Bloom.proj /t:TestOnly `
                     /p:BUILD_NUMBER=$env:BUILD_NUMBER `
                     /p:excludedCategories=SkipOnTeamCity
+
+            # ----- Visual regression tests -----
+            # src/BloomVisualRegressionTests drives a real Release Bloom.exe (which it finds at
+            # output/Release/x64/Bloom.exe) over HTTP and compares rendered screenshots against
+            # committed reference images (pixelmatch). It needs BOTH builds: the C# build (the
+            # Bloom.exe it launches) AND the front-end build (Bloom loads its UI from the built
+            # browser assets that the C# build copies into its output). So both must have
+            # succeeded — build_csharp already implies build_frontend (the C# chain is gated on
+            # it), but we require both explicitly for clarity. !cancelled() lets these run even
+            # when the unit-test steps above failed, so the nightly still reports visual breakage.
+            # The run step then chains on this setup step's success (like the C# chain), so a
+            # failed install/browser-download cleanly skips the run rather than triggering a
+            # confusing secondary failure — the failed setup step still turns the job red.
+            - name: Set up visual regression tests
+              id: setup_visual_regression
+              if: ${{ !cancelled() && steps.build_frontend.outcome == 'success' && steps.build_csharp.outcome == 'success' }}
+              working-directory: src/BloomVisualRegressionTests
+              shell: bash
+              run: |
+                  pnpm install --frozen-lockfile
+                  # The suite drives a headless chromium (Playwright) to capture bloom-player pages.
+                  pnpm exec playwright install chromium
+
+            - name: Run visual regression tests
+              id: visual_regression
+              if: ${{ !cancelled() && steps.setup_visual_regression.outcome == 'success' }}
+              working-directory: src/BloomVisualRegressionTests
+              shell: bash
+              run: pnpm test
+
+            # On failure, keep the current + diff images so a human can see what changed. The
+            # committed *-reference.png baselines are already in the repo; *-current.png and
+            # *-diff.png are generated (gitignored). if-no-files-found: ignore avoids a warning
+            # when the failure was not a pixel mismatch (e.g. Bloom failed to launch).
+            - name: Upload visual regression diffs
+              if: ${{ !cancelled() && steps.visual_regression.outcome == 'failure' }}
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                  name: visual-regression-diffs
+                  path: |
+                      src/BloomVisualRegressionTests/collections/**/screenshots/*-current.png
+                      src/BloomVisualRegressionTests/collections/**/screenshots/*-diff.png
+                  retention-days: 14
+                  if-no-files-found: ignore
 
             # Renders both suites as a human-readable report: pass/fail/skip counts in the
             # job summary page, a check run on the commit, and per-test annotations for

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -352,12 +352,25 @@ namespace Bloom
                 // by the user.
                 if (!Settings.Default.LicenseAccepted)
                 {
-                    using (LegacyDpiDialogLauncher.EnterLegacyDpiScope())
-                    using (var dlg = new LicenseDialog("license.htm"))
-                        if (dlg.ShowDialog() != DialogResult.OK)
-                            return 1;
-                    Settings.Default.LicenseAccepted = true;
-                    Settings.Default.Save();
+                    if (RunningE2eTests)
+                    {
+                        // e2e / visual-regression runs (--e2e) launch Bloom with a collection
+                        // argument and no human to click Accept. Showing the modal LicenseDialog
+                        // would block startup forever (Bloom never opens the collection or starts
+                        // its server), so treat the license as accepted and proceed. Mirrors the
+                        // debugger-prompt skip below.
+                        Settings.Default.LicenseAccepted = true;
+                        Settings.Default.Save();
+                    }
+                    else
+                    {
+                        using (LegacyDpiDialogLauncher.EnterLegacyDpiScope())
+                        using (var dlg = new LicenseDialog("license.htm"))
+                            if (dlg.ShowDialog() != DialogResult.OK)
+                                return 1;
+                        Settings.Default.LicenseAccepted = true;
+                        Settings.Default.Save();
+                    }
                 }
 
 #if DEBUG

--- a/src/BloomVisualRegressionTests/index.spec.ts
+++ b/src/BloomVisualRegressionTests/index.spec.ts
@@ -30,6 +30,18 @@ const repoCollectionsRoot = Path.join(process.cwd(), "collections");
 let tempCollectionsRoot: string | null = null;
 // The dedicated Bloom we launch, kept so we can shut it down afterwards.
 let bloomProcess: ChildProcess | null = null;
+// Everything Bloom writes to stdout/stderr, kept so that when a launch fails (Bloom crashed, or its
+// server never came up) we can report WHY instead of an opaque "did not open within 90s" timeout.
+// Capped so a chatty-but-healthy Bloom can't grow this unbounded.
+let bloomOutput = "";
+const MAX_BLOOM_OUTPUT = 20000;
+function recordBloomOutput(chunk: string) {
+    bloomOutput = (bloomOutput + chunk).slice(-MAX_BLOOM_OUTPUT);
+}
+// Set if the Bloom process we spawned exits before it starts serving our collection. Distinguishes a
+// crash-on-startup (fail fast with the exit code) from a still-running-but-not-ready poll.
+let bloomExit: { code: number | null; signal: NodeJS.Signals | null } | null =
+    null;
 // The PID of the Bloom actually serving our temp collection. Bloom can relaunch into a new process
 // after startup, so the process we spawned is not necessarily the one serving — killing only the
 // spawned PID left orphaned Blooms holding the temp folder open. We read the real PID from
@@ -698,6 +710,27 @@ async function launchDedicatedBloom() {
     // Bloom problem fails the test instead of hanging the run. --automation: allow this instance to
     // run alongside a Bloom the developer already has open (bypasses the single-instance token).
     bloomProcess = execFile(exe, [collection, "--e2e", "--automation"]);
+    // Capture Bloom's output and watch for an early exit. Without this a launch failure (crash on
+    // startup, missing WebView2 runtime, first-run dialog) is invisible: the poll below just runs
+    // out the full 90s and reports "seen: none" with no clue why. Echo to our own stderr too so the
+    // CI step log shows Bloom's startup output inline. execFile (no stdio:'ignore') gives us pipes.
+    bloomProcess.stdout?.on("data", (d) => {
+        const s = d.toString();
+        recordBloomOutput(s);
+        process.stderr.write(`[bloom stdout] ${s}`);
+    });
+    bloomProcess.stderr?.on("data", (d) => {
+        const s = d.toString();
+        recordBloomOutput(s);
+        process.stderr.write(`[bloom stderr] ${s}`);
+    });
+    // 'error' fires when the exe can't even be spawned (e.g. not found / not executable).
+    bloomProcess.on("error", (err) =>
+        recordBloomOutput(`\n[spawn error] ${err.message}\n`),
+    );
+    bloomProcess.on("exit", (code, signal) => {
+        bloomExit = { code, signal };
+    });
 
     // Discover which port our instance opened on by matching the collection folder it has open.
     const wantFolder = Path.join(tempCollectionsRoot, "basic");
@@ -711,6 +744,17 @@ async function launchDedicatedBloom() {
                 `Dedicated Bloom is ready at ${bloomOrigin} (pid ${bloomServingPid ?? "?"})`,
             );
             return;
+        }
+        // Fail fast if Bloom died on startup instead of waiting out the full timeout: the exit code
+        // plus captured output tells us it crashed rather than that discovery merely couldn't see it.
+        if (bloomExit) {
+            throw new Error(
+                `The dedicated Bloom exited before serving the temp collection ` +
+                    `(code ${bloomExit.code}, signal ${bloomExit.signal}).\n` +
+                    `  exe: ${exe}\n` +
+                    `  wanted: ${wantFolder}\n` +
+                    formatBloomOutput(),
+            );
         }
         await new Promise((resolve) => setTimeout(resolve, 1500));
     }
@@ -733,9 +777,20 @@ async function launchDedicatedBloom() {
     }
     throw new Error(
         `The dedicated Bloom did not open the temp collection within 90s.\n` +
+            `  exe: ${exe}\n` +
             `  wanted: ${wantFolder}\n` +
-            `  Bloom instances seen: ${seen.length ? seen.join("; ") : "none"}`,
+            `  still running: ${bloomExit ? "no (already exited)" : "yes"}\n` +
+            `  Bloom instances seen: ${seen.length ? seen.join("; ") : "none"}\n` +
+            formatBloomOutput(),
     );
+}
+
+// Render the tail of Bloom's captured stdout/stderr for inclusion in a launch-failure error, so the
+// CI log shows what Bloom actually said. Kept separate so both failure paths format it identically.
+function formatBloomOutput(): string {
+    const trimmed = bloomOutput.trim();
+    if (!trimmed) return `  Bloom output: (none captured)`;
+    return `  Bloom output (last ${MAX_BLOOM_OUTPUT} chars):\n${trimmed}`;
 }
 
 // Kill the dedicated Bloom we launched, along with its WebView2 child processes. We kill both the


### PR DESCRIPTION
Follow-up to #8098 (the nightly workflow, now merged): adds the
`src/BloomVisualRegressionTests` suite as a step in `nightly.yml`.

**What it does**
- After the front-end and C# builds, launches the Release `Bloom.exe`
  (`output/Release/x64`) over HTTP and compares rendered screenshots against the
  committed reference images (pixelmatch). Setup installs the suite's own pnpm deps
  and the Playwright chromium it uses to capture bloom-player pages.

**Gating — both builds must succeed first**
- The step runs only when **both** the front-end build (`build_frontend`) and the C#
  build (`build_csharp`) succeeded: Bloom loads its UI from the built browser assets the
  C# build copies in, and the suite launches the built `Bloom.exe`.
- Uses `!cancelled()` so it still runs (and reports visual breakage) even when the unit
  test steps above failed — consistent with the workflow's health-check philosophy.

**On failure**
- The generated `*-current.png` / `*-diff.png` images are uploaded as a
  `visual-regression-diffs` artifact for inspection (the `*-reference.png` baselines are
  already committed).

The suite's `pnpm-lock.yaml` is added to the setup-node cache key.

No YouTrack ticket (nightly/CI tooling).


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8103)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8103)
<!-- Reviewable:end -->
