### PR TITLE
Fix Format dialog controls silently dying after a style-switch error (BL-16589)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditor.ts
@@ -2210,37 +2210,48 @@ export default class StyleEditor {
 
     public UpdateControlsToReflectAppliedStyle(oldFontName: string) {
         const current = this.getFormatValues();
+        // While we push the new style's values into the controls, their change handlers
+        // must not treat those updates as user edits. The finally is essential: if any
+        // step here throws, leaving ignoreControlChanges stuck true would silently
+        // disable every control in the dialog from then on (the document would stop
+        // responding to them) for the rest of the page's life.
         this.ignoreControlChanges = true;
-
-        // IF the new style changed fonts, we need to reset the font control
-        if (oldFontName !== current.fontName) {
-            get("fonts/metadata", (result) => {
-                const fontMetadata: IFontMetaData[] = result.data;
-                this.updateFontControl(fontMetadata, current.fontName);
-            });
+        try {
+            // IF the new style changed fonts, we need to reset the font control
+            if (oldFontName !== current.fontName) {
+                get("fonts/metadata", (result) => {
+                    const fontMetadata: IFontMetaData[] = result.data;
+                    this.updateFontControl(fontMetadata, current.fontName);
+                });
+            }
+            this.setValueAndUpdateSelect2Control("size-select", current.ptSize);
+            this.setValueAndUpdateSelect2Control(
+                "line-height-select",
+                current.lineHeight,
+            );
+            this.setValueAndUpdateSelect2Control(
+                "word-space-select",
+                current.wordSpacing,
+            );
+            this.setValueAndUpdateSelect2Control(
+                "para-spacing-select",
+                current.paraSpacing,
+            );
+            const buttonIds = this.getButtonIds();
+            for (let i = 0; i < buttonIds.length; i++) {
+                $("#" + buttonIds[i]).removeClass("selectedIcon");
+            }
+            this.selectButtons(current);
+            this.setColorButtonColor("colorSelectButton", current.color);
+            this.changeHiliteProps(
+                current.hiliteTextColor,
+                current.hiliteBgColor,
+                current.color,
+            );
+            this.changeCanvasElementProps(current.padding);
+        } finally {
+            this.ignoreControlChanges = false;
         }
-        this.setValueAndUpdateSelect2Control("size-select", current.ptSize);
-        this.setValueAndUpdateSelect2Control(
-            "line-height-select",
-            current.lineHeight,
-        );
-        this.setValueAndUpdateSelect2Control(
-            "word-space-select",
-            current.wordSpacing,
-        );
-        this.setValueAndUpdateSelect2Control(
-            "para-spacing-select",
-            current.paraSpacing,
-        );
-        const buttonIds = this.getButtonIds();
-        for (let i = 0; i < buttonIds.length; i++) {
-            $("#" + buttonIds[i]).removeClass("selectedIcon");
-        }
-        this.selectButtons(current);
-        this.setColorButtonColor("colorSelectButton", current.color);
-        this.changeHiliteProps(current.color, current.hiliteBgColor);
-        this.changeCanvasElementProps(current.padding);
-        this.ignoreControlChanges = false;
         this.cleanupAfterStyleChange();
     }
 
@@ -2394,6 +2405,11 @@ export default class StyleEditor {
                     this.textColorTitle = results[2].data.text;
 
                     this.boxBeingEdited = targetBox;
+                    // Make sure a freshly opened dialog never starts with its control
+                    // change handlers disabled (e.g. if some earlier failure left this
+                    // flag set); otherwise the dialog looks fine but nothing the user
+                    // chooses affects the document.
+                    this.ignoreControlChanges = false;
                     const styleName =
                         StyleEditor.GetBaseStyleNameForElement(targetBox);
                     const current = this.getFormatValues();

--- a/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditorSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/StyleEditor/StyleEditorSpec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 /// <reference path="./StyleEditor.ts" />
 /// <reference path="../../typings/jquery/jquery.d.ts" />
 
@@ -439,5 +439,93 @@ describe("StyleEditor", () => {
         MakeBigger2("#testTarget2");
 
         expect(GetRuleForCoverTitleStyle()).not.toBeNull();
+    });
+
+    it("changeWordSpace still updates the style rules after UpdateControlsToReflectAppliedStyle fails partway", () => {
+        // GetSettings is normally injected into the page by C#.
+        (globalThis as any).GetSettings = () => ({
+            languageForNewTextBoxes: "xyz",
+        });
+        try {
+            $("body").append(
+                "<div id='testTarget' class='foo-style' lang='xyz'></div>" +
+                    "<select id='word-space-select'><option>Normal</option><option>Wide</option><option>Extra Wide</option></select>",
+            );
+            const editor = new StyleEditor(
+                "file://" + "C:/dev/Bloom/src/BloomBrowserUI/bookEdit",
+            );
+            editor.boxBeingEdited = $("#testTarget").get(0);
+            // cleanupAfterStyleChange does page-layout work (overflow checking, box
+            // resizing) that requires real browser layout, not jsdom; it is irrelevant
+            // to the rule-writing and control-guard behavior under test here.
+            vi.spyOn(editor, "cleanupAfterStyleChange").mockImplementation(
+                () => {},
+            );
+
+            const select = document.getElementById(
+                "word-space-select",
+            ) as HTMLSelectElement;
+            select.selectedIndex = 1; // Wide
+            editor.changeWordSpace();
+            // sanity check: the control works before anything goes wrong
+            expect(
+                GetRuleMatchingSelector('.foo-style[lang="xyz"]')?.cssText,
+            ).toContain("word-spacing: 5pt");
+
+            // Simulate a failure occurring somewhere in the middle of
+            // UpdateControlsToReflectAppliedStyle (which runs when the user applies a
+            // different style in the Format dialog, after it sets ignoreControlChanges).
+            vi.spyOn(editor, "changeCanvasElementProps").mockImplementation(
+                () => {
+                    throw new Error("simulated failure");
+                },
+            );
+            expect(() =>
+                editor.UpdateControlsToReflectAppliedStyle(""),
+            ).toThrow("simulated failure");
+
+            // The dialog controls must not be left permanently dead: choosing a new
+            // word spacing must still change the document.
+            select.selectedIndex = 2; // Extra Wide
+            editor.changeWordSpace();
+            expect(
+                GetRuleMatchingSelector('.foo-style[lang="xyz"]')?.cssText,
+            ).toContain("word-spacing: 10pt");
+        } finally {
+            delete (globalThis as any).GetSettings;
+        }
+    });
+
+    it("UpdateControlsToReflectAppliedStyle passes the real highlight colors to changeHiliteProps", () => {
+        $("body").append(
+            "<div id='testTarget' class='foo-style' lang='xyz'></div>",
+        );
+        const editor = new StyleEditor(
+            "file://" + "C:/dev/Bloom/src/BloomBrowserUI/bookEdit",
+        );
+        editor.boxBeingEdited = $("#testTarget").get(0);
+        // cleanupAfterStyleChange does page-layout work that needs real browser layout.
+        vi.spyOn(editor, "cleanupAfterStyleChange").mockImplementation(
+            () => {},
+        );
+        // Give the style a custom audio-highlight text and background color.
+        editor.putAudioHiliteRulesInDom(
+            "foo-style",
+            "rgb(1, 2, 3)",
+            "rgb(4, 5, 6)",
+        );
+        // sanity check that getFormatValues sees those colors
+        expect(editor.getFormatValues().hiliteTextColor).toBe("rgb(1, 2, 3)");
+
+        const spy = vi.spyOn(editor, "changeHiliteProps");
+        editor.UpdateControlsToReflectAppliedStyle("");
+        // The highlight controls must be re-rendered with the style's actual highlight
+        // colors, not with the ordinary text color in the hiliteTextColor slot (which
+        // both displayed wrongly and could then be written back into the book).
+        expect(spy).toHaveBeenCalledWith(
+            "rgb(1, 2, 3)",
+            "rgb(4, 5, 6)",
+            expect.any(String),
+        );
     });
 });


### PR DESCRIPTION
Fixes the reported "word spacing control in the Format dialog stops affecting the document" problem (and a related Highlighting-tab color bug found along the way).

**Root cause:** `UpdateControlsToReflectAppliedStyle` (runs when the user picks a different style in the Format dialog's Style dropdown) set `ignoreControlChanges = true`, refreshed all the controls, and only reset the flag at the end — with no `try/finally`. If anything threw during the refresh, the flag stayed stuck `true`, and from then on every control change handler (`changeWordSpace`, `changeSize`, …) silently returned without touching the document, for the rest of the page's life. Closing and reopening the dialog didn't help, because `runFormatDialog` never reset the flag.

**Changes**

- Wrap the control refresh in `try/finally` so `ignoreControlChanges` is always restored (the original exception still propagates).
- Reset the flag whenever the Format dialog opens, so a freshly opened dialog can never start dead.
- Fix an argument-order bug in the same refresh: `changeHiliteProps(current.color, current.hiliteBgColor)` passed the ordinary text color as the *highlight* text color, so after a style switch the Highlighting tab displayed a bogus highlight text color — and a subsequent background-color change would write it into the book. Now called as `(current.hiliteTextColor, current.hiliteBgColor, current.color)`.
- Two new unit tests: one proves the controls stay alive after a mid-refresh exception (failed before the fix), one proves the highlight controls are re-rendered with the style's real highlight colors (failed before the fix).

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16589

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8104)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8104)
<!-- Reviewable:end -->
