### PR TITLE
Refresh the image copyright/metadata button on the Ctrl+V paste path (BL-16605)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementClipboard.test.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementClipboard.test.ts
@@ -126,7 +126,11 @@ function makeClipboard(host: ICanvasElementClipboardHost) {
 describe("CanvasElementClipboard paste refreshes the metadata button (BL-16605)", () => {
     beforeEach(() => {
         document.body.innerHTML = "";
-        vi.mocked(SetupMetadataButton).mockClear();
+        // mockReset (not mockClear) so an implementation installed by one test cannot leak
+        // into the next. Safe here because the mock factory gives SetupMetadataButton no
+        // implementation of its own.
+        vi.mocked(SetupMetadataButton).mockReset();
+        // changeImageInfo must keep the implementation from its factory, so only clear calls.
         vi.mocked(changeImageInfo).mockClear();
     });
 
@@ -172,7 +176,6 @@ describe("CanvasElementClipboard paste refreshes the metadata button (BL-16605)"
 
         expect(srcWhenButtonBuilt).toBe("pasted.png");
         expect(copyrightWhenButtonBuilt).toBe(pastedImageInfo.copyright);
-        vi.mocked(SetupMetadataButton).mockReset();
     });
 
     test("pasting into a selected overlay does not touch the metadata button", () => {

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementClipboard.test.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementClipboard.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+    kBackgroundImageClass,
+    kCanvasElementClass,
+} from "../../toolbox/canvas/canvasElementConstants";
+
+// CanvasElementClipboard pulls in the whole editing/games/toolbox world at module load
+// time. We only care about how it updates the DOM after an image arrives from the
+// clipboard, so stub the collaborators out. SetupMetadataButton is the one we assert on:
+// this suite exists because the Ctrl+V path used to skip it (BL-16605).
+vi.mock("../bloomImages", () => ({
+    kImageContainerClass: "bloom-imageContainer",
+    isPlaceHolderImage: (src: string | null) =>
+        !!src && src.includes("placeHolder"),
+    SetupMetadataButton: vi.fn(),
+}));
+
+vi.mock("../bloomEditing", () => ({
+    kMakeNewCanvasElement: "makeNewCanvasElement",
+    // Just the part of the real changeImageInfo that this suite depends on: the new src and
+    // metadata attributes land on the img synchronously, before the button is rebuilt.
+    changeImageInfo: vi.fn(
+        (img: HTMLElement, info: { src: string; copyright: string }) => {
+            img.setAttribute("src", info.src);
+            img.setAttribute("data-copyright", info.copyright);
+        },
+    ),
+    notifyToolOfChangedImage: vi.fn(),
+    wrapWithRequestPageContentDelay: vi.fn(),
+}));
+
+vi.mock("../../toolbox/games/GameTool", () => ({
+    adjustTarget: vi.fn(),
+    // Not the play tab, so pasting is allowed, and not a start/correct/wrong tab either.
+    getActiveGameTab: () => -1,
+    startTabIndex: 0,
+    correctTabIndex: 1,
+    wrongTabIndex: 2,
+    playTabIndex: 3,
+}));
+
+vi.mock("bloom-player", () => ({ getTarget: vi.fn() }));
+vi.mock("../../../utils/bloomApi", () => ({ postJson: vi.fn(), get: vi.fn() }));
+vi.mock("../../../react_components/featureStatus", () => ({}));
+vi.mock("../../../react_components/requiresSubscription", () => ({
+    showRequiresSubscriptionDialogInEditView: vi.fn(),
+}));
+vi.mock("../../../utils/bloomMessageBoxSupport", () => ({
+    default: {
+        CreateAndShowSimpleMessageBoxWithLocalizedText: vi.fn(),
+    },
+}));
+vi.mock("../../toolbox/canvas/CanvasElementItem", () => ({
+    makeTargetAndMatchSize: vi.fn(),
+}));
+
+import { SetupMetadataButton } from "../bloomImages";
+import { changeImageInfo } from "../bloomEditing";
+import {
+    CanvasElementClipboard,
+    ICanvasElementClipboardHost,
+} from "./CanvasElementClipboard";
+import { CanvasSnapProvider } from "./CanvasSnapProvider";
+
+const pastedImageInfo = {
+    imageId: "makeNewCanvasElement",
+    src: "pasted.png",
+    copyright: "Copyright © 2026, Somebody",
+    creator: "Somebody",
+    license: "cc-by",
+};
+
+// Build a bloom-canvas holding one canvas element, whose image starts out as a placeholder.
+// isBackground controls whether that canvas element is the background image or an overlay.
+function makeCanvasWithPlaceholder(isBackground: boolean): {
+    bloomCanvas: HTMLElement;
+    canvasElement: HTMLElement;
+    img: HTMLImageElement;
+} {
+    const bloomCanvas = document.createElement("div");
+    bloomCanvas.classList.add("bloom-canvas");
+    const canvasElement = document.createElement("div");
+    canvasElement.classList.add(kCanvasElementClass);
+    if (isBackground) {
+        canvasElement.classList.add(kBackgroundImageClass);
+    }
+    canvasElement.innerHTML =
+        '<div class="bloom-imageContainer"><img src="placeHolder.png" /></div>';
+    bloomCanvas.appendChild(canvasElement);
+    document.body.appendChild(bloomCanvas);
+    return {
+        bloomCanvas,
+        canvasElement,
+        img: canvasElement.getElementsByTagName("img")[0],
+    };
+}
+
+// A host that records the geometry calls, so we can tell which branch ran.
+function makeHost(
+    bloomCanvas: HTMLElement,
+    activeElement: HTMLElement | undefined,
+) {
+    return {
+        getActiveOrFirstBloomCanvasOnPage: () => bloomCanvas,
+        getActiveElement: () => activeElement,
+        adjustBackgroundImageSize: vi.fn(),
+        adjustContainerAspectRatio: vi.fn(),
+        addPictureCanvasElement: vi.fn(),
+        setDoAfterNewImageAdjusted: vi.fn(),
+    } as unknown as ICanvasElementClipboardHost & {
+        adjustBackgroundImageSize: ReturnType<typeof vi.fn>;
+        adjustContainerAspectRatio: ReturnType<typeof vi.fn>;
+    };
+}
+
+function makeClipboard(host: ICanvasElementClipboardHost) {
+    return new CanvasElementClipboard(
+        host,
+        {} as unknown as CanvasSnapProvider,
+        10,
+        10,
+    );
+}
+
+describe("CanvasElementClipboard paste refreshes the metadata button (BL-16605)", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        vi.mocked(SetupMetadataButton).mockClear();
+        vi.mocked(changeImageInfo).mockClear();
+    });
+
+    test("pasting into an empty canvas rebuilds the background image's metadata button", () => {
+        const { bloomCanvas, canvasElement, img } =
+            makeCanvasWithPlaceholder(true);
+        const host = makeHost(bloomCanvas, undefined);
+
+        // Sanity checks: we start with a placeholder, no copyright, and no button calls yet.
+        expect(img.getAttribute("src")).toBe("placeHolder.png");
+        expect(img.hasAttribute("data-copyright")).toBe(false);
+        expect(SetupMetadataButton).not.toHaveBeenCalled();
+
+        makeClipboard(host).finishPasteImageFromClipboard(pastedImageInfo);
+
+        expect(img.getAttribute("src")).toBe("pasted.png");
+        expect(img.getAttribute("data-copyright")).toBe(
+            pastedImageInfo.copyright,
+        );
+        expect(host.adjustBackgroundImageSize).toHaveBeenCalledTimes(1);
+        expect(SetupMetadataButton).toHaveBeenCalledTimes(1);
+        // It must be given the background canvas element itself, as
+        // updateCanvasElementForChangedImage does.
+        expect(vi.mocked(SetupMetadataButton).mock.calls[0][0]).toBe(
+            canvasElement,
+        );
+    });
+
+    test("the metadata button is rebuilt only after the new image info is in place", () => {
+        const { bloomCanvas, img } = makeCanvasWithPlaceholder(true);
+        const host = makeHost(bloomCanvas, undefined);
+
+        // A stale button would show the old image's copyright, so capture what the img looked
+        // like at the moment SetupMetadataButton was called.
+        let srcWhenButtonBuilt: string | null = "not called";
+        let copyrightWhenButtonBuilt: string | null = "not called";
+        vi.mocked(SetupMetadataButton).mockImplementation(() => {
+            srcWhenButtonBuilt = img.getAttribute("src");
+            copyrightWhenButtonBuilt = img.getAttribute("data-copyright");
+        });
+
+        makeClipboard(host).finishPasteImageFromClipboard(pastedImageInfo);
+
+        expect(srcWhenButtonBuilt).toBe("pasted.png");
+        expect(copyrightWhenButtonBuilt).toBe(pastedImageInfo.copyright);
+        vi.mocked(SetupMetadataButton).mockReset();
+    });
+
+    test("pasting into a selected overlay does not touch the metadata button", () => {
+        // Two canvas elements, so we skip the empty-canvas branch and land on the
+        // selected-element branch. Only background images get a metadata button, so there is
+        // nothing to rebuild here.
+        const { bloomCanvas } = makeCanvasWithPlaceholder(true);
+        const background = bloomCanvas.getElementsByTagName("img")[0];
+        background.setAttribute("src", "realBackground.png");
+        const overlay = document.createElement("div");
+        overlay.classList.add(kCanvasElementClass);
+        overlay.innerHTML =
+            '<div class="bloom-imageContainer"><img src="placeHolder.png" /></div>';
+        bloomCanvas.appendChild(overlay);
+        const overlayImg = overlay.getElementsByTagName("img")[0];
+        const host = makeHost(bloomCanvas, overlay);
+
+        expect(overlayImg.getAttribute("src")).toBe("placeHolder.png");
+
+        makeClipboard(host).finishPasteImageFromClipboard(pastedImageInfo);
+
+        expect(overlayImg.getAttribute("src")).toBe("pasted.png");
+        expect(host.adjustContainerAspectRatio).toHaveBeenCalledTimes(1);
+        expect(host.adjustBackgroundImageSize).not.toHaveBeenCalled();
+        expect(SetupMetadataButton).not.toHaveBeenCalled();
+    });
+});

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementClipboard.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementClipboard.ts
@@ -10,7 +10,11 @@ import {
     notifyToolOfChangedImage,
     wrapWithRequestPageContentDelay,
 } from "../bloomEditing";
-import { isPlaceHolderImage, kImageContainerClass } from "../bloomImages";
+import {
+    isPlaceHolderImage,
+    kImageContainerClass,
+    SetupMetadataButton,
+} from "../bloomImages";
 import {
     adjustTarget,
     correctTabIndex,
@@ -200,6 +204,38 @@ export class CanvasElementClipboard {
         );
     }
 
+    // Put a pasted image into an image that is already on the page, then bring the canvas
+    // element up to date the way the ordinary (non-clipboard) image-change path does.
+    // changeImage() in bloomEditing.ts routes through
+    // CanvasElementManager.updateCanvasElementForChangedImage(), which fixes the geometry and,
+    // for a background image, rebuilds the copyright/metadata button. The clipboard path gets
+    // dispatched here before that happens, so it has to do the equivalent itself; forgetting
+    // the metadata button is what BL-16605 was about.
+    // Only background images have a metadata button (see SetupMetadataButton), so there is
+    // nothing to refresh on the overlay path.
+    private replaceImageInCanvasElement(
+        bloomCanvas: HTMLElement,
+        canvasElement: HTMLElement,
+        img: HTMLElement,
+        imageInfo: IImageInfo,
+    ): void {
+        changeImageInfo(img, imageInfo);
+        if (canvasElement.classList.contains(kBackgroundImageClass)) {
+            this.host.adjustBackgroundImageSize(
+                bloomCanvas,
+                canvasElement,
+                true,
+            );
+            // changeImageInfo() has already set src and the data-copyright/creator/license
+            // attributes synchronously, so the button we build now reflects the new image.
+            SetupMetadataButton(canvasElement);
+        } else {
+            this.host.adjustContainerAspectRatio(canvasElement, true);
+            adjustTarget(canvasElement, getTarget(canvasElement));
+        }
+        notifyToolOfChangedImage(img);
+    }
+
     public finishPasteImageFromClipboard(imageInfo: IImageInfo): void {
         const bloomCanvas = this.host.getActiveOrFirstBloomCanvasOnPage()!;
         const canvasElements =
@@ -215,13 +251,12 @@ export class CanvasElementClipboard {
         ) {
             const bgimg = canvasElements[0].getElementsByTagName("img")[0];
             if (isPlaceHolderImage(bgimg.getAttribute("src"))) {
-                changeImageInfo(bgimg, imageInfo);
-                this.host.adjustBackgroundImageSize(
+                this.replaceImageInCanvasElement(
                     bloomCanvas,
                     canvasElements[0] as HTMLElement,
-                    true,
+                    bgimg,
+                    imageInfo,
                 );
-                notifyToolOfChangedImage(bgimg);
                 return;
             }
         }
@@ -237,13 +272,12 @@ export class CanvasElementClipboard {
                 .getElementsByClassName(kImageContainerClass)[0]
                 ?.getElementsByTagName("img")[0];
             if (img && isPlaceHolderImage(img.getAttribute("src"))) {
-                changeImageInfo(img, imageInfo);
-                this.host.adjustContainerAspectRatio(
+                this.replaceImageInCanvasElement(
+                    bloomCanvas,
                     activeElement as HTMLElement,
-                    true,
+                    img,
+                    imageInfo,
                 );
-                adjustTarget(activeElement, getTarget(activeElement));
-                notifyToolOfChangedImage(img);
                 return;
             }
         }


### PR DESCRIPTION
Ctrl+V / top-bar **Paste** did not refresh a background image's copyright/metadata button after replacing the image, so the button kept reflecting the previous (placeholder) state until the page was reloaded.

## Cause

`changeImage()` in `bloomEditing.ts` normally routes through `CanvasElementManager.updateCanvasElementForChangedImage()`, which rebuilds the button via `SetupMetadataButton()`. But it returns early when `imageId === kMakeNewCanvasElement` — the clipboard path — handing off to `CanvasElementClipboard.finishPasteImageFromClipboard()`, which set the image and fixed the geometry itself and never refreshed the button.

## Fix

Extracted `CanvasElementClipboard.replaceImageInCanvasElement()`, shared by both branches that paste into an image already on the page, and had it call `SetupMetadataButton()` for background images. Only background images ever get a metadata button (see `SetupMetadataButton`), so the overlay branch deliberately does not call it.

Apart from the added `SetupMetadataButton()` call, behavior is unchanged: each branch still makes exactly the same geometry/notification calls as before.

Two deliberate deviations from the approach suggested on the card:

- `SetupMetadataButton` is **imported directly** from `../bloomImages` rather than added to `ICanvasElementClipboardHost`. `CanvasElementClipboard` already imports from that module, and sibling `CanvasElementBackgroundImageManager` imports it the same way, so there was no reason for interface churn.
- **No call on the overlay path**, since it would be a no-op.

## Note for #8102 / BL-16542 (still open)

That PR widens the second branch so it can replace a *background* image too, and its version also omits the metadata refresh. The helper added here is deliberately the shape that branch converges to, so the merge will conflict in this region and the resolution should collapse #8102's branch into `replaceImageInCanvasElement()` rather than losing the fix.

## Testing

New `CanvasElementClipboard.test.ts` (3 cases): background paste rebuilds the button; the button is rebuilt only *after* the new `src`/`data-copyright` are in place; the overlay path does not touch it.

Both a unit-level and an in-app negative control confirm the tests and the fix actually track the bug:

- Unit: commenting out the new call made the two background tests fail while the overlay test still passed.
- In the running app, same clipboard image and same code path, differing only by that one line:

| | fix off | fix on |
|---|---|---|
| before | `placeHolder.png`, no button | `placeHolder.png`, no button |
| after Ctrl+V | `image1.png`, **no button** | `image2.png`, **button present** |

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16605


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8106)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8106)
<!-- Reviewable:end -->
