### PR TITLE
Dev launcher control API, and an in-app restart toast for pending C# changes

### DIFF
--- a/.claude/skills/run-bloom/SKILL.md
+++ b/.claude/skills/run-bloom/SKILL.md
@@ -4,162 +4,81 @@ description: Run, launch, screenshot, or drive the Bloom desktop app (Bloom.exe 
 model: sonnet
 ---
 
-# Run Bloom (desktop app)
+# Run Bloom (desktop app) — quick path
 
 Bloom is a C#/WinForms shell hosting a React UI in WebView2. You drive it
-programmatically: launch with `./go.sh`, discover the instance's HTTP/CDP
-ports, then attach over CDP. The driver scripts live in
-`.github/skills/bloom-automation/` (shared with Copilot agents) plus
-`screenshotBloom.mjs` in this skill directory. All paths below are relative
-to the repo root; all commands are bash unless noted.
+programmatically through the dev launcher's control API and CDP. This skill is
+the task-oriented quick path; the **authoritative reference** for every
+mechanism, fallback, rule, and field-verified gotcha is
+`.github/skills/bloom-automation/SKILL.md` (shared with Copilot agents; the
+driver scripts live in that directory). All paths are repo-root-relative;
+commands are bash.
 
-For deep detail (multi-instance rules, exe-backed Playwright tests, CDP
-workflow), read `.github/skills/bloom-automation/SKILL.md`. This skill is the
-verified quick path.
-
-## Prerequisites
-
-Dev machines already have: node 24 + pnpm 11.5.2 (see .node-version and the
-packageManager field), .NET SDK 10, WebView2 runtime. On a machine missing
-dependencies, run `./init.sh` (fetches C# deps, pnpm installs, initial
-`pnpm build`) — documented but not re-verified here; a failed C# build with
-CS0246 errors (missing `PodcastUtilities` etc.) means `./init.sh` is needed.
-
-Never run `pnpm build` while a watch/dev build is running (see AGENTS.md).
-Never launch a previously built `Bloom.exe` directly — it can be stale.
-
-## Step 1: Is Bloom already running?
+## 1. Make sure Bloom is running
 
 ```bash
-node .github/skills/bloom-automation/bloomProcessStatus.mjs --running-bloom --json
+node .github/skills/bloom-automation/launcherControl.mjs --status --json
+# exit 0 → launcher live; status has state, httpPort, cdpPort, vitePort, bloomProcessId
+# exit 2 → nobody home (or starting:true = a launch is underway; never start another)
+node .github/skills/bloom-automation/launcherControl.mjs --ensure-running --wait-ready --json
 ```
 
-Look at `runningBloomInstances` — each entry has `httpPort`, `cdpPort`,
-`processId`, `detectedRepoRoot`, `vitePort`. This discovery is HTTP-based
-(scans Bloom's standard port range, asks each instance
-`/bloom/api/common/instanceInfo`) and keeps working even when WMI breaks
-(see Gotchas). If an instance from **this** worktree is running, reuse it
-and skip to Step 3. Don't kill another worktree's Bloom without asking.
+`--ensure-running` handles everything: stale discovery files, a launcher
+mid-startup (waits instead of double-launching), an uninitialized worktree
+(go.mjs runs ./init.sh itself, `phase:"init"`), and starting the stack
+decoupled from your session (Orca terminal tab when available, else detached
+to `output/bloom-launcher.log`). Never launch `./go.sh` tied to your own
+shell except when debugging the launcher itself, and never run an
+already-built `Bloom.exe` directly (stale).
 
-## Step 2: Launch from source
-
-Run in a **background** task (it is a long-lived launcher — never wait for
-exit):
+## 2. Get a .NET change into Bloom
 
 ```bash
-./go.sh > /tmp/go-bloom.log 2>&1   # run_in_background
+node .github/skills/bloom-automation/launcherControl.mjs --restart --wait-ready --json
 ```
 
-It starts Vite on a random port, waits for quiescence, then `dotnet watch
-run` on `src/BloomExe`. Poll the log for the ready line (~2–4 min when the
-C# build is warm):
+THE way — never ask the human to quit/restart, never kill-and-relaunch by
+hand. Returns the fresh ports. Front-end (.ts/.tsx/.less) edits need no
+restart at all: the Vite dev server pushes them into the running Bloom.
+
+## 3. Drive it
 
 ```bash
-until grep -qE "Bloom ready\. HTTP|exited shortly after" /tmp/go-bloom.log; do sleep 2; done
-grep -E "Bloom ready\. HTTP" /tmp/go-bloom.log | tail -1
-# => Bloom ready. HTTP 8092, CDP 8094, Bloom PID 51040.
-```
-
-The same info is on the machine-readable line
-`BLOOM_AUTOMATION_READY {"processId":...,"httpPort":...,"cdpPort":...}`.
-Use that HTTP port as the identity of your instance in every later command.
-Multiple instances coexist; each takes the next port block (8089, 8092, …).
-
-Sanity check the instance:
-
-```bash
-curl -s http://localhost:<httpPort>/bloom/api/common/instanceInfo
-```
-
-## Step 3: Drive it
-
-Switch workspace tabs (clicks the real tab over CDP, waits for the backend
-to report it active):
-
-```bash
-node .github/skills/bloom-automation/switchWorkspaceTab.mjs --http-port <httpPort> --tab edit --json
-# --tab collection | edit | publish
-```
-
-Screenshot the embedded browser (lands in git-ignored `output/`):
-
-```bash
+node .github/skills/bloom-automation/switchWorkspaceTab.mjs --http-port <httpPort> --tab edit --json   # collection | edit | publish
 node .claude/skills/run-bloom/screenshotBloom.mjs --http-port <httpPort> --out output/screenshots/bloom.png --json
 ```
 
 For arbitrary DOM/console/network work, attach Playwright (loaded from
 `src/BloomBrowserUI/react_components/component-tester`) to
-`http://localhost:<cdpPort>` with `chromium.connectOverCDP` — see
-`switchWorkspaceTab.mjs` and `screenshotBloom.mjs` as templates. On the Edit
-tab, the page content lives inside the iframe named `page`; the top-level
-document is shell UI.
+`http://localhost:<cdpPort>` with `chromium.connectOverCDP` — the two scripts
+above are templates. On the Edit tab the page content is inside the iframe
+named `page`. If a "Bloom had a problem" dialog appears, use
+`dismissProblemDialog.mjs` (see bloom-automation SKILL.md).
 
-## Step 4: Stop the instance you started
+## 4. Stop it
 
 ```bash
-node .github/skills/bloom-automation/killBloomProcess.mjs --http-port <httpPort> --json
+node .github/skills/bloom-automation/launcherControl.mjs --quit-bloom   # Bloom off (graceful), launcher parked for --start/--restart
+node .github/skills/bloom-automation/launcherControl.mjs --shutdown     # everything down: Bloom, dotnet watch, launcher, Vite
 ```
 
-Check that `killedProcessIds` includes **the Bloom PID itself**, not just
-its `dotnet` parents. In real runs here it was sometimes `[]` (WMI blind +
-`taskkill` failing silently) and sometimes partial (parents killed, Bloom.exe
-survived). For any PID still standing, fall back to PowerShell:
+## Behavior notes
 
-```powershell
-Stop-Process -Id <bloomPid> -Force
-```
+- **The human closing Bloom (window X) shuts the whole stack down** (by
+  design, to free memory). A launcher that was there and is gone now usually
+  means exactly that — `--ensure-running` again when needed. dotnet-watch
+  rebuilds after C# edits do NOT tear the stack down.
+- `/status`'s `sourceChangedSinceReady` says whether a restart would pick up
+  .NET changes; it also drives the dev-only restart toast Bloom shows itself
+  (bottom right, non-expiring, with a "Restart" action).
+- Human path: `./go.sh` in a terminal; Ctrl+C tears everything down.
 
-Then stop the `./go.sh` background task itself (TaskStop or kill its shell).
-This matters: after Bloom.exe dies, its `dotnet watch` chain stays alive
-("Waiting for a file to change before restarting") and will **relaunch Bloom
-on the next C# file edit** if left orphaned.
+## No launcher? (Bloom started some other way)
 
-## Human path
-
-`./go.sh` in a terminal; the Bloom window opens on the desktop; Ctrl+C shuts
-the whole flow down.
-
-## Gotchas (all hit in real runs)
-
-- **WMI/wmic can go blind mid-session.** `bloomProcessStatus.mjs` (plain
-  mode) and `killBloomProcess.mjs` enumerate processes via `wmic`; on this
-  machine WMI stopped answering partway through a session — status reported
-  zero Bloom processes while one was demonstrably serving HTTP, and
-  `Get-CimInstance` hung for minutes. Trust the HTTP-based
-  `--running-bloom` discovery and `instanceInfo` over process enumeration.
-- **`killBloomProcess.mjs` under-kills.** Observed both `killedProcessIds:
-  []` for a valid target and partial kills where the `dotnet watch` parents
-  died but Bloom.exe survived. Always verify the port went dark
-  (`instanceInfo` curl fails) and the Bloom PID is gone; `Stop-Process` any
-  survivors.
-- **Orphaned `dotnet watch` chains relaunch Bloom.** If Bloom.exe is killed
-  but its watcher chain survives (e.g. someone kills Blooms from Task
-  Manager), the watchers sit at "Waiting for a file to change" and respawn
-  Bloom on the next C# edit. Check with `bloomProcessStatus.mjs --json`
-  (`watchProcesses`) and `Stop-Process` stale ones.
-- **Never type `taskkill /PID ...` in Git Bash** — MSYS rewrites `/PID` to
-  `C:/Program Files/Git/PID`. Use the node helpers or PowerShell.
-- **Grep for `Bloom ready\. HTTP`, not `Bloom ready\.`** — early in the log
-  watchBloomExe prints an instructional message that *quotes* the phrase
-  `'Bloom ready.'`, which matches the looser pattern long before launch
-  completes.
-- **`dotnet watch` noise:** the launch log contains scary
-  `⚠ msbuild: [Failure] Package 'X' was restored using .NETFramework...`
-  lines. They are warnings; launch still succeeds. Don't grep the log for
-  bare `Failure`/`error` as a failure signal — wait for `Bloom ready.` or
-  `exited shortly after` instead.
-- **`bloomProcessStatus.mjs` may print
-  `Assertion failed: !(handle->flags & UV_HANDLE_CLOSING)`** (libuv, on
-  exit, after the JSON is complete). Ignore it; the JSON on stdout is valid.
-- **Agent shells may auto-background kill commands.** Capture the task
-  output file and read it; don't assume the inline result is the output.
-- `body.className` of the top-level page is `developer` in dev builds;
-  page URL looks like `http://localhost:<port>/bloom/C%3A/...Temp/bloomXXXX.htm`.
-
-## Tests
-
-Exe-backed Playwright suite (not re-run this session; see
-`.github/skills/bloom-automation/SKILL.md` for detail): from
-`src/BloomBrowserUI/react_components/component-tester`,
-`BLOOM_HTTP_PORT=<httpPort> pnpm playwright test --config playwright.bloom-exe.config.ts`.
-TypeScript unit tests: `pnpm test` in `src/BloomBrowserUI` (Vitest).
+Discover instances with
+`node .github/skills/bloom-automation/bloomProcessStatus.mjs --running-bloom --json`
+(HTTP-based; each entry has httpPort/cdpPort/processId/detectedRepoRoot) and
+stop with `killBloomProcess.mjs`. That path has sharp edges (WMI going blind,
+under-kills, orphaned watchers) — read the **Field-verified gotchas** in
+`.github/skills/bloom-automation/SKILL.md` before relying on it, and don't
+kill another worktree's Bloom without asking.

--- a/.github/skills/bloom-automation/SKILL.md
+++ b/.github/skills/bloom-automation/SKILL.md
@@ -58,6 +58,71 @@ node "$repo_root/.github/skills/bloom-automation/bloomProcessStatus.mjs" --http-
 
 Reports Bloom.exe processes, detected repo roots, attributable `dotnet watch` parents, ambiguous watchers, and whether the workspace API and CDP endpoint are reachable.
 
+### Launcher control (preferred whenever go.sh is running)
+
+The go.sh launcher (`scripts/watchBloomExe.mjs`) runs a loopback-only HTTP
+control server and advertises it in `<repoRoot>/output/bloom-launcher.json`
+plus a `BLOOM_LAUNCHER_READY {...}` stdout line. `launcherControl.mjs` wraps
+it; use it INSTEAD of kill-and-relaunch or asking the human to press Enter:
+
+```bash
+node "$repo_root/.github/skills/bloom-automation/launcherControl.mjs" --status --json
+node "$repo_root/.github/skills/bloom-automation/launcherControl.mjs" --restart --wait-ready --json   # rebuild + relaunch, any state
+node "$repo_root/.github/skills/bloom-automation/launcherControl.mjs" --start --wait-ready --json     # relaunch only when parked (awaiting-restart)
+node "$repo_root/.github/skills/bloom-automation/launcherControl.mjs" --quit-bloom --json             # graceful WM_CLOSE quit; also stops the watch child, so C# edits do NOT respawn Bloom
+node "$repo_root/.github/skills/bloom-automation/launcherControl.mjs" --shutdown --json               # whole stack: Bloom + dotnet watch + launcher + Vite
+node "$repo_root/.github/skills/bloom-automation/launcherControl.mjs" --ensure-running --wait-ready --json  # start the stack if nobody's home
+```
+
+Semantics agents rely on:
+- **Liveness is HTTP truth, never the file.** A discovery file whose
+  `controlUrl` does not answer means nobody is home (hard-killed launcher);
+  the helper reports `launcherFound:false, staleFile:true` and exits 2. A
+  fresh launcher overwrites the stale file.
+- **A launch-in-progress is advertised too.** go.mjs writes an early record
+  (`state:"starting"`, a `phase` of `starting`/`init`/`dev-server`/
+  `starting-bloom`, and its `goPid`) from the first moment, before the control
+  server exists. The helper reports it as `launcherFound:false, starting:true,
+  phase:...` (exit 2) and `--ensure-running` WAITS for it instead of starting
+  a second stack. Startup can take minutes: `init` means the worktree was
+  uninitialized and go.mjs is running ./init.sh for you (go.mjs detects
+  missing node_modules / lib/dotnet deps / output/browser bundles and runs
+  init automatically — agents never need to run init.sh themselves).
+- `--status` states: `building`, `bloom-running`, `awaiting-restart`
+  (reached only via `--quit-bloom` — see below), `restarting`,
+  `launch-failed`. During a dotnet-watch hot rebuild the state passes
+  through `building` transiently — poll for `bloom-running` (`--wait-ready`
+  does) rather than sampling once.
+- **The human closing Bloom (window X) tears the whole stack down** —
+  launcher, dotnet watch, and Vite all exit, so an idle stack stops holding
+  memory. If `--status` suddenly reports nobody home, that is the normal
+  meaning; just `--ensure-running` when you need Bloom again. (The launcher
+  distinguishes this from a dotnet-watch rebuild via the watcher's
+  file-changed output, so C# edits do not kill the stack.) Only
+  `--quit-bloom` leaves the launcher parked in `awaiting-restart`.
+- `/status` also reports `sourceChangedSinceReady`: whether dotnet watch has
+  seen C# source changes since the current Bloom became ready — i.e. whether
+  a `--restart` would incorporate anything new. Bloom itself polls that field
+  (only when launched by go.sh via `--launcher-port`, see `DevLauncher.cs`) and
+  shows a dev-only non-expiring toast whose "Restart" action posts the same
+  `/restart`.
+- `--wait-ready` waits for a NEW launch (`launchNumber` increased) to reach
+  `bloom-running` and prints the fresh `httpPort`/`cdpPort` — this replaces
+  grepping logs for `Bloom ready. HTTP`.
+- `--ensure-running` starts the stack decoupled from your session when no
+  launcher answers: in an Orca terminal tab titled "go.sh" when the Orca
+  runtime is reachable, else as a detached process logging to
+  `output/bloom-launcher.log` (reported as `logPath` in `/status`). A
+  `output/bloom-launcher.starting.lock` prevents two agents double-launching.
+- Every action prints a `[control] ... requested` line in the launcher's
+  terminal so the human can see why Bloom moved.
+- The raw API (for tools, not typed curl): `GET /status`, `POST /restart`,
+  `POST /start`, `POST /quit-bloom`, `POST /shutdown` on the `controlUrl`
+  from the discovery file.
+
+The status/kill helpers below remain the fallback for Bloom instances that
+have no live launcher (started outside go.sh, or the launcher was killed).
+
 Use `--running-bloom` when the user explicitly wants the already-running Bloom instead of a worktree-owned instance. This scans Bloom's standard HTTP port range, asks any running Bloom for `common/instanceInfo`, and reports the ports that instance says it is using.
 Use `--http-port <port>` when you launched Bloom through `./go.sh` or another repo-supported source-aware launcher and want the exact instance that owns that HTTP port. This is the preferred multi-instance workflow because it gives you the precise Bloom PID and CDP port even when several Blooms from the same worktree are running.
 ### Kill Bloom
@@ -72,9 +137,15 @@ node "$repo_root/.github/skills/bloom-automation/killBloomProcess.mjs" --pid 123
 Use the plain form to stop all detected Bloom-related processes. Use `--only-mismatched` to stop only the Bloom instance that does not belong to the current worktree.
 Use `--http-port <port>` to stop the exact Bloom instance bound to that HTTP port, together with any `dotnet` parent in its process chain. Use `--pid` or `--watch-pid` only when you already know the exact process IDs you want to stop.
 
-Important: if Bloom was started with `dotnet watch run`, killing only `Bloom.exe` is not enough because the watcher will restart it. Prefer the provided kill script so the watcher and child process are both terminated.
+Important: if Bloom was started with `dotnet watch run`, killing only `Bloom.exe` is not enough because the watcher will restart it. Prefer `launcherControl.mjs --quit-bloom` / `--shutdown` when the launcher is live (they handle the watcher for you); otherwise use the provided kill script so the watcher and child process are both terminated.
 
 ### Start Bloom
+
+Preferred: `launcherControl.mjs --ensure-running --wait-ready` (see "Launcher
+control" above) — it reuses a live launcher or starts one decoupled from your
+session, so other agents and the human share it. Launch `./go.sh` from your
+own shell only when the control surface can't be used (e.g. you are debugging
+the launcher itself):
 
 ```bash
 "$repo_root/go.sh"
@@ -110,6 +181,14 @@ node "$repo_root/.github/skills/bloom-automation/switchWorkspaceTab.mjs" --http-
 ```
 
 This helper attaches to the reported WebView2 target over CDP, clicks the real top bar tab, waits for `workspace/tabs` to report it active, and prints the resulting state.
+
+### Screenshot
+
+```bash
+node "$repo_root/.claude/skills/run-bloom/screenshotBloom.mjs" --http-port <httpPort> --out output/screenshots/bloom.png --json
+```
+
+(Lives in the Claude-specific run-bloom skill directory but works for any agent; output/ is gitignored.)
 
 ## Minimal Running Bloom Attach Workflow
 
@@ -164,6 +243,7 @@ Use this when the user says to reuse the already-running Bloom.
 - Reuse it.
 - Attach over CDP and drive the UI directly.
 - Do not restart unless the user explicitly wants a fresh run or you need to load new code.
+- When you DO need to load new .NET code, use `launcherControl.mjs --restart --wait-ready` (if the launcher is live) instead of killing and relaunching by hand or asking the human to quit Bloom.
 
 ### Do not accumulate worktree-owned instances
 - Do not start another Bloom from the same worktree just because explicit ports are available.
@@ -236,6 +316,51 @@ These tests attach to the real Bloom.exe target over CDP and verify tab switchin
   - Use `node .github/skills/bloom-automation/dismissProblemDialog.mjs --http-port <httpPort> [--wait] [--json]`. It (1) finds the dialog by DOM (so it never closes a legitimate modal), (2) GATHERS the underlying problem — it clicks the dialog's own "Learn More" to reveal the exception + missing-file/stack that Bloom would send, and prints it, and (3) closes the dialog with the SAME action as its Close button, `POST /bloom/api/common/closeReactDialog`, which does NOT submit. It drains a backlog (Bloom queues reports and shows them one at a time), gathering each, up to a cap.
   - NEVER click Submit / POST `problemReport/submit` in automation: that sends a report (with a screenshot and the book) to Bloom's servers.
   - If the SAME problem keeps reappearing after being closed, it is a real recurring error in the code under test (e.g. a resource that 404s on every render) — read the gathered detail, fix the root cause, and re-test; do not just loop-dismiss. The Bloom log at `%TEMP%\SIL\Bloom\Log-*.txt` has the same detail if you need it out-of-band, but note its writes can lag, so the dialog's own "Learn More" (what the helper scrapes) is the authoritative live source.
+
+## Field-verified gotchas (all hit in real agent runs)
+
+- **WMI/wmic can go blind mid-session.** `bloomProcessStatus.mjs` (plain
+  mode) and `killBloomProcess.mjs` enumerate processes via `wmic`; WMI has
+  stopped answering partway through a session — status reported zero Bloom
+  processes while one was demonstrably serving HTTP, and `Get-CimInstance`
+  hung for minutes. Trust the HTTP-based `--running-bloom` discovery and
+  `instanceInfo` over process enumeration.
+- **`killBloomProcess.mjs` under-kills.** Observed both `killedProcessIds:
+  []` for a valid target and partial kills where the `dotnet watch` parents
+  died but Bloom.exe survived. Always verify the port went dark
+  (`instanceInfo` curl fails) and the Bloom PID is gone; PowerShell
+  `Stop-Process -Id <pid> -Force` any survivors. (The launcher control API's
+  `--quit-bloom`/`--shutdown` avoid this whole class of problem — prefer
+  them whenever a launcher is live.)
+- **Orphaned `dotnet watch` chains relaunch Bloom.** If Bloom.exe is killed
+  but its watcher chain survives (e.g. Task Manager kills), the watchers sit
+  at "Waiting for a file to change" and respawn Bloom on the next C# edit.
+  Check `bloomProcessStatus.mjs --json` (`watchProcesses`) and stop stale
+  ones.
+- **Never type `taskkill /PID ...` in Git Bash** — MSYS rewrites `/PID` to
+  `C:/Program Files/Git/PID`. Use the node helpers or PowerShell.
+- **Grep launch logs for `Bloom ready\. HTTP`, not `Bloom ready\.`** — early
+  in the log watchBloomExe prints an instructional message that *quotes* the
+  phrase `'Bloom ready.'`, which matches the looser pattern long before
+  launch completes. (Better: poll `launcherControl.mjs --status` instead of
+  grepping logs at all.)
+- **`dotnet watch` noise:** the launch log contains scary
+  `⚠ msbuild: [Failure] Package 'X' was restored using .NETFramework...`
+  lines. They are warnings; launch still succeeds. Don't grep the log for
+  bare `Failure`/`error` as a failure signal — wait for `Bloom ready.` /
+  `exited shortly after`, or use `--status`.
+- **`bloomProcessStatus.mjs` may print
+  `Assertion failed: !(handle->flags & UV_HANDLE_CLOSING)`** (libuv, on
+  exit, after the JSON is complete). Ignore it; the JSON on stdout is valid.
+- **Agent shells may auto-background long commands.** Capture the task
+  output file and read it; don't assume the inline result is the output.
+- `body.className` of the top-level page is `developer` in dev builds; page
+  URLs look like `http://localhost:<port>/bloom/C%3A/...Temp/bloomXXXX.htm`.
+- **Uninitialized worktrees self-heal at launch.** go.mjs detects missing
+  node_modules / `lib/dotnet` deps / `output/browser` bundles and runs
+  `./init.sh` itself (discovery file shows `phase:"init"`, takes minutes).
+  CS0246 (`PodcastUtilities` etc.) on other build paths still means init
+  hasn't run.
 
 ## Completion Checks
 - Bloom's status is known: not running, running from current worktree, or running from different worktree.

--- a/.github/skills/bloom-automation/launcherControl.mjs
+++ b/.github/skills/bloom-automation/launcherControl.mjs
@@ -1,0 +1,621 @@
+// Agent CLI for the go.sh launcher control surface (see
+// scripts/watchBloomExeControl.mjs). Lets an agent discover the launcher
+// running for this worktree, query its state, and command it — quit Bloom,
+// rebuild+relaunch, or tear the whole dev stack down — without a human
+// pressing Enter in the launcher terminal.
+//
+//   node .github/skills/bloom-automation/launcherControl.mjs --status [--json]
+//   node ... --restart [--wait-ready] [--json]      # rebuild + relaunch (any state)
+//   node ... --start [--wait-ready] [--json]        # relaunch, only when awaiting-restart
+//   node ... --quit-bloom [--json]                  # durably stop Bloom, launcher stays
+//   node ... --shutdown [--json]                    # stop Bloom + launcher + Vite
+//   node ... --ensure-running [--wait-ready] [--json]  # start the stack if nobody's home
+//   options: --repo-root <path> (default: this checkout), --timeout-ms <n> (default 300000)
+//
+// Exit codes: 0 = success; 2 = no live launcher found (fall back to
+// --ensure-running or launching go.sh yourself); 1 = other failure.
+
+import { execFileSync, spawn } from "node:child_process";
+import {
+    closeSync,
+    mkdirSync,
+    openSync,
+    rmSync,
+    statSync,
+    writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import {
+    getDefaultRepoRoot,
+    requireOptionValue,
+} from "./bloomProcessCommon.mjs";
+import {
+    getDiscoveryFilePath,
+    readDiscoveryFile,
+} from "../../../scripts/watchBloomExeControl.mjs";
+
+const actionNames = [
+    "--status",
+    "--restart",
+    "--start",
+    "--quit-bloom",
+    "--shutdown",
+    "--ensure-running",
+];
+
+const parseArgs = () => {
+    const args = process.argv.slice(2);
+    const options = {
+        action: undefined,
+        json: false,
+        waitReady: false,
+        repoRoot: getDefaultRepoRoot(),
+        timeoutMs: 300000,
+    };
+
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
+
+        if (actionNames.includes(arg)) {
+            if (options.action) {
+                throw new Error(
+                    `Only one action may be given (saw ${options.action} and ${arg}).`,
+                );
+            }
+            options.action = arg.slice(2);
+            continue;
+        }
+
+        if (arg === "--json") {
+            options.json = true;
+            continue;
+        }
+
+        if (arg === "--wait-ready") {
+            options.waitReady = true;
+            continue;
+        }
+
+        if (arg === "--repo-root") {
+            options.repoRoot = path.resolve(
+                requireOptionValue(args, i, "--repo-root"),
+            );
+            i++;
+            continue;
+        }
+
+        if (arg === "--timeout-ms") {
+            options.timeoutMs = Number(
+                requireOptionValue(args, i, "--timeout-ms"),
+            );
+            if (
+                !Number.isInteger(options.timeoutMs) ||
+                options.timeoutMs <= 0
+            ) {
+                throw new Error("--timeout-ms must be a positive integer.");
+            }
+            i++;
+            continue;
+        }
+
+        throw new Error(
+            `Unsupported option ${arg}. Actions: ${actionNames.join(", ")}; options: --json, --wait-ready, --repo-root <path>, --timeout-ms <n>.`,
+        );
+    }
+
+    if (!options.action) {
+        throw new Error(`An action is required: ${actionNames.join(", ")}.`);
+    }
+
+    return options;
+};
+
+const normalizeComparablePath = (value) =>
+    path.resolve(value).replace(/\//g, "\\").toLowerCase();
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const isPidAlive = (pid) => {
+    if (!Number.isInteger(pid) || pid <= 0) {
+        return false;
+    }
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+// Reads the discovery file and verifies over HTTP that the launcher it
+// advertises is actually alive and belongs to this worktree. The file alone
+// proves nothing: a hard-killed launcher leaves it behind.
+const probeLauncher = async (repoRoot) => {
+    const discoveryFilePath = getDiscoveryFilePath(repoRoot);
+    const discovery = readDiscoveryFile(discoveryFilePath);
+
+    if (!discovery?.controlUrl) {
+        // go.mjs writes an early record (state "starting", no controlUrl yet)
+        // during init / dev-server startup, which can take minutes. A live
+        // goPid means a launch is underway: wait for it, don't start another.
+        if (
+            discovery?.kind === "bloom-launcher" &&
+            discovery.state === "starting" &&
+            isPidAlive(discovery.goPid)
+        ) {
+            return {
+                launcherFound: false,
+                starting: true,
+                phase: discovery.phase,
+                goPid: discovery.goPid,
+                startedAt: discovery.startedAt,
+                discoveryFilePath,
+            };
+        }
+
+        return {
+            launcherFound: false,
+            staleFile: !!discovery,
+            discoveryFilePath,
+        };
+    }
+
+    try {
+        const response = await fetch(`${discovery.controlUrl}/status`, {
+            signal: AbortSignal.timeout(2000),
+        });
+        if (!response.ok) {
+            throw new Error(`status ${response.status}`);
+        }
+
+        const status = await response.json();
+        if (
+            !status.repoRoot ||
+            normalizeComparablePath(status.repoRoot) !==
+                normalizeComparablePath(repoRoot)
+        ) {
+            return {
+                launcherFound: false,
+                staleFile: true,
+                mismatchedRepoRoot: status.repoRoot,
+                discoveryFilePath,
+            };
+        }
+
+        return { launcherFound: true, discovery, status, discoveryFilePath };
+    } catch {
+        return { launcherFound: false, staleFile: true, discoveryFilePath };
+    }
+};
+
+const postAction = async (controlUrl, route) => {
+    const response = await fetch(`${controlUrl}${route}`, {
+        method: "POST",
+        signal: AbortSignal.timeout(5000),
+    });
+    return { statusCode: response.status, body: await response.json() };
+};
+
+const fetchStatus = async (controlUrl) => {
+    const response = await fetch(`${controlUrl}/status`, {
+        signal: AbortSignal.timeout(2000),
+    });
+    if (!response.ok) {
+        throw new Error(`GET /status returned ${response.status}`);
+    }
+    return response.json();
+};
+
+// Polls /status until predicate(status) is true. Tolerates transient fetch
+// failures (e.g. mid-teardown) by re-probing via the discovery file, which a
+// relaunched launcher rewrites.
+const waitForStatus = async (repoRoot, controlUrl, predicate, deadline) => {
+    let lastStatus;
+
+    while (Date.now() < deadline) {
+        try {
+            lastStatus = await fetchStatus(controlUrl);
+            if (predicate(lastStatus)) {
+                return lastStatus;
+            }
+        } catch {
+            const probe = await probeLauncher(repoRoot);
+            if (probe.launcherFound) {
+                controlUrl = probe.discovery.controlUrl;
+            }
+        }
+
+        await sleep(1000);
+    }
+
+    throw new Error(
+        `Timed out waiting for the launcher to reach the requested state. Last observed: ${JSON.stringify(lastStatus)}`,
+    );
+};
+
+const waitForLauncherGone = async (controlUrl, deadline) => {
+    while (Date.now() < deadline) {
+        try {
+            await fetchStatus(controlUrl);
+        } catch {
+            return true;
+        }
+        await sleep(500);
+    }
+    return false;
+};
+
+// --- ensure-running helpers --------------------------------------------------
+
+const isOrcaRuntimeReachable = () => {
+    try {
+        const output = execFileSync("orca", ["status", "--json"], {
+            encoding: "utf8",
+            timeout: 15000,
+            windowsHide: true,
+            stdio: ["ignore", "pipe", "ignore"],
+        });
+        const parsed = JSON.parse(output);
+        return (
+            parsed?.ok === true && parsed?.result?.runtime?.reachable === true
+        );
+    } catch {
+        return false;
+    }
+};
+
+const goMjsPath = (repoRoot) =>
+    path.join(repoRoot, "src", "BloomBrowserUI", "scripts", "go.mjs");
+
+// Launches the go.sh flow in its own Orca terminal tab. The tab is owned by
+// the Orca app — visible to the human, independent of the agent session that
+// requested it, and controllable by any agent via the HTTP API.
+const launchViaOrca = (repoRoot) => {
+    // "node <go.mjs>" rather than "./go.sh" because the Orca terminal's shell
+    // may not be bash; go.sh is a 4-line shim around exactly this command.
+    const command = `node "${goMjsPath(repoRoot)}"`;
+    const output = execFileSync(
+        "orca",
+        [
+            "terminal",
+            "create",
+            "--worktree",
+            `path:${repoRoot}`,
+            "--title",
+            "go.sh",
+            "--command",
+            command,
+            "--json",
+        ],
+        {
+            encoding: "utf8",
+            timeout: 30000,
+            windowsHide: true,
+            stdio: ["ignore", "pipe", "pipe"],
+        },
+    );
+
+    const parsed = JSON.parse(output);
+    if (parsed?.ok !== true) {
+        throw new Error(`orca terminal create failed: ${output}`);
+    }
+
+    return { method: "orca-terminal", orcaResult: parsed.result };
+};
+
+// Non-Orca fallback: a fully detached process. It has no terminal window, but
+// it survives the agent session that started it; its output goes to a log
+// file that /status advertises as logPath.
+const launchDetached = (repoRoot) => {
+    const logPath = path.join(repoRoot, "output", "bloom-launcher.log");
+    mkdirSync(path.dirname(logPath), { recursive: true });
+    const logFd = openSync(logPath, "a");
+
+    try {
+        const child = spawn(process.execPath, [goMjsPath(repoRoot)], {
+            cwd: repoRoot,
+            detached: true,
+            stdio: ["ignore", logFd, logFd],
+            env: { ...process.env, BLOOM_LAUNCHER_LOG: logPath },
+            windowsHide: true,
+        });
+        child.unref();
+        return { method: "detached", goPid: child.pid, logPath };
+    } finally {
+        closeSync(logFd);
+    }
+};
+
+const startingLockPath = (repoRoot) =>
+    path.join(repoRoot, "output", "bloom-launcher.starting.lock");
+
+const startingLockStaleMs = 5 * 60 * 1000;
+
+// Guards against two agents racing --ensure-running into a double launch.
+// Best-effort: O_EXCL create wins; a lock older than 5 minutes is presumed
+// abandoned and stolen.
+const tryAcquireStartingLock = (repoRoot) => {
+    const lockPath = startingLockPath(repoRoot);
+    mkdirSync(path.dirname(lockPath), { recursive: true });
+    const lockContent = JSON.stringify({
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
+    });
+
+    try {
+        writeFileSync(lockPath, lockContent, { flag: "wx" });
+        return { acquired: true, lockPath };
+    } catch {}
+
+    try {
+        const ageMs = Date.now() - statSync(lockPath).mtimeMs;
+        if (ageMs > startingLockStaleMs) {
+            rmSync(lockPath, { force: true });
+            writeFileSync(lockPath, lockContent, { flag: "wx" });
+            return { acquired: true, lockPath };
+        }
+    } catch {}
+
+    return { acquired: false, lockPath };
+};
+
+const releaseStartingLock = (lockPath) => {
+    try {
+        rmSync(lockPath, { force: true });
+    } catch {}
+};
+
+const waitForLauncher = async (repoRoot, deadline, note) => {
+    while (Date.now() < deadline) {
+        const probe = await probeLauncher(repoRoot);
+        if (probe.launcherFound) {
+            return probe;
+        }
+        await sleep(1000);
+    }
+
+    throw new Error(
+        `Timed out waiting for a launcher to appear for ${repoRoot}${note ? ` (${note})` : ""}.`,
+    );
+};
+
+const ensureRunning = async (options, deadline) => {
+    let probe = await probeLauncher(options.repoRoot);
+    let launch;
+
+    if (!probe.launcherFound && probe.starting) {
+        // A launcher (possibly human-started) is mid-startup — init.sh or the
+        // Vite dev server can take minutes. Wait for it instead of launching.
+        probe = await waitForLauncher(
+            options.repoRoot,
+            deadline,
+            `a launcher is already starting (phase: ${probe.phase})`,
+        );
+        launch = { method: "waited-for-starting-launcher" };
+    } else if (!probe.launcherFound) {
+        const lock = tryAcquireStartingLock(options.repoRoot);
+
+        if (!lock.acquired) {
+            // Another agent is already starting the stack; wait for it.
+            probe = await waitForLauncher(
+                options.repoRoot,
+                deadline,
+                "another agent holds the starting lock",
+            );
+            launch = { method: "waited-for-other-agent" };
+        } else {
+            try {
+                launch = isOrcaRuntimeReachable()
+                    ? launchViaOrca(options.repoRoot)
+                    : launchDetached(options.repoRoot);
+                probe = await waitForLauncher(options.repoRoot, deadline);
+            } finally {
+                releaseStartingLock(lock.lockPath);
+            }
+        }
+    }
+
+    let status = probe.status;
+
+    // The launcher may be parked with Bloom stopped; nudge it.
+    if (status.state === "awaiting-restart") {
+        await postAction(probe.discovery.controlUrl, "/start");
+        status = await fetchStatus(probe.discovery.controlUrl);
+    }
+
+    if (options.waitReady) {
+        status = await waitForStatus(
+            options.repoRoot,
+            probe.discovery.controlUrl,
+            (current) => current.state === "bloom-running",
+            deadline,
+        );
+    }
+
+    return { launcherFound: true, launch, status };
+};
+
+// --- main --------------------------------------------------------------------
+
+let options;
+try {
+    options = parseArgs();
+} catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+}
+
+const deadline = Date.now() + options.timeoutMs;
+
+const report = (result, exitCode = 0) => {
+    if (options.json) {
+        console.log(JSON.stringify(result, null, 2));
+    } else {
+        if (result.launcherFound === false) {
+            if (result.starting) {
+                console.log(
+                    `A launcher is starting for ${options.repoRoot} (phase: ${result.phase}, go PID ${result.goPid}, since ${result.startedAt}).`,
+                );
+                console.log(
+                    "Wait for it (e.g. --ensure-running --wait-ready) instead of launching another.",
+                );
+            } else {
+                console.log(
+                    `No live launcher found for ${options.repoRoot}${result.staleFile ? " (stale discovery file: nobody home at its controlUrl)" : ""}.`,
+                );
+                console.log(
+                    "Use --ensure-running to start one, or ./go.sh for an interactive session.",
+                );
+            }
+        }
+        if (result.launch?.method) {
+            console.log(`Launched via: ${result.launch.method}`);
+            if (result.launch.logPath) {
+                console.log(`Launcher log: ${result.launch.logPath}`);
+            }
+        }
+        if (result.response) {
+            console.log(
+                `${result.action}: HTTP ${result.response.statusCode} ${JSON.stringify(result.response.body)}`,
+            );
+        }
+        if (result.status) {
+            const s = result.status;
+            console.log(`Launcher state: ${s.state}`);
+            console.log(
+                `Bloom PID: ${s.bloomProcessId ?? "none"}, HTTP ${s.httpPort ?? "-"}, CDP ${s.cdpPort ?? "-"}, Vite ${s.vitePort ?? "-"}`,
+            );
+            console.log(
+                `Launch ${s.launchNumber}, control ${result.controlUrl ?? ""}`,
+            );
+        }
+        if (result.shutdownComplete !== undefined) {
+            console.log(
+                result.shutdownComplete
+                    ? "Launcher stack shut down."
+                    : "Shutdown requested, but the launcher was still responding at timeout.",
+            );
+        }
+    }
+
+    process.exit(exitCode);
+};
+
+try {
+    if (options.action === "ensure-running") {
+        const result = await ensureRunning(options, deadline);
+        report({
+            ...result,
+            controlUrl: (await probeLauncher(options.repoRoot)).discovery
+                ?.controlUrl,
+        });
+    }
+
+    const probe = await probeLauncher(options.repoRoot);
+
+    if (!probe.launcherFound) {
+        report(
+            {
+                launcherFound: false,
+                starting: probe.starting,
+                phase: probe.phase,
+                goPid: probe.goPid,
+                startedAt: probe.startedAt,
+                staleFile: probe.staleFile,
+                discoveryFilePath: probe.discoveryFilePath,
+                repoRoot: options.repoRoot,
+            },
+            2,
+        );
+    }
+
+    const controlUrl = probe.discovery.controlUrl;
+
+    if (options.action === "status") {
+        report({
+            launcherFound: true,
+            controlUrl,
+            discovery: probe.discovery,
+            status: probe.status,
+        });
+    }
+
+    if (options.action === "shutdown") {
+        const response = await postAction(controlUrl, "/shutdown");
+        const shutdownComplete = await waitForLauncherGone(
+            controlUrl,
+            Math.min(deadline, Date.now() + 60000),
+        );
+        report(
+            {
+                launcherFound: true,
+                action: "shutdown",
+                response,
+                shutdownComplete,
+            },
+            shutdownComplete ? 0 : 1,
+        );
+    }
+
+    if (options.action === "quit-bloom") {
+        const response = await postAction(controlUrl, "/quit-bloom");
+        let status = probe.status;
+        if (response.statusCode === 202) {
+            status = await waitForStatus(
+                options.repoRoot,
+                controlUrl,
+                (current) => current.state === "awaiting-restart",
+                deadline,
+            );
+        }
+        report({
+            launcherFound: true,
+            action: "quit-bloom",
+            response,
+            controlUrl,
+            status,
+        });
+    }
+
+    // restart / start
+    const baselineLaunchNumber = probe.status.launchNumber ?? 0;
+    const route = options.action === "start" ? "/start" : "/restart";
+    const response = await postAction(controlUrl, route);
+
+    if (response.statusCode >= 400) {
+        report(
+            {
+                launcherFound: true,
+                action: options.action,
+                response,
+                controlUrl,
+                status: probe.status,
+            },
+            1,
+        );
+    }
+
+    let status = probe.status;
+    if (options.waitReady) {
+        status = await waitForStatus(
+            options.repoRoot,
+            controlUrl,
+            (current) =>
+                current.state === "bloom-running" &&
+                (current.launchNumber ?? 0) > baselineLaunchNumber,
+            deadline,
+        );
+    }
+
+    report({
+        launcherFound: true,
+        action: options.action,
+        response,
+        controlUrl,
+        status,
+        waitedForReady: options.waitReady,
+    });
+} catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,12 @@ means you do **not** need to stop the developer's Bloom to build or run unit tes
 multiple terminals can build/test at once. See `Directory.Build.props` for how it works.
 
 - This wrapper is for **building and running tests only**. To *run* Bloom, still use
-  `./go.sh` (see "Running Bloom" below) — the wrapper builds without a native apphost.
+  `./go.sh` (see "Running Bloom" below) — the wrapper builds no `Bloom.exe` apphost.
+  (`BloomPdfMaker.exe` is the one apphost it does build, because Bloom's PDF code shells
+  out to that file by name and the PDF tests fail without it.)
+- The full C# suite is expected to be **green** through this wrapper. If you see the
+  PdfMaker or xmatter-locating tests fail, that is a real regression in the wrapper /
+  `Directory.Build.props`, not the known environment noise it used to be.
 - The first build in a fresh terminal is a full (cold) build into that terminal's private
   tree; subsequent builds there are incremental. `output/` is gitignored.
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,6 +43,18 @@
     <PropertyGroup Condition="'$(BLOOM_AGENT_BUILD_DIR)' != ''">
         <BaseIntermediateOutputPath>$(BLOOM_AGENT_BUILD_DIR)\obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
         <!--
+            No native apphosts (.exe launchers) in the private tree: nobody runs Bloom
+            from here (use ./go.sh for that), so generating them is wasted work.
+            WebView2PdfMaker is the one exception. Bloom does not reference its assembly;
+            it shells out to the file BloomPdfMaker.exe by name
+            (Publish/PDF/MakePdfUsingExternalPdfMakerProgram.cs), so without that one
+            apphost every PdfMakerTests case fails in the private tree with
+            "BloomPdfMaker.exe seems to be missing" while passing in a normal build.
+            This lives here rather than as a -p: on the wrapper's command line because a
+            global property cannot be varied per project.
+        -->
+        <UseAppHost Condition="'$(MSBuildProjectName)' != 'WebView2PdfMaker'">false</UseAppHost>
+        <!--
             Once obj moves out of the project directory, the SDK no longer treats the
             conventional in-tree obj\ and bin\ as intermediate output, so their stale
             auto-generated *.cs (AssemblyInfo, .AssemblyAttributes) left over from a

--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -19,6 +19,16 @@ House rules:
 
 ---
 
+## 2026-07-24 — agent-dotnet.sh collides with itself when a build and a test run overlap
+- **Cut:** The wrapper isolates per *terminal*, not per *command*, so a `build` started while
+  that same terminal's `test` is still running fails with MSB3027 — "Bloom.dll ... locked by:
+  testhost". Agents that kick a full suite into the background and keep working hit this and
+  can mistake it for a real build break.
+- **Idea:** Either serialize (a lock file in `output/agent/<key>/`) or give a concurrent
+  invocation its own subtree, and make the error message say "another agent-dotnet command is
+  using this tree" instead of a raw MSBuild copy failure.
+- **Context:** BloomDesktop, `/preflight` of PR #8107 (dev launcher control API).
+
 ## 2026-07-24 — go.sh "succeeds" on a fresh worktree whose output/browser was never built
 - **Cut:** On a never-initialized worktree, after fixing the obvious failures (pnpm install,
   getDependencies for CS0246), `./go.sh` launches and Bloom looks healthy — but opening a book

--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -19,6 +19,17 @@ House rules:
 
 ---
 
+## 2026-07-24 — go.sh "succeeds" on a fresh worktree whose output/browser was never built
+- **Cut:** On a never-initialized worktree, after fixing the obvious failures (pnpm install,
+  getDependencies for CS0246), `./go.sh` launches and Bloom looks healthy — but opening a book
+  fails with "Cannot Find File: bookPreviewBundle.js", because a few entry points are served
+  from `output/browser` (populated only by init.sh's one-shot `pnpm build`), not by the Vite
+  dev server. Neither go.sh nor the run-bloom skill warns about this half-initialized state.
+- **Idea:** Have go.mjs (or the run-bloom skill's preflight) check for a marker like
+  `output/browser/bookPreviewBundle.js` and say "run ./init.sh first" instead of launching
+  into a Bloom that fails later.
+- **Context:** BuildServer worktree, while verifying the new launcher control surface.
+
 
 ## 2026-07-15 — agent-dotnet full suite can never be fully green (9 environmental failures)
 

--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -41,20 +41,6 @@ House rules:
 - **Context:** BuildServer worktree, while verifying the new launcher control surface.
 
 
-## 2026-07-15 — agent-dotnet full suite can never be fully green (9 environmental failures)
-
-- **Cut:** Running the full C# suite through `build/agent-dotnet.sh` always fails 9 tests for
-  environment reasons: the per-terminal agent output tree lacks `BloomPdfMaker.exe` (4
-  `PdfMakerTests` failures) and `XMatterHelper` can't locate the checked-in
-  `src/BloomTests/xMatter/Test-XMatter` packs from that tree (5 failures in
-  `XMatterHelperTests` and `InsertPageAfter_FromDifferentBook_MergesStyles`). Agents can't get
-  a green full-suite baseline, so every preflight has to re-establish that these 9 are noise.
-- **Idea:** Make the wrapper copy/link `BloomPdfMaker.exe` into its private output tree and fix
-  the xmatter file-locator path (or document the 9 known failures in AGENTS.md as expected under
-  the wrapper).
-- **Context:** BloomDesktop, found during `/preflight` of PR #8067 (speedUpCSharpTests).
-
-
 ## 2026-07-13 — pnpm-lock.yaml reformats wholesale on any install (format drift)
 - **Cut:** The committed `src/BloomBrowserUI/pnpm-lock.yaml` (on master too) is in an
   older pnpm serialization style (double-quoted `lockfileVersion`, 4-space indent, and it

--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -19,6 +19,15 @@ House rules:
 
 ---
 
+## 2026-07-24 — killBloomProcess.mjs --help kills Bloom instead of printing usage
+- **Cut:** Running `node .github/skills/bloom-automation/killBloomProcess.mjs --help` to check
+  its options killed the running Bloom (output: "Killed process IDs: 56212, 55352"). Unknown
+  flags are ignored and the destructive default action runs, so the conventional "let me read
+  the usage first" move is itself the dangerous one. The sibling scripts may have the same shape.
+- **Idea:** Have these scripts recognize `--help`/`-h` (print usage, exit 0) and reject unknown
+  flags instead of silently proceeding — especially the ones that kill processes.
+- **Context:** BloomDesktop, during `/preflight` live verification of PR #8107.
+
 ## 2026-07-24 — agent-dotnet.sh collides with itself when a build and a test run overlap
 - **Cut:** The wrapper isolates per *terminal*, not per *command*, so a `build` started while
   that same terminal's `test` is still running fails with MSB3027 — "Bloom.dll ... locked by:

--- a/build/agent-dotnet.ps1
+++ b/build/agent-dotnet.ps1
@@ -27,6 +27,10 @@ $scratch = Join-Path $repoRoot "output/agent/$key"
 
 Write-Host "[agent-dotnet] isolated build dir: $scratch"
 
+# OutDir must be a global -p: (see Directory.Build.props). Apphost suppression used to
+# be a global here too, but it has to vary per project — WebView2PdfMaker's apphost is
+# the BloomPdfMaker.exe the PDF tests shell out to — so it now lives in
+# Directory.Build.props, which a global property would have overridden.
 $env:BLOOM_AGENT_BUILD_DIR = $scratch
-& dotnet @args "-p:OutDir=$scratch/bin/" "-p:UseAppHost=false"
+& dotnet @args "-p:OutDir=$scratch/bin/"
 exit $LASTEXITCODE

--- a/build/agent-dotnet.sh
+++ b/build/agent-dotnet.sh
@@ -13,8 +13,9 @@
 #   This wrapper redirects the whole build (obj + bin) into a private per-terminal tree
 #   under output/agent/<key>/, so you can build and run unit tests while a Bloom keeps
 #   running and while other terminals do their own builds. See Directory.Build.props
-#   for the mechanism (obj is redirected there via BLOOM_AGENT_BUILD_DIR; bin/OutDir
-#   and UseAppHost are the global -p: values this script appends).
+#   for the mechanism (obj is redirected there via BLOOM_AGENT_BUILD_DIR; bin/OutDir is
+#   the one global -p: this script appends, and apphost policy lives in that same props
+#   file because it has to vary per project).
 #
 # Usage (exactly like dotnet, just build/test through this script):
 #   build/agent-dotnet.sh test src/BloomTests/BloomTests.csproj --filter "FullyQualifiedName~UrlPathStringTests"

--- a/build/agent-dotnet.sh
+++ b/build/agent-dotnet.sh
@@ -43,6 +43,9 @@ fi
 
 echo "[agent-dotnet] isolated build dir: $SCRATCH" >&2
 
+# OutDir must be a global -p: (see Directory.Build.props). Apphost suppression used to
+# be a global here too, but it has to vary per project — WebView2PdfMaker's apphost is
+# the BloomPdfMaker.exe the PDF tests shell out to — so it now lives in
+# Directory.Build.props, which a global property would have overridden.
 BLOOM_AGENT_BUILD_DIR="$SCRATCH" exec dotnet "$@" \
-    -p:OutDir="$SCRATCH/bin/" \
-    -p:UseAppHost=false
+    -p:OutDir="$SCRATCH/bin/"

--- a/scripts/watchBloomExe.mjs
+++ b/scripts/watchBloomExe.mjs
@@ -227,6 +227,9 @@ let lastAutomationInfo;
 // Set when the control API deliberately stops Bloom: tells the watch child's
 // exit handler to park in awaiting-restart instead of exiting the launcher.
 let stopRequested = false;
+// Set once we are exiting the launcher on purpose (teardownStack), so the exit
+// handler stays quiet instead of inviting the developer to relaunch.
+let tearingDownStack = false;
 // When dotnet watch last reported a source-file change (it kills + rebuilds
 // the app right after). Lets the Bloom-exit monitor tell "watch is rebuilding
 // Bloom" from "the developer closed Bloom".
@@ -236,10 +239,14 @@ let lastWatchRestartSignalAt;
 // Conservative: an edit dotnet watch hot-reloaded still counts, since for
 // Bloom a full restart is the only trusted way to take a .NET change.
 let sourceChangedSinceReady = false;
-// How fresh that signal must be to explain a Bloom exit. dotnet watch kills
-// the app within a beat of printing the file-changed line, so a short window
-// suffices; a hot reload that did NOT kill Bloom ages out past this quickly.
-const watchRestartSignalWindowMs = 10000;
+// How fresh that signal must be to explain a Bloom exit. dotnet watch usually
+// kills the app within a beat of printing the file-changed line, but on a busy
+// machine (or when it tries a hot reload first) the gap can stretch. Erring
+// generous is deliberate: mistaking a rebuild for "the developer closed Bloom"
+// destroys the whole dev stack, while the opposite mistake merely leaves the
+// stack up a little longer — and in that window dotnet watch would have
+// relaunched Bloom anyway.
+const watchRestartSignalWindowMs = 30000;
 
 const isProcessRunning = (pid) => {
     if (!Number.isInteger(pid) || pid <= 0) {
@@ -327,12 +334,18 @@ const handleBloomExitUnderWatch = async (exitedPid, runtimeMs) => {
     }
 
     // While we waited, a control-API restart/quit/shutdown may have taken
-    // over, or a new launch may have started. Defer to it.
+    // over, or the rebuilt Bloom may already have announced itself. Defer to it.
     if (
         launchToken !== activeLaunchToken ||
         restartInProgress ||
         stopRequested ||
         awaitingManualRestart ||
+        // A rebuilt Bloom that announced itself during the wait replaced
+        // bloomProcessId with its own live pid (a watch rebuild does not bump
+        // activeLaunchToken, so this is what "someone got there first" looks
+        // like). Note we cannot test launchCompleted here: it is still true
+        // from the launch whose Bloom just exited.
+        (bloomProcessId && isProcessRunning(bloomProcessId)) ||
         !isWatchChildAlive()
     ) {
         return;
@@ -346,8 +359,16 @@ const handleBloomExitUnderWatch = async (exitedPid, runtimeMs) => {
         launchCompleted = false;
         bloomProcessId = undefined;
         bloomReadyAt = undefined;
+        // Deliberately NO launch timeout while waiting for a watch rebuild. The
+        // usual reason the rebuilt Bloom doesn't appear is a C# compile error:
+        // dotnet watch has already killed Bloom, the build failed, and the
+        // watcher now waits for the developer to fix the code — a human-paced
+        // wait that easily outlasts launchTimeoutMs. Arming the timeout here
+        // would make that ordinary typo exit the launcher, and go.mjs would
+        // then tear down Vite too. The watch child is still alive, so a
+        // successful rebuild announces itself through reportAutomationReady;
+        // POST /restart (or Ctrl+C) is always available meanwhile.
         clearLaunchTimeout();
-        startLaunchTimeout();
         return;
     }
 
@@ -618,6 +639,11 @@ const spawnWatchChild = () => {
         // Park in awaiting-restart (like the human closing Bloom's window)
         // instead of exiting the launcher. Checked after restartRequested so
         // a restart requested mid-quit wins.
+        if (tearingDownStack) {
+            // teardownStack is about to process.exit; say nothing.
+            return;
+        }
+
         if (stopRequested) {
             stopRequested = false;
             stopBloomMonitor();
@@ -751,15 +777,23 @@ const quitBloom = async () => {
     clearLaunchTimeout();
     stopBloomMonitor();
 
+    // Set BEFORE taking Bloom down: quitting it can take up to 15 s, and if the
+    // watch child happens to exit during that window its exit handler must see
+    // that this was a deliberate stop. Otherwise it would fall through to
+    // exitForFinishedLaunch and take the whole stack (including Vite) down,
+    // which is the opposite of what /quit-bloom promises.
+    stopRequested = true;
+
     if (bloomProcessId) {
         await quitBloomProcessGracefully(bloomProcessId);
     }
 
     if (isWatchChildAlive()) {
-        stopRequested = true;
         await terminateChild(child);
         return;
     }
+
+    stopRequested = false;
 
     if (!awaitingManualRestart) {
         awaitingManualRestart = true;
@@ -774,6 +808,10 @@ const quitBloom = async () => {
 // handler shut down the Vite dev server and the rest.
 const teardownStack = async (reason) => {
     console.log(reason);
+    // Both flags: stopRequested keeps the child's exit handler from treating
+    // this as a finished launch, and tearingDownStack keeps it from printing
+    // the "press Enter to relaunch" invitation into a terminal that is exiting.
+    tearingDownStack = true;
     stopRequested = true;
     clearLaunchTimeout();
     stopBloomMonitor();

--- a/scripts/watchBloomExe.mjs
+++ b/scripts/watchBloomExe.mjs
@@ -680,8 +680,10 @@ const spawnWatchChild = () => {
     });
 };
 
-const isWatchChildAlive = () =>
-    !!child && child.exitCode === null && !child.signalCode;
+const isChildAlive = (candidate) =>
+    !!candidate && candidate.exitCode === null && !candidate.signalCode;
+
+const isWatchChildAlive = () => isChildAlive(child);
 
 const restartWatchChild = async () => {
     if (restartInProgress) {
@@ -777,19 +779,35 @@ const quitBloom = async () => {
     clearLaunchTimeout();
     stopBloomMonitor();
 
-    // Set BEFORE taking Bloom down: quitting it can take up to 15 s, and if the
-    // watch child happens to exit during that window its exit handler must see
-    // that this was a deliberate stop. Otherwise it would fall through to
-    // exitForFinishedLaunch and take the whole stack (including Vite) down,
-    // which is the opposite of what /quit-bloom promises.
+    // Remember which watch child we set out to stop, and which launch we are
+    // acting on: closing Bloom below can take up to 15 s, and a /restart in
+    // that window recycles both.
+    const childToStop = child;
+    const launchToken = activeLaunchToken;
+
+    // Set BEFORE taking Bloom down: if the watch child happens to exit while we
+    // wait, its exit handler must see that this was a deliberate stop.
+    // Otherwise it would fall through to exitForFinishedLaunch and take the
+    // whole stack (including Vite) down, which is the opposite of what
+    // /quit-bloom promises.
     stopRequested = true;
 
     if (bloomProcessId) {
         await quitBloomProcessGracefully(bloomProcessId);
     }
 
-    if (isWatchChildAlive()) {
-        await terminateChild(child);
+    // A /restart that arrived while we were closing Bloom has already replaced
+    // the watch child (and cleared stopRequested). Terminating that replacement
+    // would kill the only process able to launch Bloom, so let the restart win.
+    if (launchToken !== activeLaunchToken) {
+        console.log(
+            "A restart took over while Bloom was closing; leaving the new watch cycle alone.",
+        );
+        return;
+    }
+
+    if (isChildAlive(childToStop)) {
+        await terminateChild(childToStop);
         return;
     }
 

--- a/scripts/watchBloomExe.mjs
+++ b/scripts/watchBloomExe.mjs
@@ -7,6 +7,16 @@ import {
     requireOptionValue,
     requireTcpPortOption,
 } from "../.github/skills/bloom-automation/bloomProcessCommon.mjs";
+import {
+    discoveryFileSchemaVersion,
+    getDiscoveryFilePath,
+    isDotnetWatchRestartSignal,
+    launcherReadyPrefix,
+    readDiscoveryFile,
+    removeDiscoveryFile,
+    startControlServer,
+    writeDiscoveryFile,
+} from "./watchBloomExeControl.mjs";
 import { isManualRestartCommand } from "./watchBloomExeInput.mjs";
 import { getHelpfulStartupLabel } from "./watchBloomExeLabel.mjs";
 
@@ -71,8 +81,6 @@ const launchTimeoutMs = 120000;
 const bloomMonitorPollMs = 500;
 const shortLivedBloomMs = 5000;
 const launchesUnderWatch = true;
-const restartPrompt =
-    "Bloom is closed. Press Enter to relaunch, or press Ctrl+C to stop watching.";
 const projectPath = path.join(
     options.repoRoot,
     "src",
@@ -213,6 +221,25 @@ let activeLaunchToken = 0;
 let restartRequested = false;
 let awaitingManualRestart = false;
 let restartInProgress = false;
+// Full BLOOM_AUTOMATION_READY payload (processId/httpPort/cdpPort) for the
+// current Bloom, kept so the control API can report the ports.
+let lastAutomationInfo;
+// Set when the control API deliberately stops Bloom: tells the watch child's
+// exit handler to park in awaiting-restart instead of exiting the launcher.
+let stopRequested = false;
+// When dotnet watch last reported a source-file change (it kills + rebuilds
+// the app right after). Lets the Bloom-exit monitor tell "watch is rebuilding
+// Bloom" from "the developer closed Bloom".
+let lastWatchRestartSignalAt;
+// Whether dotnet watch has reported ANY source change since the current Bloom
+// reported ready — i.e. whether a restart would incorporate .NET changes.
+// Conservative: an edit dotnet watch hot-reloaded still counts, since for
+// Bloom a full restart is the only trusted way to take a .NET change.
+let sourceChangedSinceReady = false;
+// How fresh that signal must be to explain a Bloom exit. dotnet watch kills
+// the app within a beat of printing the file-changed line, so a short window
+// suffices; a hot reload that did NOT kill Bloom ages out past this quickly.
+const watchRestartSignalWindowMs = 10000;
 
 const isProcessRunning = (pid) => {
     if (!Number.isInteger(pid) || pid <= 0) {
@@ -249,6 +276,12 @@ const resetLaunchState = () => {
     childExited = false;
     bloomProcessId = undefined;
     bloomReadyAt = undefined;
+    lastAutomationInfo = undefined;
+    lastWatchRestartSignalAt = undefined;
+    sourceChangedSinceReady = false;
+    // A restart won over any in-flight quit; drop the stale stop request so it
+    // cannot mis-park a later, unrelated child exit.
+    stopRequested = false;
     childExitCode = 0;
     childExitSignal = undefined;
     launchCompleted = false;
@@ -270,6 +303,59 @@ const exitForFinishedLaunch = (exitCode = 0) => {
     process.exit(exitCode);
 };
 
+const hasFreshWatchRestartSignal = () =>
+    lastWatchRestartSignalAt !== undefined &&
+    Date.now() - lastWatchRestartSignalAt < watchRestartSignalWindowMs;
+
+// Bloom exited while dotnet watch is still alive. Two possibilities:
+// - dotnet watch is rebuilding Bloom because a source file changed: keep the
+//   stack alive and wait for the rebuilt Bloom to announce itself.
+// - the developer closed Bloom (window X, File > Quit, crash): tear the whole
+//   dev stack down so it stops holding memory once the developer has moved
+//   on. Agents can start a fresh stack with launcherControl --ensure-running.
+const handleBloomExitUnderWatch = async (exitedPid, runtimeMs) => {
+    const launchToken = activeLaunchToken;
+    console.log(
+        `Bloom PID ${exitedPid} exited after ${runtimeMs} ms while dotnet watch remains active.`,
+    );
+
+    // dotnet watch prints its file-changed line right before killing the app,
+    // but that output can land a beat after we notice the process die — give
+    // it a moment before concluding the developer closed Bloom.
+    if (!hasFreshWatchRestartSignal()) {
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+
+    // While we waited, a control-API restart/quit/shutdown may have taken
+    // over, or a new launch may have started. Defer to it.
+    if (
+        launchToken !== activeLaunchToken ||
+        restartInProgress ||
+        stopRequested ||
+        awaitingManualRestart ||
+        !isWatchChildAlive()
+    ) {
+        return;
+    }
+
+    if (hasFreshWatchRestartSignal()) {
+        lastWatchRestartSignalAt = undefined;
+        console.log(
+            "dotnet watch is rebuilding Bloom after a file change. Waiting for the new instance...",
+        );
+        launchCompleted = false;
+        bloomProcessId = undefined;
+        bloomReadyAt = undefined;
+        clearLaunchTimeout();
+        startLaunchTimeout();
+        return;
+    }
+
+    await teardownStack(
+        "Bloom was closed. Shutting down the whole dev stack (dotnet watch, Vite) to free its memory. Start it again with ./go.sh; agents use launcherControl.mjs --ensure-running.",
+    );
+};
+
 const startBloomMonitor = () => {
     if (bloomMonitor || !bloomProcessId) {
         return;
@@ -285,14 +371,8 @@ const startBloomMonitor = () => {
             runtimeMs !== undefined && runtimeMs < shortLivedBloomMs;
 
         if (launchesUnderWatch && !exitedTooSoon) {
-            console.log(
-                `Bloom PID ${bloomProcessId} exited after ${runtimeMs} ms while dotnet watch remains active.`,
-            );
             stopBloomMonitor();
-            awaitingManualRestart = true;
-            if (process.stdin.isTTY) {
-                console.log(restartPrompt);
-            }
+            void handleBloomExitUnderWatch(bloomProcessId, runtimeMs);
             return;
         }
 
@@ -353,6 +433,9 @@ const reportAutomationReady = (rawAutomationInfo) => {
     launchCompleted = true;
     clearLaunchTimeout();
     bloomProcessId = automationInfo.processId;
+    lastAutomationInfo = automationInfo;
+    lastWatchRestartSignalAt = undefined;
+    sourceChangedSinceReady = false;
     bloomReadyAt = Date.now();
     stopBloomMonitor();
     awaitingManualRestart = false;
@@ -373,6 +456,11 @@ const reportAutomationReady = (rawAutomationInfo) => {
 const handleOutputLine = (launchToken, line) => {
     if (launchToken !== activeLaunchToken) {
         return;
+    }
+
+    if (isDotnetWatchRestartSignal(line)) {
+        lastWatchRestartSignalAt = Date.now();
+        sourceChangedSinceReady = true;
     }
 
     if (!line.startsWith(automationReadyPrefix)) {
@@ -526,6 +614,23 @@ const spawnWatchChild = () => {
             return;
         }
 
+        // A control-API quit deliberately stopped Bloom and its watch child.
+        // Park in awaiting-restart (like the human closing Bloom's window)
+        // instead of exiting the launcher. Checked after restartRequested so
+        // a restart requested mid-quit wins.
+        if (stopRequested) {
+            stopRequested = false;
+            stopBloomMonitor();
+            clearLaunchTimeout();
+            if (!awaitingManualRestart) {
+                awaitingManualRestart = true;
+                console.log(
+                    "Bloom stopped by control request. Press Enter here (or POST /restart to the control API) to rebuild and relaunch.",
+                );
+            }
+            return;
+        }
+
         if (
             bloomProcessId &&
             isProcessRunning(bloomProcessId) &&
@@ -549,8 +654,20 @@ const spawnWatchChild = () => {
     });
 };
 
+const isWatchChildAlive = () =>
+    !!child && child.exitCode === null && !child.signalCode;
+
 const restartWatchChild = async () => {
     if (restartInProgress) {
+        return;
+    }
+
+    if (!isWatchChildAlive()) {
+        // The watch child is already gone (e.g. after a control-API quit), so
+        // there is no exit event coming to respawn for us. Spawn directly.
+        awaitingManualRestart = false;
+        console.log("Restarting Bloom...");
+        spawnWatchChild();
         return;
     }
 
@@ -558,8 +675,122 @@ const restartWatchChild = async () => {
     restartRequested = true;
     awaitingManualRestart = false;
     console.log("Restarting Bloom...");
+    // Stop watching Bloom's pid before we take it down on purpose, and close
+    // Bloom via WM_CLOSE first so it saves its state; only then recycle the
+    // dotnet watch child (whose tree-kill would hard-kill Bloom otherwise).
+    stopBloomMonitor();
+    clearLaunchTimeout();
+    if (bloomProcessId) {
+        await quitBloomProcessGracefully(bloomProcessId);
+    }
     await terminateChild(child);
 };
+
+const runTaskkill = (args) =>
+    new Promise((resolve) => {
+        const killer = spawn("taskkill", args, {
+            stdio: "ignore",
+            shell: false,
+        });
+        killer.on("exit", resolve);
+        killer.on("error", () => resolve(undefined));
+    });
+
+const waitForProcessExit = async (pid, timeoutMs) => {
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+        if (!isProcessRunning(pid)) {
+            return true;
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+
+    return !isProcessRunning(pid);
+};
+
+const quitBloomProcessGracefully = async (pid) => {
+    if (!isProcessRunning(pid)) {
+        return;
+    }
+
+    if (process.platform === "win32") {
+        // taskkill without /f sends WM_CLOSE — the same as the user clicking
+        // the window's X, so Bloom saves and exits cleanly.
+        await runTaskkill(["/pid", String(pid)]);
+        if (await waitForProcessExit(pid, 10000)) {
+            return;
+        }
+
+        console.log(
+            `Bloom PID ${pid} did not close gracefully within 10 s (a modal dialog may be blocking it); force-killing.`,
+        );
+        await runTaskkill(["/pid", String(pid), "/f"]);
+        await waitForProcessExit(pid, 5000);
+        return;
+    }
+
+    try {
+        process.kill(pid, "SIGTERM");
+    } catch {}
+    if (await waitForProcessExit(pid, 10000)) {
+        return;
+    }
+
+    try {
+        process.kill(pid, "SIGKILL");
+    } catch {}
+};
+
+// Control-API action: durably stop Bloom. Unlike the human closing Bloom's
+// window (which leaves dotnet watch alive, so the next C# edit silently
+// respawns Bloom), this also stops the watch child; the launcher parks in
+// awaiting-restart until Enter or POST /restart.
+const quitBloom = async () => {
+    clearLaunchTimeout();
+    stopBloomMonitor();
+
+    if (bloomProcessId) {
+        await quitBloomProcessGracefully(bloomProcessId);
+    }
+
+    if (isWatchChildAlive()) {
+        stopRequested = true;
+        await terminateChild(child);
+        return;
+    }
+
+    if (!awaitingManualRestart) {
+        awaitingManualRestart = true;
+        console.log(
+            "Bloom stopped by control request. Press Enter here (or POST /restart to the control API) to rebuild and relaunch.",
+        );
+    }
+};
+
+// Tears down the whole dev stack: gracefully quits Bloom, stops the dotnet
+// watch child, then exits this process — which makes go.mjs's exe-exit
+// handler shut down the Vite dev server and the rest.
+const teardownStack = async (reason) => {
+    console.log(reason);
+    stopRequested = true;
+    clearLaunchTimeout();
+    stopBloomMonitor();
+
+    if (bloomProcessId) {
+        await quitBloomProcessGracefully(bloomProcessId);
+    }
+
+    await terminateChild(child);
+    process.exit(0);
+};
+
+// Control-API action: tear down the whole dev stack on request.
+const shutdownStack = () =>
+    teardownStack(
+        "Shutting down the Bloom launcher stack by control request...",
+    );
 
 if (process.stdin.readable) {
     process.stdin.setEncoding("utf8");
@@ -571,6 +802,126 @@ if (process.stdin.readable) {
         void restartWatchChild();
     });
     process.stdin.resume();
+}
+
+// --- Launcher control surface -----------------------------------------------
+// A loopback-only HTTP server through which agents can query and drive this
+// launcher (see watchBloomExeControl.mjs and the bloom-automation skill).
+// Discovered via output/bloom-launcher.json and the BLOOM_LAUNCHER_READY line.
+// Started BEFORE the first dotnet spawn so the control port can be passed to
+// Bloom (--launcher-port), which uses it for its in-app restart toast.
+
+const launcherStartedAt = new Date().toISOString();
+// In the go.sh flow our parent is go.mjs, which owns the Vite dev server.
+const goPid = process.ppid;
+const discoveryFilePath = getDiscoveryFilePath(options.repoRoot);
+
+const getControlSnapshot = () => ({
+    restartInProgress,
+    launchCompleted,
+    launchFailed,
+    awaitingManualRestart,
+    bloomRunning: !!bloomProcessId && isProcessRunning(bloomProcessId),
+    watchChildAlive: isWatchChildAlive(),
+    launchNumber,
+    dotnetWatchPid: child?.pid,
+    bloomProcessId,
+    httpPort: lastAutomationInfo?.httpPort,
+    cdpPort: lastAutomationInfo?.cdpPort,
+    vitePort: effectiveVitePort,
+    sourceChangedSinceReady,
+    label: startupLabel,
+    repoRoot: options.repoRoot,
+    launcherPid: process.pid,
+    goPid,
+    logPath: process.env.BLOOM_LAUNCHER_LOG || undefined,
+    startedAt: launcherStartedAt,
+    bloomReadyAt,
+});
+
+const warnIfAnotherLauncherIsLive = async () => {
+    const existing = readDiscoveryFile(discoveryFilePath);
+    if (!existing?.controlUrl || existing.launcherPid === process.pid) {
+        return;
+    }
+
+    try {
+        const response = await fetch(`${existing.controlUrl}/status`, {
+            signal: AbortSignal.timeout(1000),
+        });
+        if (response.ok) {
+            console.warn(
+                `Another Bloom launcher (PID ${existing.launcherPid}) appears to be running for this worktree at ${existing.controlUrl}. Overwriting its discovery file; the last launcher started wins.`,
+            );
+        }
+    } catch {
+        // Nobody home: the file is stale, which is normal after a hard kill.
+    }
+};
+
+const startControlSurface = async () => {
+    try {
+        await warnIfAnotherLauncherIsLive();
+
+        const { port } = await startControlServer({
+            actions: { restart: restartWatchChild, quitBloom, shutdownStack },
+            getSnapshot: getControlSnapshot,
+            log: console.log,
+        });
+
+        const controlUrl = `http://127.0.0.1:${port}`;
+        writeDiscoveryFile(discoveryFilePath, {
+            schemaVersion: discoveryFileSchemaVersion,
+            kind: "bloom-launcher",
+            controlPort: port,
+            controlUrl,
+            launcherPid: process.pid,
+            goPid,
+            repoRoot: options.repoRoot,
+            label: startupLabel,
+            vitePort: effectiveVitePort,
+            logPath: process.env.BLOOM_LAUNCHER_LOG || undefined,
+            startedAt: launcherStartedAt,
+        });
+
+        process.on("exit", () => {
+            // Only remove the file if it is still ours; a newer launcher may
+            // have overwritten it while we were shutting down.
+            if (
+                readDiscoveryFile(discoveryFilePath)?.launcherPid ===
+                process.pid
+            ) {
+                removeDiscoveryFile(discoveryFilePath);
+            }
+        });
+
+        console.log(
+            `Launcher control: ${controlUrl} (state file: ${discoveryFilePath})`,
+        );
+        console.log(
+            `${launcherReadyPrefix}${JSON.stringify({
+                controlPort: port,
+                controlUrl,
+                launcherPid: process.pid,
+                repoRoot: options.repoRoot,
+            })}`,
+        );
+
+        return port;
+    } catch (error) {
+        // The launcher still works for the human without the control surface.
+        console.error(
+            `Could not start the launcher control server: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        return undefined;
+    }
+};
+
+const controlPort = await startControlSurface();
+if (controlPort) {
+    // Bloom's dev-only restart toast polls /status here and posts /restart back
+    // to this port (see DevLauncher.cs).
+    dotnetArgs.push("--launcher-port", String(controlPort));
 }
 
 spawnWatchChild();

--- a/scripts/watchBloomExe.mjs
+++ b/scripts/watchBloomExe.mjs
@@ -241,12 +241,19 @@ let lastWatchRestartSignalAt;
 let sourceChangedSinceReady = false;
 // How fresh that signal must be to explain a Bloom exit. dotnet watch usually
 // kills the app within a beat of printing the file-changed line, but on a busy
-// machine (or when it tries a hot reload first) the gap can stretch. Erring
-// generous is deliberate: mistaking a rebuild for "the developer closed Bloom"
-// destroys the whole dev stack, while the opposite mistake merely leaves the
-// stack up a little longer — and in that window dotnet watch would have
-// relaunched Bloom anyway.
+// machine the gap can stretch. Erring generous is deliberate: mistaking a rebuild
+// for "the developer closed Bloom" destroys the whole dev stack, whereas the
+// opposite mistake only delays freeing memory.
+// This window is only trusted while Bloom actually died in it — see
+// disarmSignalIfBloomSurvives, which throws the signal away once Bloom is seen
+// surviving the change (i.e. the watcher hot-reloaded and will NOT relaunch).
 const watchRestartSignalWindowMs = 30000;
+// How long to let dotnet watch act on a file change before concluding it chose a
+// hot reload over killing Bloom. Comfortably longer than the "prints the line,
+// then kills the app" gap, and short enough that a close right after an edit is
+// still read as a close.
+const watchHotReloadGraceMs = 15000;
+let hotReloadCheckTimer;
 
 const isProcessRunning = (pid) => {
     if (!Number.isInteger(pid) || pid <= 0) {
@@ -285,6 +292,8 @@ const resetLaunchState = () => {
     bloomReadyAt = undefined;
     lastAutomationInfo = undefined;
     lastWatchRestartSignalAt = undefined;
+    clearTimeout(hotReloadCheckTimer);
+    hotReloadCheckTimer = undefined;
     sourceChangedSinceReady = false;
     // A restart won over any in-flight quit; drop the stale stop request so it
     // cannot mis-park a later, unrelated child exit.
@@ -313,6 +322,23 @@ const exitForFinishedLaunch = (exitCode = 0) => {
 const hasFreshWatchRestartSignal = () =>
     lastWatchRestartSignalAt !== undefined &&
     Date.now() - lastWatchRestartSignalAt < watchRestartSignalWindowMs;
+
+// A file-changed line means a rebuild is imminent ONLY if dotnet watch is going to
+// kill Bloom. When it hot-reloads instead, Bloom keeps running and no rebuilt
+// instance ever announces itself — so nothing would clear the signal, and a close
+// minutes later (well, up to watchRestartSignalWindowMs later) would be misread as
+// "a rebuild is coming", leaving the whole stack waiting forever for a Bloom that
+// is never rebuilt. So: if Bloom is still alive a beat after the change line, the
+// watcher chose hot reload, and this signal no longer explains any later exit.
+const disarmSignalIfBloomSurvives = () => {
+    clearTimeout(hotReloadCheckTimer);
+    hotReloadCheckTimer = setTimeout(() => {
+        hotReloadCheckTimer = undefined;
+        if (bloomProcessId && isProcessRunning(bloomProcessId)) {
+            lastWatchRestartSignalAt = undefined;
+        }
+    }, watchHotReloadGraceMs);
+};
 
 // Bloom exited while dotnet watch is still alive. Two possibilities:
 // - dotnet watch is rebuilding Bloom because a source file changed: keep the
@@ -482,6 +508,7 @@ const handleOutputLine = (launchToken, line) => {
     if (isDotnetWatchRestartSignal(line)) {
         lastWatchRestartSignalAt = Date.now();
         sourceChangedSinceReady = true;
+        disarmSignalIfBloomSurvives();
     }
 
     if (!line.startsWith(automationReadyPrefix)) {

--- a/scripts/watchBloomExe.mjs
+++ b/scripts/watchBloomExe.mjs
@@ -726,6 +726,11 @@ const restartWatchChild = async () => {
         return;
     }
 
+    // Remember which child we set out to recycle: closing Bloom below takes a
+    // while, and the global `child` can be replaced meanwhile.
+    const childToRecycle = child;
+    const launchToken = activeLaunchToken;
+
     restartInProgress = true;
     restartRequested = true;
     awaitingManualRestart = false;
@@ -736,7 +741,21 @@ const restartWatchChild = async () => {
     stopBloomMonitor();
     clearLaunchTimeout();
     await closeAnyRunningBloom();
-    await terminateChild(child);
+
+    // If the watch child exited on its own while we were closing Bloom (losing
+    // Bloom often takes dotnet watch down with it), its exit handler already
+    // honored the restartRequested flag by spawning a replacement — that fresh
+    // cycle IS our restart. Terminating it here, through a `child` that now
+    // points at the replacement, would undo the restart and leave the launcher
+    // with nothing able to start Bloom.
+    if (launchToken !== activeLaunchToken) {
+        console.log(
+            "The watch child recycled itself while Bloom was closing; that fresh cycle is the restart.",
+        );
+        return;
+    }
+
+    await terminateChild(childToRecycle);
 };
 
 const runTaskkill = (args) =>

--- a/scripts/watchBloomExe.mjs
+++ b/scripts/watchBloomExe.mjs
@@ -735,9 +735,7 @@ const restartWatchChild = async () => {
     // dotnet watch child (whose tree-kill would hard-kill Bloom otherwise).
     stopBloomMonitor();
     clearLaunchTimeout();
-    if (bloomProcessId) {
-        await quitBloomProcessGracefully(bloomProcessId);
-    }
+    await closeAnyRunningBloom();
     await terminateChild(child);
 };
 
@@ -798,6 +796,35 @@ const quitBloomProcessGracefully = async (pid) => {
     } catch {}
 };
 
+// Closes whatever Bloom is running right now, and keeps going if another one turns
+// up while we are working: a dotnet-watch rebuild can announce a replacement Bloom
+// while we are still closing the previous one, and because the watch child is the
+// same process that does NOT bump activeLaunchToken. Any Bloom left alive when we
+// then stop the watch child is orphaned, not killed with it — terminateChild kills
+// the watcher by pid, so Windows leaves its descendants running, and a stray Bloom
+// means port conflicts and a duplicate instance next time.
+// Bounded on purpose: each pass closes at most one Bloom, and a watcher that keeps
+// producing new instances faster than we close them is a runaway we should not spin
+// on forever.
+const closeAnyRunningBloom = async () => {
+    for (let attempt = 0; attempt < 3; attempt++) {
+        const pid = bloomProcessId;
+        if (!pid || !isProcessRunning(pid)) {
+            return;
+        }
+
+        await quitBloomProcessGracefully(pid);
+
+        if (bloomProcessId === pid) {
+            return; // nothing newer announced itself while we closed that one
+        }
+
+        console.log(
+            `A rebuilt Bloom (PID ${bloomProcessId}) appeared while PID ${pid} was closing; closing it too.`,
+        );
+    }
+};
+
 // Control-API action: durably stop Bloom. Unlike the human closing Bloom's
 // window (which leaves dotnet watch alive, so the next C# edit silently
 // respawns Bloom), this also stops the watch child; the launcher parks in
@@ -819,9 +846,7 @@ const quitBloom = async () => {
     // /quit-bloom promises.
     stopRequested = true;
 
-    if (bloomProcessId) {
-        await quitBloomProcessGracefully(bloomProcessId);
-    }
+    await closeAnyRunningBloom();
 
     // A /restart that arrived while we were closing Bloom has already replaced
     // the watch child (and cleared stopRequested). Terminating that replacement
@@ -861,9 +886,7 @@ const teardownStack = async (reason) => {
     clearLaunchTimeout();
     stopBloomMonitor();
 
-    if (bloomProcessId) {
-        await quitBloomProcessGracefully(bloomProcessId);
-    }
+    await closeAnyRunningBloom();
 
     await terminateChild(child);
     process.exit(0);

--- a/scripts/watchBloomExeControl.mjs
+++ b/scripts/watchBloomExeControl.mjs
@@ -1,0 +1,292 @@
+import http from "node:http";
+import {
+    existsSync,
+    mkdirSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import path from "node:path";
+
+// Machine-readable stdout marker, parallel to BLOOM_AUTOMATION_READY: lets an
+// agent that just launched go.sh grab the control port from the log without
+// racing the discovery-file write.
+export const launcherReadyPrefix = "BLOOM_LAUNCHER_READY ";
+
+export const discoveryFileSchemaVersion = 1;
+
+// The discovery file advertises a running launcher for one worktree. It lives
+// under output/ (gitignored). It can be left behind by a hard kill, so
+// consumers must treat the HTTP probe of controlUrl as the only source of
+// truth about liveness.
+export const getDiscoveryFilePath = (repoRoot) =>
+    path.join(repoRoot, "output", "bloom-launcher.json");
+
+export const writeDiscoveryFile = (filePath, info) => {
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, `${JSON.stringify(info, null, 4)}\n`);
+};
+
+// Best-effort: cleanup paths must never throw (they run in exit handlers).
+export const removeDiscoveryFile = (filePath) => {
+    try {
+        rmSync(filePath, { force: true });
+    } catch {}
+};
+
+// Returns undefined for a missing or unparseable file.
+export const readDiscoveryFile = (filePath) => {
+    try {
+        return JSON.parse(readFileSync(filePath, "utf8"));
+    } catch {
+        return undefined;
+    }
+};
+
+// One marker per init.sh step. If any is missing, the worktree was created but
+// ./init.sh has not (fully) run, and go.mjs runs it before launching — without
+// this, go.sh appears to succeed but Bloom later fails on requests for files
+// only a full init produces (e.g. "Cannot Find File: bookPreviewBundle.js").
+const initMarkers = [
+    ["src/BloomBrowserUI/node_modules", "front-end packages (pnpm install)"],
+    ["src/content/node_modules", "content packages (pnpm install)"],
+    [
+        "lib/dotnet/PodcastUtilities.PortableDevices.dll",
+        "C# binary dependencies (getDependencies)",
+    ],
+    [
+        "output/browser/bookPreviewBundle.js",
+        "static browser bundles (pnpm build)",
+    ],
+];
+
+// Returns [relativePath, description] for each init.sh product that is absent.
+export const getMissingInitMarkers = (repoRoot) =>
+    initMarkers.filter(
+        ([relativePath]) => !existsSync(path.join(repoRoot, relativePath)),
+    );
+
+// True for dotnet-watch "a file changed" lines — the signal that any imminent
+// Bloom exit is the watcher rebuilding the app, not the developer closing it.
+// Deliberately narrow: the idle line "Waiting for a file to change before
+// restarting ..." (printed when the app exits on its own) must NOT match.
+export const isDotnetWatchRestartSignal = (line) =>
+    /dotnet watch/i.test(line) &&
+    // The verb varies by SDK version: .NET 10's watcher says "File updated".
+    /File (changed|updated|added|created|deleted|renamed)/i.test(line);
+
+// Derives the launcher's externally visible state from the flags
+// watchBloomExe.mjs already maintains. Note that during a dotnet-watch
+// hot rebuild (C# file edit while Bloom runs) the monitor transiently reports
+// awaiting-restart until the rebuilt Bloom announces itself; clients that need
+// "Bloom is up" should poll for bloom-running rather than sampling once.
+export const deriveLauncherState = ({
+    restartInProgress,
+    launchCompleted,
+    launchFailed,
+    awaitingManualRestart,
+    bloomRunning,
+}) => {
+    if (restartInProgress) {
+        return "restarting";
+    }
+
+    if (awaitingManualRestart) {
+        return "awaiting-restart";
+    }
+
+    if (launchFailed) {
+        return "launch-failed";
+    }
+
+    if (launchCompleted && bloomRunning) {
+        return "bloom-running";
+    }
+
+    // Covers the initial build, dotnet-watch rebuilds before the ready line,
+    // and the sub-second window between Bloom exiting and the monitor noticing.
+    return "building";
+};
+
+// Shapes the GET /status response from a snapshot of launcher state.
+export const buildStatusPayload = (snapshot) => ({
+    schemaVersion: discoveryFileSchemaVersion,
+    kind: "bloom-launcher",
+    state: deriveLauncherState(snapshot),
+    awaitingManualRestart: !!snapshot.awaitingManualRestart,
+    watchChildAlive: !!snapshot.watchChildAlive,
+    launchNumber: snapshot.launchNumber,
+    dotnetWatchPid: snapshot.dotnetWatchPid,
+    bloomProcessId: snapshot.bloomProcessId,
+    httpPort: snapshot.httpPort,
+    cdpPort: snapshot.cdpPort,
+    vitePort: snapshot.vitePort,
+    sourceChangedSinceReady: !!snapshot.sourceChangedSinceReady,
+    label: snapshot.label,
+    repoRoot: snapshot.repoRoot,
+    launcherPid: snapshot.launcherPid,
+    goPid: snapshot.goPid,
+    logPath: snapshot.logPath,
+    startedAt: snapshot.startedAt,
+    bloomReadyAt: snapshot.bloomReadyAt,
+});
+
+const sendJson = (response, statusCode, body) => {
+    const text = `${JSON.stringify(body, null, 4)}\n`;
+    response.writeHead(statusCode, {
+        "Content-Type": "application/json",
+        "Content-Length": Buffer.byteLength(text),
+    });
+    response.end(text);
+};
+
+// Starts the loopback-only control server through which agents drive the
+// launcher. `actions` supplies {restart, quitBloom, shutdownStack};
+// `getSnapshot` returns the current launcher state for /status and routing
+// guards; `log` prints human-visible lines to the launcher's terminal.
+export const startControlServer = ({
+    host = "127.0.0.1",
+    actions,
+    getSnapshot,
+    log = console.log,
+}) => {
+    const runAction = (name, action) => {
+        Promise.resolve()
+            .then(action)
+            .catch((error) => {
+                log(
+                    `[control] ${name} failed: ${error instanceof Error ? error.message : String(error)}`,
+                );
+            });
+    };
+
+    const server = http.createServer((request, response) => {
+        const url = new URL(request.url, `http://${host}`);
+        const route = url.pathname.replace(/\/+$/, "") || "/";
+        const snapshot = getSnapshot();
+        const state = deriveLauncherState(snapshot);
+
+        if (route === "/status") {
+            if (request.method !== "GET") {
+                sendJson(response, 405, {
+                    ok: false,
+                    error: "/status only supports GET.",
+                });
+                return;
+            }
+
+            sendJson(response, 200, buildStatusPayload(snapshot));
+            return;
+        }
+
+        const isActionRoute = [
+            "/restart",
+            "/start",
+            "/quit-bloom",
+            "/shutdown",
+        ].includes(route);
+
+        if (!isActionRoute) {
+            sendJson(response, 404, {
+                ok: false,
+                error: `Unknown endpoint ${route}. Supported: GET /status, POST /restart, POST /start, POST /quit-bloom, POST /shutdown.`,
+            });
+            return;
+        }
+
+        if (request.method !== "POST") {
+            sendJson(response, 405, {
+                ok: false,
+                error: `${route} only supports POST.`,
+            });
+            return;
+        }
+
+        if (route === "/restart") {
+            if (state === "restarting") {
+                sendJson(response, 200, {
+                    ok: true,
+                    state,
+                    note: "A restart is already in progress.",
+                });
+                return;
+            }
+
+            log("[control] restart requested via control API");
+            sendJson(response, 202, {
+                ok: true,
+                action: "restart",
+                previousState: state,
+            });
+            runAction("restart", actions.restart);
+            return;
+        }
+
+        if (route === "/start") {
+            if (state !== "awaiting-restart") {
+                sendJson(response, 409, {
+                    ok: false,
+                    state,
+                    error: `start is only valid in the awaiting-restart state (current: ${state}). Use /restart to force a rebuild+relaunch.`,
+                });
+                return;
+            }
+
+            log("[control] start requested via control API");
+            sendJson(response, 202, {
+                ok: true,
+                action: "start",
+                previousState: state,
+            });
+            runAction("start", actions.restart);
+            return;
+        }
+
+        if (route === "/quit-bloom") {
+            if (state === "awaiting-restart") {
+                sendJson(response, 200, {
+                    ok: true,
+                    state,
+                    note: "Bloom is already stopped.",
+                });
+                return;
+            }
+
+            if (state === "restarting") {
+                sendJson(response, 409, {
+                    ok: false,
+                    state,
+                    error: "A restart is in progress; retry quit-bloom once it settles.",
+                });
+                return;
+            }
+
+            log("[control] quit-bloom requested via control API");
+            sendJson(response, 202, {
+                ok: true,
+                action: "quit-bloom",
+                previousState: state,
+            });
+            runAction("quit-bloom", actions.quitBloom);
+            return;
+        }
+
+        // /shutdown: valid in every state. Delay the action slightly so the
+        // response flushes before the process starts tearing itself down.
+        log("[control] shutdown requested via control API");
+        sendJson(response, 202, {
+            ok: true,
+            action: "shutdown",
+            previousState: state,
+        });
+        setTimeout(() => runAction("shutdown", actions.shutdownStack), 50);
+    });
+
+    return new Promise((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, host, () => {
+            server.removeListener("error", reject);
+            resolve({ server, port: server.address().port });
+        });
+    });
+};

--- a/scripts/watchBloomExeControl.mjs
+++ b/scripts/watchBloomExeControl.mjs
@@ -70,6 +70,23 @@ export const getMissingInitMarkers = (repoRoot) =>
 // Bloom exit is the watcher rebuilding the app, not the developer closing it.
 // Deliberately narrow: the idle line "Waiting for a file to change before
 // restarting ..." (printed when the app exits on its own) must NOT match.
+//
+// IF YOU ARE HERE BECAUSE THE WHOLE DEV STACK DIED WHILE YOU WERE JUST EDITING C#:
+// this regex is very likely the culprit. It is the only thing distinguishing "the
+// watcher killed Bloom and is rebuilding it" (wait) from "the developer closed
+// Bloom" (tear the stack down, freeing dotnet watch and Vite). When it fails to
+// match, an ordinary C# edit is misread as a deliberate close and the launcher
+// shuts everything down — see handleBloomExitUnderWatch in watchBloomExe.mjs.
+// The wording is SDK-dependent and has already changed once: .NET 10 prints
+// "File updated" where older SDKs printed "File changed". So compare the verb the
+// installed SDK actually prints (run ./go.sh, touch a .cs file, read the watcher's
+// line) against the alternatives below and add the new phrasing here.
+// This was reviewed and deliberately kept as a plain text match rather than made
+// more robust: Devin flagged the brittleness on PR #8107 and we chose to accept it
+// (the failure is rare and recoverable by restarting ./go.sh) rather than add a
+// grace-wait state machine. If it bites more than once, revisit that call —
+// the alternative on the table was to wait a bounded period for a rebuilt Bloom
+// to appear before ever concluding the developer closed it.
 export const isDotnetWatchRestartSignal = (line) =>
     /dotnet watch/i.test(line) &&
     // The verb varies by SDK version: .NET 10's watcher says "File updated".

--- a/scripts/watchBloomExeControl.test.mjs
+++ b/scripts/watchBloomExeControl.test.mjs
@@ -1,0 +1,314 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+    buildStatusPayload,
+    deriveLauncherState,
+    getDiscoveryFilePath,
+    getMissingInitMarkers,
+    isDotnetWatchRestartSignal,
+    readDiscoveryFile,
+    removeDiscoveryFile,
+    startControlServer,
+    writeDiscoveryFile,
+} from "./watchBloomExeControl.mjs";
+
+test("isDotnetWatchRestartSignal matches file-change lines only", () => {
+    const restartSignals = [
+        // .NET 10's watcher (the one go.sh actually runs) says "File updated".
+        "dotnet watch ⌚ File updated: D:\\bloom\\BuildServer\\src\\BloomExe\\Shell.cs",
+        "dotnet watch ⌚ File changed: D:\\bloom\\BuildServer\\src\\BloomExe\\Shell.cs.",
+        "[exe] dotnet watch ⌚ File added: ./src/BloomExe/New.cs",
+        "dotnet watch ⌚ File deleted: ./src/BloomExe/Old.cs",
+    ];
+    for (const line of restartSignals) {
+        assert.equal(isDotnetWatchRestartSignal(line), true, line);
+    }
+
+    const notRestartSignals = [
+        // The idle line after the app exits on its own — the case that must
+        // tear the stack down, so it must NOT read as a restart signal.
+        "dotnet watch ⌚ Waiting for a file to change before restarting ...",
+        "dotnet watch ⌚ [BloomExe (net8.0-windows)] Exited",
+        "dotnet watch 🔨 Building...",
+        "dotnet watch 🔥 Hot reload of changes succeeded.",
+        "Bloom ready. HTTP 8089, CDP 8091, Bloom PID 123.",
+        "File changed: something (a non-watcher line)",
+    ];
+    for (const line of notRestartSignals) {
+        assert.equal(isDotnetWatchRestartSignal(line), false, line);
+    }
+});
+
+test("deriveLauncherState covers each state with defined precedence", () => {
+    const cases = [
+        // [flags, expectedState]
+        [{ restartInProgress: true }, "restarting"],
+        // restarting wins even if stale flags linger from the previous launch
+        [
+            {
+                restartInProgress: true,
+                awaitingManualRestart: true,
+                launchCompleted: true,
+                bloomRunning: true,
+            },
+            "restarting",
+        ],
+        [{ awaitingManualRestart: true }, "awaiting-restart"],
+        [
+            { awaitingManualRestart: true, launchCompleted: true },
+            "awaiting-restart",
+        ],
+        [{ launchFailed: true }, "launch-failed"],
+        [{ launchCompleted: true, bloomRunning: true }, "bloom-running"],
+        // launch completed but Bloom just exited and the monitor has not
+        // reacted yet: transient, reported as building
+        [{ launchCompleted: true, bloomRunning: false }, "building"],
+        [{}, "building"],
+    ];
+
+    for (const [flags, expectedState] of cases) {
+        assert.equal(
+            deriveLauncherState(flags),
+            expectedState,
+            `flags ${JSON.stringify(flags)}`,
+        );
+    }
+});
+
+test("buildStatusPayload derives state and passes launcher facts through", () => {
+    const payload = buildStatusPayload({
+        launchCompleted: true,
+        bloomRunning: true,
+        watchChildAlive: true,
+        launchNumber: 3,
+        dotnetWatchPid: 111,
+        bloomProcessId: 222,
+        httpPort: 8089,
+        cdpPort: 8091,
+        vitePort: 5173,
+        label: "/BuildServer/",
+        repoRoot: "D:\\bloom\\BuildServer",
+        launcherPid: 333,
+        goPid: 444,
+        startedAt: "2026-01-01T00:00:00.000Z",
+        bloomReadyAt: 1234,
+    });
+
+    assert.equal(payload.state, "bloom-running");
+    assert.equal(payload.kind, "bloom-launcher");
+    assert.equal(payload.launchNumber, 3);
+    assert.equal(payload.bloomProcessId, 222);
+    assert.equal(payload.httpPort, 8089);
+    assert.equal(payload.cdpPort, 8091);
+    assert.equal(payload.vitePort, 5173);
+    assert.equal(payload.watchChildAlive, true);
+    assert.equal(payload.goPid, 444);
+});
+
+test("discovery file helpers roundtrip, tolerate garbage, and remove quietly", () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "bloom-launcher-test-"));
+
+    try {
+        const filePath = getDiscoveryFilePath(tempDir);
+        assert.equal(
+            filePath,
+            path.join(tempDir, "output", "bloom-launcher.json"),
+        );
+
+        // Sanity: nothing there yet.
+        assert.equal(readDiscoveryFile(filePath), undefined);
+
+        const info = { schemaVersion: 1, controlPort: 4567, launcherPid: 99 };
+        writeDiscoveryFile(filePath, info); // creates output/ as needed
+        assert.deepEqual(readDiscoveryFile(filePath), info);
+
+        writeFileSync(filePath, "not json at all");
+        assert.equal(readDiscoveryFile(filePath), undefined);
+
+        removeDiscoveryFile(filePath);
+        assert.equal(readDiscoveryFile(filePath), undefined);
+        // Removing a file that is already gone must not throw.
+        removeDiscoveryFile(filePath);
+    } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+    }
+});
+
+test("getMissingInitMarkers reports each absent init.sh product", () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "bloom-init-test-"));
+
+    try {
+        // Empty worktree: everything is missing.
+        const allMissing = getMissingInitMarkers(tempDir);
+        assert.equal(allMissing.length, 4);
+
+        // Create every marker; nothing is missing.
+        for (const relativePath of [
+            "src/BloomBrowserUI/node_modules",
+            "src/content/node_modules",
+        ]) {
+            const dirPath = path.join(tempDir, relativePath);
+            writeDiscoveryFile(path.join(dirPath, "placeholder.json"), {}); // mkdir -p + file
+        }
+        for (const relativePath of [
+            "lib/dotnet/PodcastUtilities.PortableDevices.dll",
+            "output/browser/bookPreviewBundle.js",
+        ]) {
+            writeDiscoveryFile(path.join(tempDir, relativePath), {});
+        }
+        assert.deepEqual(getMissingInitMarkers(tempDir), []);
+
+        // Remove one marker; exactly that one is reported.
+        rmSync(path.join(tempDir, "output/browser/bookPreviewBundle.js"));
+        const oneMissing = getMissingInitMarkers(tempDir);
+        assert.equal(oneMissing.length, 1);
+        assert.equal(oneMissing[0][0], "output/browser/bookPreviewBundle.js");
+    } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+    }
+});
+
+// Spins up a real control server against stubbed actions and a mutable
+// snapshot, so routing/guard behavior is tested over actual HTTP.
+const withControlServer = async (run) => {
+    const calls = [];
+    const snapshot = {
+        launchCompleted: true,
+        bloomRunning: true,
+        launchNumber: 1,
+    };
+    const settle = () => new Promise((resolve) => setTimeout(resolve, 100));
+
+    const { server, port } = await startControlServer({
+        actions: {
+            restart: () => calls.push("restart"),
+            quitBloom: () => calls.push("quitBloom"),
+            shutdownStack: () => calls.push("shutdownStack"),
+        },
+        getSnapshot: () => ({ ...snapshot }),
+        log: () => {},
+    });
+
+    try {
+        const request = async (method, route) => {
+            const response = await fetch(`http://127.0.0.1:${port}${route}`, {
+                method,
+            });
+            return { status: response.status, body: await response.json() };
+        };
+
+        await run({ request, snapshot, calls, settle });
+    } finally {
+        server.close();
+    }
+};
+
+test("GET /status reports the derived state", async () => {
+    await withControlServer(async ({ request, snapshot }) => {
+        let { status, body } = await request("GET", "/status");
+        assert.equal(status, 200);
+        assert.equal(body.state, "bloom-running");
+        assert.equal(body.launchNumber, 1);
+
+        snapshot.bloomRunning = false;
+        snapshot.awaitingManualRestart = true;
+        ({ status, body } = await request("GET", "/status"));
+        assert.equal(body.state, "awaiting-restart");
+    });
+});
+
+test("POST /restart triggers the restart action in any non-restarting state", async () => {
+    await withControlServer(async ({ request, snapshot, calls, settle }) => {
+        const { status, body } = await request("POST", "/restart");
+        assert.equal(status, 202);
+        assert.equal(body.previousState, "bloom-running");
+        await settle();
+        assert.deepEqual(calls, ["restart"]);
+
+        snapshot.restartInProgress = true;
+        const repeat = await request("POST", "/restart");
+        assert.equal(repeat.status, 200);
+        assert.match(repeat.body.note, /already in progress/);
+        await settle();
+        assert.deepEqual(
+            calls,
+            ["restart"],
+            "no second restart while restarting",
+        );
+    });
+});
+
+test("POST /start only works when awaiting-restart", async () => {
+    await withControlServer(async ({ request, snapshot, calls, settle }) => {
+        const denied = await request("POST", "/start");
+        assert.equal(denied.status, 409);
+        assert.equal(denied.body.state, "bloom-running");
+
+        snapshot.bloomRunning = false;
+        snapshot.awaitingManualRestart = true;
+        const accepted = await request("POST", "/start");
+        assert.equal(accepted.status, 202);
+        await settle();
+        assert.deepEqual(calls, ["restart"]);
+    });
+});
+
+test("POST /quit-bloom guards awaiting and restarting states", async () => {
+    await withControlServer(async ({ request, snapshot, calls, settle }) => {
+        const accepted = await request("POST", "/quit-bloom");
+        assert.equal(accepted.status, 202);
+        await settle();
+        assert.deepEqual(calls, ["quitBloom"]);
+
+        snapshot.bloomRunning = false;
+        snapshot.awaitingManualRestart = true;
+        const noop = await request("POST", "/quit-bloom");
+        assert.equal(noop.status, 200);
+        assert.match(noop.body.note, /already stopped/);
+
+        snapshot.awaitingManualRestart = false;
+        snapshot.restartInProgress = true;
+        const denied = await request("POST", "/quit-bloom");
+        assert.equal(denied.status, 409);
+        await settle();
+        assert.deepEqual(
+            calls,
+            ["quitBloom"],
+            "guards must not re-invoke quit",
+        );
+    });
+});
+
+test("POST /shutdown fires shutdownStack after the response", async () => {
+    await withControlServer(async ({ request, calls, settle }) => {
+        const { status } = await request("POST", "/shutdown");
+        assert.equal(status, 202);
+        assert.deepEqual(
+            calls,
+            [],
+            "action is deferred until response flushes",
+        );
+        await settle();
+        assert.deepEqual(calls, ["shutdownStack"]);
+    });
+});
+
+test("unknown routes get 404 and wrong methods get 405", async () => {
+    await withControlServer(async ({ request, calls, settle }) => {
+        const missing = await request("POST", "/nope");
+        assert.equal(missing.status, 404);
+
+        const statusPost = await request("POST", "/status");
+        assert.equal(statusPost.status, 405);
+
+        const restartGet = await request("GET", "/restart");
+        assert.equal(restartGet.status, 405);
+
+        await settle();
+        assert.deepEqual(calls, [], "no actions fired for rejected requests");
+    });
+});

--- a/src/BloomBrowserUI/scripts/go.mjs
+++ b/src/BloomBrowserUI/scripts/go.mjs
@@ -17,6 +17,14 @@ import {
     libraryNames,
     resolveCheckoutDir,
 } from "./devLibraries.mjs";
+import {
+    discoveryFileSchemaVersion,
+    getDiscoveryFilePath,
+    getMissingInitMarkers,
+    readDiscoveryFile,
+    removeDiscoveryFile,
+    writeDiscoveryFile,
+} from "../../../scripts/watchBloomExeControl.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -189,6 +197,141 @@ const children = [];
 // layers, and can outrace taskkill /t, so we sweep these markers on startup and shutdown.
 const linkedCheckouts = new Set();
 let isShuttingDown = false;
+
+const discoveryFilePath = getDiscoveryFilePath(repoRoot);
+const launcherStartedAt = new Date().toISOString();
+
+const isPidAlive = (pid) => {
+    if (!Number.isInteger(pid) || pid <= 0) {
+        return false;
+    }
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+// Advertises this launch from the very first moment, BEFORE the control server
+// exists (watchBloomExe.mjs later overwrites this with the full record that has
+// a controlUrl). Init + Vite startup can take minutes; without this early
+// record an agent's --ensure-running would see "nobody home" and start a
+// second stack. `phase` tells watchers what stage we're in.
+const updateLauncherPhase = (phase) => {
+    try {
+        writeDiscoveryFile(discoveryFilePath, {
+            schemaVersion: discoveryFileSchemaVersion,
+            kind: "bloom-launcher",
+            state: "starting",
+            phase,
+            goPid: process.pid,
+            repoRoot,
+            startedAt: launcherStartedAt,
+        });
+    } catch (error) {
+        console.warn(
+            `[go] Could not write launcher discovery file: ${error.message}`,
+        );
+    }
+};
+
+const warnIfAnotherLauncherActive = async () => {
+    const existing = readDiscoveryFile(discoveryFilePath);
+    if (!existing || existing.goPid === process.pid) {
+        return;
+    }
+
+    if (existing.controlUrl) {
+        try {
+            const response = await fetch(`${existing.controlUrl}/status`, {
+                signal: AbortSignal.timeout(1000),
+            });
+            if (response.ok) {
+                console.warn(
+                    `[go] Another Bloom launcher (go PID ${existing.goPid}) is already running for this worktree. Continuing; the discovery file follows the last launcher started.`,
+                );
+            }
+        } catch {
+            // Nobody home; the file is stale, which is normal after a hard kill.
+        }
+        return;
+    }
+
+    if (existing.state === "starting" && isPidAlive(existing.goPid)) {
+        console.warn(
+            `[go] Another Bloom launcher (go PID ${existing.goPid}) appears to be starting for this worktree (phase: ${existing.phase}). Continuing; the discovery file follows the last launcher started.`,
+        );
+    }
+};
+
+// On Windows, prefer Git's bash explicitly: a bare "bash" on PATH can resolve
+// to the WSL stub in System32, which cannot run our repo scripts.
+const findBash = () => {
+    if (process.platform !== "win32") {
+        return "bash";
+    }
+
+    return (
+        [
+            "C:\\Program Files\\Git\\bin\\bash.exe",
+            "C:\\Program Files (x86)\\Git\\bin\\bash.exe",
+        ].find((candidate) => fs.existsSync(candidate)) ?? "bash"
+    );
+};
+
+// Worktrees are normally initialized (./init.sh) right after creation, but a
+// skipped or half-finished init produces confusing late failures: the C# build
+// dies with CS0246, or Bloom launches fine and then can't serve bundles that
+// only `pnpm build` produces. Detect that state here — the one place every
+// launch path goes through — and run init.sh before proceeding.
+const ensureWorktreeInitialized = async () => {
+    const missing = getMissingInitMarkers(repoRoot);
+    if (missing.length === 0) {
+        return;
+    }
+
+    console.log(
+        "[go] This worktree has not been (fully) initialized. Missing:",
+    );
+    for (const [relativePath, description] of missing) {
+        console.log(`[go]   ${relativePath}  — ${description}`);
+    }
+    console.log(
+        "[go] Running ./init.sh first; this one-time step takes a few minutes...",
+    );
+    updateLauncherPhase("init");
+
+    await new Promise((resolve, reject) => {
+        const child = spawn(findBash(), ["./init.sh"], {
+            cwd: repoRoot,
+            stdio: ["ignore", "pipe", "pipe"],
+            shell: false,
+        });
+        children.push(child);
+        pipeChildOutput(child, "[init] ");
+
+        child.on("error", (error) => {
+            reject(new Error(`Could not run init.sh: ${error.message}`));
+        });
+        child.on("exit", (code) => {
+            if (code === 0) {
+                resolve();
+            } else {
+                reject(new Error(`init.sh failed with exit code ${code}.`));
+            }
+        });
+    });
+
+    const stillMissing = getMissingInitMarkers(repoRoot);
+    if (stillMissing.length > 0) {
+        throw new Error(
+            `init.sh completed but these are still missing: ${stillMissing.map(([relativePath]) => relativePath).join(", ")}`,
+        );
+    }
+
+    console.log("[go] init.sh finished; continuing the launch.");
+};
 
 const delay = (milliseconds) =>
     new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -436,6 +579,16 @@ const shutdown = async (exitCode = 0) => {
             log: (message) => console.log(`[go] ${message}`),
         });
     }
+
+    // Remove the launcher discovery file if it belongs to this stack (both the
+    // early "starting" record and watchBloomExe's full record carry our pid as
+    // goPid). watchBloomExe usually cannot clean up itself here because the
+    // tree-kill above gives it no chance to run exit handlers.
+    try {
+        if (readDiscoveryFile(discoveryFilePath)?.goPid === process.pid) {
+            removeDiscoveryFile(discoveryFilePath);
+        }
+    } catch {}
 
     process.exit(normalizedExitCode);
 };
@@ -857,6 +1010,9 @@ const resolveLinks = () => {
 };
 
 const main = async () => {
+    await warnIfAnotherLauncherActive();
+    updateLauncherPhase("starting");
+
     // Defensive reap: a prior launcher that was hard-killed (terminal closed,
     // SIGKILL, timeout) cannot run its shutdown handlers, so its Vite + watcher
     // node processes orphan. Left uncleaned, these accumulate across worktrees and
@@ -870,6 +1026,8 @@ const main = async () => {
         excludePids: [process.pid],
         log: (message) => console.log(`[go] ${message}`),
     });
+
+    await ensureWorktreeInitialized();
 
     const { bundled, iframe } = resolveLinks();
 
@@ -920,6 +1078,7 @@ const main = async () => {
     console.log(
         "[go] Launching Vite first and waiting for it to go quiet before starting Bloom.",
     );
+    updateLauncherPhase("dev-server");
 
     // AI Image Editor: either run its own dev server (linked, HMR) or stage the prebuilt
     // app for Bloom to serve, before Bloom starts.
@@ -963,6 +1122,9 @@ const main = async () => {
     console.log(
         `[go] Vite is reachable and quiet on port ${dev.port}. Starting Bloom...`,
     );
+    // watchBloomExe overwrites this with the full record (controlUrl etc.)
+    // as soon as its control server is up.
+    updateLauncherPhase("starting-bloom");
     startBloomExe(dev.port);
 };
 

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -106,6 +106,12 @@ namespace Bloom
         internal static string StartupLabel { get; private set; }
         internal static bool StartupAutomation { get; private set; }
 
+        // Control port of the dev launcher (scripts/watchBloomExe.mjs) that started
+        // this Bloom, passed as --launcher-port. When present, DevLauncher watches for
+        // pending C# changes and offers a dev-only toast that asks the launcher to
+        // rebuild and relaunch us.
+        internal static int? StartupLauncherPort { get; private set; }
+
         internal static string StartupRequestedPortSummary =>
             string.Join(
                 ", ",
@@ -113,6 +119,9 @@ namespace Bloom
                 {
                     StartupAutomation ? "automation=true" : null,
                     StartupVitePort.HasValue ? $"vitePort={StartupVitePort.Value}" : null,
+                    StartupLauncherPort.HasValue
+                        ? $"launcherPort={StartupLauncherPort.Value}"
+                        : null,
                 }.Where(value => value != null)
             );
 
@@ -757,6 +766,7 @@ namespace Bloom
             StartupVitePort = null;
             StartupLabel = null;
             StartupAutomation = false;
+            StartupLauncherPort = null;
             RunningE2eTests = false;
 
             var remainingArgs = new List<string>();
@@ -770,6 +780,14 @@ namespace Bloom
                         "--vite-port",
                         () => StartupVitePort,
                         value => StartupVitePort = value,
+                        out errorMessage
+                    )
+                    || TryHandleStartupPortArgument(
+                        args,
+                        ref i,
+                        "--launcher-port",
+                        () => StartupLauncherPort,
+                        value => StartupLauncherPort = value,
                         out errorMessage
                     )
                     || TryHandleStartupStringArgument(

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -1546,6 +1546,8 @@ window.showWorkspaceInitializationFailure = function(message) {
             );
             // Whether we showed the dialog or not we'll check for a new version in 1 minute.
             _applicationUpdateCheckTimer.Enabled = true;
+            // Dev only: does nothing unless the go.sh launcher started this Bloom.
+            DevLauncher.StartMonitoringForSourceChanges();
             SendTopBarState();
         }
 

--- a/src/BloomExe/web/DevLauncher.cs
+++ b/src/BloomExe/web/DevLauncher.cs
@@ -58,8 +58,11 @@ namespace Bloom.web
         }
 
         /// <summary>
-        /// Poll the launcher until we ask it to restart us (after which this
-        /// process is about to be replaced anyway).
+        /// Poll the launcher for the life of the process, offering the restart
+        /// toast whenever it reports pending C# changes. While a restart request
+        /// is in flight we stay quiet (this process is about to be replaced), but
+        /// the loop keeps running so a request the launcher never honors leaves
+        /// the developer with the offer again rather than with nothing.
         /// The toast is re-sent on every poll rather than only when the change
         /// flag flips, because the dev loop reloads the browser page often
         /// (Vite) and a reload wipes the toast stack. Re-sending restores it;
@@ -68,7 +71,7 @@ namespace Bloom.web
         /// </summary>
         private static async Task MonitorForSourceChangesAsync()
         {
-            while (!s_restartRequested)
+            while (true)
             {
                 await Task.Delay(kPollInterval);
 
@@ -118,22 +121,44 @@ namespace Bloom.web
 
         /// <summary>
         /// Ask the dev launcher that started us to quit Bloom, rebuild, and
-        /// relaunch it. Fire-and-forget: the launcher replies 202 and then
-        /// closes this very process as part of the restart, so there is nobody
-        /// left to care about the outcome.
+        /// relaunch it. The launcher accepts with a 202 and then closes this very
+        /// process as part of the restart, so we do not wait for the restart
+        /// itself — only for the launcher to accept the request.
         /// </summary>
         private static void RequestRestart()
         {
             Logger.WriteEvent("Dev launcher restart requested from the restart toast.");
-            // Stop polling: the launcher is about to take this process down, and
-            // re-showing the toast in the meantime would just be noise.
+            // Stop polling while the request is in flight: the launcher is about to
+            // take this process down, and re-showing the toast meanwhile is noise.
             s_restartRequested = true;
-            Task.Run(() =>
-                s_client.PostAsync(
+            Task.Run(RequestRestartAsync);
+        }
+
+        private static async Task RequestRestartAsync()
+        {
+            try
+            {
+                var response = await s_client.PostAsync(
                     $"http://127.0.0.1:{Program.StartupLauncherPort}/restart",
                     new StringContent("")
-                )
-            );
+                );
+                if (response.IsSuccessStatusCode)
+                    return;
+
+                Logger.WriteEvent(
+                    $"The dev launcher refused the restart request: {(int)response.StatusCode}."
+                );
+            }
+            catch (Exception error)
+            {
+                Logger.WriteEvent($"Could not reach the dev launcher to restart: {error.Message}");
+            }
+
+            // Nobody is going to take this Bloom down after all (the launcher is
+            // gone, or refused), and ToastService already consumed the toast's
+            // one-shot callback. Let the still-running poll loop offer the restart
+            // again rather than leaving the developer with no affordance.
+            s_restartRequested = false;
         }
     }
 }

--- a/src/BloomExe/web/DevLauncher.cs
+++ b/src/BloomExe/web/DevLauncher.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using SIL.Reporting;
+
+namespace Bloom.web
+{
+    /// <summary>
+    /// Developer-only glue between Bloom and the dev launcher (go.sh /
+    /// scripts/watchBloomExe.mjs). A launcher-started Bloom gets the launcher's
+    /// control port on the command line (--launcher-port); we poll that
+    /// launcher's /status and, once it reports that dotnet watch has seen C#
+    /// source changes since this Bloom became ready, show a non-expiring toast
+    /// whose action asks the launcher to quit Bloom, rebuild, and relaunch it.
+    ///
+    /// None of this happens for end users: without --launcher-port every method
+    /// here is a no-op.
+    /// </summary>
+    public static class DevLauncher
+    {
+        // One identity for every show event, so the browser keeps a single
+        // visible toast and ToastService reuses a single callback registration
+        // instead of accumulating one per poll.
+        private const string kRestartToastId = "dev-launcher-restart";
+
+        // Deliberately not localized; developers are the only audience.
+        private const string kRestartToastText =
+            "C# code has changed since this Bloom started. Restarting will rebuild and relaunch it.";
+        private const string kRestartToastActionLabel = "Restart";
+
+        private static readonly TimeSpan kPollInterval = TimeSpan.FromSeconds(5);
+
+        // These are tiny loopback calls; a launcher that does not answer
+        // promptly is effectively dead, hence the short timeout.
+        private static readonly HttpClient s_client = new HttpClient
+        {
+            Timeout = TimeSpan.FromSeconds(5),
+        };
+
+        private static bool s_monitoring;
+        private static bool s_restartRequested;
+
+        /// <summary>
+        /// Begin watching the dev launcher for pending C# changes, showing the
+        /// restart toast whenever there are some. Safe to call more than once
+        /// (only the first call does anything), and a no-op unless the dev
+        /// launcher started this Bloom.
+        /// </summary>
+        public static void StartMonitoringForSourceChanges()
+        {
+            if (s_monitoring || Program.StartupLauncherPort == null)
+                return;
+
+            s_monitoring = true;
+            // Fire and forget: this loop lives as long as the process does.
+            Task.Run(MonitorForSourceChangesAsync);
+        }
+
+        /// <summary>
+        /// Poll the launcher until we ask it to restart us (after which this
+        /// process is about to be replaced anyway).
+        /// The toast is re-sent on every poll rather than only when the change
+        /// flag flips, because the dev loop reloads the browser page often
+        /// (Vite) and a reload wipes the toast stack. Re-sending restores it;
+        /// while the toast is still on screen the browser treats the repeat as
+        /// a duplicate and leaves the existing one alone.
+        /// </summary>
+        private static async Task MonitorForSourceChangesAsync()
+        {
+            while (!s_restartRequested)
+            {
+                await Task.Delay(kPollInterval);
+
+                if (!s_restartRequested && await HasLauncherSeenSourceChangesAsync())
+                    ShowRestartToast();
+            }
+        }
+
+        /// <summary>
+        /// Ask the launcher whether dotnet watch has seen C# source changes
+        /// since this Bloom reported ready — i.e. whether a restart would
+        /// actually incorporate .NET changes. False if the launcher is gone or
+        /// does not answer.
+        /// </summary>
+        private static async Task<bool> HasLauncherSeenSourceChangesAsync()
+        {
+            try
+            {
+                var body = await s_client.GetStringAsync(
+                    $"http://127.0.0.1:{Program.StartupLauncherPort}/status"
+                );
+                return JObject.Parse(body)["sourceChangedSinceReady"]?.Value<bool>() == true;
+            }
+            catch (Exception)
+            {
+                // The launcher has probably exited; nothing to offer.
+                return false;
+            }
+        }
+
+        private static void ShowRestartToast()
+        {
+            ToastService.ShowToast(
+                ToastType.Warning,
+                text: kRestartToastText,
+                action: new ToastAction
+                {
+                    Label = kRestartToastActionLabel,
+                    Callback = RequestRestart,
+                },
+                toastId: kRestartToastId
+            );
+        }
+
+        /// <summary>
+        /// Ask the dev launcher that started us to quit Bloom, rebuild, and
+        /// relaunch it. Fire-and-forget: the launcher replies 202 and then
+        /// closes this very process as part of the restart, so there is nobody
+        /// left to care about the outcome.
+        /// </summary>
+        private static void RequestRestart()
+        {
+            Logger.WriteEvent("Dev launcher restart requested from the restart toast.");
+            // Stop polling: the launcher is about to take this process down, and
+            // re-showing the toast in the meantime would just be noise.
+            s_restartRequested = true;
+            Task.Run(() =>
+                s_client.PostAsync(
+                    $"http://127.0.0.1:{Program.StartupLauncherPort}/restart",
+                    new StringContent("")
+                )
+            );
+        }
+    }
+}

--- a/src/BloomExe/web/DevLauncher.cs
+++ b/src/BloomExe/web/DevLauncher.cs
@@ -31,7 +31,7 @@ namespace Bloom.web
 
         private static readonly TimeSpan kPollInterval = TimeSpan.FromSeconds(5);
 
-        // These are tiny loopback calls; a launcher that does not answer
+        // These are tiny loopback calls to the launcher; one that does not answer
         // promptly is effectively dead, hence the short timeout.
         private static readonly HttpClient s_client = new HttpClient
         {
@@ -101,8 +101,11 @@ namespace Bloom.web
 
         private static void ShowRestartToast()
         {
+            // Update, not Warning: nothing is wrong, there is just a newer build
+            // waiting — the same message Bloom's own "new version downloaded"
+            // toast carries.
             ToastService.ShowToast(
-                ToastType.Warning,
+                ToastType.Update,
                 text: kRestartToastText,
                 action: new ToastAction
                 {

--- a/src/BloomExe/web/controllers/CommonApi.cs
+++ b/src/BloomExe/web/controllers/CommonApi.cs
@@ -277,6 +277,9 @@ namespace Bloom.web.controllers
                     cdpPort,
                     vitePort,
                     cdpOrigin = cdpPort.HasValue ? $"http://localhost:{cdpPort.Value}" : null,
+                    // Control port of the dev launcher that started us (null when not
+                    // launched via go.sh); see .github/skills/bloom-automation.
+                    launcherControlPort = Program.StartupLauncherPort,
                 }
             );
         }

--- a/src/BloomTests/Book/TestBook.cs
+++ b/src/BloomTests/Book/TestBook.cs
@@ -38,16 +38,16 @@ namespace BloomTests.Book
             BookPath = Path.Combine(_folder.FolderPath, testName + ".htm");
             File.WriteAllText(BookPath, content);
             var settings = CreateDefaultCollectionsSettings();
-            var codeBaseDir = BloomFileLocator.GetCodeBaseFolder();
             // This is minimal...if the content doesn't specify xmatter Bloom defaults to Traditional
             // and needs the file locator to know this folder so it can find it.
             // May later need to include more folders or allow the individual tests to do so.
+            // Ask BloomFileLocator where the shipping xmatter is rather than hopping a fixed
+            // number of "../" from the test assembly: the assembly's depth below the repo
+            // root differs in the isolated tree the agent build wrapper uses, and a wrong
+            // path here surfaces as the baffling "It should not be possible to get an error
+            // here, because the collection verifies its xmatter name" from XMatterHelper.
             var locator = new FileLocator(
-                new string[]
-                {
-                    codeBaseDir
-                        + $"{BloomFileLocatorTests.kRelativePathToBrowserFolder}/templates/xMatter",
-                }
+                new string[] { BloomFileLocator.GetFactoryXMatterDirectory() }
             );
             var storage = new BookStorage(BookFolder, locator, new BookRenamedEvent(), settings);
             // very minimal...enhance if we need to test something that can really find source collections.

--- a/src/BloomTests/Book/XMatterHelperTests.cs
+++ b/src/BloomTests/Book/XMatterHelperTests.cs
@@ -23,8 +23,37 @@ namespace BloomTests.Book
         public void OneTimeSetup()
         {
             _factoryXMatter = BloomFileLocator.GetFactoryXMatterDirectory();
-            var codeBaseDir = BloomFileLocator.GetCodeBaseFolder();
-            _testXmatter = $"{codeBaseDir}/../../../src/BloomTests/xMatter";
+            _testXmatter = FindTestXMatterDirectory();
+        }
+
+        /// <summary>
+        /// Locates the xmatter packs checked in at src/BloomTests/xMatter (Test-XMatter
+        /// and Test-Device-XMatter), which several tests here use to exercise xmatter
+        /// selection without depending on the shipping packs.
+        /// Found by walking up from the test assembly rather than by a fixed number of
+        /// "../" steps: the assembly sits three levels below the repo root in a normal
+        /// build (output/Tests/Debug/AnyCPU) but four in the isolated tree the agent
+        /// build wrapper uses (output/agent/&lt;key&gt;/bin), and a hard-coded depth
+        /// silently resolved to a nonexistent folder there.
+        /// </summary>
+        private static string FindTestXMatterDirectory()
+        {
+            const string relativePath = "src/BloomTests/xMatter";
+            var directory = new DirectoryInfo(BloomFileLocator.GetCodeBaseFolder());
+
+            while (directory != null)
+            {
+                var candidate = Path.Combine(directory.FullName, relativePath);
+                if (Directory.Exists(candidate))
+                    return candidate;
+
+                directory = directory.Parent;
+            }
+
+            Assert.Fail(
+                $"Could not find {relativePath} above {BloomFileLocator.GetCodeBaseFolder()}."
+            );
+            return null; // unreachable; keeps the compiler happy
         }
 
         [SetUp]


### PR DESCRIPTION
Developer-tooling only: nothing here changes what end users see.

## 1. A control API for the dev launcher

`./go.sh`'s launcher (`scripts/watchBloomExe.mjs`) now runs a loopback-only HTTP control
server, so agents (and the developer) can drive the dev stack instead of someone having to
press Enter in the launcher's terminal:

- `GET /status`, `POST /restart`, `POST /start`, `POST /quit-bloom`, `POST /shutdown`
- discovered via `output/bloom-launcher.json` and a `BLOOM_LAUNCHER_READY` line
- server + state derivation live in the new `scripts/watchBloomExeControl.mjs`, unit-tested in
  `scripts/watchBloomExeControl.test.mjs`
- agents drive it through `.github/skills/bloom-automation/launcherControl.mjs`
  (`--status`, `--restart`, `--ensure-running`, `--wait-ready`, `--quit-bloom`, `--shutdown`)

The launcher now also distinguishes **"dotnet watch is rebuilding Bloom"** from **"the human
closed Bloom"**, using dotnet watch's file-changed output: a rebuild keeps the stack alive,
while closing Bloom's window tears the whole stack down (launcher, dotnet watch, Vite) so an
idle stack stops holding memory.

## 2. An in-app restart toast instead of a top-bar button

Bloom gets the launcher's control port as `--launcher-port`. The new
`src/BloomExe/web/DevLauncher.cs` polls the launcher's `/status` and, once
`sourceChangedSinceReady` is true — i.e. a restart would actually incorporate .NET changes —
shows a **non-expiring toast** whose `Restart` action asks the launcher to quit Bloom, rebuild,
and relaunch it.

This uses the existing production toast path (`ToastService` → `ToastHost`), so:

- the affordance lives in one place instead of being wired into all three tabs' top bars;
- the browser needs no launcher-specific API endpoints. An earlier iteration of this branch had
  a `LauncherRestartButton.tsx` plus `common/launcherInfo` / `common/launcherStatus` /
  `common/launcherRestart`; those are gone, their logic now in `DevLauncher.cs`.
  `common/instanceInfo` still reports `launcherControlPort` for the automation skills.

Verified live: restarted via `launcherControl.mjs --restart`, touched a `.cs` file, and the
toast appeared within the poll interval; clicking `Restart` hands off to the launcher.

## Docs

`.claude/skills/run-bloom/SKILL.md` and `.github/skills/bloom-automation/SKILL.md` document the
control API, the teardown-on-close behavior, and the toast.


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8107)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8107)
<!-- Reviewable:end -->
