### PR TITLE
Stop publishing hanging forever on the page-checks browser (BL-16612)

### DIFF
--- a/src/BloomExe/Publish/OffScreenBrowser.cs
+++ b/src/BloomExe/Publish/OffScreenBrowser.cs
@@ -38,10 +38,9 @@ namespace Bloom.Publish
     /// Blocking here cannot deadlock on the message loop, since the thread that blocks is never the thread
     /// that must pump. But it is NOT immune to deadlock in general: navigation asks BloomServer for the page,
     /// so a caller that blocks while holding the last free BloomServer worker would be waiting for a page
-    /// that nobody is left to serve. Two things address that (BL-16612): every blocking call is bounded by a
-    /// backstop timeout and throws <see cref="OffScreenBrowserTimeoutException"/> rather than waiting
-    /// forever, and we register the block with BloomServer so its own starvation logic can see this thread
-    /// at all (see RunAndBlock).
+    /// that nobody is left to serve. Two things guard against that (BL-16612): we register the block with
+    /// BloomServer so it can add a worker (see RunAndBlock), and every blocking call is bounded by a backstop
+    /// timeout and throws <see cref="OffScreenBrowserTimeoutException"/> rather than waiting forever.
     ///
     /// The browser is a real <see cref="WebView2Browser"/> (not a bare WebView2 control) so navigation goes
     /// through Bloom's BloomServer/in-memory-file plumbing and resolves CSS, fonts, and relative paths.
@@ -344,11 +343,16 @@ namespace Bloom.Publish
             // Tell BloomServer that this thread is about to block, in case it is one of its workers.
             // BloomServer does NOT work that out for itself (see RegisterThreadBlocking): a worker that
             // blocks without registering is invisible to the logic in QueueRequest that adds a worker when
-            // every existing one is blocked. Thread stacks from the 2026-08-03 nightly hang show exactly
-            // that blind spot: six workers, five of them registered as blocked on the API lock and the
-            // sixth -- this one -- blocked here without registering, so the top-up test asked 5 >= 6 and
-            // said no while the true state was 6 of 6 unavailable (BL-16612).
+            // every existing one is blocked. That matters a great deal here, because what we are waiting
+            // for is a browser navigating to a page that BloomServer itself has to serve. If every worker
+            // is blocked and none is left to serve that page, the navigation can never complete and we
+            // would be waiting for something that cannot happen (BL-16612).
+            //
+            // NoteWorkerPoolHeadroom is pure measurement: it records how close the pool came to having
+            // nothing left to serve requests, which is what makes the starvation theory testable on a
+            // healthy run instead of only after a failure.
             var server = BloomServer._theOneInstance;
+            server?.NoteWorkerPoolHeadroom();
             server?.RegisterThreadBlocking();
             try
             {
@@ -376,7 +380,8 @@ namespace Bloom.Publish
                     // the browser, so the browser is now in an unknown state: the caller must discard it
                     // (StartFreshBrowser) or stop using this instance.
                     throw new OffScreenBrowserTimeoutException(
-                        $"The off-screen browser did not respond within {effectiveTimeoutMs}ms."
+                        $"The off-screen browser did not respond within {effectiveTimeoutMs}ms. "
+                            + BloomServer.GetWorkerPoolDiagnostics()
                     );
                 }
                 return tcs.Task.GetAwaiter().GetResult();

--- a/src/BloomExe/Publish/OffScreenBrowser.cs
+++ b/src/BloomExe/Publish/OffScreenBrowser.cs
@@ -352,9 +352,14 @@ namespace Bloom.Publish
             // the request that would unblock us can already be sitting in the queue by the time we get here.
             var server = BloomServer._theOneInstance;
             server?.NoteWorkerPoolHeadroom();
-            server?.RegisterThreadBlockingAndEnsureAFreeWorker();
+            // Register INSIDE the try, and unregister only if we got that far, so the pairing is guaranteed
+            // by structure rather than by an argument about what can throw. A leaked count would make the
+            // server permanently believe a worker is blocked.
+            var registered = false;
             try
             {
+                server?.RegisterThreadBlockingAndEnsureAFreeWorker();
+                registered = true;
                 bool completed;
                 try
                 {
@@ -387,7 +392,8 @@ namespace Bloom.Publish
             }
             finally
             {
-                server?.RegisterThreadUnblocked();
+                if (registered)
+                    server?.RegisterThreadUnblocked();
             }
         }
 

--- a/src/BloomExe/Publish/OffScreenBrowser.cs
+++ b/src/BloomExe/Publish/OffScreenBrowser.cs
@@ -38,9 +38,10 @@ namespace Bloom.Publish
     /// Blocking here cannot deadlock on the message loop, since the thread that blocks is never the thread
     /// that must pump. But it is NOT immune to deadlock in general: navigation asks BloomServer for the page,
     /// so a caller that blocks while holding the last free BloomServer worker would be waiting for a page
-    /// that nobody is left to serve. What keeps that survivable (BL-16612) is that every blocking call is
-    /// bounded by a backstop timeout and throws <see cref="OffScreenBrowserTimeoutException"/> rather than
-    /// waiting forever.
+    /// that nobody is left to serve. Two things address that (BL-16612): every blocking call is bounded by a
+    /// backstop timeout and throws <see cref="OffScreenBrowserTimeoutException"/> rather than waiting
+    /// forever, and we register the block with BloomServer so its own starvation logic can see this thread
+    /// at all (see RunAndBlock).
     ///
     /// The browser is a real <see cref="WebView2Browser"/> (not a bare WebView2 control) so navigation goes
     /// through Bloom's BloomServer/in-memory-file plumbing and resolves CSS, fonts, and relative paths.
@@ -340,34 +341,50 @@ namespace Bloom.Publish
                 null
             );
 
-            bool completed;
+            // Tell BloomServer that this thread is about to block, in case it is one of its workers.
+            // BloomServer does NOT work that out for itself (see RegisterThreadBlocking): a worker that
+            // blocks without registering is invisible to the logic in QueueRequest that adds a worker when
+            // every existing one is blocked. Thread stacks from the 2026-08-03 nightly hang show exactly
+            // that blind spot: six workers, five of them registered as blocked on the API lock and the
+            // sixth -- this one -- blocked here without registering, so the top-up test asked 5 >= 6 and
+            // said no while the true state was 6 of 6 unavailable (BL-16612).
+            var server = BloomServer._theOneInstance;
+            server?.RegisterThreadBlocking();
             try
             {
-                completed = tcs.Task.Wait(effectiveTimeoutMs);
+                bool completed;
+                try
+                {
+                    completed = tcs.Task.Wait(effectiveTimeoutMs);
+                }
+                catch (AggregateException)
+                {
+                    // The work threw. Fall through to GetResult() below, which rethrows the original
+                    // exception rather than the AggregateException that Wait wraps it in.
+                    completed = true;
+                }
+                if (!completed)
+                {
+                    // Nobody will ever await the task we are abandoning, so observe its exception here;
+                    // otherwise a later failure on it resurfaces as an unobserved TaskException. We already
+                    // have the diagnosis we need, so there is nothing else to do with it.
+                    _ = tcs.Task.ContinueWith(
+                        t => _ = t.Exception,
+                        TaskContinuationOptions.OnlyOnFaulted
+                    );
+                    // The posted work is still queued or running on the dedicated thread and may yet touch
+                    // the browser, so the browser is now in an unknown state: the caller must discard it
+                    // (StartFreshBrowser) or stop using this instance.
+                    throw new OffScreenBrowserTimeoutException(
+                        $"The off-screen browser did not respond within {effectiveTimeoutMs}ms."
+                    );
+                }
+                return tcs.Task.GetAwaiter().GetResult();
             }
-            catch (AggregateException)
+            finally
             {
-                // The work threw. Fall through to GetResult() below, which rethrows the original
-                // exception rather than the AggregateException that Wait wraps it in.
-                completed = true;
+                server?.RegisterThreadUnblocked();
             }
-            if (!completed)
-            {
-                // Nobody will ever await the task we are abandoning, so observe its exception here;
-                // otherwise a later failure on it resurfaces as an unobserved TaskException. We already
-                // have the diagnosis we need, so there is nothing else to do with it.
-                _ = tcs.Task.ContinueWith(
-                    t => _ = t.Exception,
-                    TaskContinuationOptions.OnlyOnFaulted
-                );
-                // The posted work is still queued or running on the dedicated thread and may yet touch
-                // the browser, so the browser is now in an unknown state: the caller must discard it
-                // (StartFreshBrowser) or stop using this instance.
-                throw new OffScreenBrowserTimeoutException(
-                    $"The off-screen browser did not respond within {effectiveTimeoutMs}ms."
-                );
-            }
-            return tcs.Task.GetAwaiter().GetResult();
         }
 
         /// <summary>

--- a/src/BloomExe/Publish/OffScreenBrowser.cs
+++ b/src/BloomExe/Publish/OffScreenBrowser.cs
@@ -31,10 +31,16 @@ namespace Bloom.Publish
     /// message loop, and THAT thread — not the caller — services the browser's callbacks. So a caller can
     /// simply block for a result. It never has to pump the MAIN UI message loop the way
     /// Browser.RunJavascriptWithStringResult_Sync_Dangerous does (Application.DoEvents), which lets unrelated
-    /// user commands run in the middle of the call stack — the reentrancy blamed for BL-12614 / BL-13120. And
-    /// it never deadlocks, because the thread that blocks is never the thread that must pump. Async
-    /// continuations for the browser's operations run on the owning thread, so the WebView2 is only ever
-    /// touched by that thread.
+    /// user commands run in the middle of the call stack — the reentrancy blamed for BL-12614 / BL-13120.
+    /// Async continuations for the browser's operations run on the owning thread, so the WebView2 is only
+    /// ever touched by that thread.
+    ///
+    /// Blocking here cannot deadlock on the message loop, since the thread that blocks is never the thread
+    /// that must pump. But it is NOT immune to deadlock in general: navigation asks BloomServer for the page,
+    /// so a caller that blocks while holding the last free BloomServer worker would be waiting for a page
+    /// that nobody is left to serve. What keeps that survivable (BL-16612) is that every blocking call is
+    /// bounded by a backstop timeout and throws <see cref="OffScreenBrowserTimeoutException"/> rather than
+    /// waiting forever.
     ///
     /// The browser is a real <see cref="WebView2Browser"/> (not a bare WebView2 control) so navigation goes
     /// through Bloom's BloomServer/in-memory-file plumbing and resolves CSS, fonts, and relative paths.
@@ -62,6 +68,25 @@ namespace Bloom.Publish
 
         private const int kInitTimeoutMs = 20000;
 
+        // Longest we will block a caller waiting for work we posted to the dedicated thread. This is a
+        // BACKSTOP, not a normal budget: the operations that can legitimately take a while carry their own
+        // timeout (Navigate, and the browser creation inside StartFreshBrowser) and pass it plus a margin,
+        // so the only way to hit this is a WebView2 — or the message loop that services it — that has
+        // stopped making progress altogether. We used to block forever in that case, which wedged the
+        // calling thread permanently; when the caller was a BloomServer worker that wedged publishing with
+        // it, and the process never recovered (BL-16612).
+        private const int kDefaultBlockTimeoutMs = 30000;
+
+        // Added to an operation's own timeout to get the backstop for waiting on it, so a normal timeout
+        // (which makes the operation return by itself) always wins over the backstop.
+        private const int kBlockTimeoutMarginMs = 15000;
+
+        /// <summary>
+        /// Test hook: shortens the backstop of <see cref="kDefaultBlockTimeoutMs"/> so a test can prove it
+        /// fires without having to wedge a real browser for 30 seconds. Never set in production.
+        /// </summary>
+        internal int? DefaultBlockTimeoutMsForTests;
+
         /// <summary>
         /// Starts the dedicated thread and blocks until its WebView2 is initialized and ready to navigate.
         /// </summary>
@@ -70,7 +95,17 @@ namespace Bloom.Publish
             _thread = new Thread(ThreadMain) { IsBackground = true, Name = "OffScreenBrowser" };
             _thread.SetApartmentState(ApartmentState.STA);
             _thread.Start();
-            _ready.Wait();
+            // Bounded for the same reason as RunAndBlock: InitializeAsync enforces kInitTimeoutMs itself,
+            // but only once its message loop is actually pumping. If the thread never gets that far, _ready
+            // is never set, and an unbounded wait here would hang whoever asked for the browser.
+            if (!_ready.Wait(kInitTimeoutMs + kBlockTimeoutMarginMs))
+            {
+                Dispose();
+                throw new OffScreenBrowserTimeoutException(
+                    $"The off-screen browser's thread did not finish initializing within "
+                        + $"{kInitTimeoutMs + kBlockTimeoutMarginMs}ms."
+                );
+            }
             if (_startupError != null)
             {
                 // Initialization failed (e.g. the WebView2 readiness timeout). The dedicated thread may still be
@@ -165,6 +200,9 @@ namespace Bloom.Publish
         /// timeout or cancellation — matching NavigateAndWaitTillDone's contract for the caller. The source
         /// controls how BloomServer serves the page (e.g. JustCheckingPage swaps videos for placeholders,
         /// Frame serves the page as-is for the editing bundle).
+        ///
+        /// Throws <see cref="OffScreenBrowserTimeoutException"/> in the separate case where the browser stops
+        /// responding altogether, so it cannot even tell us it timed out.
         /// </summary>
         public bool Navigate(
             HtmlDom htmlDom,
@@ -173,7 +211,12 @@ namespace Bloom.Publish
             InMemoryHtmlFileSource source = InMemoryHtmlFileSource.JustCheckingPage
         )
         {
-            return RunAndBlock(() => NavigateAsync(htmlDom, timeoutMs, cancelCheck, source));
+            // NavigateAsync enforces timeoutMs and returns false by itself, so the backstop only has to be
+            // comfortably larger than that.
+            return RunAndBlock(
+                () => NavigateAsync(htmlDom, timeoutMs, cancelCheck, source),
+                timeoutMs + kBlockTimeoutMarginMs
+            );
         }
 
         /// <summary>
@@ -258,19 +301,29 @@ namespace Bloom.Publish
         /// </summary>
         public void StartFreshBrowser()
         {
-            RunAndBlock(async () =>
-            {
-                _browser?.Dispose();
-                await CreateInnerBrowserAndWaitReadyAsync();
-                return true;
-            });
+            RunAndBlock(
+                async () =>
+                {
+                    _browser?.Dispose();
+                    await CreateInnerBrowserAndWaitReadyAsync();
+                    return true;
+                },
+                // CreateInnerBrowserAndWaitReadyAsync enforces kInitTimeoutMs itself.
+                kInitTimeoutMs + kBlockTimeoutMarginMs
+            );
         }
 
         // Marshals an async function onto the dedicated thread and BLOCKS the calling thread for its result.
         // Blocking is safe here precisely because the dedicated thread — not the caller — pumps the messages
         // that let the awaited WebView2 operations complete.
-        private T RunAndBlock<T>(Func<Task<T>> asyncFunc)
+        //
+        // timeoutMs is the backstop for the wait (see kDefaultBlockTimeoutMs): callers whose operation has
+        // its own timeout pass that plus kBlockTimeoutMarginMs, so the operation's own timeout normally
+        // wins and this only fires when the browser has stopped making progress entirely.
+        private T RunAndBlock<T>(Func<Task<T>> asyncFunc, int? timeoutMs = null)
         {
+            var effectiveTimeoutMs =
+                timeoutMs ?? DefaultBlockTimeoutMsForTests ?? kDefaultBlockTimeoutMs;
             var tcs = new TaskCompletionSource<T>();
             _ctx.Post(
                 async _ =>
@@ -286,6 +339,34 @@ namespace Bloom.Publish
                 },
                 null
             );
+
+            bool completed;
+            try
+            {
+                completed = tcs.Task.Wait(effectiveTimeoutMs);
+            }
+            catch (AggregateException)
+            {
+                // The work threw. Fall through to GetResult() below, which rethrows the original
+                // exception rather than the AggregateException that Wait wraps it in.
+                completed = true;
+            }
+            if (!completed)
+            {
+                // Nobody will ever await the task we are abandoning, so observe its exception here;
+                // otherwise a later failure on it resurfaces as an unobserved TaskException. We already
+                // have the diagnosis we need, so there is nothing else to do with it.
+                _ = tcs.Task.ContinueWith(
+                    t => _ = t.Exception,
+                    TaskContinuationOptions.OnlyOnFaulted
+                );
+                // The posted work is still queued or running on the dedicated thread and may yet touch
+                // the browser, so the browser is now in an unknown state: the caller must discard it
+                // (StartFreshBrowser) or stop using this instance.
+                throw new OffScreenBrowserTimeoutException(
+                    $"The off-screen browser did not respond within {effectiveTimeoutMs}ms."
+                );
+            }
             return tcs.Task.GetAwaiter().GetResult();
         }
 
@@ -316,5 +397,17 @@ namespace Bloom.Publish
             }
             _thread.Join(5000);
         }
+    }
+
+    /// <summary>
+    /// Thrown when the off-screen browser stops making progress: it did not finish initializing, or work we
+    /// posted to its thread did not come back within the backstop timeout. Distinct from a plain
+    /// ApplicationException so callers can tell "the browser is wedged" (retry on a fresh one, or fail the
+    /// operation) from an error thrown by the script or navigation itself.
+    /// </summary>
+    public class OffScreenBrowserTimeoutException : ApplicationException
+    {
+        public OffScreenBrowserTimeoutException(string message)
+            : base(message) { }
     }
 }

--- a/src/BloomExe/Publish/OffScreenBrowser.cs
+++ b/src/BloomExe/Publish/OffScreenBrowser.cs
@@ -346,14 +346,13 @@ namespace Bloom.Publish
             // every existing one is blocked. That matters a great deal here, because what we are waiting
             // for is a browser navigating to a page that BloomServer itself has to serve. If every worker
             // is blocked and none is left to serve that page, the navigation can never complete and we
-            // would be waiting for something that cannot happen (BL-16612).
-            //
-            // NoteWorkerPoolHeadroom is pure measurement: it records how close the pool came to having
-            // nothing left to serve requests, which is what makes the starvation theory testable on a
-            // healthy run instead of only after a failure.
+            // would be waiting for something that cannot happen (BL-16612). Registering lets BloomServer
+            // spin up the worker that breaks the cycle — and we use the ...AndEnsureAFreeWorker variant
+            // because the plain one only takes effect when the NEXT request arrives, which may be never:
+            // the request that would unblock us can already be sitting in the queue by the time we get here.
             var server = BloomServer._theOneInstance;
             server?.NoteWorkerPoolHeadroom();
-            server?.RegisterThreadBlocking();
+            server?.RegisterThreadBlockingAndEnsureAFreeWorker();
             try
             {
                 bool completed;

--- a/src/BloomExe/Publish/PublishHelper.cs
+++ b/src/BloomExe/Publish/PublishHelper.cs
@@ -174,6 +174,11 @@ namespace Bloom.Publish
                     }
                 }
             }
+            // Deliberately NOT localized, per the guidance in .github/skills/xlf-strings: strings seen only
+            // when something has gone wrong internally are left in English. Reaching here means the
+            // off-screen browser failed twice in a row, which is a fault condition rather than a normal
+            // outcome -- and keeping the wording identical to the log entry above is what makes a user's
+            // report match what we read in their log.
             throw new ApplicationException(
                 "Bloom could not determine which parts of this book are visible, so it stopped rather than "
                     + "publish a book with the wrong content or missing fonts. See the log for details."

--- a/src/BloomExe/Publish/PublishHelper.cs
+++ b/src/BloomExe/Publish/PublishHelper.cs
@@ -77,6 +77,83 @@ namespace Bloom.Publish
             return _pageChecksBrowser ??= new OffScreenBrowser();
         }
 
+        // How long to give the off-screen browser to navigate to the page-checks DOM. This is the same
+        // budget as the literal it replaced; what covers a browser that stumbles is the retry in
+        // TryGetPageChecksInfo, not a longer wait.
+        private const int kPageChecksNavigationTimeoutMs = 10000;
+
+        private const int kPageChecksAttempts = 2;
+
+        /// <summary>
+        /// Navigate the off-screen page-checks browser to the given DOM and return, in elementsInfo, the JSON
+        /// display and font information for its elements. Returns false (with no information) only when a newer
+        /// PublishHelper has superseded us and the caller should simply stop. Throws if the browser will not
+        /// give us the information at all.
+        /// </summary>
+        /// <remarks>
+        /// We used to log a failed navigation and carry on regardless (BL-7892). That is worse than it sounds:
+        /// with no element information, IsDisplayed() answers "displayed" for everything and FontsUsed comes
+        /// back empty, so a BloomPUB silently keeps content that should have been stripped and embeds none of
+        /// the fonts it needs. Only epub publishing noticed, because IsDisplayed throws for it. So now we retry
+        /// once on a clean renderer — which also covers a browser left in an unknown state by a timeout — and
+        /// if that fails too we fail the publish rather than quietly produce a bad book (BL-16612).
+        /// </remarks>
+        private bool TryGetPageChecksInfo(HtmlDom displayDom, out string elementsInfo)
+        {
+            elementsInfo = null;
+            var browser = GetOrCreatePageChecksBrowser();
+            for (var attempt = 1; attempt <= kPageChecksAttempts; attempt++)
+            {
+                string whatWentWrong;
+                try
+                {
+                    if (
+                        browser.Navigate(
+                            displayDom,
+                            kPageChecksNavigationTimeoutMs,
+                            () => this != _latestInstance
+                        )
+                    )
+                    {
+                        elementsInfo = browser.RunJavascript(
+                            GetElementDisplayAndFontInfoJavascript
+                        );
+                        if (!string.IsNullOrEmpty(elementsInfo))
+                            return true;
+                        whatWentWrong = "the page checks script returned nothing";
+                    }
+                    else
+                    {
+                        // Navigate also returns false when our cancelCheck fires, which is not a failure.
+                        if (this != _latestInstance)
+                            return false;
+                        whatWentWrong =
+                            $"navigation did not complete within {kPageChecksNavigationTimeoutMs}ms";
+                    }
+                }
+                catch (OffScreenBrowserTimeoutException e)
+                {
+                    // As above: if a newer publish superseded us, this is not a failure worth retrying or
+                    // reporting — whatever we produced is being discarded anyway.
+                    if (this != _latestInstance)
+                        return false;
+                    whatWentWrong = e.Message;
+                }
+
+                var message =
+                    $"Page checks failed on attempt {attempt} of {kPageChecksAttempts}: {whatWentWrong}";
+                Debug.WriteLine(message);
+                Logger.WriteEvent(message);
+
+                if (attempt < kPageChecksAttempts)
+                    browser.StartFreshBrowser();
+            }
+            throw new ApplicationException(
+                "Bloom could not determine which parts of this book are visible, so it stopped rather than "
+                    + "publish a book with the wrong content or missing fonts. See the log for details."
+            );
+        }
+
         // The only reason this isn't just ../* is performance. We could change it.  It comes from the need to actually
         // remove any elements that the style rules would hide, because epub readers ignore visibility settings.
         private const string kSelectThingsThatCanBeHidden = ".//div | .//img";
@@ -428,25 +505,10 @@ namespace Bloom.Publish
                 epubMaker.AddEpubVisibilityStylesheetAndClass(displayDom);
             if (this != _latestInstance)
                 return;
-            if (
-                !GetOrCreatePageChecksBrowser()
-                    .Navigate(displayDom, 10000, () => this != _latestInstance)
-            )
-            {
-                // We started having problems with timeouts here (BL-7892).
-                // We may as well carry on. We only need the browser to have navigated so calls to IsDisplayed(elt)
-                // below will give accurate answers. Even if the browser hasn't gotten that far yet (e.g., in
-                // a long document), it may stay ahead of us. We'll report a failure (currently only for epubs, see above)
-                // if we actually can't find the element we need in IsDisplayed().
-                Debug.WriteLine("Failed to navigate fully to RemoveUnwantedContentInternal DOM");
-                Logger.WriteEvent("Failed to navigate fully to RemoveUnwantedContentInternal DOM");
-            }
-            if (this != _latestInstance)
-                return;
 
             // Get and store the display and font information for each element in the DOM.
-            var elementsInfo = GetOrCreatePageChecksBrowser()
-                .RunJavascript(GetElementDisplayAndFontInfoJavascript);
+            if (!TryGetPageChecksInfo(displayDom, out var elementsInfo))
+                return; // a newer publish superseded us; nothing left to do
             var rawInfo = Newtonsoft.Json.JsonConvert.DeserializeObject<ElementInfoArray>(
                 elementsInfo
             );
@@ -505,8 +567,10 @@ namespace Bloom.Publish
                         // This is necessary for retaining any associated audio files to play.
                         // (If they are empty, they won't have any audio and may trigger embedding an unneeded font.)
                         // See https://issues.bloomlibrary.org/youtrack/issue/BL-7237.
-                        // As noted above, if the displayDom is not sufficiently loaded for a definitive
-                        // answer to IsDisplayed, we will throw when making epubs but not for bloom reader.
+                        // TryGetPageChecksInfo has already made sure we have display information, so an
+                        // element missing from it now is an individual oddity rather than a wholesale
+                        // failure to load: IsDisplayed throws for that when making epubs but not for
+                        // bloom reader.
                         if (
                             !IsDisplayed(elt, epubMaker != null) && !IsNonEmptyImageDescription(elt)
                         )

--- a/src/BloomExe/Publish/PublishHelper.cs
+++ b/src/BloomExe/Publish/PublishHelper.cs
@@ -157,7 +157,22 @@ namespace Bloom.Publish
                 Logger.WriteEvent(message);
 
                 if (attempt < kPageChecksAttempts)
-                    browser.StartFreshBrowser();
+                {
+                    // Asking an unresponsive browser for a clean renderer can itself time out -- this is the
+                    // same wedged browser, after all. Left uncaught that would skip the retry entirely and
+                    // surface a technical timeout instead of the explanation below, in exactly the hang this
+                    // retry exists for. So swallow it and let the loop reach its own verdict.
+                    try
+                    {
+                        browser.StartFreshBrowser();
+                    }
+                    catch (OffScreenBrowserTimeoutException e)
+                    {
+                        Logger.WriteEvent(
+                            "Could not start a fresh page-checks browser either: " + e.Message
+                        );
+                    }
+                }
             }
             throw new ApplicationException(
                 "Bloom could not determine which parts of this book are visible, so it stopped rather than "

--- a/src/BloomExe/Publish/PublishHelper.cs
+++ b/src/BloomExe/Publish/PublishHelper.cs
@@ -41,6 +41,10 @@ namespace Bloom.Publish
                 );
             }
             _latestInstance = this;
+            // One PublishHelper is created per publish (BloomPubMaker wraps one in a using; EpubMaker
+            // keeps one for the whole epub), so this bounds the measurement reported in Dispose to this
+            // publish rather than the whole session.
+            BloomServer.ResetTightestWorkerPoolReport();
         }
 
         public static void Cancel()
@@ -104,6 +108,7 @@ namespace Bloom.Publish
             var browser = GetOrCreatePageChecksBrowser();
             for (var attempt = 1; attempt <= kPageChecksAttempts; attempt++)
             {
+                var timer = Stopwatch.StartNew();
                 string whatWentWrong;
                 try
                 {
@@ -140,8 +145,14 @@ namespace Bloom.Publish
                     whatWentWrong = e.Message;
                 }
 
+                // Log the worker-pool state too: if every BloomServer worker is busy or blocked while
+                // requests sit in the queue, then the page we asked the browser to load could not be served
+                // and we are looking at starvation, not a slow renderer. That is the open question behind
+                // BL-16612, so leave this in even once the retry usually saves us.
                 var message =
-                    $"Page checks failed on attempt {attempt} of {kPageChecksAttempts}: {whatWentWrong}";
+                    $"Page checks failed on attempt {attempt} of {kPageChecksAttempts} after "
+                    + $"{timer.ElapsedMilliseconds}ms: {whatWentWrong}. "
+                    + BloomServer.GetWorkerPoolDiagnostics();
                 Debug.WriteLine(message);
                 Logger.WriteEvent(message);
 
@@ -1589,6 +1600,14 @@ namespace Bloom.Publish
                 if (disposing)
                 {
                     ReleaseBrowser();
+                    // One line per publish saying how much headroom the server had while we were blocked
+                    // on the page-checks browser. Logged on success as much as on failure, on purpose:
+                    // it is what lets a HEALTHY run speak to whether worker starvation could be behind
+                    // the intermittent hang, instead of us only ever seeing the pool once it is too late
+                    // (BL-16612).
+                    Logger.WriteEvent(
+                        "Publish finished. " + BloomServer.GetTightestWorkerPoolReport()
+                    );
                 }
                 _isDisposed = true;
             }

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -2433,6 +2433,19 @@ namespace Bloom.Api
             }
         }
 
+        /// <summary>
+        /// Registers that the current thread is about to block (exactly as <see cref="RegisterThreadBlocking"/>)
+        /// and, if that leaves no worker free to take new work, adds one right away. Pair it with
+        /// <see cref="RegisterThreadUnblocked"/> just like the plain version.
+        /// </summary>
+        /// <remarks>
+        /// RegisterThreadBlocking on its own only makes starvation *visible*; the escape hatch in QueueRequest
+        /// acts on it when the NEXT request arrives. That is too late for a thread that blocks waiting on
+        /// something a queued request has to produce — the page an off-screen browser is loading, say — because
+        /// the request that would unblock it may already be sitting in the queue, with nothing new coming in
+        /// behind it to trigger the check. Then everyone waits forever. So callers who block on our own server
+        /// use this instead, and we do the check at the moment the count goes up (BL-16612).
+        /// </remarks>
         // The worker-pool snapshot from the tightest moment seen so far — the moment when the fewest
         // workers were left able to pick up new work — since the last ResetTightestWorkerPoolReport().
         // A hang blamed on starvation needs the pool to actually run near empty, so this is the number
@@ -2463,16 +2476,44 @@ namespace Bloom.Api
                 : "BloomServer at its tightest: " + _tightestSnapshot;
         }
 
+        public void RegisterThreadBlockingAndEnsureAFreeWorker()
+        {
+            RegisterThreadBlocking();
+            var addedWorker = false;
+            lock (_queue)
+            {
+                // SpinUpAWorker mutates _workers, so it must be called inside this lock.
+                if (_countBlockedThreads >= _workers.Count)
+                {
+                    SpinUpAWorker();
+                    addedWorker = true;
+                }
+            }
+            // Say so when we actually had to add one. This is the only POSITIVE evidence that the
+            // starvation BL-16612 suspects is real: every other diagnostic here speaks only after
+            // something has already gone wrong, which means a guard that is quietly doing its job looks
+            // exactly like a bug that quietly went away. If this line shows up in a passing run's log,
+            // the condition was real and this is what kept requests moving.
+            // Logged outside the lock so we never hold it while writing to a file.
+            if (addedWorker)
+                Logger.WriteEvent(
+                    "Every server worker was blocked, so added one to keep requests moving. "
+                        + GetWorkerPoolDiagnostics()
+                );
+        }
+
         /// <summary>
         /// Records how much headroom the worker pool has at this instant, keeping the tightest reading
         /// seen since the last <see cref="ResetTightestWorkerPoolReport"/>. Call it right before blocking
         /// on something this server has to serve.
         /// </summary>
         /// <remarks>
-        /// Pure measurement, deliberately kept as its own method rather than folded into the registering
-        /// of a blocked thread: measuring stands on its own merits, while anything that CHANGES what the
-        /// pool does rests on the still-unproven starvation theory in BL-16612. Keeping them apart means
-        /// this measurement survives whatever we decide about that.
+        /// Deliberately separate from <see cref="RegisterThreadBlockingAndEnsureAFreeWorker"/>, even
+        /// though both take the queue lock and callers want both: this is pure measurement and stands on
+        /// its own, whereas adding a worker is a behavior change resting on the (still unproven)
+        /// starvation theory in BL-16612. Keeping them apart means the measurement can be kept whatever
+        /// we decide about the guard. The extra lock acquisition costs nothing measurable -- it happens
+        /// once per blocking call and holds the lock for a few field reads.
         ///
         /// Busy (not merely blocked) is the right measure of "cannot take new work": a worker busy
         /// serving a long request is just as unable to serve the page we are waiting for as a blocked one.

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -2433,19 +2433,6 @@ namespace Bloom.Api
             }
         }
 
-        /// <summary>
-        /// Registers that the current thread is about to block (exactly as <see cref="RegisterThreadBlocking"/>)
-        /// and, if that leaves no worker free to take new work, adds one right away. Pair it with
-        /// <see cref="RegisterThreadUnblocked"/> just like the plain version.
-        /// </summary>
-        /// <remarks>
-        /// RegisterThreadBlocking on its own only makes starvation *visible*; the escape hatch in QueueRequest
-        /// acts on it when the NEXT request arrives. That is too late for a thread that blocks waiting on
-        /// something a queued request has to produce — the page an off-screen browser is loading, say — because
-        /// the request that would unblock it may already be sitting in the queue, with nothing new coming in
-        /// behind it to trigger the check. Then everyone waits forever. So callers who block on our own server
-        /// use this instead, and we do the check at the moment the count goes up (BL-16612).
-        /// </remarks>
         // The worker-pool snapshot from the tightest moment seen so far — the moment when the fewest
         // workers were left able to pick up new work — since the last ResetTightestWorkerPoolReport().
         // A hang blamed on starvation needs the pool to actually run near empty, so this is the number
@@ -2476,6 +2463,19 @@ namespace Bloom.Api
                 : "BloomServer at its tightest: " + _tightestSnapshot;
         }
 
+        /// <summary>
+        /// Registers that the current thread is about to block (exactly as <see cref="RegisterThreadBlocking"/>)
+        /// and, if that leaves no worker free to take new work, adds one right away. Pair it with
+        /// <see cref="RegisterThreadUnblocked"/> just like the plain version.
+        /// </summary>
+        /// <remarks>
+        /// RegisterThreadBlocking on its own only makes starvation *visible*; the escape hatch in QueueRequest
+        /// acts on it when the NEXT request arrives. That is too late for a thread that blocks waiting on
+        /// something a queued request has to produce — the page an off-screen browser is loading, say — because
+        /// the request that would unblock it may already be sitting in the queue, with nothing new coming in
+        /// behind it to trigger the check. Then everyone waits forever. So callers who block on our own server
+        /// use this instead, and we do the check at the moment the count goes up (BL-16612).
+        /// </remarks>
         public void RegisterThreadBlockingAndEnsureAFreeWorker()
         {
             RegisterThreadBlocking();

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -2433,8 +2433,87 @@ namespace Bloom.Api
             }
         }
 
+        // The worker-pool snapshot from the tightest moment seen so far — the moment when the fewest
+        // workers were left able to pick up new work — since the last ResetTightestWorkerPoolReport().
+        // A hang blamed on starvation needs the pool to actually run near empty, so this is the number
+        // that makes the hypothesis testable on a HEALTHY run: if the pool never drops below a
+        // comfortable margin during a normal publish, starvation is not a plausible explanation, and we
+        // learn that without having to catch a failure in the act (BL-16612).
+        private static int _tightestIdleWorkers = int.MaxValue;
+        private static string _tightestSnapshot;
+
+        /// <summary>
+        /// Start a fresh measurement window for <see cref="GetTightestWorkerPoolReport"/> — e.g. at the
+        /// start of one publish, so the report describes that publish rather than the whole session.
+        /// </summary>
+        public static void ResetTightestWorkerPoolReport()
+        {
+            _tightestIdleWorkers = int.MaxValue;
+            _tightestSnapshot = null;
+        }
+
+        /// <summary>
+        /// How close the worker pool came to having nothing left to serve requests during the current
+        /// measurement window. "no blocking measured" means we never blocked on the server at all.
+        /// </summary>
+        public static string GetTightestWorkerPoolReport()
+        {
+            return _tightestSnapshot == null
+                ? "BloomServer: no blocking measured"
+                : "BloomServer at its tightest: " + _tightestSnapshot;
+        }
+
+        /// <summary>
+        /// Records how much headroom the worker pool has at this instant, keeping the tightest reading
+        /// seen since the last <see cref="ResetTightestWorkerPoolReport"/>. Call it right before blocking
+        /// on something this server has to serve.
+        /// </summary>
+        /// <remarks>
+        /// Pure measurement, deliberately kept as its own method rather than folded into the registering
+        /// of a blocked thread: measuring stands on its own merits, while anything that CHANGES what the
+        /// pool does rests on the still-unproven starvation theory in BL-16612. Keeping them apart means
+        /// this measurement survives whatever we decide about that.
+        ///
+        /// Busy (not merely blocked) is the right measure of "cannot take new work": a worker busy
+        /// serving a long request is just as unable to serve the page we are waiting for as a blocked one.
+        /// </remarks>
+        public void NoteWorkerPoolHeadroom()
+        {
+            lock (_queue)
+            {
+                var idleWorkers = _workers.Count - _busyThreads;
+                if (idleWorkers < _tightestIdleWorkers)
+                {
+                    _tightestIdleWorkers = idleWorkers;
+                    // Safe to call under the lock: it deliberately takes no lock of its own.
+                    _tightestSnapshot = GetWorkerPoolDiagnostics();
+                }
+            }
+        }
+
         private bool IsWorkerThread(Thread thread) =>
             thread?.Name?.IndexOf(WorkerThreadNamePrefix) == 0;
+
+        /// <summary>
+        /// A one-line snapshot of the worker pool's state, for logging when we suspect something is
+        /// stuck waiting on the server. If every worker is busy or blocked while requests sit in the
+        /// queue, then whatever the stuck code is waiting for cannot be served, and we are looking at
+        /// a starvation deadlock rather than mere slowness.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately reads the counters WITHOUT locking _queue: this gets called precisely when we
+        /// suspect the pool is wedged, and taking that lock could block the very report we need. The
+        /// numbers are therefore a possibly-inconsistent snapshot, which is all a diagnostic needs.
+        /// </remarks>
+        public static string GetWorkerPoolDiagnostics()
+        {
+            var server = _theOneInstance;
+            if (server == null)
+                return "BloomServer: none running";
+            return $"BloomServer: workers={server._workers.Count}, busy={server._busyThreads}, "
+                + $"blocked={server._countBlockedThreads}, "
+                + $"recursive={server._threadsDoingRecursiveRequests}, queued={server._queue.Count}";
+        }
 
         private string GetHtmlForRootOfBloomUI()
         {

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -2480,20 +2480,35 @@ namespace Bloom.Api
         {
             RegisterThreadBlocking();
             var addedWorker = false;
-            lock (_queue)
+            // Nothing from here on may throw. The caller unregisters in a finally that only covers the
+            // block AFTER this method returns, so an exception escaping here would leave
+            // _countBlockedThreads permanently incremented -- and an inflated count makes this guard fire
+            // on essentially every later block, quietly corrupting the server's own accounting. Adding a
+            // worker is an optimisation; failing to add one must never fail the caller or leak the count.
+            try
             {
-                // SpinUpAWorker mutates _workers, so it must be called inside this lock.
-                if (_countBlockedThreads >= _workers.Count)
+                lock (_queue)
                 {
-                    SpinUpAWorker();
-                    addedWorker = true;
+                    // SpinUpAWorker mutates _workers, so it must be called inside this lock.
+                    if (_countBlockedThreads >= _workers.Count)
+                    {
+                        SpinUpAWorker();
+                        addedWorker = true;
+                    }
                 }
             }
-            // Say so when we actually had to add one. This is the only POSITIVE evidence that the
-            // starvation BL-16612 suspects is real: every other diagnostic here speaks only after
-            // something has already gone wrong, which means a guard that is quietly doing its job looks
-            // exactly like a bug that quietly went away. If this line shows up in a passing run's log,
-            // the condition was real and this is what kept requests moving.
+            catch (Exception e)
+            {
+                Logger.WriteEvent(
+                    "Could not add a server worker while one was blocking: " + e.Message
+                );
+            }
+            // Say so when we actually had to add one. This is the POSITIVE evidence that the starvation
+            // behind BL-16612 is real and that this is what kept requests moving: every other diagnostic
+            // here speaks only after something has already gone wrong, so a guard quietly doing its job
+            // would otherwise be indistinguishable from a bug that quietly went away. Stacks captured at
+            // the moment of failure (nightly run 30864382766) showed 4 workers, 0 idle, so this line
+            // appearing on a run that then PASSES is the confirmation that it engaged.
             // Logged outside the lock so we never hold it while writing to a file.
             if (addedWorker)
                 Logger.WriteEvent(

--- a/src/BloomTests/Publish/OffScreenBrowserTests.cs
+++ b/src/BloomTests/Publish/OffScreenBrowserTests.cs
@@ -111,6 +111,60 @@ namespace BloomTests.Publish
             }
         }
 
+        /// <summary>
+        /// The diagnostics we log when something is stuck waiting on the server have to work at exactly the
+        /// moment things are going wrong, so at least prove they report real counts rather than throwing.
+        /// </summary>
+        [Test]
+        public void GetWorkerPoolDiagnostics_WithAServerRunning_ReportsWorkerCounts()
+        {
+            var diagnostics = BloomServer.GetWorkerPoolDiagnostics();
+
+            Assert.That(
+                diagnostics,
+                Does.Contain("workers="),
+                "diagnostics should report the worker count"
+            );
+            Assert.That(
+                diagnostics,
+                Does.Contain("blocked="),
+                "diagnostics should report how many workers are blocked, the key number for a starvation hang"
+            );
+            Assert.That(
+                diagnostics,
+                Does.Not.Contain("none running"),
+                "the fixture's BloomServer should have been found"
+            );
+        }
+
+        /// <summary>
+        /// The per-publish "how much headroom did the server have" line is what lets a PASSING run speak
+        /// to the starvation hypothesis, so it has to actually record something when we block.
+        /// </summary>
+        [Test]
+        public void TightestWorkerPoolReport_AfterBlocking_ReportsTheSnapshot()
+        {
+            BloomServer.ResetTightestWorkerPoolReport();
+
+            // SANITY: with nothing measured yet it must say so rather than invent a number, otherwise a
+            // publish that never blocked would look like one that ran the pool dry.
+            Assert.That(
+                BloomServer.GetTightestWorkerPoolReport(),
+                Does.Contain("no blocking measured"),
+                "before any blocking, the report should say nothing was measured"
+            );
+
+            // Note the headroom, which is what the measurement hangs off — deliberately independent of
+            // whether we also add a worker, so the measurement survives any decision about the guard.
+            s_bloomServer.NoteWorkerPoolHeadroom();
+
+            Assert.That(
+                BloomServer.GetTightestWorkerPoolReport(),
+                Does.Contain("at its tightest").And.Contain("workers="),
+                "after noting the headroom, the report should carry the pool snapshot from that moment"
+            );
+        }
+
         [Test]
         public void MultipleInstances_CanNavigateConcurrently_WithoutCrossContamination()
         {

--- a/src/BloomTests/Publish/OffScreenBrowserTests.cs
+++ b/src/BloomTests/Publish/OffScreenBrowserTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -65,6 +66,47 @@ namespace BloomTests.Publish
                     result,
                     Is.EqualTo("3"),
                     "javascript executed on the dedicated-thread browser should return its result"
+                );
+            }
+        }
+
+        /// <summary>
+        /// The point of the backstop timeout (BL-16612): a browser that stops making progress must fail the
+        /// caller rather than block it forever. Blocking forever used to wedge the calling thread, and when
+        /// that thread was a BloomServer worker it took publishing down with it for the rest of the session.
+        /// </summary>
+        [Test]
+        public void RunJavascript_WhenTheBrowserDoesNotComeBackInTime_ThrowsRatherThanBlockingForever()
+        {
+            using (var host = new OffScreenBrowser())
+            {
+                // SANITY: a normal script works on this browser, so the failure below is really about the
+                // timeout and not about a browser that never worked in the first place.
+                Assert.That(
+                    host.RunJavascript("(1 + 2).toString()"),
+                    Is.EqualTo("3"),
+                    "setup: the browser should run a trivial script before we test the timeout"
+                );
+
+                const int kBackstopMs = 500;
+                const int kScriptMs = 5000;
+                host.DefaultBlockTimeoutMsForTests = kBackstopMs;
+
+                // A script that keeps the renderer busy for far longer than the backstop. It does finish on
+                // its own, so we leave no spinning renderer behind for the rest of the suite.
+                var timer = Stopwatch.StartNew();
+                Assert.That(
+                    () =>
+                        host.RunJavascript(
+                            $"const end = Date.now() + {kScriptMs}; while (Date.now() < end) {{}} 'done'"
+                        ),
+                    Throws.TypeOf<OffScreenBrowserTimeoutException>(),
+                    "a browser that does not come back must fail the caller, not block it forever"
+                );
+                Assert.That(
+                    timer.ElapsedMilliseconds,
+                    Is.LessThan(kScriptMs),
+                    "should have given up at the backstop rather than waiting out the whole script"
                 );
             }
         }

--- a/src/BloomVisualRegressionTests/index.spec.ts
+++ b/src/BloomVisualRegressionTests/index.spec.ts
@@ -8,7 +8,7 @@ import {
     expect,
     Page,
 } from "@playwright/test";
-import { afterAll, beforeAll, describe, test } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, test } from "vitest";
 import { argosScreenshot } from "@argos-ci/playwright";
 import * as fs from "fs";
 import * as os from "os";
@@ -243,33 +243,123 @@ describe("All books", () => {
         return path;
     }
 
+    // How long we allow any single request to Bloom. Generously more than the few seconds these take
+    // when healthy (a whole case is normally 12-25s), but comfortably under vitest's 120s testTimeout,
+    // so that when Bloom stops answering we report WHICH call hung instead of an opaque "test timed
+    // out" pointing at the test function, which is all BL-16612 gave us to go on.
+    const kRequestTimeoutMs = 45000;
+    // Staging a whole BloomPUB is the slowest thing we ask Bloom for, so it gets more room.
+    const kStagingTimeoutMs = 60000;
+    // A trivial read used in a polling loop; it should answer at once.
+    const kQuickReadTimeoutMs = 10000;
+
+    // Set once Bloom fails to answer. Bloom is one process shared by every case in this file, so once
+    // it stops answering, no later case can pass either: each would burn the full 120s testTimeout and
+    // tell us nothing new (12 cases x 120s = the 24 wasted minutes in BL-16612). So the rest fail
+    // immediately instead. Deliberately NOT done for ordinary assertion/image-diff failures — there we
+    // want every case to run so we get every diff.
+    let bloomWedged: string | null = null;
+
+    // Runs a request to Bloom under a single timeout that covers BOTH the fetch and whatever the caller
+    // does with the response (`use`). The abort signal stays armed until the body is consumed, so reading
+    // the body outside this would reject with a raw error that never got the "which call hung" treatment.
+    // On failure we say which call it was, and on a timeout we remember that Bloom stopped answering.
+    async function bloomRequest<T>(
+        what: string,
+        url: string,
+        init: Parameters<typeof fetch>[1],
+        timeoutMs: number,
+        use: (response: Awaited<ReturnType<typeof fetch>>) => Promise<T>,
+    ): Promise<T> {
+        // Check .aborted rather than the error's name/class: it is the signal itself, not whatever error
+        // node-fetch chooses to throw, that reliably tells us we hit the timeout. (It throws AbortError,
+        // not TimeoutError, so testing the name would silently never match.)
+        const signal = AbortSignal.timeout(timeoutMs);
+        try {
+            return await use(await fetch(url, { ...init, signal }));
+        } catch (e) {
+            // Only a timeout means Bloom has stopped answering and no later case can pass. A one-off
+            // connection error may be transient, and if Bloom really has died then every later case fails
+            // fast by itself anyway (a refused connection returns at once) — so we don't need the flag for
+            // that, and leaving it unset means a single blip can't mask the remaining image diffs.
+            if (signal.aborted) {
+                bloomWedged = `Bloom did not answer ${what} within ${timeoutMs}ms (${url}). Look at the end of Bloom's log for the last thing it managed to do.`;
+                throw new Error(bloomWedged);
+            }
+            throw new Error(
+                `The request to Bloom for ${what} failed (${url}): ${
+                    (e as Error)?.message
+                }`,
+            );
+        }
+    }
+
+    // The common case: we only care whether Bloom accepted the request.
+    async function bloomFetchOk(
+        what: string,
+        url: string,
+        init?: Parameters<typeof fetch>[1],
+        timeoutMs = kRequestTimeoutMs,
+    ) {
+        return bloomRequest(what, url, init, timeoutMs, async (r) => r.ok);
+    }
+
+    // For the calls whose reply we actually read.
+    async function bloomFetchText(
+        what: string,
+        url: string,
+        init?: Parameters<typeof fetch>[1],
+        timeoutMs = kRequestTimeoutMs,
+    ) {
+        return bloomRequest(what, url, init, timeoutMs, async (r) => ({
+            ok: r.ok,
+            text: await r.text(),
+        }));
+    }
+
+    // Once Bloom is wedged, waiting out each remaining case's timeout adds nothing, so fail at once
+    // with the reason we already know.
+    beforeEach(() => {
+        if (bloomWedged)
+            throw new Error(`Bloom is no longer responding: ${bloomWedged}`);
+    });
+
     async function setBranding(branding: string) {
         // Enhance: get us on the correct collection (currently we can only handle the one collection)
 
         // Branding is normally derived from the (checksum-validated) subscription code and can't
         // be set directly. This test-only endpoint (registered only in e2e test mode) forces the
         // branding and brings the selected book up to date so it picks up that branding's files.
-        let result = await fetch(`${bloomOrigin}/bloom/api/e2e/setBranding`, {
-            method: "POST",
-            body: branding,
-        });
-        expect(result.ok).toBe(true);
+        let ok = await bloomFetchOk(
+            "setBranding",
+            `${bloomOrigin}/bloom/api/e2e/setBranding`,
+            {
+                method: "POST",
+                body: branding,
+            },
+        );
+        expect(ok).toBe(true);
     }
     async function setTheme(theme: string) {
         // Appearance theme is a per-book setting. This test-only endpoint (registered only in e2e
         // test mode) sets it and brings the selected book up to date so its appearance.css is
         // regenerated for that theme.
-        let result = await fetch(`${bloomOrigin}/bloom/api/e2e/setTheme`, {
-            method: "POST",
-            body: theme,
-        });
-        expect(result.ok).toBe(true);
+        let ok = await bloomFetchOk(
+            "setTheme",
+            `${bloomOrigin}/bloom/api/e2e/setTheme`,
+            {
+                method: "POST",
+                body: theme,
+            },
+        );
+        expect(ok).toBe(true);
     }
     async function selectBook(bookPath: string) {
         // Enhance: get us on the correct collection (currently we can only handle the one collection)
 
         // get us on the correct book
-        let result = await fetch(
+        let ok = await bloomFetchOk(
+            "selectBook",
             `${bloomOrigin}/bloom/api/collections/selected-book?path=${bookPath}&collection-id=${encodeURIComponent(
                 Path.dirname(bookPath),
             )}`,
@@ -277,14 +367,15 @@ describe("All books", () => {
                 method: "POST",
             },
         );
-        expect(result.ok).toBe(true);
+        expect(ok).toBe(true);
     }
 
     // Switch Bloom to the given workspace tab ("collection" | "edit" | "publish"), going through
     // the same code path the UI uses. Staging a BloomPUB requires the publish tab; selecting a book
     // requires the collection tab.
     async function selectTab(tab: string) {
-        const result = await fetch(
+        const ok = await bloomFetchOk(
+            `selectTab(${tab})`,
             `${bloomOrigin}/bloom/api/workspace/selectTab`,
             {
                 method: "POST",
@@ -292,7 +383,7 @@ describe("All books", () => {
                 body: JSON.stringify({ tab }),
             },
         );
-        expect(result.ok).toBe(true);
+        expect(ok).toBe(true);
     }
 
     // Wait until the editable collection is loaded and its books are enumerable. Switching to the
@@ -302,10 +393,13 @@ describe("All books", () => {
         // Up to 30s: switching to the collection tab reloads its webview, which can be slow on a
         // loaded machine; a too-short wait was an occasional source of spurious failures.
         for (let attempt = 0; attempt < 60; attempt++) {
-            const result = await fetch(
+            const { ok, text } = await bloomFetchText(
+                "isCollectionReady",
                 `${bloomOrigin}/bloom/api/e2e/isCollectionReady`,
+                undefined,
+                kQuickReadTimeoutMs,
             );
-            if (result.ok && (await result.text()) === "true") return;
+            if (ok && text === "true") return;
             await new Promise((resolve) => setTimeout(resolve, 500));
         }
         throw new Error("The collection tab did not become ready in time");
@@ -315,15 +409,17 @@ describe("All books", () => {
     // the localhost URL of the staged book's .htm file, for loading in bloom-player. Requires the
     // publish tab to be active. This test-only endpoint is registered only in e2e test mode.
     async function makeBloomPubPreview(): Promise<string> {
-        const result = await fetch(
+        const { ok, text } = await bloomFetchText(
+            "makeBloomPubPreview",
             `${bloomOrigin}/bloom/api/e2e/makeBloomPubPreview`,
             {
                 method: "POST",
                 body: "",
             },
+            kStagingTimeoutMs,
         );
-        expect(result.ok).toBe(true);
-        return result.text();
+        expect(ok).toBe(true);
+        return text;
     }
 
     // Build the bloom-player URL for the staged book at a specific page (0-based). Mirrors what the

--- a/src/BloomVisualRegressionTests/index.spec.ts
+++ b/src/BloomVisualRegressionTests/index.spec.ts
@@ -250,8 +250,11 @@ describe("All books", () => {
     const kRequestTimeoutMs = 45000;
     // Staging a whole BloomPUB is the slowest thing we ask Bloom for, so it gets more room.
     const kStagingTimeoutMs = 60000;
-    // A trivial read used in a polling loop; it should answer at once.
-    const kQuickReadTimeoutMs = 10000;
+    // A trivial read used in a polling loop; it should answer at once. Still generous, because a timeout
+    // here does not just fail one case -- it marks Bloom wedged and fails every remaining case. Switching
+    // to the collection tab reloads its webview, which on a loaded machine can genuinely take a while, and
+    // a spurious abort of the whole suite is far worse than waiting.
+    const kQuickReadTimeoutMs = 30000;
 
     // Set once Bloom fails to answer. Bloom is one process shared by every case in this file, so once
     // it stops answering, no later case can pass either: each would burn the full 120s testTimeout and


### PR DESCRIPTION
Found while investigating repeated Nightly Build and Test failures where all 12 visual-regression cases timed out (~24 minutes wasted). The hang is in **publishing**, not in the tests. Bloom's log ended at the same point in every failing run:

```
Failed to navigate fully to RemoveUnwantedContentInternal DOM
```

and then went silent for 23 minutes. Three consecutive nightlies ran the *same* commit `e2a5d45e62` with results fail / pass / fail, so it is a flake rather than a regression.

## Two defects, which have to be fixed together

**1. `OffScreenBrowser.RunAndBlock` waited with no timeout.** When the page-checks navigation failed, `PublishHelper` carried on (per the BL-7892 comment) and called `RunJavascript` on a browser whose page had never loaded — and that never returned. The blocked thread is a BloomServer worker, so the request was never answered and publishing stayed wedged for the life of the process. Every blocking call is now bounded and throws `OffScreenBrowserTimeoutException` instead of waiting forever. The unbounded `_ready.Wait()` in the constructor is bounded for the same reason.

**2. Carrying on after a failed navigation silently produced a bad book.** With no element information, `IsDisplayed` answers "displayed" for everything and `FontsUsed` comes back empty, so a BloomPUB keeps content that should have been stripped and embeds none of its fonts. Only epub publishing noticed, because `IsDisplayed` throws for it. So merely adding the timeout from (1) would have converted the hang into quiet corruption — which is why both land together. Page checks now retry once on a fresh renderer and, failing that, fail the publish (the existing handler reports it) rather than emit a book we know is wrong.

## Why the navigation stalls is still unproven

The leading hypothesis is **BloomServer worker starvation**: the thread blocking on the browser is itself a worker, and the browser's navigation needs a worker to serve the page it is loading. `_countBlockedThreads` is not computed automatically — callers must register — and `OffScreenBrowser` never did, so a worker blocked there was invisible to the logic in `QueueRequest` that adds a worker when all of them are blocked. `RunAndBlock` now registers, which should break that cycle if it is the cause.

Deliberately *not* raised: the 10s navigation budget. Per-test durations from the passing run show the entire first case (tab switches, book select, branding, theme, preview screenshot, full BloomPUB staging, several player captures) taking **18.4s**, so that navigation normally finishes in a small fraction of 10s. The failures blew through 10s and then never completed — bimodal, i.e. a stall rather than a near-miss, so a longer wait is not the fix. Added `BloomServer.GetWorkerPoolDiagnostics()` and log it, with the elapsed time, whenever page checks fail, so the next occurrence tells us whether the pool was starved.

## Test-side

The visual-regression suite now bounds each request to Bloom and names the call that hung, instead of an opaque "test timed out" pointing at the test function — which was all the original failure gave us to go on. Once Bloom stops answering, the remaining cases fail immediately rather than each burning 120s. Ordinary image-diff failures still run every case, so we keep every diff.

## Testing

- New `OffScreenBrowserTests.RunJavascript_WhenTheBrowserDoesNotComeBackInTime_ThrowsRatherThanBlockingForever` proves the backstop fires (it gives up at 500ms rather than waiting out a 5s script) and `GetWorkerPoolDiagnostics_WithAServerRunning_ReportsWorkerCounts` covers the new diagnostics. Both pass, with the existing test as a sanity check.
- Verified separately that `node-fetch` honors `AbortSignal.timeout` — and that it reports `AbortError`, **not** `TimeoutError`, which is why the new code checks `signal.aborted` rather than the error name.
- `BloomTests.Publish` (which drives `RemoveUnwantedContent`) cannot run in a worktree without a built `output/browser`: it aborts on a `Debug.Fail` for a missing `favicon.ico`. Confirmed identical on pristine code (163 vs 164 failures, same abort point), so this PR's CI run is the real check on those suites.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16612


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8110)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8110)
<!-- Reviewable:end -->
