### PR TITLE
Fix BL-16602: Talking Book highlighting dead after visiting a game page

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.spec.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.spec.tsx
@@ -1,0 +1,189 @@
+import * as React from "react";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderRoot, unmountRoot } from "../../utils/reactRender";
+
+// The real ./toolbox module drags in the whole legacy toolbox (jQuery, every tool, the
+// edit-page frames...). All ToolboxRoot wants from it is the list of tools that exist,
+// which it uses to decide which enabled tool ids are real.
+vi.mock("./toolbox", () => {
+    return {
+        getMasterToolList: () => [
+            { id: () => "talkingBook" },
+            { id: () => "game" },
+        ],
+    };
+});
+
+// The real LocalizedString wants a live localization manager. The tool labels aren't what
+// these tests are about, so just show the English.
+vi.mock("../../react_components/l10nComponents", async (importOriginal) => {
+    const actual =
+        await importOriginal<
+            typeof import("../../react_components/l10nComponents")
+        >();
+    const reactModule = await import("react");
+    return {
+        ...actual,
+        LocalizedString: (props: { children?: React.ReactNode }) =>
+            reactModule.createElement("span", undefined, props.children),
+    };
+});
+
+vi.mock("axios", () => {
+    return {
+        default: {
+            get: (url: string) => {
+                if (url.includes("toolbox/enabledTools")) {
+                    return Promise.resolve({ data: "talkingBook,settings" });
+                }
+                // Nothing else here should be making requests; be loud rather than
+                // quietly returning something plausible if that ever changes.
+                return Promise.reject(new Error(`unexpected GET of ${url}`));
+            },
+        },
+    };
+});
+
+// Imported after the mocks above are registered.
+const { ToolboxRoot } = await import("./ToolboxRoot");
+
+// The adapter object is rebuilt on every render, so always read the current one rather
+// than holding on to it.
+const getAdapter = () => {
+    const adapter = window.toolboxReactAdapter;
+    if (!adapter) {
+        throw new Error(
+            "ToolboxRoot did not publish window.toolboxReactAdapter; the component probably failed to render.",
+        );
+    }
+    return adapter;
+};
+
+// Each accordion header carries the tool's id on its icon span, so this is the order of
+// the sections the user would see.
+const getHeaderToolIds = (container: HTMLElement): string[] =>
+    Array.from(
+        container.querySelectorAll(".MuiAccordionSummary-root [data-toolid]"),
+    ).map((element) => element.getAttribute("data-toolid") ?? "");
+
+describe("ToolboxRoot", () => {
+    let container: HTMLDivElement | null = null;
+
+    beforeEach(() => {
+        container = document.createElement("div");
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        if (container) {
+            unmountRoot(container);
+            container.remove();
+            container = null;
+        }
+        delete window.toolboxReactAdapter;
+    });
+
+    // BL-16602: visiting a game page auto-activates the Game tool; leaving the page removes
+    // it again. The legacy toolbox code owns each tool's showTool()/hideTool() lifecycle and
+    // learns about activation changes only through onActiveToolChanged, so if removing the
+    // active tool doesn't report the replacement, the tool the user can see is never
+    // activated. That left the Talking Book tool doing no highlighting at all.
+    it("reports the replacement tool when the active tool is removed", async () => {
+        if (!container) {
+            throw new Error("render container not initialized");
+        }
+
+        await act(async () => {
+            renderRoot(<ToolboxRoot />, container);
+        });
+
+        const reportedToolIds: string[] = [];
+        getAdapter().onActiveToolChanged((toolId) => {
+            reportedToolIds.push(toolId);
+        });
+
+        expect(getHeaderToolIds(container)).toEqual([
+            "talkingBook",
+            "settings",
+        ]);
+
+        // Arriving on a game page: legacy code adds the required Game tool and makes it active.
+        await act(async () => {
+            window.dispatchEvent(
+                new CustomEvent("toolbox-tool-added", {
+                    detail: { toolId: "gameTool" },
+                }),
+            );
+            getAdapter().setActiveToolByToolId("gameTool");
+        });
+
+        // Sanity checks, so that a failure below can't just mean the setup never worked.
+        expect(getHeaderToolIds(container)).toEqual([
+            "game",
+            "talkingBook",
+            "settings",
+        ]);
+        expect(getAdapter().getActiveToolId()).toBe("gameTool");
+        expect(reportedToolIds).toEqual(["gameTool"]);
+
+        // Leaving the game page: legacy code removes the Game tool it required.
+        await act(async () => {
+            window.dispatchEvent(
+                new CustomEvent("toolbox-tool-removed", {
+                    detail: { toolId: "gameTool" },
+                }),
+            );
+        });
+
+        expect(getHeaderToolIds(container)).toEqual([
+            "talkingBook",
+            "settings",
+        ]);
+        expect(getAdapter().getActiveToolId()).toBe("talkingBookTool");
+        expect(reportedToolIds).toEqual(["gameTool", "talkingBookTool"]);
+    });
+
+    it("leaves the active tool alone when some other tool is removed", async () => {
+        if (!container) {
+            throw new Error("render container not initialized");
+        }
+
+        await act(async () => {
+            renderRoot(<ToolboxRoot />, container);
+        });
+
+        const reportedToolIds: string[] = [];
+        getAdapter().onActiveToolChanged((toolId) => {
+            reportedToolIds.push(toolId);
+        });
+
+        await act(async () => {
+            window.dispatchEvent(
+                new CustomEvent("toolbox-tool-added", {
+                    detail: { toolId: "gameTool" },
+                }),
+            );
+            getAdapter().setActiveToolByToolId("talkingBookTool");
+        });
+
+        expect(getAdapter().getActiveToolId()).toBe("talkingBookTool");
+        expect(reportedToolIds).toEqual(["talkingBookTool"]);
+
+        await act(async () => {
+            window.dispatchEvent(
+                new CustomEvent("toolbox-tool-removed", {
+                    detail: { toolId: "gameTool" },
+                }),
+            );
+        });
+
+        expect(getHeaderToolIds(container)).toEqual([
+            "talkingBook",
+            "settings",
+        ]);
+        // Removing a tool that wasn't active must not disturb the active tool.
+        expect(getAdapter().getActiveToolId()).toBe("talkingBookTool");
+        expect(reportedToolIds).toEqual(["talkingBookTool"]);
+    });
+});

--- a/src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.tsx
@@ -403,6 +403,29 @@ export const ToolboxRoot: React.FunctionComponent = () => {
     >([]);
     const hydratedToolIds = React.useRef<Set<string>>(new Set());
 
+    // Expand the given section and tell the legacy toolbox code about it.
+    // The legacy code keeps its own idea of which tool is current and drives each tool's
+    // showTool()/hideTool() lifecycle from it, so every path that changes which section is
+    // expanded has to go through here. A path that quietly changed only the React state left
+    // the two out of sync, so the tool the user could see was never activated: that is how
+    // visiting a game page killed Talking Book highlighting (BL-16602).
+    // Passing undefined means "nothing is expanded"; we deliberately don't notify legacy in
+    // that case, since it has no representation for "no current tool" and re-expanding the
+    // same section will notify with the same tool anyway.
+    const setActiveSection = React.useCallback(
+        (sectionId: string | undefined) => {
+            setExpandedSectionId(sectionId);
+            if (!sectionId) {
+                return;
+            }
+            const toolId = toToolboxToolId(sectionId);
+            activeToolChangedCallbacks.current.forEach((callback) => {
+                callback(toolId);
+            });
+        },
+        [],
+    );
+
     // Resolve body content for a section.
     // Prefer a live legacy element to avoid duplicate tool roots; otherwise
     // load static legacy HTML as a temporary fallback.
@@ -680,24 +703,26 @@ export const ToolboxRoot: React.FunctionComponent = () => {
             const removedToolId = normalizeToolId(customEvent.detail.toolId);
             hydratedToolIds.current.delete(removedToolId);
 
-            setSections((previousSections) => {
-                const nextSections = previousSections.filter(
+            setSections((previousSections) =>
+                previousSections.filter(
                     (section) => section.id !== removedToolId,
-                );
+                ),
+            );
 
-                const firstSection = nextSections[0];
-                // actually changes the expanded section only if the removed tool was the expanded one.
-                // The awkward way of doing this is to guard against a stale value of expandedSectionId.
-                setExpandedSectionId((previousExpandedSectionId) =>
-                    previousExpandedSectionId === removedToolId
-                        ? firstSection
-                            ? firstSection.id
-                            : undefined
-                        : previousExpandedSectionId,
-                );
+            if (expandedSectionId !== removedToolId) {
+                // The tool that went away wasn't the active one, so the active tool is unaffected.
+                return;
+            }
 
-                return nextSections;
-            });
+            // The active tool has just been taken away from us (e.g. leaving a game page removes
+            // the Game tool, which that page required). Something else has to become active, and
+            // it must go through setActiveSection so that the legacy code actually activates it.
+            // (Before the React toolbox, the jQuery accordion's refresh did the equivalent, firing
+            // its activate event when the active panel disappeared.)
+            const replacementSection = sections.find(
+                (section) => section.id !== removedToolId,
+            );
+            setActiveSection(replacementSection?.id);
         };
 
         // These events get dispatched by legacy toolbox code when tools are added or removed
@@ -709,7 +734,11 @@ export const ToolboxRoot: React.FunctionComponent = () => {
             window.removeEventListener("toolbox-tool-added", onToolAdded);
             window.removeEventListener("toolbox-tool-removed", onToolRemoved);
         };
-    }, [hydrateToolBody]);
+        // sections and expandedSectionId are dependencies because onToolRemoved has to know
+        // what is currently active and what is left to activate in its place. Re-subscribing
+        // when they change can't lose an event: the removal and re-adding of the listener
+        // happen together, synchronously, when React commits.
+    }, [hydrateToolBody, sections, expandedSectionId, setActiveSection]);
 
     // Expose activation adapter so legacy toolbox code can drive and observe React accordion state.
     React.useEffect(() => {
@@ -729,12 +758,7 @@ export const ToolboxRoot: React.FunctionComponent = () => {
         window.toolboxReactAdapter = {
             isEnabled: () => true,
             setActiveToolByToolId: (toolId: string) => {
-                const normalizedToolId = normalizeToolId(toolId);
-                setExpandedSectionId(normalizedToolId);
-                const callbackToolId = toToolboxToolId(normalizedToolId);
-                activeToolChangedCallbacks.current.forEach((callback) => {
-                    callback(callbackToolId);
-                });
+                setActiveSection(normalizeToolId(toolId));
             },
             getActiveToolId: () => {
                 if (!expandedSectionId) {
@@ -746,7 +770,7 @@ export const ToolboxRoot: React.FunctionComponent = () => {
                 activeToolChangedCallbacks.current.push(callback);
             },
         };
-    }, [expandedSectionId, sections]);
+    }, [expandedSectionId, sections, setActiveSection]);
 
     // The old jQuery toolbox logic still runs for now, and it calls .show() on #toolbox.
     // Keep that legacy root hidden so only the React root is visible.
@@ -867,19 +891,9 @@ export const ToolboxRoot: React.FunctionComponent = () => {
                             disableGutters
                             expanded={expandedSectionId === section.id}
                             onChange={(_event, expanded) => {
-                                const nextSectionId = expanded
-                                    ? section.id
-                                    : undefined;
-                                setExpandedSectionId(nextSectionId);
-                                if (nextSectionId) {
-                                    const toolId =
-                                        toToolboxToolId(nextSectionId);
-                                    activeToolChangedCallbacks.current.forEach(
-                                        (callback) => {
-                                            callback(toolId);
-                                        },
-                                    );
-                                }
+                                setActiveSection(
+                                    expanded ? section.id : undefined,
+                                );
                             }}
                         >
                             <AccordionSummary


### PR DESCRIPTION
## The bug

A game page requires the Game tool, so arriving on one auto-activates it and leaving one removes it again. When the removed tool was the active one, the React toolbox picked a replacement section to expand but **never told the legacy toolbox code**, which still owns each tool's `showTool()`/`hideTool()` lifecycle.

So legacy went on thinking the Game tool was current: `getActiveToolId()` kept returning `"game"` and the Talking Book tool never got `showTool()` again, leaving `AudioRecording.isShowing` false. Every highlight path is gated on `doesCurrentToolPlayAudio()`, so nothing was ever highlighted — and closing and reopening the Talking Book tool didn't help, because the desync outlived it. Only restarting Bloom cleared it.

This is a regression from 6.3, where the jQuery accordion did the equivalent for us: its `refresh()` noticed the active panel had been removed and activated another one, which fired the `activate` event that ran `switchTool()`. The React accordion that replaced it in 6.4 had no such path.

## The fix

Funnel every change of the expanded section through one `setActiveSection()` helper that both sets the React state and notifies the legacy listeners, and use it on the tool-removed path.

That also covers the same class of bug for any other way the active tool can be taken away — for instance unchecking the currently-active tool in "More...", which left the same dead state.

## Tests

`src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.spec.tsx` (new) walks the add/activate/remove sequence through the `window.toolboxReactAdapter` surface and asserts the replacement tool is reported to legacy, plus that removing a *non*-active tool leaves the active tool alone. Verified it fails without the fix (`expected [ 'gameTool' ] to deeply equal [ 'gameTool', 'talkingBookTool' ]`) and passes with it.

## Note for the reviewer

Which tool becomes active after the Game tool is removed is "the first remaining section" — it does not remember that you were on Talking Book before you visited the game page. That matches 6.3 (jQuery picked the panel before the removed one, also not necessarily the one you came from), so this restores the old behavior rather than improving on it. Making it restore the pre-game tool would be a separate, larger change.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16602

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8112)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8112)
<!-- Reviewable:end -->
