### PR TITLE
Get the Playwright component-test harness running again

### DIFF
--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -20,20 +20,49 @@ House rules:
 ---
 
 
-## 2026-07-27 — ToolboxRoot's Playwright component tests have been dead since React 18
+## 2026-07-27 — The component-tester uitest suites still aren't in CI
 
-- **Cut:** All 7 tests in `react_components/ToolboxRootTestHarness/component-tests/
-  toolbox-root-react.uitest.ts` fail on master before rendering anything: the component-tester
-  workspace pins `react-dom` 17.0.2, so Vite can't resolve `react-dom/client`, which
-  `utils/reactRender.tsx` has imported since the app moved to React 18. Nobody noticed because
-  these tests aren't in CI. That harness was the natural home for a regression test of the
-  toolbox's activation bridge (BL-16602); the test had to go into a vitest spec instead.
-- **Idea:** Bump `react`/`react-dom`/`@types/*` in
-  `src/BloomBrowserUI/react_components/component-tester/package.json` to 18 to match the app,
-  re-verify the 7 tests, and consider whether these should run in CI — a harness nothing runs
-  will rot again.
-- **Context:** BloomDesktop, found during `/preflight` of PR #8112 (BL-16602). Note the
-  component-tester README already says these aren't run by CI or any script.
+- **Cut:** Nothing runs `react_components/component-tester`'s Playwright suites — `nightly.yml`
+  runs vitest, C# and visual-regression only, and doesn't even `pnpm install` that workspace. That
+  is why the whole harness sat broken (React 17 pin + a second-Playwright-copy config bug) without
+  anyone noticing. It is now green at 144 passed / 25 skipped, so it will silently rot again.
+- **Idea:** Add a nightly job mirroring the visual-regression one (`pnpm install --frozen-lockfile`
+  in the component-tester dir, `pnpm exec playwright install chromium`, then
+  `pnpm exec playwright test --config playwright.config.ts`) and publish its junit output. The
+  bloom-exe config needs a running Bloom.exe, so only the component config is CI-able for now.
+- **Context:** BloomDesktop, branch `fix-component-tester`. The component-tester README still
+  says these are "not currently run as part of CI or other script" — update it if this lands.
+
+
+## 2026-07-27 — Changing harness imports + `reuseExistingServer` = 20 bogus test failures
+
+- **Cut:** Adding one bare import (`jquery`) to `component-harness.tsx` invalidated Vite's dep
+  optimizer, but `playwright.config.ts` sets `reuseExistingServer: true`, so the already-running dev
+  server served a half-rebuilt `node_modules/.vite/deps` chunk. Every BookGridSetup test (21 of
+  them) failed with `styled_default is not a function` — which looks exactly like a real MUI/emotion
+  regression and cost a chunk of debugging. Killing the server and deleting `node_modules/.vite`
+  fixed it with no code change.
+- **Idea:** Note this in the component-tester README/AGENTS ("if you add or remove an import in the
+  harness, stop the dev server and `rm -rf node_modules/.vite` before trusting a red run"), or have
+  the config/dev script clear the deps cache when `component-harness.tsx` is newer than it.
+- **Context:** BloomDesktop, branch `fix-component-tester`.
+
+
+## 2026-07-27 — Toolbox test harness has to duplicate toolboxBootstrap's tool registration
+
+- **Cut:** `ToolboxRoot` only renders a section for a tool in `getMasterToolList()`, and tools land
+  there as a side effect of importing `toolboxBootstrap.ts`. The harness can't import that module —
+  it also does `$(document).ready(renderToolboxRoot)` and assigns `window.toolboxBundle`, which
+  would double-render the root and clobber the stub some tests install. So
+  `ToolboxRootTestHarness.tsx` now repeats the 11 `ToolBox.registerTool(...)` calls, with a
+  "keep in sync" comment — i.e. a list that will drift.
+- **Idea:** Extract the registrations into a side-effect-free `registerAllToolboxTools()` module
+  that both `toolboxBootstrap.ts` and the harness import. Probably best folded into the toolbox
+  React refactor (BL-16608 / PR #8109) rather than done separately.
+- **Context:** BloomDesktop, branch `fix-component-tester`. Related: one test there is now
+  `test.fixme` because it asserts on `.subscription-badge` (legacy-toolbox-only) and
+  `.toolbox-react-header-icon` (never existed) via computed `background-image`; re-enabling it
+  needs a decision on whether the React header renders badges/icons and what classes to expose.
 
 
 ## 2026-07-27 — C# test host aborts mid-run when the suite runs alongside vitest

--- a/src/BloomBrowserUI/react_components/BookGridSetup/component-tests/bookgridsetup-basic.uitest.ts
+++ b/src/BloomBrowserUI/react_components/BookGridSetup/component-tests/bookgridsetup-basic.uitest.ts
@@ -34,7 +34,7 @@ test.describe("BookGridSetup - Initial Setup", () => {
         });
 
         await expect(
-            page.getByRole("heading", { name: /book in app/i }),
+            page.getByRole("heading", { name: /books in app/i }),
         ).toBeVisible();
     });
 

--- a/src/BloomBrowserUI/react_components/BookGridSetup/component-tests/test-helpers.ts
+++ b/src/BloomBrowserUI/react_components/BookGridSetup/component-tests/test-helpers.ts
@@ -126,7 +126,7 @@ export async function expectTargetBookNotVisible(page: Page, bookId: string) {
  */
 export async function getTargetCount(page: Page): Promise<number> {
     const header = page.getByRole("heading", {
-        name: /links in grid|book in app/i,
+        name: /links in grid|books in app/i,
     });
     const text = await header.textContent();
     const match = text?.match(/\((\d+)\)/);

--- a/src/BloomBrowserUI/react_components/ToolboxRootTestHarness/ToolboxRootTestHarness.tsx
+++ b/src/BloomBrowserUI/react_components/ToolboxRootTestHarness/ToolboxRootTestHarness.tsx
@@ -1,5 +1,43 @@
 import * as React from "react";
 import { ToolboxRoot } from "../../bookEdit/toolbox/ToolboxRoot";
+import { ToolBox } from "../../bookEdit/toolbox/toolbox";
+import { DecodableReaderTool } from "../../bookEdit/toolbox/readers/decodableReader/decodableReaderTool";
+import { LeveledReaderTool } from "../../bookEdit/toolbox/readers/leveledReader/leveledReaderTool";
+import { MusicToolAdaptor } from "../../bookEdit/toolbox/music/musicToolControls";
+import { ImpairmentVisualizerAdaptor } from "../../bookEdit/toolbox/impairmentVisualizer/impairmentVisualizer";
+import { MotionTool } from "../../bookEdit/toolbox/motion/motionTool";
+import TalkingBookTool from "../../bookEdit/toolbox/talkingBook/talkingBookTool";
+import { SignLanguageTool } from "../../bookEdit/toolbox/signLanguage/signLanguageTool";
+import { ImageDescriptionAdapter } from "../../bookEdit/toolbox/imageDescription/imageDescription";
+import { CanvasTool } from "../../bookEdit/toolbox/canvas/canvasTool";
+import { GameTool } from "../../bookEdit/toolbox/games/GameTool";
+import { SettingsTool } from "../../bookEdit/toolbox/settings/settingsTool";
+
+// ToolboxRoot only renders a section for a tool that is in the master tool list, and tools
+// put themselves there by being registered. In the running app that happens as a side effect
+// of loading toolboxBootstrap. We deliberately do NOT import that module here: besides
+// registering tools it also renders its own toolbox root on $(document).ready and assigns
+// window.toolboxBundle, which would both duplicate the root this harness renders and
+// overwrite the toolboxBundle stub some tests install. So we register the same set of tools
+// ourselves. Keep this list in sync with toolboxBootstrap.ts.
+let toolsRegistered = false;
+function registerToolsOnce() {
+    if (toolsRegistered) return;
+    toolsRegistered = true;
+    ToolBox.registerTool(new DecodableReaderTool());
+    ToolBox.registerTool(new LeveledReaderTool());
+    ToolBox.registerTool(new MusicToolAdaptor());
+    ToolBox.registerTool(new ImpairmentVisualizerAdaptor());
+    ToolBox.registerTool(new MotionTool());
+    ToolBox.registerTool(new TalkingBookTool());
+    ToolBox.registerTool(new SignLanguageTool());
+    ToolBox.registerTool(new ImageDescriptionAdapter());
+    ToolBox.registerTool(new CanvasTool());
+    ToolBox.registerTool(new GameTool());
+    ToolBox.registerTool(new SettingsTool());
+}
+
+registerToolsOnce();
 
 export const ToolboxRootTestHarness: React.FunctionComponent = () => {
     return <ToolboxRoot />;

--- a/src/BloomBrowserUI/react_components/ToolboxRootTestHarness/ToolboxRootTestHarness.tsx
+++ b/src/BloomBrowserUI/react_components/ToolboxRootTestHarness/ToolboxRootTestHarness.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { ToolboxRoot } from "../../bookEdit/toolbox/ToolboxRoot";
-import { ToolBox } from "../../bookEdit/toolbox/toolbox";
+import { ToolBox, getMasterToolList } from "../../bookEdit/toolbox/toolbox";
 import { DecodableReaderTool } from "../../bookEdit/toolbox/readers/decodableReader/decodableReaderTool";
 import { LeveledReaderTool } from "../../bookEdit/toolbox/readers/leveledReader/leveledReaderTool";
 import { MusicToolAdaptor } from "../../bookEdit/toolbox/music/musicToolControls";
@@ -20,10 +20,14 @@ import { SettingsTool } from "../../bookEdit/toolbox/settings/settingsTool";
 // window.toolboxBundle, which would both duplicate the root this harness renders and
 // overwrite the toolboxBundle stub some tests install. So we register the same set of tools
 // ourselves. Keep this list in sync with toolboxBootstrap.ts.
-let toolsRegistered = false;
+// The guard keys off the shared master list rather than a module-local flag on purpose.
+// This file is a valid React-Refresh boundary (its only export is a component), so editing
+// it during `pnpm dev` re-executes this module without reloading the page. A module-local
+// flag would reset to false while masterToolList — which lives in toolbox.ts and is not
+// invalidated — kept its entries, and ToolBox.registerTool is a bare push with no dedupe,
+// so we would end up with 11 duplicate tools and duplicate accordion sections.
 function registerToolsOnce() {
-    if (toolsRegistered) return;
-    toolsRegistered = true;
+    if (getMasterToolList().length > 0) return;
     ToolBox.registerTool(new DecodableReaderTool());
     ToolBox.registerTool(new LeveledReaderTool());
     ToolBox.registerTool(new MusicToolAdaptor());

--- a/src/BloomBrowserUI/react_components/ToolboxRootTestHarness/component-tests/toolbox-root-react.uitest.ts
+++ b/src/BloomBrowserUI/react_components/ToolboxRootTestHarness/component-tests/toolbox-root-react.uitest.ts
@@ -87,7 +87,12 @@ test.describe("ToolboxRoot React mode", () => {
             timeout: 15000,
         });
 
-        await expect(page.getByText("Decodable Reader Tool")).toHaveCount(0);
+        // Scoped to the accordion headers on purpose: the "More..." panel lists every
+        // registered tool as a checkbox, so a bare getByText would match that label and
+        // report the tool as present before it has been added as a section.
+        await expect(getToolHeader(page, "Decodable Reader Tool")).toHaveCount(
+            0,
+        );
 
         await page.evaluate(() => {
             window.dispatchEvent(
@@ -100,9 +105,7 @@ test.describe("ToolboxRoot React mode", () => {
             );
         });
 
-        await expect(
-            page.getByText("Decodable Reader Tool").first(),
-        ).toBeVisible({
+        await expect(getToolHeader(page, "Decodable Reader Tool")).toBeVisible({
             timeout: 10000,
         });
         await expect(
@@ -206,9 +209,7 @@ test.describe("ToolboxRoot React mode", () => {
         ]);
     });
 
-    test("header shows icons and subscription badges without chevrons", async ({
-        page,
-    }) => {
+    test("headers show tool names without chevrons", async ({ page }) => {
         await routeToolboxApis(page);
 
         await page.route("**/bloom/api/toolbox/enabledTools", async (route) => {
@@ -236,17 +237,60 @@ test.describe("ToolboxRoot React mode", () => {
         await expect(
             page.locator(".MuiAccordionSummary-expandIconWrapper"),
         ).toHaveCount(0);
-
-        await expect(page.locator(".subscription-badge")).toHaveCount(3);
-
-        await expect(
-            page.locator(".toolbox-react-header-icon[data-toolid='canvas']"),
-        ).toHaveCSS("background-image", /Canvas%20Icon\.svg|Canvas Icon\.svg/);
-        await expect(
-            page.locator(".toolbox-react-header-icon[data-toolid='motion']"),
-        ).toHaveCSS("background-image", /motion\.svg/);
-        await expect(
-            page.locator(".toolbox-react-header-icon[data-toolid='music']"),
-        ).toHaveCSS("background-image", /music-notes-white\.svg/);
     });
+
+    // Split out of the test above and disabled rather than deleted, because it asserts on
+    // things the React header has never produced, and deciding what it *should* produce is a
+    // product question, not a test fix:
+    //  - ".subscription-badge" is emitted by the legacy jQuery toolbox
+    //    (toolbox.ts buildToolboxHeader), not by the React header, so the count is 0 here.
+    //  - ".toolbox-react-header-icon" does not exist anywhere in the app — no component or
+    //    stylesheet has ever defined that class.
+    // It also checks tool icons via computed background-image, which
+    // src/BloomBrowserUI/AGENTS.md tells us not to do ("Don't check for styles in tests as a
+    // way to know the status of something... have components add css classes"). So whoever
+    // re-enables this should first decide whether the React header renders subscription
+    // badges and icons at all, then give those elements stable classes/test ids to assert on.
+    test.fixme(
+        "header shows icons and subscription badges",
+        async ({ page }) => {
+            await routeToolboxApis(page);
+
+            await page.route(
+                "**/bloom/api/toolbox/enabledTools",
+                async (route) => {
+                    await route.fulfill({
+                        status: 200,
+                        contentType: "text/plain",
+                        body: "canvas,motion,music,settings",
+                    });
+                },
+            );
+
+            await page.goto("/?component=ToolboxRootTestHarness");
+
+            await expect(page.getByText("Loading component…")).toHaveCount(0, {
+                timeout: 15000,
+            });
+
+            await expect(page.locator(".subscription-badge")).toHaveCount(3);
+
+            await expect(
+                page.locator(
+                    ".toolbox-react-header-icon[data-toolid='canvas']",
+                ),
+            ).toHaveCSS(
+                "background-image",
+                /Canvas%20Icon\.svg|Canvas Icon\.svg/,
+            );
+            await expect(
+                page.locator(
+                    ".toolbox-react-header-icon[data-toolid='motion']",
+                ),
+            ).toHaveCSS("background-image", /motion\.svg/);
+            await expect(
+                page.locator(".toolbox-react-header-icon[data-toolid='music']"),
+            ).toHaveCSS("background-image", /music-notes-white\.svg/);
+        },
+    );
 });

--- a/src/BloomBrowserUI/react_components/component-tester/README.md
+++ b/src/BloomBrowserUI/react_components/component-tester/README.md
@@ -18,6 +18,20 @@ To set up a component for ui testing:
 ### Imports
 `vite dev` has to be able to handle your component. Eventually that will not be a big deal, but for now, it may mean that you have to extract out the core of it with few imports. For the RegistrationDialog, we had to extract out the core behavior and test that.
 
+### If a red run looks impossible, clear Vite's dep cache
+Adding or removing an import in `component-harness.tsx` invalidates Vite's optimized-dependency
+cache, but `playwright.config.ts` uses `reuseExistingServer: true`, so an already-running dev
+server can keep serving a half-rebuilt chunk. That shows up as a whole component's tests failing
+with something like `styled_default is not a function` — which looks like a real MUI/emotion
+regression but is not. Stop the dev server, `rm -rf node_modules/.vite`, and re-run before
+believing it.
+
+### Tools/plugins that read global jQuery
+The harness assigns the real jQuery to `window.$`/`window.jQuery`. Don't replace that with a
+hand-rolled stub: some dependencies are jQuery plugins (select2, via `StyleEditor`) whose UMD
+wrappers attach to `$.fn` at import time by reading the global, and they throw if it isn't real
+jQuery.
+
 ### Callback Props
 Component props must be JSON-serializable because the Playwright test runs in a different process than the browser. Functions cannot be serialized.
 

--- a/src/BloomBrowserUI/react_components/component-tester/component-harness.tsx
+++ b/src/BloomBrowserUI/react_components/component-tester/component-harness.tsx
@@ -12,6 +12,7 @@
  */
 
 import * as React from "react";
+import $ from "jquery";
 import { renderRoot } from "../../utils/reactRender";
 // import { StyledEngineProvider, ThemeProvider } from "@mui/material/styles";
 // import { lightTheme } from "../../../../bloomMaterialUITheme";
@@ -22,52 +23,21 @@ import {
 } from "./component-registry";
 import { bypassLocalization } from "../../lib/localizationManager/localizationManager";
 
-// Mock jQuery for localization system
-// The localization system uses jQuery promises ($.Deferred) which need done/fail methods
-(window as any).$ = (window as any).jQuery = {
-    Deferred: () => {
-        let resolveCallback: any;
-        let rejectCallback: any;
-        const promise = new Promise((resolve, reject) => {
-            resolveCallback = resolve;
-            rejectCallback = reject;
-        });
-
-        // Create the jQuery-style promise with done/fail methods
-        const jQueryPromise = {
-            done: (callback: any) => {
-                promise.then(callback);
-                return jQueryPromise;
-            },
-            fail: (callback: any) => {
-                promise.catch(callback);
-                return jQueryPromise;
-            },
-            then: (callback: any) => {
-                promise.then(callback);
-                return jQueryPromise;
-            },
-        };
-
-        const deferred = {
-            resolve: (value: any) => {
-                resolveCallback(value);
-                return deferred;
-            },
-            reject: (reason: any) => {
-                rejectCallback(reason);
-                return deferred;
-            },
-            fail: (callback: any) => {
-                promise.catch(callback);
-                return deferred;
-            },
-            promise: () => jQueryPromise,
-        };
-
-        return deferred;
-    },
-};
+// Expose the real jQuery as a global for the components under test.
+//
+// The localization system needs jQuery promises ($.Deferred), which real jQuery provides,
+// so there is nothing here worth mocking. It matters that this is the genuine jQuery: some
+// of our dependencies are jQuery *plugins* that attach themselves to $.fn at import time,
+// reading the global rather than any module import. select2 is the case that bit us — under
+// Vite it loads as an optimized ESM dep, so `module` is undefined and its UMD wrapper falls
+// through to the browser-globals branch, which does `factory(jQuery)` against window.jQuery.
+// A stand-in object with only Deferred on it has no `.fn`, so select2 threw at import time
+// and took down every component whose graph reaches StyleEditor (e.g. anything under the
+// toolbox). Assigning the real jQuery here keeps those plugins working.
+//
+// This runs before any component module is loaded: components are pulled in lazily by
+// renderRequest() below, well after this module's top-level code.
+window.$ = window.jQuery = $;
 
 const manualConfigModules = import.meta.glob<ManualConfigModule>(
     "./manualConfig.ts",

--- a/src/BloomBrowserUI/react_components/component-tester/package.json
+++ b/src/BloomBrowserUI/react_components/component-tester/package.json
@@ -17,18 +17,18 @@
         "manual:interactive": "playwright test --headed --timeout=0"
     },
     "dependencies": {
-        "react": "17.0.2",
-        "react-dom": "17.0.2"
+        "react": "18.3.1",
+        "react-dom": "18.3.1"
     },
     "devDependencies": {
         "@playwright/test": "1.56.1",
         "@types/node": "24.13.0",
-        "@types/react": "17.0.89",
-        "@types/react-dom": "17.0.26",
+        "@types/react": "18.3.31",
+        "@types/react-dom": "18.3.7",
         "@vitejs/plugin-react": "4.7.0",
+        "tsx": "4.20.6",
         "typescript": "6.0.3",
-        "vite": "5.4.20",
-        "tsx": "4.20.6"
+        "vite": "5.4.20"
     },
     "packageManager": "pnpm@11.5.2"
 }

--- a/src/BloomBrowserUI/react_components/component-tester/playwright.config.ts
+++ b/src/BloomBrowserUI/react_components/component-tester/playwright.config.ts
@@ -30,10 +30,25 @@ Object.keys(require.cache).forEach((key) => {
 const config: PlaywrightTestConfig = {
     testDir: "..",
     testMatch: "**/*.uitest.*",
+    // The bloom-exe*.uitest.ts specs belong to the other config
+    // (playwright.bloom-exe.config.ts): they attach over CDP to a running Bloom.exe and
+    // import from the repo-level `playwright/test` rather than this package's
+    // @playwright/test. Collecting them here loads a second copy of Playwright, which
+    // fails hard with "Requiring @playwright/test second time" and aborts the whole run
+    // before any component test executes. node_modules is pruned so the crawl stays fast.
+    testIgnore: ["**/bloom-exe*.uitest.*", "**/node_modules/**"],
     // Allow extra time for the first Vite build when the harness is cold.
-    timeout: 15000,
+    timeout: 30000,
     expect: {
-        timeout: 1000,
+        // This is the retry budget for web-first assertions, not a fixed wait: a passing
+        // assertion still returns as soon as it is true, so raising it costs nothing on
+        // green runs. It was 1000ms, which was too tight to wait for a component's first
+        // mount while the dev server was still transforming its module graph — roughly one
+        // test per full-suite run failed with "element(s) not found", a different one each
+        // time, while passing in isolation. 5000ms matches playwright.bloom-exe.config.ts.
+        // The overall test timeout above is raised in step so that a genuinely broken
+        // assertion still reports as an assertion failure rather than a whole-test timeout.
+        timeout: 5000,
     },
     use: {
         baseURL: "http://127.0.0.1:5183",

--- a/src/BloomBrowserUI/react_components/component-tester/pnpm-lock.yaml
+++ b/src/BloomBrowserUI/react_components/component-tester/pnpm-lock.yaml
@@ -8,11 +8,11 @@ importers:
     .:
         dependencies:
             react:
-                specifier: 17.0.2
-                version: 17.0.2
+                specifier: 18.3.1
+                version: 18.3.1
             react-dom:
-                specifier: 17.0.2
-                version: 17.0.2(react@17.0.2)
+                specifier: 18.3.1
+                version: 18.3.1(react@18.3.1)
         devDependencies:
             "@playwright/test":
                 specifier: 1.56.1
@@ -21,11 +21,11 @@ importers:
                 specifier: 24.13.0
                 version: 24.13.0
             "@types/react":
-                specifier: 17.0.89
-                version: 17.0.89
+                specifier: 18.3.31
+                version: 18.3.31
             "@types/react-dom":
-                specifier: 17.0.26
-                version: 17.0.26(@types/react@17.0.89)
+                specifier: 18.3.7
+                version: 18.3.7(@types/react@18.3.31)
             "@vitejs/plugin-react":
                 specifier: 4.7.0
                 version: 4.7.0(vite@5.4.20(@types/node@24.13.0))
@@ -924,24 +924,18 @@ packages:
                 integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==,
             }
 
-    "@types/react-dom@17.0.26":
+    "@types/react-dom@18.3.7":
         resolution:
             {
-                integrity: sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==,
+                integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==,
             }
         peerDependencies:
-            "@types/react": ^17.0.0
+            "@types/react": ^18.0.0
 
-    "@types/react@17.0.89":
+    "@types/react@18.3.31":
         resolution:
             {
-                integrity: sha512-I98SaDCar5lvEYl80ClRIUztH/hyWHR+I2f+5yTVp/MQ205HgYkA2b5mVdry/+nsEIrf8I65KA5V/PASx68MsQ==,
-            }
-
-    "@types/scheduler@0.16.8":
-        resolution:
-            {
-                integrity: sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==,
+                integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==,
             }
 
     "@vitejs/plugin-react@4.7.0":
@@ -1234,13 +1228,6 @@ packages:
         version: 24.13.0
         hasBin: true
 
-    object-assign@4.1.1:
-        resolution:
-            {
-                integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==,
-            }
-        engines: { node: ">=0.10.0" }
-
     picocolors@1.1.1:
         resolution:
             {
@@ -1270,13 +1257,13 @@ packages:
             }
         engines: { node: ^10 || ^12 || >=14 }
 
-    react-dom@17.0.2:
+    react-dom@18.3.1:
         resolution:
             {
-                integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==,
+                integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==,
             }
         peerDependencies:
-            react: 17.0.2
+            react: ^18.3.1
 
     react-refresh@0.17.0:
         resolution:
@@ -1285,10 +1272,10 @@ packages:
             }
         engines: { node: ">=0.10.0" }
 
-    react@17.0.2:
+    react@18.3.1:
         resolution:
             {
-                integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==,
+                integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==,
             }
         engines: { node: ">=0.10.0" }
 
@@ -1306,10 +1293,10 @@ packages:
         engines: { node: ">=18.0.0", npm: ">=8.0.0" }
         hasBin: true
 
-    scheduler@0.20.2:
+    scheduler@0.23.2:
         resolution:
             {
-                integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==,
+                integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==,
             }
 
     semver@6.3.1:
@@ -1786,17 +1773,14 @@ snapshots:
 
     "@types/prop-types@15.7.15": {}
 
-    "@types/react-dom@17.0.26(@types/react@17.0.89)":
+    "@types/react-dom@18.3.7(@types/react@18.3.31)":
         dependencies:
-            "@types/react": 17.0.89
+            "@types/react": 18.3.31
 
-    "@types/react@17.0.89":
+    "@types/react@18.3.31":
         dependencies:
             "@types/prop-types": 15.7.15
-            "@types/scheduler": 0.16.8
             csstype: 3.2.3
-
-    "@types/scheduler@0.16.8": {}
 
     "@vitejs/plugin-react@4.7.0(vite@5.4.20(@types/node@24.13.0))":
         dependencies:
@@ -1923,8 +1907,6 @@ snapshots:
 
     node@runtime:24.13.0: {}
 
-    object-assign@4.1.1: {}
-
     picocolors@1.1.1: {}
 
     playwright-core@1.56.1: {}
@@ -1941,19 +1923,17 @@ snapshots:
             picocolors: 1.1.1
             source-map-js: 1.2.1
 
-    react-dom@17.0.2(react@17.0.2):
+    react-dom@18.3.1(react@18.3.1):
         dependencies:
             loose-envify: 1.4.0
-            object-assign: 4.1.1
-            react: 17.0.2
-            scheduler: 0.20.2
+            react: 18.3.1
+            scheduler: 0.23.2
 
     react-refresh@0.17.0: {}
 
-    react@17.0.2:
+    react@18.3.1:
         dependencies:
             loose-envify: 1.4.0
-            object-assign: 4.1.1
 
     resolve-pkg-maps@1.0.0: {}
 
@@ -1988,10 +1968,9 @@ snapshots:
             "@rollup/rollup-win32-x64-msvc": 4.62.2
             fsevents: 2.3.3
 
-    scheduler@0.20.2:
+    scheduler@0.23.2:
         dependencies:
             loose-envify: 1.4.0
-            object-assign: 4.1.1
 
     semver@6.3.1: {}
 

--- a/src/BloomBrowserUI/react_components/registration/component-tests/registration-email.uitest.ts
+++ b/src/BloomBrowserUI/react_components/registration/component-tests/registration-email.uitest.ts
@@ -36,7 +36,7 @@ test.describe("Registration Dialog - Email Field - Initial Load", () => {
         const emailField = await field.email.getElement();
 
         await expect(emailField).toHaveValue("");
-        expect(await field.email.markedInvalid).toBe(false);
+        await field.email.expectMarkedInvalid(false);
     });
 
     test("Email field loads with pre-populated valid email", async ({
@@ -52,7 +52,7 @@ test.describe("Registration Dialog - Email Field - Initial Load", () => {
         const emailField = await field.email.getElement();
 
         await expect(emailField).toHaveValue("john.doe@example.com");
-        expect(await field.email.markedInvalid).toBe(false);
+        await field.email.expectMarkedInvalid(false);
     });
 
     test("Email field shows error on load with invalid pre-populated email", async ({
@@ -69,7 +69,7 @@ test.describe("Registration Dialog - Email Field - Initial Load", () => {
 
         await expect(emailField).toHaveValue("invalid-email");
         // Error should show immediately for pre-populated invalid email
-        expect(await field.email.markedInvalid).toBe(true);
+        await field.email.expectMarkedInvalid(true);
     });
 });
 
@@ -100,7 +100,7 @@ test.describe("Registration Dialog - Email Field - Valid Formats", () => {
             await emailInput.fill(email);
             await page.keyboard.press("Tab");
             await expect(emailInput).toHaveValue(email);
-            expect(await field.email.markedInvalid).toBe(false);
+            await field.email.expectMarkedInvalid(false);
         }
     });
 });
@@ -131,7 +131,7 @@ test.describe("Registration Dialog - Email Field - Invalid Formats", () => {
             await emailInput.fill(email);
             await page.keyboard.press("Tab");
             await expect(emailInput).toHaveValue(email);
-            expect(await field.email.markedInvalid).toBe(true);
+            await field.email.expectMarkedInvalid(true);
         }
     });
 });
@@ -149,12 +149,12 @@ test.describe("Registration Dialog - Email Field - Typing Behavior", () => {
         // Enter invalid email and trigger validation
         await emailInput.fill("invalid");
         await clickRegisterButton(page);
-        expect(await field.email.markedInvalid).toBe(true);
+        await field.email.expectMarkedInvalid(true);
 
         // Now type a valid email
         await emailInput.fill("valid@email.com");
         // Error should clear immediately on valid input
-        expect(await field.email.markedInvalid).toBe(false);
+        await field.email.expectMarkedInvalid(false);
     });
 
     test("Can clear email field", async ({ page }) => {
@@ -172,7 +172,7 @@ test.describe("Registration Dialog - Email Field - Typing Behavior", () => {
         await field.email.clear();
         await expect(emailInput).toHaveValue("");
         // Empty email is valid in optional mode
-        expect(await field.email.markedInvalid).toBe(false);
+        await field.email.expectMarkedInvalid(false);
     });
 
     test("Can modify existing email", async ({ page }) => {
@@ -189,7 +189,7 @@ test.describe("Registration Dialog - Email Field - Typing Behavior", () => {
 
         await emailInput.fill("new@example.com");
         await expect(emailInput).toHaveValue("new@example.com");
-        expect(await field.email.markedInvalid).toBe(false);
+        await field.email.expectMarkedInvalid(false);
     });
 });
 
@@ -205,7 +205,7 @@ test.describe("Registration Dialog - Email Field - Optional vs Required", () => 
         await clickRegisterButton(page);
 
         // Email should NOT show error when it's optional
-        expect(await field.email.markedInvalid).toBe(false);
+        await field.email.expectMarkedInvalid(false);
     });
 
     test("Empty email is required when emailRequiredForTeamCollection is true", async ({
@@ -221,7 +221,7 @@ test.describe("Registration Dialog - Email Field - Optional vs Required", () => 
         await clickRegisterButton(page);
 
         // Email should show error when required
-        expect(await field.email.markedInvalid).toBe(true);
+        await field.email.expectMarkedInvalid(true);
     });
 
     test("Email Required mode displays correctly", async ({ page }) => {
@@ -249,7 +249,7 @@ test.describe("Registration Dialog - Email Field - Optional vs Required", () => 
         await clickRegisterButton(page);
 
         // Valid email should not show error even when required
-        expect(await field.email.markedInvalid).toBe(false);
+        await field.email.expectMarkedInvalid(false);
     });
 });
 
@@ -265,7 +265,7 @@ test.describe("Registration Dialog - Email Field - Edge Cases", () => {
             "very.long.username.with.many.dots@subdomain.example.com";
         await emailInput.fill(longEmail);
         await expect(emailInput).toHaveValue(longEmail);
-        expect(await field.email.markedInvalid).toBe(false);
+        await field.email.expectMarkedInvalid(false);
     });
 
     test("Handles email with just whitespace", async ({ page }) => {
@@ -279,7 +279,7 @@ test.describe("Registration Dialog - Email Field - Edge Cases", () => {
         await clickRegisterButton(page);
 
         // Whitespace-only should be treated as empty (valid in optional mode)
-        expect(await field.email.markedInvalid).toBe(false);
+        await field.email.expectMarkedInvalid(false);
     });
 
     test("Trims whitespace from email before validation", async ({ page }) => {
@@ -292,7 +292,7 @@ test.describe("Registration Dialog - Email Field - Edge Cases", () => {
         // Email with leading/trailing spaces should still be valid
         await emailInput.fill("  user@example.com  ");
         // Should not show error as trimmed value is valid
-        expect(await field.email.markedInvalid).toBe(false);
+        await field.email.expectMarkedInvalid(false);
     });
 });
 
@@ -329,7 +329,7 @@ test.describe("Registration Dialog - Email Case Sensitivity", () => {
         for (const email of caseVariations) {
             await emailField.fill(email);
             await page.keyboard.press("Tab");
-            expect(await field.email.markedInvalid).toBe(false);
+            await field.email.expectMarkedInvalid(false);
         }
     });
 });

--- a/src/BloomBrowserUI/react_components/registration/component-tests/registration-interaction.uitest.ts
+++ b/src/BloomBrowserUI/react_components/registration/component-tests/registration-interaction.uitest.ts
@@ -46,12 +46,12 @@ test.describe("Registration Dialog - Form Submission", () => {
         await clickRegisterButton(page);
 
         // what are the required fields? Make sure each shows error state
-        expect(await field.firstName.markedInvalid).toBe(true);
-        expect(await field.surname.markedInvalid).toBe(true);
+        await field.firstName.expectMarkedInvalid(true);
+        await field.surname.expectMarkedInvalid(true);
         // Email is optional by default, so it should NOT be marked as invalid when empty
-        expect(await field.email.markedInvalid).toBe(false);
-        expect(await field.organization.markedInvalid).toBe(true);
-        expect(await field.usingFor.markedInvalid).toBe(true);
+        await field.email.expectMarkedInvalid(false);
+        await field.organization.expectMarkedInvalid(true);
+        await field.usingFor.expectMarkedInvalid(true);
     });
 });
 
@@ -136,11 +136,11 @@ test.describe("Registration Dialog - Data Pre-population", () => {
         await expect(usingForField).toHaveValue("Creating literacy materials");
 
         // Verify no fields show error states initially
-        expect(await field.firstName.markedInvalid).toBe(false);
-        expect(await field.surname.markedInvalid).toBe(false);
-        expect(await field.email.markedInvalid).toBe(false);
-        expect(await field.organization.markedInvalid).toBe(false);
-        expect(await field.usingFor.markedInvalid).toBe(false);
+        await field.firstName.expectMarkedInvalid(false);
+        await field.surname.expectMarkedInvalid(false);
+        await field.email.expectMarkedInvalid(false);
+        await field.organization.expectMarkedInvalid(false);
+        await field.usingFor.expectMarkedInvalid(false);
     });
 });
 

--- a/src/BloomBrowserUI/react_components/registration/component-tests/registration-validation.uitest.ts
+++ b/src/BloomBrowserUI/react_components/registration/component-tests/registration-validation.uitest.ts
@@ -73,10 +73,10 @@ test.describe("Registration Dialog - Required Fields Validation", () => {
 
         await clickRegisterButton(page);
 
-        expect(await field.firstName.markedInvalid).toBe(true);
-        expect(await field.surname.markedInvalid).toBe(true);
-        expect(await field.organization.markedInvalid).toBe(true);
-        expect(await field.usingFor.markedInvalid).toBe(true);
+        await field.firstName.expectMarkedInvalid(true);
+        await field.surname.expectMarkedInvalid(true);
+        await field.organization.expectMarkedInvalid(true);
+        await field.usingFor.expectMarkedInvalid(true);
     });
 
     test("Whitespace-only is invalid", async ({ page }) => {
@@ -89,7 +89,7 @@ test.describe("Registration Dialog - Required Fields Validation", () => {
 
         await clickRegisterButton(page);
 
-        expect(await field.firstName.markedInvalid).toBe(true);
+        await field.firstName.expectMarkedInvalid(true);
     });
 });
 

--- a/src/BloomBrowserUI/react_components/registration/component-tests/test-helpers.ts
+++ b/src/BloomBrowserUI/react_components/registration/component-tests/test-helpers.ts
@@ -180,12 +180,3 @@ export async function waitForAndClickOptOutButton(page: Page) {
     });
     await optOutButton.click();
 }
-
-export async function getMarkedInvalid(
-    page: Page,
-    fieldHelper: FieldHelper,
-): Promise<boolean> {
-    const field = page.getByTestId(fieldHelper.name);
-    const ariaInvalid = await field.getAttribute("aria-invalid");
-    return ariaInvalid === "true";
-}

--- a/src/BloomBrowserUI/react_components/registration/component-tests/test-helpers.ts
+++ b/src/BloomBrowserUI/react_components/registration/component-tests/test-helpers.ts
@@ -20,7 +20,7 @@ type FieldHelper = {
     getValue: () => Promise<string>;
     fill: (value: string) => Promise<void>;
     clear: () => Promise<void>;
-    markedInvalid: Promise<boolean>;
+    expectMarkedInvalid: (expected: boolean) => Promise<void>;
 };
 
 // Field name constants for registration form
@@ -78,22 +78,31 @@ function createFieldHelper(testId: string): FieldHelper {
                 .first()
                 .clear();
         },
-        get markedInvalid(): Promise<boolean> {
+        // Asserts whether the field is showing its error state (aria-invalid on the input).
+        // This deliberately retries rather than reading the attribute once: React 18's
+        // createRoot commits asynchronously, so a state change made by (say) a blur handler
+        // is not guaranteed to be in the DOM by the time the next Playwright command runs. A
+        // one-shot getAttribute races that re-render and fails intermittently. The retry uses
+        // Playwright's configured expect timeout, so there is no hand-rolled wait.
+        expectMarkedInvalid: async (expected: boolean) => {
             if (!currentPage) {
                 throw new Error(
                     "Page not initialized. Call setupRegistrationComponent first.",
                 );
             }
-            return (async () => {
-                // Check aria-invalid on the actual input element
-                const inputElement = currentPage
-                    .getByTestId(testId)
-                    .locator("input,textarea")
-                    .first();
-                const ariaInvalid =
-                    await inputElement.getAttribute("aria-invalid");
-                return ariaInvalid === "true";
-            })();
+            const inputElement = currentPage
+                .getByTestId(testId)
+                .locator("input,textarea")
+                .first();
+            // aria-invalid is absent (not "false") when the field is valid in some MUI
+            // versions, so compare the normalized boolean rather than the raw attribute.
+            await expect
+                .poll(async () => {
+                    const ariaInvalid =
+                        await inputElement.getAttribute("aria-invalid");
+                    return ariaInvalid === "true";
+                })
+                .toBe(expected);
         },
     };
 }


### PR DESCRIPTION
The Playwright "component tester" harness under `src/BloomBrowserUI/react_components/component-tester` could not run at all — every test died at import time. This branch gets the whole suite running again: **144 passed, 0 failed, 25 skipped**, stable across warm and cold-dev-server runs.

The breakage was pre-existing on master and independent of any feature work.

## Three independent blockers

**1. A stale React 17 pin.** The component-tester workspace pinned `react`/`react-dom` at 17.0.2 while the app is on 18.3.1, so Vite could not resolve `react-dom/client` — which `utils/reactRender.tsx` has imported since the React 18 migration. Because `component-harness.tsx` (the harness *entry point*) imports `renderRoot` from that module, this killed all 24 vite-served component tests, not just ones whose components happened to use it.

The pin was a missed spot in the migration, not a deliberate constraint: commit 6d1e449 ("@ upgrade to react 18") edited `component-harness.tsx` inside that very folder while leaving its `package.json` at 17, and nothing documents a reason. Bumped to 18.3.1 / `@types/react` 18.3.31 / `@types/react-dom` 18.3.7 to match the app.

**2. `playwright.config.ts` collected the wrong specs.** With `testDir: ".."` and `testMatch: "**/*.uitest.*"` it also picked up the `bloom-exe*.uitest.ts` specs, which belong to `playwright.bloom-exe.config.ts` and import the repo-level `playwright/test`. That loaded a second copy of Playwright and aborted the entire run with "Requiring @playwright/test second time" before a single test executed. This only manifests once `src/BloomBrowserUI/node_modules` exists — i.e. in the normal developer state — so the React fix alone would not have unblocked anything. Added a `testIgnore`.

**3. The harness's fake jQuery broke select2.** `component-harness.tsx` replaced `window.$`/`window.jQuery` with a stand-in object carrying only `Deferred`. Under Vite, select2 loads as an optimized ESM dep where `module` is undefined, so its UMD wrapper falls through to the browser-globals branch and does `factory(jQuery)` against `window.jQuery`. An object with no `.fn` makes it throw at import time, taking down every component whose graph reaches `StyleEditor` — everything under the toolbox. Replaced the stub with the real jQuery, which provides `Deferred` natively, so nothing was lost.

## Toolbox harness

`ToolboxRoot` only renders a section for a tool present in `getMasterToolList()`, and tools land there as a side effect of importing `toolboxBootstrap.ts`. The harness cannot import that module — it also does `$(document).ready(renderToolboxRoot)` and assigns `window.toolboxBundle`, which would double-render the root and clobber the stub one test installs — so `ToolboxRootTestHarness.tsx` now performs the same registrations itself. That duplicated list can drift; the proper fix (extract a side-effect-free `registerAllToolboxTools()`) is logged in `PAPERCUTS.md` and is probably best folded into the toolbox React refactor rather than done twice.

## Test reliability

Raised the Playwright `expect` timeout from 1000ms to 5000ms (matching `playwright.bloom-exe.config.ts`), with the overall test timeout raised 15s→30s in step so a genuinely broken assertion still reports as an assertion failure rather than a whole-test timeout. This is a retry budget, not a fixed wait, so passing runs cost nothing. At 1000ms roughly one test per full-suite run failed with "element(s) not found" — a different one each time, each passing in isolation.

Also made the registration tests' error-state assertion retry: `markedInvalid` did a one-shot `getAttribute("aria-invalid")`, which was safe under React 17's synchronous `ReactDOM.render` but races React 18's asynchronous `createRoot` commit. Replaced with `expectMarkedInvalid(expected)` across 31 call sites and removed the now-unused racy getter.

## Test assertions corrected

- `bookgridsetup-basic`: matched `/book in app/i`, but commit c7f4795 renamed the heading to "Books in App (%0)" to match `Bloom.xlf` without updating the test.
- `toolbox-root-react`: a precondition used a bare `getByText("Decodable Reader Tool")`, which also matches the tool's checkbox label in the "More..." panel; scoped it to the accordion headers via the file's existing `getToolHeader` helper.
- `toolbox-root-react`: split "header shows icons and subscription badges without chevrons". The valid half (tool names, no chevrons) is now a passing test; the rest is `test.fixme` with an explanation, because it asserts on `.subscription-badge` (emitted only by the legacy jQuery toolbox) and `.toolbox-react-header-icon` (a class that exists nowhere in the app), via computed `background-image` — which `src/BloomBrowserUI/AGENTS.md` tells us not to do. Re-enabling it needs a product decision about whether the React header renders badges and icons at all, so it was not forced green.

## Not in CI

These suites are still not run by CI — `nightly.yml` covers vitest, C# and visual-regression, and does not even install this workspace, which is why the harness rotted unnoticed. It is now green and stable enough to wire in; see `PAPERCUTS.md` for the suggested nightly job.

## Scope

No C# and no shipped front-end source is touched. `ToolboxRootTestHarness.tsx` is referenced only by the component-tester's dynamic `import.meta.glob`, so it never enters the app bundle.


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8113)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8113)
<!-- Reviewable:end -->
