### PR TITLE
Capture thread stacks when the nightly's Bloom hangs (BL-16612)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -189,6 +189,44 @@ jobs:
                   # The suite drives a headless chromium (Playwright) to capture bloom-player pages.
                   pnpm exec playwright install chromium
 
+            # This suite hangs intermittently (BL-16612): Bloom stops making progress, stops writing
+            # to its log, and every case then times out — so the run tells us only that something
+            # stopped, never what. What would identify it is each thread's stack while it was stuck,
+            # and we cannot collect that afterwards: the suite's own afterAll kills Bloom
+            # (taskkill /T /F) before any later step could look. So start a watchdog that runs
+            # ALONGSIDE the tests and grabs the stacks while Bloom is still wedged (on the observed
+            # failures it stayed stuck ~24 minutes, so there is plenty of time).
+            #
+            # Purely observational: it reads process state and never touches Bloom, so it cannot
+            # change the outcome of the run it is watching. Best-effort — `|| true` because a
+            # watchdog that fails to start must never turn the nightly red.
+            - name: Start the hung-Bloom watchdog
+              if: ${{ !cancelled() && steps.setup_visual_regression.outcome == 'success' }}
+              shell: pwsh
+              run: |
+                  try { dotnet tool install --global dotnet-stack } catch { Write-Host "dotnet-stack install skipped: $_" }
+                  $env:PATH = "$env:USERPROFILE\.dotnet\tools;$env:PATH"
+
+                  # Start-Process resolves relative paths against the PROCESS working directory, which is
+                  # not necessarily PowerShell's location, so be explicit about both. A watchdog that
+                  # silently fails to launch would cost us a whole night.
+                  $repo = (Get-Location).Path
+                  Start-Process pwsh `
+                    -ArgumentList '-NoProfile', '-File', "$repo\build\ci\watch-for-hung-bloom.ps1" `
+                    -WorkingDirectory $repo `
+                    -WindowStyle Hidden
+
+                  # Confirm it really came up, so a non-start is visible in this log rather than being
+                  # discovered as an empty artifact tomorrow.
+                  Start-Sleep -Seconds 5
+                  if (Test-Path "$repo\bloom-watchdog\samples.txt") {
+                      Write-Host "watchdog confirmed running:"
+                      Get-Content "$repo\bloom-watchdog\samples.txt"
+                  } else {
+                      Write-Host "WARNING: the watchdog did not start; the run continues without stack capture"
+                  }
+                  exit 0
+
             # Reporter flags rather than config so this suite's own vitest.config.ts stays about
             # timeouts. Same no-`--` rule as the browser UI tests above — see that step's comment.
             - name: Run visual regression tests
@@ -205,13 +243,23 @@ jobs:
             # event log. Gather whatever exists into a fixed folder so the next step can upload it,
             # rather than losing the one thing that explains a "Bloom never came up" failure.
             # Best-effort throughout: never let missing logs turn this diagnostic step red.
+            #
+            # Runs on SUCCESS as well as failure (BL-16612). Chasing an intermittent hang means the
+            # healthy runs are evidence too: without a known-good log and watchdog sample to compare
+            # against, a failing run's numbers mean nothing in isolation. Throwing away everything
+            # from the green runs is precisely what has made this bug so hard to pin down.
             - name: Collect Bloom diagnostics
-              if: ${{ !cancelled() && steps.visual_regression.outcome == 'failure' }}
+              if: ${{ !cancelled() && steps.visual_regression.outcome != 'skipped' }}
               shell: bash
               run: |
                   set +e
                   dest="bloom-diagnostics"
                   mkdir -p "$dest"
+                  # Thread stacks + process samples from the watchdog, if it saw anything worth keeping.
+                  if [ -d "bloom-watchdog" ]; then
+                      echo "Found watchdog output"
+                      cp -r "bloom-watchdog" "$dest/watchdog" 2>/dev/null
+                  fi
                   for src in "$TEMP/SIL/Bloom" "$LOCALAPPDATA/SIL/Bloom" "$LOCALAPPDATA/Temp/SIL/Bloom"; do
                       if [ -d "$src" ]; then
                           echo "Found Bloom logs in: $src"
@@ -226,13 +274,14 @@ jobs:
                   echo "----- collected diagnostics -----"
                   ls -R "$dest" || true
 
-            # On failure, keep the current + diff images so a human can see what changed, plus the
-            # Bloom logs / crash events gathered above. The committed *-reference.png baselines are
-            # already in the repo; *-current.png and *-diff.png are generated (gitignored).
-            # if-no-files-found: ignore avoids a warning when the failure was not a pixel mismatch
-            # (e.g. Bloom failed to launch, so no screenshots were produced).
+            # Keep the current + diff images so a human can see what changed, plus the Bloom logs /
+            # crash events / watchdog stacks gathered above. The committed *-reference.png baselines
+            # are already in the repo; *-current.png and *-diff.png are generated (gitignored).
+            # if-no-files-found: ignore avoids a warning when there was no pixel mismatch at all
+            # (e.g. a clean run, or Bloom failed to launch so no screenshots were produced).
+            # Uploaded on success too, for the reason given on the collect step above.
             - name: Upload visual regression diffs
-              if: ${{ !cancelled() && steps.visual_regression.outcome == 'failure' }}
+              if: ${{ !cancelled() && steps.visual_regression.outcome != 'skipped' }}
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: visual-regression-diffs

--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,8 @@ pr-comments*.md
 # Per-developer Claude Code settings (the shared .claude/CLAUDE.md stays tracked).
 .claude/settings.json
 .claude/settings.local.json
+
+# Scratch folders the nightly's diagnostics steps create at the repo root (also created if you
+# run build/ci/watch-for-hung-bloom.ps1 locally). Never meant to be committed.
+bloom-diagnostics/
+bloom-watchdog/

--- a/build/ci/watch-for-hung-bloom.ps1
+++ b/build/ci/watch-for-hung-bloom.ps1
@@ -1,0 +1,113 @@
+<#
+.SYNOPSIS
+    Background watchdog for the nightly's visual-regression step: captures managed thread stacks
+    from a Bloom.exe that has stopped making progress.
+
+.DESCRIPTION
+    The nightly visual-regression suite intermittently hangs (BL-16612). When it does, Bloom stops
+    writing to its log and every test case then times out, so the run tells us only that something
+    stopped — never what. The one thing that would identify the cause is what each thread was doing
+    while it was stuck, and we cannot get that after the fact: the suite's afterAll kills Bloom with
+    `taskkill /T /F` before any later workflow step could look at it.
+
+    So this runs alongside the tests instead. It polls for a Bloom.exe that has been alive far longer
+    than a healthy run needs, and captures `dotnet-stack report` for it while it is still wedged. On
+    the observed failures Bloom sat stuck for roughly 24 minutes, so there is a wide window to catch.
+
+    Deliberately uses dotnet-stack (text call stacks) and NOT dotnet-dump: this repo is public and
+    workflow artifacts are widely downloadable, so we must not publish a memory dump of a process
+    that holds CI secrets. Text stacks carry no heap contents.
+
+    Purely observational — it reads process state and never signals, kills, or otherwise touches
+    Bloom, so it cannot change the outcome of the run it is watching. Every failure is swallowed:
+    a broken watchdog must never turn a nightly red.
+
+.PARAMETER HungAfterSeconds
+    How long a Bloom.exe must have been alive before we treat it as stuck. Healthy visual-regression
+    runs launch Bloom, do their work, and kill it inside about 5 minutes; the hangs keep it alive for
+    over 20. The default of 8 minutes sits clearly between the two.
+
+.PARAMETER PollSeconds
+    How often to sample. Sampling is cheap (a process listing), and the samples themselves are useful:
+    a starved-but-alive server and a spinning renderer look quite different in CPU over time.
+
+.PARAMETER Captures
+    How many stack captures to take, spaced CaptureGapSeconds apart. More than one matters: identical
+    stacks minutes apart prove it is genuinely stuck rather than crawling.
+#>
+param(
+    [int] $HungAfterSeconds = 480,
+    [int] $PollSeconds = 30,
+    [int] $Captures = 3,
+    [int] $CaptureGapSeconds = 240,
+    [int] $GiveUpAfterMinutes = 75,
+    [string] $OutputDir = "bloom-watchdog"
+)
+
+$ErrorActionPreference = "Continue"
+
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+$sampleLog = Join-Path $OutputDir "samples.txt"
+
+function Write-Sample([string] $text) {
+    try {
+        "$(Get-Date -Format 'o')  $text" | Add-Content -Path $sampleLog -Encoding utf8
+    } catch {
+        # Never let logging failures stop the watchdog.
+    }
+}
+
+Write-Sample "watchdog started; treating a Bloom older than ${HungAfterSeconds}s as hung"
+
+$capturesTaken = 0
+$nextCaptureAllowedAt = Get-Date
+$deadline = (Get-Date).AddMinutes($GiveUpAfterMinutes)
+
+while ((Get-Date) -lt $deadline) {
+    try {
+        $blooms = @(Get-Process -Name "Bloom" -ErrorAction SilentlyContinue)
+
+        if ($blooms.Count -eq 0) {
+            Write-Sample "no Bloom process running"
+        }
+
+        foreach ($bloom in $blooms) {
+            # StartTime throws for processes we lack rights to query; such a process is not ours anyway.
+            $ageSeconds = $null
+            try {
+                $ageSeconds = [int]((Get-Date) - $bloom.StartTime).TotalSeconds
+            } catch {
+                Write-Sample "pid=$($bloom.Id) age unavailable ($($_.Exception.Message))"
+                continue
+            }
+
+            Write-Sample ("pid={0} age={1}s cpu={2} threads={3} workingSetMB={4}" -f `
+                    $bloom.Id, $ageSeconds, $bloom.CPU, $bloom.Threads.Count,
+                [int]($bloom.WorkingSet64 / 1MB))
+
+            if ($ageSeconds -lt $HungAfterSeconds) { continue }
+            if ($capturesTaken -ge $Captures) { continue }
+            if ((Get-Date) -lt $nextCaptureAllowedAt) { continue }
+
+            $capturesTaken++
+            $stackFile = Join-Path $OutputDir "bloom-stacks-$($bloom.Id)-$capturesTaken.txt"
+            Write-Sample "CAPTURE $capturesTaken/$Captures for pid=$($bloom.Id) (alive ${ageSeconds}s) -> $stackFile"
+            try {
+                # dotnet-stack talks to the runtime's diagnostics server, which is serviced by its own
+                # thread — so it still answers while the app's own threads are deadlocked, which is
+                # exactly the case we are here for.
+                & dotnet-stack report --process-id $bloom.Id *> $stackFile
+                Write-Sample "capture $capturesTaken finished (exit=$LASTEXITCODE, $((Get-Item $stackFile -ErrorAction SilentlyContinue).Length) bytes)"
+            } catch {
+                Write-Sample "capture $capturesTaken FAILED: $($_.Exception.Message)"
+            }
+            $nextCaptureAllowedAt = (Get-Date).AddSeconds($CaptureGapSeconds)
+        }
+    } catch {
+        Write-Sample "poll failed: $($_.Exception.Message)"
+    }
+
+    Start-Sleep -Seconds $PollSeconds
+}
+
+Write-Sample "watchdog finished after ${GiveUpAfterMinutes} minutes; captures taken: $capturesTaken"


### PR DESCRIPTION
CI-only instrumentation so that the **next** time the nightly's visual-regression suite hangs, we learn why. No product code — nothing here can change Bloom's behavior for users, or the behavior of the run it is watching.

## The problem it solves

The suite hangs intermittently ([BL-16612](https://issues.bloomlibrary.org/youtrack/issue/BL-16612)) — 2 of the 4 scheduled nightlies so far. Bloom stops making progress, stops writing to its log, and all 12 cases then time out at 120s each. Every one of those runs has told us only that *something* stopped, never what.

What would identify it is each thread's stack while it was stuck. We cannot get that after the fact: the suite's own `afterAll` kills Bloom with `taskkill /T /F` before any later workflow step could look at the process.

## What this adds

**A watchdog that runs alongside the tests** (`build/ci/watch-for-hung-bloom.ps1`), started just before the visual-regression step. It polls for a `Bloom.exe` that has been alive far longer than a healthy run needs — ~5 minutes healthy versus 20+ when hung — and captures `dotnet-stack report` for it *while it is still wedged*. On the observed failures Bloom sat stuck for about 24 minutes, so there is a wide window to catch it.

It takes up to 3 captures a few minutes apart, plus a 30-second process sample line (CPU, thread count, working set). Both matter:

- identical stacks minutes apart prove it is genuinely **stuck** rather than crawling;
- the CPU trend distinguishes a starved-but-idle server from a spinning renderer.

**`dotnet-stack`, deliberately not `dotnet-dump`.** This repo is public and workflow artifacts are widely downloadable, so we must not publish a memory dump of a process that holds CI secrets. `dotnet-stack` emits text call stacks only — no heap contents.

**Diagnostics are now collected and uploaded on success too**, not only on failure. Chasing an intermittent fault means the healthy runs are evidence as well: without a known-good log and sample to compare against, a failing run's numbers mean little on their own. Discarding everything from the green runs is a large part of why this has been so hard to pin down.

## Safety

- **No product code.** Only the workflow, a new CI script, and two `.gitignore` lines for the scratch folders those steps create.
- **Purely observational.** The watchdog reads process state; it never signals, kills, or otherwise touches Bloom.
- **Cannot fail the nightly.** Every operation is best-effort and swallowed; the step ends in `exit 0`. If the watchdog does not start, the step says so loudly in the log rather than being discovered as an empty artifact the next day.

## Why this lands ahead of the actual fix

There is a fix for this hang on a separate branch (#8110). It is deliberately **not** in this PR. The fix suppresses the failure — so if it lands first, the hang may simply stop happening and the root cause stays unknown, leaving mitigation in place justified by a hypothesis we could never test. The diagnostic opportunity is perishable; the fix can wait a few days.

## Verified locally

- The script parses cleanly, and its no-process and polling paths were exercised.
- The detached `Start-Process` launch writes where expected — worth checking, because `Start-Process` resolves relative paths against the process working directory rather than PowerShell's location, so a wrong path would mean a watchdog that silently never starts.
- `dotnet-stack report` against a live .NET process returns real per-thread managed stacks (exit 0, 4.7 KB of text, no memory contents).

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16612


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8114)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8114)
<!-- Reviewable:end -->
