### PR TITLE
Preserve CKEditor bookmark spans so the cursor doesn't jump in reader tools (BL-16490)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markup.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markup.ts
@@ -394,17 +394,12 @@ import { ReaderToolsModel } from "../readerToolsModel";
                     );
                     // CKeditor copies the highlight style as a barebones inline style containing
                     // only the background-color property.
-                    return (
-                        !!style &&
-                        /^background-color: [^;]*;$/.test(style)
-                    );
+                    return !!style && /^background-color: [^;]*;$/.test(style);
                 })
                 .contents()
                 .unwrap();
-            // remove spans belonging to CKEditor that are hidden.
-            $(this)
-                .find("span[id^=cke_][style*='display: none;']")
-                .remove();
+            // leave CKEditor-specific hidden spans that serve as bookmarks intact so that
+            // the cursor can be restored after marking up the text.  (BL-16490)
         });
     };
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markupSpec.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markupSpec.js
@@ -266,13 +266,16 @@ describe("jquery.text-markup", function () {
         expect($("#text_entry1").html()).toBe("<p>pre new text post</p>");
     });
 
-    it("removeCkEditorMarkup removes hidden cke_ spans", function () {
+    it("removeCkEditorMarkup preserves hidden cke_ spans (BL-16490)", function () {
+        // The hidden cke_ spans are CKEditor bookmarks marking the cursor position.
+        // We must leave them intact so the cursor can be restored after the text is
+        // marked up; removing them here made the cursor jump to the start of the box.
         const input =
             '<p>pre <span id="cke_1" style="display: none;">hidden</span> post</p>';
 
         $("#text_entry1").html(input).removeCkEditorMarkup();
 
-        expect($("#text_entry1").html()).toBe("<p>pre  post</p>");
+        expect($("#text_entry1").html()).toBe(input);
     });
 
     it("checkWrapWordsExtraIgnoresEmptyItems", function () {


### PR DESCRIPTION
## Problem

When the Decodable (or Leveled) Reader tool is active, pausing while typing in a text box made the cursor jump to the **beginning** of the box.

## Cause

Pausing typing triggers a 500 ms-debounced re-markup pass that rewrites the editable box's `innerHTML`, which destroys the live caret. The caret is saved/restored via hidden CKEditor "bookmark" spans (`<span id="cke_bm_..." style="display: none;">`) inserted before the rewrite and re-selected (via `selectBookmarks`) after. But `removeCkEditorMarkup()` was deleting exactly those bookmark spans (`span[id^=cke_][style*='display: none;']`) during the markup pass — so afterward `selectBookmarks()` could not find them and the selection collapsed to the start of the box.

## Fix

Stop removing the hidden `cke_` bookmark spans in `removeCkEditorMarkup()`. It still unwraps CKEditor's background-color highlight spans, which was its other job. With the bookmarks left intact, the caret is restored to where the user was typing.

Updated the corresponding unit test (`removeCkEditorMarkup ... hidden cke_ spans`) to assert the bookmark spans are now **preserved**.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16490


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8116)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8116)
<!-- Reviewable:end -->
