### PR TITLE
Highlight decodable/leveled reader violations without touching the DOM (BL-16558)

### DIFF
--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -34,6 +34,19 @@ House rules:
 - **Context:** BL-16638 / PR #8134. Andrew chose "make a papercut entry" over fixing it inline.
   Loop at `index.spec.ts:426`, assertion at `index.spec.ts:486`.
 
+## 2026-07-28 — One talkingBookSpec test fails only under full-suite worker load
+- **Cut:** `talkingBookSpec.ts > showTool(checksum=missing, audio=missing, scenario=PreTextBox) => UPDATE`
+  fails intermittently in `pnpm test`, but passes when its file is run alone, passes on a
+  re-run of the identical tree, and passes if you exclude *any* one unrelated spec file
+  (`--exclude "**/textHighlightManagerSpec.ts"` works just as well as excluding a related
+  one). So it's sensitive to how many files the pool is juggling, not to any code change —
+  but it reads as a real regression and costs 15+ minutes to clear each time it appears.
+- **Idea:** Make the test wait for the audio player's `src` deterministically instead of
+  relying on timing, or mark it as needing serial execution. Failing that, note it in the
+  spec so the next person doesn't re-triage it from scratch.
+- **Context:** BL-16558 preflight. Full suite 611 passing; this test failed on two
+  consecutive runs then passed on the third with no code change in between.
+
 ## 2026-07-24 — killBloomProcess.mjs --help kills Bloom instead of printing usage
 - **Cut:** Running `node .github/skills/bloom-automation/killBloomProcess.mjs --help` to check
   its options killed the running Bloom (output: "Killed process IDs: 56212, 55352"). Unknown

--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -1062,23 +1062,65 @@ even when the div is focused (as long as it is empty).*/
         position: unset;
     }
 }
-// For an INLINE element that is itself background-colored (e.g. a decodable/leveled-reader
-// violation span, or the sentence span that is the ::highlight range), also unset position
-// on the element itself. Do not use this on block containers - see the note above.
+// For an INLINE element that is itself background-colored (e.g. the sentence span that is the
+// ::highlight range), also unset position on the element itself. Do not use this on block
+// containers - see the note above.
 .bl11633-unset-position() {
     position: unset;
     .bl11633-unset-position-on-children();
 }
 
-/*This block handles marking elements that violate decodable book and leveled reader constraints*/
-span.sentence-too-long {
-    background-color: @LeveledReaderViolationColor;
-    .bl11633-unset-position();
+// This block handles marking text that violates decodable book and leveled reader constraints.
+// These are ::highlight() pseudo-elements painted over Ranges by readerHighlights.ts, not
+// classes on spans: marking up the DOM inside a contenteditable tempts CKEditor into copying
+// the highlight's background color into a permanent inline style (BL-16558).
+// As for the Talking Book highlight, we paint with a thick offset underline rather than a
+// background color. Because the underline is drawn behind the glyphs and does not extend as far
+// upwards as a background would, it covers much less of the previous line when lines are
+// tightly spaced.
+.reader-violation-highlight(@color) {
+    text-decoration-line: underline;
+    text-decoration-style: solid;
+    text-decoration-color: @color;
+    // The skip-ink setting allows the underline to be drawn right against the text.
+    text-decoration-thickness: 1.1em;
+    text-underline-offset: -0.8em;
+    text-decoration-skip-ink: none;
 }
 
-span.word-too-long {
-    background-color: @bloom-lightblue;
-    .bl11633-unset-position();
+::highlight(bloom-reader-sentence-too-long) {
+    .reader-violation-highlight(@LeveledReaderViolationColor);
+}
+
+::highlight(bloom-reader-word-too-long) {
+    .reader-violation-highlight(@bloom-lightblue);
+}
+
+::highlight(bloom-reader-word-not-decodable) {
+    .reader-violation-highlight(@DecodableReaderViolationColor);
+}
+
+// Sight words get no paint of their own; the highlight exists so that hovering one can explain
+// why it is not marked as a problem. (See bloom-reader-highlight-tip below.)
+
+// The hover tip readerHighlights.ts shows when the mouse is over one of the highlights above.
+// Since the highlights are pseudo-elements there is no element to hang a tooltip on, so we
+// position our own. bloom-ui keeps it out of the saved page.
+.bloom-reader-highlight-tip {
+    position: absolute;
+    z-index: 25000;
+    display: none;
+    max-width: 250px;
+    padding: 3px 6px;
+    border: 1px solid @bloom-gray;
+    border-radius: 3px;
+    background-color: white;
+    color: black;
+    font-family: @UIFontStack;
+    font-size: 9pt;
+    // The tip must never intercept clicks meant for the text underneath it, nor trigger the
+    // mousemove hit test against itself.
+    pointer-events: none;
 }
 
 .page-too-many-words-or-sentences .marginBox {
@@ -1097,14 +1139,6 @@ span.word-too-long {
     z-index: 20000;
 }
 
-span.sight-word {
-}
-
-span.word-not-found {
-    background-color: @DecodableReaderViolationColor;
-    .bl11633-unset-position();
-}
-
 // div.bloom-editable and p are block-level and carry the language-code tags and paragraph/
 // line-break markers, which are positioned relative to them, so they must keep their own
 // position:relative; only their inline children need position:unset. (In the edit tab the
@@ -1121,15 +1155,6 @@ div.bloom-editable p > .audio-sentence,
 div.bloom-editable p > .bloom-highlightSegment {
     .bl11633-unset-position();
 }
-
-/* We are disabling the "Possible Word" feature at this time.
-SPAN.possible-word
-{
-    -moz-text-decoration-style: wavy;
-    -moz-text-decoration-line: underline;
-    -moz-text-decoration-color: blue;
-}
-*/
 
 div.cke_float {
     div.cke_top {

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementPointerInteractions.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementPointerInteractions.ts
@@ -129,9 +129,14 @@ export class CanvasElementPointerInteractions {
             return undefined;
         }
 
-        // We really seem to need to handle both possibilities. I had it working with just the
-        // code for range, then restarted Bloom and started getting CaretPositions. Maybe a new
-        // version of WebView2 got auto-installed? Anyway, now it should handle both.
+        // We really do need to handle both possibilities, and here is why: a new version of
+        // WebView2 had indeed been auto-installed. Chromium added the standard
+        // caretPositionFromPoint (which answers a CaretPosition) in version 128; before that only
+        // its own caretRangeFromPoint (which answers a Range) existed. Since we prefer the
+        // standard one above, WebView2 128 and later take that branch and give us CaretPositions,
+        // while everything back to our minimum of 112 (WebView2Browser.kMinimumWebView2Version)
+        // falls through to the older call and gives us Ranges. So both branches below are live
+        // across the versions we support, and neither can be deleted while 112 is the minimum.
         let range: Range;
         if ("endContainer" in rangeOrCaret) {
             range = rangeOrCaret;

--- a/src/BloomBrowserUI/bookEdit/js/textHighlightManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/textHighlightManager.ts
@@ -1,4 +1,4 @@
-import StyleEditor from "../../StyleEditor/StyleEditor";
+import StyleEditor from "../StyleEditor/StyleEditor";
 
 const kSegmentClass = "bloom-highlightSegment";
 const kEnableHighlightClass = "ui-enableHighlight";
@@ -79,7 +79,7 @@ function getStyleEditorForColorLookup(): StyleEditor {
     return styleEditorForColorLookup;
 }
 
-export class AudioTextHighlightManager {
+export class TextHighlightManager {
     // Remove all current and split highlights from the registry for the document containing contextNode.
     public clearAllManagedHighlights(contextNode?: Node): void {
         if (!contextNode) {
@@ -302,7 +302,7 @@ export class AudioTextHighlightManager {
         const documentElement = getDocumentElement(styleSource);
         if (!documentElement) {
             console.error(
-                "AudioTextHighlightManager.updateCurrentHighlightColors() could not find documentElement for the style source.",
+                "TextHighlightManager.updateCurrentHighlightColors() could not find documentElement for the style source.",
             );
             return;
         }
@@ -384,7 +384,7 @@ export class AudioTextHighlightManager {
         const ownerDocument = node.ownerDocument;
         if (!ownerDocument) {
             console.error(
-                "AudioTextHighlightManager.makeRange() could not find ownerDocument for a highlighted node.",
+                "TextHighlightManager.makeRange() could not find ownerDocument for a highlighted node.",
             );
             return undefined;
         }

--- a/src/BloomBrowserUI/bookEdit/js/textHighlightManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/textHighlightManager.ts
@@ -89,6 +89,13 @@ export interface TextOffsetMap {
     pieces: TextPiece[];
 }
 
+// The character a visual break contributes to the mapped text. A newline, not a space, because
+// a <br> ends a line and consumers must be able to tell that from an ordinary word gap: Bloom's
+// sentence splitter counts a newline as paragraph-ending punctuation, so each line of a
+// <br>-separated stanza is analyzed as its own sentence, exactly as it was when the reader tools
+// fed raw HTML (where <br> became a paragraph-ending placeholder) to the splitter.
+const kBreakSeparator = "\n";
+
 // Tags whose boundaries separate words even though they contribute no characters. Compare
 // removeAllHtmlMarkupFromString(), which substitutes a space for these in the HTML-string world.
 const kSeparatingTags = new Set([
@@ -126,9 +133,11 @@ export function mapVisibleText(
     };
 
     const addSeparator = (): void => {
-        // No point starting with a separator, or doubling one up.
-        if (text.length > 0 && !text.endsWith(" ")) {
-            addPiece(" ");
+        // No point starting with a separator, or doubling one up. Note that we test for the
+        // separator itself, not for whitespace: text that already ends in a space still needs
+        // the break character, or a <br> after a space would stop ending the line.
+        if (text.length > 0 && !text.endsWith(kBreakSeparator)) {
+            addPiece(kBreakSeparator);
         }
     };
 

--- a/src/BloomBrowserUI/bookEdit/js/textHighlightManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/textHighlightManager.ts
@@ -1,45 +1,30 @@
-import StyleEditor from "../StyleEditor/StyleEditor";
-
-const kSegmentClass = "bloom-highlightSegment";
-const kEnableHighlightClass = "ui-enableHighlight";
-const kDisableHighlightClass = "ui-disableHighlight";
-const kPostAudioSplitClass = "bloom-postAudioSplit";
-const kTextBoxRecordingMode = "textbox";
-
-const kCurrentHighlightBackgroundCssVar =
-    "--bloom-audio-current-highlight-background";
-const kCurrentHighlightColorCssVar = "--bloom-audio-current-highlight-color";
-
-// This manager translates Bloom's audio-highlight classes into the CSS highlight registry and
-// ::highlight pseudo-elements.
-// In rare cases, the browser can automatically move computed css into an inline style within a contenteditable, which
-// we suspect is causing BL-15300 where TBT highlighting gets stuck in the book. This method of highlighting without
-// modifying the dom should prevent that, and is also the direction we want to move in for highlighting.
-// The DOM still decides which pieces of text are eligible and marks them with the appropriate classes, but in the Edit
-// Tab the visible paint comes from ::highlight pseudo-elements instead of the element
-// background colors, which we continue to use in Bloom Player etc. - we will need to keep the original class and css
-// rules for a while so that old versions of Bloom player display the highlights, but a next step would be to make
-// newer versions of Bloom Player switch to using pseudo-elements to display highlights like we do here
-
-export const currentHighlightName = "bloom-audio-current";
-
-export const splitHighlightNames = [
-    "bloom-audio-split-1",
-    "bloom-audio-split-2",
-    "bloom-audio-split-3",
-] as const;
-
-const allManagedHighlightNames = [currentHighlightName, ...splitHighlightNames];
+// This manager paints text highlights using the CSS custom highlight registry
+// (CSS.highlights) and ::highlight() pseudo-elements, instead of by wrapping the text in
+// styled spans.
+//
+// In rare cases, the browser can automatically move computed css into an inline style within a
+// contenteditable, which we suspect is causing BL-15300 (Talking Book highlighting gets stuck in
+// the book) and BL-16558 (replacing a decodable-reader-marked word leaves a permanent
+// background-color span). Highlighting without modifying the dom prevents that, and is the
+// direction we want to move in for highlighting generally.
+//
+// The DOM still decides which pieces of text are eligible; only the visible paint comes from
+// ::highlight pseudo-elements. Where the highlight classes are also meaningful outside the Edit
+// Tab (as the Talking Book ones are, for Bloom Player), we continue to write those classes and
+// their background-color rules so older consumers still work.
+//
+// Each client (the Talking Book tool, the decodable/leveled reader tools) owns an instance
+// constructed with the set of highlight names it manages. Names are global to the document's
+// registry, so they must be unique across clients, and each needs a matching ::highlight(name)
+// rule in a stylesheet loaded into the document being highlighted.
 
 type HighlightRegistry = Map<string, unknown>;
-type HighlightConstructor = new (...ranges: Range[]) => unknown;
+// A real Highlight is setlike over its Ranges and has a settable numeric priority.
+type HighlightObject = Iterable<Range> & { priority?: number };
+type HighlightConstructor = new (...ranges: Range[]) => HighlightObject;
 
 function getDocumentWindow(contextNode: Node): Window | undefined {
     return contextNode.ownerDocument?.defaultView ?? undefined;
-}
-
-function getDocumentElement(contextNode: Node): HTMLElement | undefined {
-    return contextNode.ownerDocument?.documentElement ?? undefined;
 }
 
 function getHighlightRegistry(
@@ -67,57 +52,99 @@ function getHighlightConstructor(
     return docWindow?.Highlight;
 }
 
-// A StyleEditor instance used only to read the user's audio-highlight colors from a book's
-// userModifiedStyles sheet. We share StyleEditor's rule lookup rather than duplicating the
-// selector-matching logic, so the read and the write (StyleEditor.putAudioHiliteRulesInDom)
-// can never drift apart. supportFilesRoot is irrelevant for this read-only use.
-let styleEditorForColorLookup: StyleEditor | undefined;
-function getStyleEditorForColorLookup(): StyleEditor {
-    if (!styleEditorForColorLookup) {
-        styleEditorForColorLookup = new StyleEditor("/bloom/bookEdit");
+// Make a Range covering all of node's content, or undefined if there is nothing to highlight.
+export function makeRangeForNodeContents(node: Node): Range | undefined {
+    if (node.textContent === null || node.textContent.length === 0) {
+        return undefined;
     }
-    return styleEditorForColorLookup;
+
+    const ownerDocument = node.ownerDocument;
+    if (!ownerDocument) {
+        console.error(
+            "textHighlightManager.makeRangeForNodeContents() could not find ownerDocument for a highlighted node.",
+        );
+        return undefined;
+    }
+
+    const range = ownerDocument.createRange();
+    range.selectNodeContents(node);
+    return range;
 }
 
 export class TextHighlightManager {
-    // Remove all current and split highlights from the registry for the document containing contextNode.
+    // The highlight names this instance owns. clearAllManagedHighlights() removes exactly these.
+    private readonly managedHighlightNames: readonly string[];
+
+    public constructor(managedHighlightNames: readonly string[]) {
+        this.managedHighlightNames = managedHighlightNames;
+    }
+
+    // Returns true if the document containing contextNode supports the custom highlight API,
+    // so it is worth computing ranges at all. Test environments may not provide it.
+    public canHighlight(contextNode: Node): boolean {
+        return (
+            !!getHighlightRegistry(contextNode) &&
+            !!getHighlightConstructor(contextNode)
+        );
+    }
+
+    // Paint the given ranges under the given highlight name, replacing whatever that name was
+    // painting before. An empty list of ranges removes the highlight altogether.
+    // Where highlights can overlap, a higher priority wins; the default is 0.
+    public setHighlight(
+        name: string,
+        ranges: Range[],
+        contextNode: Node,
+        priority?: number,
+    ): void {
+        const registry = getHighlightRegistry(contextNode);
+        const Highlight = getHighlightConstructor(contextNode);
+        if (!registry || !Highlight) {
+            return;
+        }
+
+        if (ranges.length === 0) {
+            registry.delete(name);
+            return;
+        }
+
+        const highlight = new Highlight(...ranges);
+        if (priority !== undefined) {
+            highlight.priority = priority;
+        }
+        registry.set(name, highlight);
+    }
+
+    // Remove the named highlights from the registry for the document containing contextNode.
+    public clearHighlights(names: readonly string[], contextNode?: Node): void {
+        if (!contextNode) {
+            return;
+        }
+
+        const registry = getHighlightRegistry(contextNode);
+        if (!registry) {
+            return;
+        }
+
+        names.forEach((name) => registry.delete(name));
+    }
+
+    // Remove all of this instance's highlights from the registry for the document containing
+    // contextNode.
     public clearAllManagedHighlights(contextNode?: Node): void {
-        if (!contextNode) {
-            return;
-        }
-
-        const registry = getHighlightRegistry(contextNode);
-        if (!registry) {
-            return;
-        }
-
-        allManagedHighlightNames.forEach((name) => registry.delete(name));
+        this.clearHighlights(this.managedHighlightNames, contextNode);
     }
 
-    // Remove only the split (blue segment) highlights from the registry, leaving the current highlight intact.
-    public clearSplitHighlights(contextNode?: Node): void {
-        if (!contextNode) {
-            return;
-        }
-
-        const registry = getHighlightRegistry(contextNode);
-        if (!registry) {
-            return;
-        }
-
-        splitHighlightNames.forEach((name) => registry.delete(name));
-    }
-
-    // Returns true if the current-highlight entry in the registry for contextNode's document
-    // exists but any of its Ranges no longer cover live content, so the highlight is still
-    // registered but paints nothing (BL-15300). That happens two ways when page-setup code
-    // rewrites the DOM under the highlight:
+    // Returns true if the named entry in the registry for contextNode's document exists but any
+    // of its Ranges no longer cover live content, so the highlight is still registered but paints
+    // nothing (BL-15300). That happens two ways when page-setup code rewrites the DOM under the
+    // highlight:
     // - the range's node itself was replaced (e.g. CKEditor's initialization replaces the
     //   paragraph): the range points at a detached node;
     // - an ANCESTOR of the range's node was removed (e.g. re-appending the bloom-editables to
     //   reorder them): per the DOM spec the live Range is then COLLAPSED onto the
     //   still-connected former parent, so a connectedness check alone would miss it.
-    public currentHighlightHasDeadRanges(contextNode?: Node): boolean {
+    public hasDeadRanges(name: string, contextNode?: Node): boolean {
         if (!contextNode) {
             return false;
         }
@@ -127,9 +154,7 @@ export class TextHighlightManager {
         }
         // A real (Chromium) Highlight is setlike over its Ranges, so we can iterate it. Test
         // environments may register a non-iterable stand-in; treat those as healthy.
-        const highlight = registry.get(currentHighlightName) as
-            | Iterable<Range>
-            | undefined;
+        const highlight = registry.get(name) as HighlightObject | undefined;
         if (!highlight || typeof highlight[Symbol.iterator] !== "function") {
             return false;
         }
@@ -143,254 +168,5 @@ export class TextHighlightManager {
             }
         }
         return false;
-    }
-
-    // currentHighlight is the element currently selected for recording etc.
-    // It might be a span (sentence mode) or text box (text box mode).
-    // currentTextBox is either the same as currentHighlight (text box mode)
-    // or its TextBox ancestor (sentence mode).
-    // Adjust pseudo-element highlights to what they should be for this state of things.
-    public refreshHighlights(
-        currentHighlight: Element | null,
-        currentTextBox: HTMLElement | null,
-        suppressCurrentHighlight?: boolean,
-    ): void {
-        const contextNode = currentHighlight ?? currentTextBox;
-        if (!contextNode) {
-            return;
-        }
-
-        const registry = getHighlightRegistry(contextNode);
-        const Highlight = getHighlightConstructor(contextNode);
-        if (!registry || !Highlight) {
-            return;
-        }
-
-        if (suppressCurrentHighlight) {
-            allManagedHighlightNames.forEach((name) => registry.delete(name));
-            return;
-        }
-
-        // Split highlights (blue segments after a textbox recording) and the current highlight
-        // (yellow sentence) are mutually exclusive: split state replaces the yellow highlight.
-        if (this.shouldShowSplitHighlights(currentHighlight, currentTextBox)) {
-            registry.delete(currentHighlightName);
-            this.refreshSplitHighlights(currentTextBox, registry, Highlight);
-        } else {
-            splitHighlightNames.forEach((name) => registry.delete(name));
-            this.refreshCurrentHighlight(
-                currentHighlight,
-                currentTextBox,
-                registry,
-                Highlight,
-            );
-        }
-    }
-
-    private refreshCurrentHighlight(
-        currentHighlight: Element | null,
-        currentTextBox: HTMLElement | null,
-        registry: HighlightRegistry,
-        Highlight: HighlightConstructor,
-    ): void {
-        const highlightInfo = this.getCurrentHighlightInfo(
-            currentHighlight,
-            currentTextBox,
-        );
-        if (!highlightInfo || highlightInfo.ranges.length === 0) {
-            registry.delete(currentHighlightName);
-            return;
-        }
-
-        // enhance: don't check for highlight color settings changes so often
-        this.updateCurrentHighlightColors(highlightInfo.styleSource);
-        registry.set(
-            currentHighlightName,
-            new Highlight(...highlightInfo.ranges),
-        );
-    }
-
-    private refreshSplitHighlights(
-        currentTextBox: HTMLElement,
-        registry: HighlightRegistry,
-        Highlight: HighlightConstructor,
-    ): void {
-        // Cycle through 3 colors using a page-relative index so adjacent paragraphs
-        // never share the same color at their boundary.
-        const rangesByName = new Map<string, Range[]>();
-        splitHighlightNames.forEach((name) => rangesByName.set(name, []));
-
-        Array.from(
-            currentTextBox.querySelectorAll(`span.${kSegmentClass}`),
-        ).forEach((segment, index) => {
-            const highlightName =
-                splitHighlightNames[index % splitHighlightNames.length];
-            const ranges = rangesByName.get(highlightName);
-            ranges?.push(...this.getRangesForSegment(segment));
-        });
-
-        splitHighlightNames.forEach((name) => {
-            const ranges = rangesByName.get(name) ?? [];
-            if (ranges.length > 0) {
-                registry.set(name, new Highlight(...ranges));
-            } else {
-                registry.delete(name);
-            }
-        });
-    }
-
-    private getCurrentHighlightInfo(
-        currentHighlight: Element | null,
-        currentTextBox: HTMLElement | null,
-    ):
-        | {
-              ranges: Range[];
-              styleSource: Element;
-          }
-        | undefined {
-        if (!currentHighlight) {
-            return undefined;
-        }
-
-        // copilot says: fixHighlighting() can carve the visible pieces into nested ui-enableHighlight
-        // spans so punctuation or outer whitespace stays unpainted. Prefer those exact
-        // spans whenever they exist so the pseudo-highlight matches the background-color highlight behavior
-        const enabledDescendants = Array.from(
-            currentHighlight.querySelectorAll(`span.${kEnableHighlightClass}`),
-        );
-        const enabledRanges = enabledDescendants
-            .map((enabledSpan) => this.makeRange(enabledSpan))
-            .filter((range): range is Range => !!range);
-        if (enabledRanges.length > 0) {
-            return {
-                ranges: enabledRanges,
-                styleSource: enabledDescendants[0],
-            };
-        }
-
-        if (currentHighlight.classList.contains(kDisableHighlightClass)) {
-            return undefined;
-        }
-
-        if (currentHighlight === currentTextBox) {
-            const paragraphs = Array.from(currentTextBox.querySelectorAll("p"));
-            const paragraphRanges = paragraphs
-                .map((paragraph) => this.makeRange(paragraph))
-                .filter((range): range is Range => !!range);
-            if (paragraphRanges.length > 0) {
-                return {
-                    ranges: paragraphRanges,
-                    styleSource: paragraphs[0],
-                };
-            }
-        }
-
-        const wholeElementRange = this.makeRange(currentHighlight);
-        if (!wholeElementRange) {
-            return undefined;
-        }
-
-        return {
-            ranges: [wholeElementRange],
-            styleSource: currentHighlight,
-        };
-    }
-
-    // Set the CSS variables that control the ::highlight colors to match the user's chosen
-    // highlight color for the current text style, falling back to the default yellow.
-    private updateCurrentHighlightColors(styleSource: Element): void {
-        const documentElement = getDocumentElement(styleSource);
-        if (!documentElement) {
-            console.error(
-                "TextHighlightManager.updateCurrentHighlightColors() could not find documentElement for the style source.",
-            );
-            return;
-        }
-
-        const bloomEditable = styleSource.closest(".bloom-editable");
-        const styleName = bloomEditable
-            ? Array.from(bloomEditable.classList).find((c) =>
-                  c.endsWith("-style"),
-              )
-            : undefined;
-
-        // Read the user's chosen highlight colors for this style from the same
-        // userModifiedStyles rules that StyleEditor.putAudioHiliteRulesInDom writes, by
-        // delegating to StyleEditor's own lookup (looking in the page's document, not the
-        // toolbox's). When there is no such style, fall back to the default yellow/black.
-        const userColors = styleName
-            ? getStyleEditorForColorLookup().getAudioHiliteProps(
-                  styleName,
-                  styleSource.ownerDocument,
-              )
-            : undefined;
-
-        documentElement.style.setProperty(
-            kCurrentHighlightBackgroundCssVar,
-            userColors?.hiliteBgColor ?? "#febf00",
-        );
-        documentElement.style.setProperty(
-            kCurrentHighlightColorCssVar,
-            userColors?.hiliteTextColor ?? "black",
-        );
-    }
-
-    private shouldShowSplitHighlights(
-        currentHighlight: Element | null,
-        currentTextBox: HTMLElement | null,
-    ): currentTextBox is HTMLElement {
-        if (!currentHighlight || !currentTextBox) {
-            return false;
-        }
-
-        if (currentHighlight !== currentTextBox) {
-            return false;
-        }
-
-        if (currentTextBox.classList.contains(kDisableHighlightClass)) {
-            return false;
-        }
-
-        // Split highlights are only for textbox recordings after AudioRecording has
-        // split the textbox into segment spans and marked it as post-split.
-        return (
-            currentTextBox.classList.contains(kPostAudioSplitClass) &&
-            currentTextBox
-                .getAttribute("data-audiorecordingmode")
-                ?.toLowerCase() === kTextBoxRecordingMode
-        );
-    }
-
-    private getRangesForSegment(segment: Element): Range[] {
-        const enabledRanges = Array.from(
-            segment.querySelectorAll(`span.${kEnableHighlightClass}`),
-        )
-            .map((enabledSpan) => this.makeRange(enabledSpan))
-            .filter((range): range is Range => !!range);
-
-        if (enabledRanges.length > 0) {
-            return enabledRanges;
-        }
-
-        const wholeSegmentRange = this.makeRange(segment);
-        return wholeSegmentRange ? [wholeSegmentRange] : [];
-    }
-
-    private makeRange(node: Node): Range | undefined {
-        if (node.textContent === null || node.textContent.length === 0) {
-            return undefined;
-        }
-
-        const ownerDocument = node.ownerDocument;
-        if (!ownerDocument) {
-            console.error(
-                "TextHighlightManager.makeRange() could not find ownerDocument for a highlighted node.",
-            );
-            return undefined;
-        }
-
-        const range = ownerDocument.createRange();
-        range.selectNodeContents(node);
-        return range;
     }
 }

--- a/src/BloomBrowserUI/bookEdit/js/textHighlightManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/textHighlightManager.ts
@@ -71,6 +71,164 @@ export function makeRangeForNodeContents(node: Node): Range | undefined {
     return range;
 }
 
+// One run of characters within a TextOffsetMap's text. Most come from a real Text node; the
+// rest are synthetic separators standing in for a visual break (a <br>, or the boundary of a
+// block element) which contributes no characters of its own but does separate words.
+interface TextPiece {
+    start: number; // offset of this piece within the map's text
+    length: number;
+    node?: Text; // undefined for a synthetic separator
+}
+
+// A snapshot of the visible text of an element, together with what is needed to turn a pair of
+// character offsets within that text back into a DOM Range. This is how a client can analyze
+// text as a plain string - which is far easier to get right than analyzing HTML - and still
+// highlight the result without touching the DOM.
+export interface TextOffsetMap {
+    text: string;
+    pieces: TextPiece[];
+}
+
+// Tags whose boundaries separate words even though they contribute no characters. Compare
+// removeAllHtmlMarkupFromString(), which substitutes a space for these in the HTML-string world.
+const kSeparatingTags = new Set([
+    "P",
+    "DIV",
+    "LI",
+    "TR",
+    "TD",
+    "TH",
+    "BLOCKQUOTE",
+    "H1",
+    "H2",
+    "H3",
+    "H4",
+    "H5",
+    "H6",
+]);
+
+// Walk root's descendants and build a TextOffsetMap of the text a reader actually sees.
+// shouldSkipElement lets the caller exclude a subtree entirely (transient UI, editor bookmarks,
+// invisible markers); its text is left out of both the string and the offset map.
+export function mapVisibleText(
+    root: Node,
+    shouldSkipElement?: (element: Element) => boolean,
+): TextOffsetMap {
+    const pieces: TextPiece[] = [];
+    let text = "";
+
+    const addPiece = (content: string, node?: Text): void => {
+        if (content.length === 0) {
+            return;
+        }
+        pieces.push({ start: text.length, length: content.length, node });
+        text += content;
+    };
+
+    const addSeparator = (): void => {
+        // No point starting with a separator, or doubling one up.
+        if (text.length > 0 && !text.endsWith(" ")) {
+            addPiece(" ");
+        }
+    };
+
+    const visitChildren = (parent: Node): void => {
+        for (let child = parent.firstChild; child; child = child.nextSibling) {
+            if (child.nodeType === Node.TEXT_NODE) {
+                const textNode = child as Text;
+                addPiece(textNode.data, textNode);
+                continue;
+            }
+            if (child.nodeType !== Node.ELEMENT_NODE) {
+                continue;
+            }
+            const element = child as Element;
+            if (shouldSkipElement?.(element)) {
+                continue;
+            }
+            if (element.tagName === "BR") {
+                addSeparator();
+                continue;
+            }
+            const isSeparating = kSeparatingTags.has(element.tagName);
+            if (isSeparating) {
+                addSeparator();
+            }
+            visitChildren(element);
+            if (isSeparating) {
+                addSeparator();
+            }
+        }
+    };
+
+    visitChildren(root);
+    return { text, pieces };
+}
+
+// Find the DOM position for an offset in the map's text. Offsets that land on a synthetic
+// separator have no DOM position of their own, so we snap to the nearest real text: forward for
+// the start of a range, backward for its end. That way a range never begins or ends on a
+// character that does not exist in the DOM.
+function positionForOffset(
+    map: TextOffsetMap,
+    offset: number,
+    isRangeStart: boolean,
+): { node: Text; offset: number } | undefined {
+    if (isRangeStart) {
+        for (const piece of map.pieces) {
+            if (piece.node && offset < piece.start + piece.length) {
+                return {
+                    node: piece.node,
+                    offset: Math.max(0, offset - piece.start),
+                };
+            }
+        }
+        return undefined;
+    }
+
+    for (let i = map.pieces.length - 1; i >= 0; i--) {
+        const piece = map.pieces[i];
+        if (piece.node && offset > piece.start) {
+            return {
+                node: piece.node,
+                offset: Math.min(piece.length, offset - piece.start),
+            };
+        }
+    }
+    return undefined;
+}
+
+// Make a Range covering [start, end) of the map's text, or undefined if that span contains no
+// actual DOM text.
+export function makeRangeFromTextOffsets(
+    map: TextOffsetMap,
+    start: number,
+    end: number,
+): Range | undefined {
+    if (end <= start) {
+        return undefined;
+    }
+    const startPosition = positionForOffset(map, start, true);
+    const endPosition = positionForOffset(map, end, false);
+    if (!startPosition || !endPosition) {
+        return undefined;
+    }
+
+    const ownerDocument = startPosition.node.ownerDocument;
+    if (!ownerDocument) {
+        console.error(
+            "textHighlightManager.makeRangeFromTextOffsets() could not find ownerDocument for a highlighted node.",
+        );
+        return undefined;
+    }
+
+    const range = ownerDocument.createRange();
+    range.setStart(startPosition.node, startPosition.offset);
+    range.setEnd(endPosition.node, endPosition.offset);
+    // Snapping can put the end before the start if the whole span was synthetic separators.
+    return range.collapsed ? undefined : range;
+}
+
 export class TextHighlightManager {
     // The highlight names this instance owns. clearAllManagedHighlights() removes exactly these.
     private readonly managedHighlightNames: readonly string[];

--- a/src/BloomBrowserUI/bookEdit/js/textHighlightManagerSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/textHighlightManagerSpec.ts
@@ -34,17 +34,25 @@ describe("textHighlightManager", () => {
             );
         });
 
-        it("puts a separator where a <br> visually breaks the text", () => {
-            // Without this, "Hello" and "world" would run together into one word.
-            expect(mapOf("Hello<br>world").text).toBe("Hello world");
+        it("puts a break where a <br> visually breaks the text", () => {
+            // A newline rather than a space, so that a consumer splitting into sentences treats
+            // each line of a <br>-separated stanza as its own sentence. Without any separator,
+            // "Hello" and "world" would run together into one word.
+            expect(mapOf("Hello<br>world").text).toBe("Hello\nworld");
         });
 
-        it("puts a separator at the boundaries of block elements", () => {
-            expect(mapOf("<p>Cat</p><p>Dog</p>").text).toBe("Cat Dog ");
+        it("puts a break at the boundaries of block elements", () => {
+            expect(mapOf("<p>Cat</p><p>Dog</p>").text).toBe("Cat\nDog\n");
         });
 
-        it("does not start with, or double up, a separator", () => {
-            expect(mapOf("<p>Cat<br><br>Dog</p>").text).toBe("Cat Dog ");
+        it("does not start with, or double up, a break", () => {
+            expect(mapOf("<p>Cat<br><br>Dog</p>").text).toBe("Cat\nDog\n");
+        });
+
+        it("still breaks the line when the text already ends in a space", () => {
+            // Testing for whitespace rather than for the break character itself would drop the
+            // break here, and the <br> would stop ending the line.
+            expect(mapOf("Hello <br>world").text).toBe("Hello \nworld");
         });
 
         it("leaves out the text of elements the caller skips", () => {
@@ -77,10 +85,10 @@ describe("textHighlightManager", () => {
         });
 
         it("snaps a boundary that lands on a synthetic separator onto real text", () => {
-            // "Cat Dog": the space at offset 3 exists in the map but not in the DOM, because it
-            // stands in for the <br>. A range over "Dog" must start in the second text node.
+            // "Cat\nDog": the newline at offset 3 exists in the map but not in the DOM, because
+            // it stands in for the <br>. A range over "Dog" must start in the second text node.
             const map = mapOf("Cat<br>Dog");
-            expect(map.text).toBe("Cat Dog");
+            expect(map.text).toBe("Cat\nDog");
 
             const range = makeRangeFromTextOffsets(map, 3, 7);
             expect(range?.toString()).toBe("Dog");

--- a/src/BloomBrowserUI/bookEdit/js/textHighlightManagerSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/textHighlightManagerSpec.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+    makeRangeForNodeContents,
+    makeRangeFromTextOffsets,
+    mapVisibleText,
+    TextHighlightManager,
+} from "./textHighlightManager";
+import {
+    FakeHighlight,
+    getHighlightRegistry,
+    installHighlightPolyfill,
+} from "../test/highlightTestSupport";
+
+describe("textHighlightManager", () => {
+    let root: HTMLElement;
+
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        installHighlightPolyfill(window);
+        root = document.createElement("div");
+        document.body.appendChild(root);
+    });
+
+    // Set root's content and return the map of its visible text.
+    function mapOf(html: string, shouldSkip?: (element: Element) => boolean) {
+        root.innerHTML = html;
+        return mapVisibleText(root, shouldSkip);
+    }
+
+    describe("mapVisibleText", () => {
+        it("joins the text of nested inline elements with nothing between", () => {
+            expect(mapOf("A sti<em>tch</em> in time").text).toBe(
+                "A stitch in time",
+            );
+        });
+
+        it("puts a separator where a <br> visually breaks the text", () => {
+            // Without this, "Hello" and "world" would run together into one word.
+            expect(mapOf("Hello<br>world").text).toBe("Hello world");
+        });
+
+        it("puts a separator at the boundaries of block elements", () => {
+            expect(mapOf("<p>Cat</p><p>Dog</p>").text).toBe("Cat Dog ");
+        });
+
+        it("does not start with, or double up, a separator", () => {
+            expect(mapOf("<p>Cat<br><br>Dog</p>").text).toBe("Cat Dog ");
+        });
+
+        it("leaves out the text of elements the caller skips", () => {
+            // This is how the reader tools see through CKEditor's hidden selection bookmarks:
+            // "Thr" + "ee" must read as the single word "Three".
+            const map = mapOf(
+                'Thr<span id="cke_bm_1" style="display: none;">x</span>ee blind mice',
+                (element) => element.id.startsWith("cke_"),
+            );
+            expect(map.text).toBe("Three blind mice");
+        });
+    });
+
+    describe("makeRangeFromTextOffsets", () => {
+        it("makes a range covering a word within a single text node", () => {
+            const map = mapOf("A stitch in time");
+            const range = makeRangeFromTextOffsets(map, 2, 8);
+            expect(range?.toString()).toBe("stitch");
+        });
+
+        it("makes a range spanning several text nodes", () => {
+            const map = mapOf("A sti<em>tch</em> in time");
+            // sanity check that the offsets really do straddle the <em>
+            expect(map.text.substring(2, 8)).toBe("stitch");
+
+            const range = makeRangeFromTextOffsets(map, 2, 8);
+            expect(range?.toString()).toBe("stitch");
+            expect(range!.startContainer.textContent).toBe("A sti");
+            expect(range!.endContainer.textContent).toBe("tch");
+        });
+
+        it("snaps a boundary that lands on a synthetic separator onto real text", () => {
+            // "Cat Dog": the space at offset 3 exists in the map but not in the DOM, because it
+            // stands in for the <br>. A range over "Dog" must start in the second text node.
+            const map = mapOf("Cat<br>Dog");
+            expect(map.text).toBe("Cat Dog");
+
+            const range = makeRangeFromTextOffsets(map, 3, 7);
+            expect(range?.toString()).toBe("Dog");
+            expect(range!.startContainer.textContent).toBe("Dog");
+            expect(range!.startOffset).toBe(0);
+        });
+
+        it("gives no range for a span that is only synthetic separators", () => {
+            const map = mapOf("Cat<br>Dog");
+            expect(makeRangeFromTextOffsets(map, 3, 4)).toBeUndefined();
+        });
+
+        it("gives no range for an empty or backwards span", () => {
+            const map = mapOf("A stitch in time");
+            expect(makeRangeFromTextOffsets(map, 4, 4)).toBeUndefined();
+            expect(makeRangeFromTextOffsets(map, 8, 2)).toBeUndefined();
+        });
+    });
+
+    describe("makeRangeForNodeContents", () => {
+        it("covers all of the node's text", () => {
+            root.innerHTML = "<p>A <em>stitch</em> in time</p>";
+            const range = makeRangeForNodeContents(root.firstElementChild!);
+            expect(range?.toString()).toBe("A stitch in time");
+        });
+
+        it("gives no range for a node with no text", () => {
+            root.innerHTML = "<p></p>";
+            expect(
+                makeRangeForNodeContents(root.firstElementChild!),
+            ).toBeUndefined();
+        });
+    });
+
+    describe("TextHighlightManager", () => {
+        const kFirst = "test-highlight-1";
+        const kSecond = "test-highlight-2";
+
+        function makeManager(): TextHighlightManager {
+            return new TextHighlightManager([kFirst, kSecond]);
+        }
+
+        function rangeOver(text: string): Range {
+            root.innerHTML = text;
+            return makeRangeForNodeContents(root)!;
+        }
+
+        it("registers and unregisters a named highlight", () => {
+            const manager = makeManager();
+            const registry = getHighlightRegistry(window);
+            const range = rangeOver("Cat");
+
+            manager.setHighlight(kFirst, [range], root);
+            expect(registry.get(kFirst)?.ranges).toEqual([range]);
+
+            // An empty list of ranges means "paint nothing", i.e. remove the entry rather than
+            // leave an empty highlight registered.
+            manager.setHighlight(kFirst, [], root);
+            expect(registry.has(kFirst)).toBe(false);
+        });
+
+        it("passes the priority on, so overlapping highlights paint in the right order", () => {
+            const manager = makeManager();
+            manager.setHighlight(kFirst, [rangeOver("Cat")], root, 3);
+            expect(getHighlightRegistry(window).get(kFirst)?.priority).toBe(3);
+        });
+
+        it("clears only the named highlights", () => {
+            const manager = makeManager();
+            const registry = getHighlightRegistry(window);
+            manager.setHighlight(kFirst, [rangeOver("Cat")], root);
+            manager.setHighlight(kSecond, [rangeOver("Cat")], root);
+
+            manager.clearHighlights([kSecond], root);
+            expect(registry.has(kFirst)).toBe(true);
+            expect(registry.has(kSecond)).toBe(false);
+        });
+
+        it("clears every highlight it manages, and nothing else", () => {
+            const manager = makeManager();
+            const registry = getHighlightRegistry(window);
+            manager.setHighlight(kFirst, [rangeOver("Cat")], root);
+            manager.setHighlight(kSecond, [rangeOver("Cat")], root);
+            registry.set("someone-elses-highlight", new FakeHighlight());
+
+            manager.clearAllManagedHighlights(root);
+            expect(registry.has(kFirst)).toBe(false);
+            expect(registry.has(kSecond)).toBe(false);
+            expect(registry.has("someone-elses-highlight")).toBe(true);
+        });
+
+        it("says it cannot highlight a document with no custom highlight support", () => {
+            const manager = makeManager();
+            expect(manager.canHighlight(root)).toBe(true);
+
+            const windowWithoutHighlights = window as Window & {
+                Highlight?: unknown;
+            };
+            const savedConstructor = windowWithoutHighlights.Highlight;
+            windowWithoutHighlights.Highlight = undefined;
+            try {
+                expect(manager.canHighlight(root)).toBe(false);
+                // ...and asking for a highlight anyway is a harmless no-op.
+                manager.setHighlight(kFirst, [rangeOver("Cat")], root);
+                expect(getHighlightRegistry(window).has(kFirst)).toBe(false);
+            } finally {
+                windowWithoutHighlights.Highlight = savedConstructor;
+            }
+        });
+
+        // BL-15300: a highlight whose ranges no longer cover live content stays registered but
+        // paints nothing, so callers need to be able to detect that and re-establish it.
+        describe("hasDeadRanges", () => {
+            it("is false for a highlight over live content", () => {
+                const manager = makeManager();
+                root.innerHTML = "<p>Cat</p>";
+                manager.setHighlight(
+                    kFirst,
+                    [makeRangeForNodeContents(root.firstElementChild!)!],
+                    root,
+                );
+                expect(manager.hasDeadRanges(kFirst, root)).toBe(false);
+            });
+
+            it("is true when the highlighted node has been replaced", () => {
+                const manager = makeManager();
+                root.innerHTML = "<p>Cat</p>";
+                const paragraph = root.firstElementChild!;
+                manager.setHighlight(
+                    kFirst,
+                    [makeRangeForNodeContents(paragraph)!],
+                    root,
+                );
+                expect(manager.hasDeadRanges(kFirst, root)).toBe(false); // sanity check
+
+                // As CKEditor's initialization does: replace the paragraph the range points at.
+                paragraph.remove();
+                root.innerHTML = "<p>Cat</p>";
+                expect(manager.hasDeadRanges(kFirst, root)).toBe(true);
+            });
+
+            it("is true when an ancestor of the highlighted node was removed", () => {
+                // Removing an ancestor collapses the live Range onto the still-connected former
+                // parent, so a connectedness check alone would miss it.
+                const manager = makeManager();
+                root.innerHTML = "<div><p>Cat</p></div>";
+                const wrapper = root.firstElementChild!;
+                manager.setHighlight(
+                    kFirst,
+                    [makeRangeForNodeContents(wrapper.firstElementChild!)!],
+                    root,
+                );
+                expect(manager.hasDeadRanges(kFirst, root)).toBe(false); // sanity check
+
+                wrapper.innerHTML = "";
+                expect(manager.hasDeadRanges(kFirst, root)).toBe(true);
+            });
+
+            it("is false when nothing is registered under that name", () => {
+                expect(makeManager().hasDeadRanges(kFirst, root)).toBe(false);
+            });
+        });
+    });
+});

--- a/src/BloomBrowserUI/bookEdit/test/highlightTestSupport.ts
+++ b/src/BloomBrowserUI/bookEdit/test/highlightTestSupport.ts
@@ -10,6 +10,12 @@ export class FakeHighlight {
     public constructor(...ranges: Range[]) {
         this.ranges = ranges;
     }
+
+    // A real Highlight is setlike over its Ranges, and TextHighlightManager.hasDeadRanges()
+    // iterates it, so the stand-in must be iterable too.
+    public [Symbol.iterator](): Iterator<Range> {
+        return this.ranges[Symbol.iterator]();
+    }
 }
 
 export type FakeHighlightRegistry = Map<string, FakeHighlight>;

--- a/src/BloomBrowserUI/bookEdit/test/highlightTestSupport.ts
+++ b/src/BloomBrowserUI/bookEdit/test/highlightTestSupport.ts
@@ -1,0 +1,59 @@
+// Test-only support for the code that paints text highlights through the CSS custom highlight
+// registry (see bookEdit/js/textHighlightManager.ts). jsdom implements neither CSS.highlights nor
+// Highlight, so specs install these stand-ins in the window under test and then read back what
+// the production code registered.
+
+export class FakeHighlight {
+    public ranges: Range[];
+    public priority?: number;
+
+    public constructor(...ranges: Range[]) {
+        this.ranges = ranges;
+    }
+}
+
+export type FakeHighlightRegistry = Map<string, FakeHighlight>;
+
+type WindowWithHighlightApis = Window & {
+    CSS?: { highlights?: FakeHighlightRegistry };
+    Highlight?: typeof FakeHighlight;
+};
+
+// Give targetWindow an empty highlight registry and a Highlight constructor, and return the
+// registry so the test can inspect it.
+export function installHighlightPolyfill(
+    targetWindow: Window,
+): FakeHighlightRegistry {
+    const windowWithHighlightApis = targetWindow as WindowWithHighlightApis;
+    if (!windowWithHighlightApis.CSS) {
+        windowWithHighlightApis.CSS = {};
+    }
+    const registry = new Map<string, FakeHighlight>();
+    windowWithHighlightApis.CSS.highlights = registry;
+    windowWithHighlightApis.Highlight = FakeHighlight;
+    return registry;
+}
+
+// The registry installed in targetWindow. Fails loudly rather than silently reporting "no
+// highlights" if the test forgot to install the polyfill.
+export function getHighlightRegistry(
+    targetWindow: Window,
+): FakeHighlightRegistry {
+    const registry = (targetWindow as WindowWithHighlightApis).CSS?.highlights;
+    if (!registry) {
+        throw new Error(
+            "Expected CSS.highlights test polyfill to be installed",
+        );
+    }
+    return registry;
+}
+
+// The text each Range of the named highlight covers, in the order the production code registered
+// them. Empty if nothing is painted under that name.
+export function getHighlightTexts(
+    targetWindow: Window,
+    highlightName: string,
+): string[] {
+    const highlight = getHighlightRegistry(targetWindow).get(highlightName);
+    return highlight ? highlight.ranges.map((range) => range.toString()) : [];
+}

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markup.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markup.ts
@@ -13,19 +13,26 @@ import * as _ from "underscore";
 import { theOneLibSynphony, LibSynphony } from "./synphony_lib";
 import "./bloomSynphonyExtensions"; //add several functions to LanguageData
 import { ReaderToolsModel } from "../readerToolsModel";
+import { TextOffsetMap } from "../../../js/textHighlightManager";
+import {
+    kSentenceTooLongHighlight,
+    kSightWordHighlight,
+    kWordNotDecodableHighlight,
+    kWordTooLongHighlight,
+    makeRangesForSpans,
+    mapReaderText,
+    theOneReaderHighlightManager,
+    TextSpan,
+    trimSpan,
+} from "../readerHighlights";
 
 /**
  * Use an 'Immediately Invoked Function Expression' to make this compatible with jQuery.noConflict().
  * @param {jQuery} $
  */
 (($) => {
-    const cssSentenceTooLong = "sentence-too-long";
-    const cssSightWord = "sight-word";
-    const cssWordNotFound = "word-not-found";
-    const cssPossibleWord = "possible-word";
     const cssDesiredGrapheme = "desired-grapheme";
     const cssTooMuchStuffOnPage = "page-too-many-words-or-sentences";
-    const cssWordTooLong = "word-too-long";
 
     /**
      * Checks the innerHTML of an HTML entity (div) using the selected options
@@ -57,7 +64,8 @@ import { ReaderToolsModel } from "../readerToolsModel";
             opts.maxSentencesPerPage = Infinity;
         }
 
-        // remove previous synphony markup
+        // Clean out markup spans inserted by earlier versions of Bloom, which used to mark
+        // violations by modifying the DOM. Current code highlights without touching the DOM.
         this.removeSynphonyMarkup();
 
         // initialize words per page
@@ -65,43 +73,36 @@ import { ReaderToolsModel } from "../readerToolsModel";
         // initialize sentences per page
         let totalSentenceCount = 0;
 
-        const checkLeaf = (leaf) => {
-            stashNonTextUIElementsInEditBox(leaf);
-            // split into sentences. We need it both with markup
-            // (to preserve bold/italic/ckEditor landmarks in the output)
-            // and without (because some markup, especially ckEditor invisible landmarks,
-            // may alter word counts and lists)
-            const fragments = theOneLibSynphony.stringToSentences(
-                $(leaf).html(),
-            );
+        // What we found in each leaf, kept until we have seen every leaf: the long-word list is
+        // cumulative over the whole page, so we can't decide which words to highlight in the
+        // first leaf until we have analyzed the last one.
+        const leafResults: {
+            map: TextOffsetMap;
+            sentenceTooLongSpans: TextSpan[];
+        }[] = [];
 
-            let newHtml = "";
+        const checkLeaf = (leaf: HTMLElement) => {
+            // The text as the reader sees it, with a note of where in the DOM each character
+            // came from so we can highlight our findings later. Analyzing plain text rather than
+            // HTML means we don't have to preserve (or work around) bold/italic markup or
+            // ckEditor's invisible landmarks: they are simply not in the string.
+            const map = mapReaderText(leaf);
+            const fragments = theOneLibSynphony.stringToSentences(map.text);
+            const sentenceTooLongSpans: TextSpan[] = [];
 
+            // The fragments concatenate to exactly map.text, so a running total tells us where
+            // each one starts.
+            let offset = 0;
             for (let i = 0; i < fragments.length; i++) {
                 const fragment = fragments[i];
 
                 if (fragment.isSpace) {
                     // this is inter-sentence space
-                    newHtml += fragment.text;
                     allWords += " ";
                 } else {
-                    // This is basically duplicating how stringToSentences comes up with
-                    // fragment.text but with removeAllHtmlMarkupFromString applied.
-                    // I don't much like that duplication. But we need removeAllHtmlMarkupFromString
-                    // so that the words we count won't be messed up by (e.g.) invisible spaces
-                    // that ckEdit puts in as bookmarks to keep our place. We can't apply it
-                    // to the input to stringToSentences, because we want to preserve the markup
-                    // and bookmark when we put the fragments back together to make the new
-                    // text. I tried making two parallel fragments arrays, one using the
-                    // unmodified text, and one from removeAllHtmlMarkupFromString; but in general they
-                    // don't come out the same length, or with pieces corresponding. For example,
-                    // removeAllHtmlMarkupFromString cleans out <br>, which otherwise becomes an element in
-                    // the list.
-                    const cleanText = removeAllHtmlMarkupFromString(
+                    const words = theOneLibSynphony.getWordsFromHtmlString(
                         fragment.text,
                     );
-                    const words =
-                        theOneLibSynphony.getWordsFromHtmlString(cleanText);
                     if (opts.maxGlyphsPerWord > 0) {
                         for (const w of words) {
                             if (
@@ -114,52 +115,28 @@ import { ReaderToolsModel } from "../readerToolsModel";
                     }
                     const sentenceWordCount = words.length;
                     totalWordCount += sentenceWordCount;
-                    allWords += cleanText;
+                    allWords += fragment.text;
                     if (sentenceWordCount) ++totalSentenceCount;
 
                     // check sentence length
                     if (sentenceWordCount > opts.maxWordsPerSentence) {
-                        // Mark this sentence as having too many words.  fragment.text
-                        // may start out with one or two </span> close tags.  We need
-                        // to insert the span marking the overly long sentence after
-                        // all of those leading close </span> tags to preserve proper
-                        // nesting of the marked sentence.
-                        let leadingClosers = "";
-                        const leadingCloseSpans =
-                            fragment.text.match(/^( *<\/span>)+ */);
-                        if (leadingCloseSpans) {
-                            leadingClosers = leadingCloseSpans[0];
-                        }
-                        newHtml +=
-                            leadingClosers +
-                            '<span class="' +
-                            cssSentenceTooLong +
-                            '" data-segment="sentence">' +
-                            fragment.text.substring(leadingClosers.length) +
-                            "</span>";
-                    } else {
-                        // nothing to see here
-                        newHtml += fragment.text;
+                        sentenceTooLongSpans.push(
+                            trimSpan(map.text, {
+                                start: offset,
+                                end: offset + fragment.text.length,
+                            }),
+                        );
                     }
                 }
+                offset += fragment.text.length;
             }
 
             // If this element represents a paragraph, then the overall page text needs a paragraph break here.
             if (leaf.tagName === "P") {
                 allWords += "\r\n";
             }
-            if (longWords.length) {
-                newHtml = theOneLibSynphony.wrap_words_extra(
-                    newHtml,
-                    longWords,
-                    cssWordTooLong,
-                    ' data-segment="word"',
-                );
-            }
 
-            // set the html
-            $(leaf).html(newHtml);
-            restoreNonTextUIElementsInEditBox(leaf);
+            leafResults.push({ map, sentenceTooLongSpans });
         };
 
         const checkRoot = (root) => {
@@ -214,6 +191,30 @@ import { ReaderToolsModel } from "../readerToolsModel";
             pageDiv.removeClass(cssTooMuchStuffOnPage);
         }
 
+        // Now that we know every long word on the page, highlight all of them, along with the
+        // sentences we found to be too long.
+        theOneReaderHighlightManager.beginPass();
+        leafResults.forEach((leafResult) => {
+            theOneReaderHighlightManager.addRanges(
+                kSentenceTooLongHighlight,
+                makeRangesForSpans(
+                    leafResult.map,
+                    leafResult.sentenceTooLongSpans,
+                ),
+            );
+            theOneReaderHighlightManager.addRanges(
+                kWordTooLongHighlight,
+                makeRangesForSpans(
+                    leafResult.map,
+                    theOneLibSynphony.find_words_extra(
+                        leafResult.map.text,
+                        longWords,
+                    ),
+                ),
+            );
+        });
+        theOneReaderHighlightManager.endPass(this[0]);
+
         this["allWords"] = allWords;
         return this;
     };
@@ -235,13 +236,17 @@ import { ReaderToolsModel } from "../readerToolsModel";
         );
         let text = "";
 
-        // remove previous synphony markup
+        // Clean out markup spans inserted by earlier versions of Bloom, and the inline
+        // background-color spans CKEditor made from them (BL-16558).
         this.removeSynphonyMarkup();
         this.removeCkEditorMarkup();
 
-        // get all text
+        // Snapshot the text of each element as the reader sees it, and get all the page's text.
+        const maps: TextOffsetMap[] = [];
         this.each(function () {
-            text += " " + removeAllHtmlMarkupFromString($(this).html());
+            const map = mapReaderText(this);
+            maps.push(map);
+            text += " " + map.text;
         });
 
         /**
@@ -255,42 +260,37 @@ import { ReaderToolsModel } from "../readerToolsModel";
             opts.sightWords.join(" "),
         );
 
-        // markup
-        this.each(function () {
-            stashNonTextUIElementsInEditBox(this);
-            let html = $(this).html();
+        // remove numbers from list of bad words
+        const notDecodable = _.difference(
+            results.remaining_words,
+            results.getNumbers(),
+        ) as string[];
 
+        theOneReaderHighlightManager.beginPass();
+        maps.forEach((map) => {
             // ignore empty elements
-            if (html.trim().length > 0 && text.trim().length > 0) {
-                html = theOneLibSynphony.wrap_words_extra(
-                    html,
-                    results.sight_words,
-                    cssSightWord,
-                    ' data-segment="word"',
-                );
-                html = theOneLibSynphony.wrap_words_extra(
-                    html,
-                    results.possible_words,
-                    cssPossibleWord,
-                    ' data-segment="word"',
-                );
-
-                // remove numbers from list of bad words
-                const notFound = _.difference(
-                    results.remaining_words,
-                    results.getNumbers(),
-                );
-
-                html = theOneLibSynphony.wrap_words_extra(
-                    html,
-                    notFound,
-                    cssWordNotFound,
-                    ' data-segment="word"',
-                );
-                $(this).html(html);
+            if (map.text.trim().length === 0 || text.trim().length === 0) {
+                return;
             }
-            restoreNonTextUIElementsInEditBox(this);
+            theOneReaderHighlightManager.addRanges(
+                kSightWordHighlight,
+                makeRangesForSpans(
+                    map,
+                    theOneLibSynphony.find_words_extra(
+                        map.text,
+                        results.sight_words,
+                    ),
+                ),
+            );
+            theOneReaderHighlightManager.addRanges(
+                kWordNotDecodableHighlight,
+                makeRangesForSpans(
+                    map,
+                    theOneLibSynphony.find_words_extra(map.text, notDecodable),
+                ),
+            );
         });
+        theOneReaderHighlightManager.endPass(this[0]);
 
         return this;
     };
@@ -438,27 +438,6 @@ import { ReaderToolsModel } from "../readerToolsModel";
         },
     });
 
-    $.extend({
-        cssSentenceTooLong: () => {
-            return cssSentenceTooLong;
-        },
-    });
-    $.extend({
-        cssSightWord: () => {
-            return cssSightWord;
-        },
-    });
-    $.extend({
-        cssWordNotFound: () => {
-            return cssWordNotFound;
-        },
-    });
-    $.extend({
-        cssPossibleWord: () => {
-            return cssPossibleWord;
-        },
-    });
-
     function oldMarkup(gpcForm, desiredGPCs) {
         let returnVal = "";
 
@@ -477,29 +456,9 @@ import { ReaderToolsModel } from "../readerToolsModel";
         return returnVal;
     }
 
-    /**
-     * The formatButton is a div at the end of the editable text that needs to be ignored as we scan and markup the text box.
-     * It should be restored witha a call to restoreFormatButton();
-     **/
-
-    let stashedFormatButton;
-
-    function stashNonTextUIElementsInEditBox(element) {
-        stashedFormatButton = $(element).find("#formatButton");
-        if (stashedFormatButton) {
-            stashedFormatButton.remove();
-        }
-    }
-    /**
-     * The formatButton is a div at the end of the editable text that needs to be ignored as we scan and markup the text box.
-     * Calls to this should be preceded by a call to stashFormatButton();
-     **/
-    function restoreNonTextUIElementsInEditBox(element) {
-        if (stashedFormatButton) {
-            $(element).append(stashedFormatButton);
-            stashedFormatButton = null;
-        }
-    }
+    // We used to have to remove the formatButton (a div of UI at the end of the editable text)
+    // before scanning, and put it back afterwards, because scanning meant rewriting the
+    // element's HTML. Now that we only read the DOM, mapReaderText() simply skips it.
 })(jQuery);
 
 /**

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markup.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markup.ts
@@ -383,9 +383,14 @@ import {
                 .removeClass(cssTooMuchStuffOnPage);
     };
 
+    /**
+     * Undo the damage described in BL-16558: when the user replaced text that the reader tools
+     * had marked, CKEditor copied the marking span's computed background-color into an inline
+     * style of its own, which got saved into the book. We no longer give it anything to copy,
+     * but books edited by earlier versions still contain these spans.
+     */
     $.fn.removeCkEditorMarkup = function () {
         this.each(function () {
-            // remove CKEditor-specific markup inserted when replacing marked text
             $(this)
                 .find("span[style]")
                 .filter((_index, element) => {
@@ -398,8 +403,13 @@ import {
                 })
                 .contents()
                 .unwrap();
-            // leave CKEditor-specific hidden spans that serve as bookmarks intact so that
-            // the cursor can be restored after marking up the text.  (BL-16490)
+            // NB: do NOT remove CKEditor's hidden cke_* spans here. We used to, so that they
+            // could not skew the word markup, but mapReaderText() now simply skips them, and
+            // removing them moved the insertion point to the start of the text box after every
+            // typing pause: the hidden spans include the selection bookmarks that
+            // readerToolsModel.doMarkup() has EditableDivUtils.doCkEditorCleanup() insert before
+            // it calls us, and that it passes to restoreSelectionFromCkEditorBookmarks()
+            // afterwards to put the caret back. See also (BL-16490)
         });
     };
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markup.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markup.ts
@@ -65,8 +65,11 @@ import {
         }
 
         // Clean out markup spans inserted by earlier versions of Bloom, which used to mark
-        // violations by modifying the DOM. Current code highlights without touching the DOM.
+        // violations by modifying the DOM, and the inline background-color spans CKEditor made
+        // from them (BL-16558). The leveled reader's markers were background-colored too, so it
+        // did the same damage the decodable reader did.
         this.removeSynphonyMarkup();
+        this.removeCkEditorMarkup();
 
         // initialize words per page
         let totalWordCount = 0;
@@ -90,8 +93,17 @@ import {
             const fragments = theOneLibSynphony.stringToSentences(map.text);
             const sentenceTooLongSpans: TextSpan[] = [];
 
-            // The fragments concatenate to exactly map.text, so a running total tells us where
-            // each one starts.
+            // Locating a sentence relies on the fragments concatenating to exactly the text we
+            // mapped, so that a running total tells us where each one starts. That holds for
+            // ordinary text, but stringToSentences canonicalizes a few HTML-ish sequences - it
+            // rewrites "<br>" to "<br />", for instance - so a box in which the user literally
+            // typed "<br>" would shift every following offset. Rather than mis-highlight, check,
+            // and if the text came back changed just don't mark sentences in this leaf. The word
+            // counts below are unaffected, as is word highlighting, which works from map.text.
+            const canLocateSentences =
+                fragments.map((fragment) => fragment.text).join("") ===
+                map.text;
+
             let offset = 0;
             for (let i = 0; i < fragments.length; i++) {
                 const fragment = fragments[i];
@@ -119,7 +131,10 @@ import {
                     if (sentenceWordCount) ++totalSentenceCount;
 
                     // check sentence length
-                    if (sentenceWordCount > opts.maxWordsPerSentence) {
+                    if (
+                        canLocateSentences &&
+                        sentenceWordCount > opts.maxWordsPerSentence
+                    ) {
                         sentenceTooLongSpans.push(
                             trimSpan(map.text, {
                                 start: offset,

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markupSpec.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markupSpec.js
@@ -121,6 +121,19 @@ describe("jquery.text-markup", function () {
         ]);
     });
 
+    it("checkLeveledReader stops highlighting once the violation is gone", function () {
+        const editable = $("#text_entry1");
+        editable
+            .html("<p>Cat elephant. Dog.</p>")
+            .checkLeveledReader({ maxGlyphsPerWord: 5 });
+        // sanity check that there is something to stop highlighting
+        expect(highlighted(kWordTooLongHighlight)).toEqual(["elephant"]);
+
+        // Raise the limit, as the user would by choosing a higher level.
+        editable.checkLeveledReader({ maxGlyphsPerWord: 20 });
+        expect(highlighted(kWordTooLongHighlight)).toEqual([]);
+    });
+
     // check the bug reported in BL-10119
     it("checkLeveledReader.handlesSentencesWithInitialMarkup", function () {
         const input =

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markupSpec.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markupSpec.js
@@ -339,6 +339,26 @@ describe("jquery.text-markup", function () {
         expect($("#text_entry1").html()).toBe(input);
     });
 
+    it("checkDecodableReader leaves the selection bookmarks in place", function () {
+        // A bookmark span, holding CKEditor's usual zero-width placeholder, sits in the middle
+        // of the word the reader tool is about to mark.
+        const zwsp = String.fromCharCode(0x200b);
+        const input = `<p>bi<span id="cke_bm_1S" style="display: none;">${zwsp}</span>g</p>`;
+        $("#text_entry1")
+            .html(input)
+            .checkDecodableReader({
+                focusWords: ["a"],
+                knownGraphemes: ["a", "e", "s"],
+            });
+
+        // The bookmark must survive: toolbox.ts needs it to put the caret back afterwards.
+        expect($("#text_entry1").html()).toBe(input);
+        // One highlight, not two: the analysis saw "big" as a single word despite the bookmark
+        // splitting it. (The painted Range spans the bookmark, so its text still contains the
+        // invisible character.)
+        expect(highlighted(kWordNotDecodableHighlight)).toEqual([`bi${zwsp}g`]);
+    });
+
     // The words find_words_extra located, as substrings of the text it searched, so a test can
     // read its results without doing offset arithmetic.
     function foundWords(text, words) {

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markupSpec.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markupSpec.js
@@ -121,6 +121,22 @@ describe("jquery.text-markup", function () {
         ]);
     });
 
+    // The Talking Book tool's phrase markers are invisible, zero-width, and saved in the book,
+    // so the reader tools must see straight through them. Unlike Bloom's transient in-page UI
+    // they carry no bloom-ui class, which is why they need their own exclusion.
+    it("checkLeveledReader sees through a Talking Book phrase marker inside a word", function () {
+        const input =
+            '<p>ele<span class="bloom-audio-split-marker">|</span>phant</p>';
+        $("#text_entry1")
+            .html(input)
+            .checkLeveledReader({ maxGlyphsPerWord: 5 });
+
+        expect($("#text_entry1").html()).toBe(input);
+        // One 8-letter word over the limit, not two short ones under it. (The painted Range
+        // spans the marker, so its text still shows up in the highlight.)
+        expect(highlighted(kWordTooLongHighlight)).toEqual(["ele|phant"]);
+    });
+
     it("checkLeveledReader stops highlighting once the violation is gone", function () {
         const editable = $("#text_entry1");
         editable

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markupSpec.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markupSpec.js
@@ -8,6 +8,15 @@
  */
 import { theOneLibSynphony } from "./synphony_lib";
 import { removeAllHtmlMarkupFromString } from "./jquery.text-markup.ts";
+import {
+    kSentenceTooLongHighlight,
+    kWordNotDecodableHighlight,
+    kWordTooLongHighlight,
+} from "../readerHighlights";
+import {
+    getHighlightTexts,
+    installHighlightPolyfill,
+} from "../../../test/highlightTestSupport";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import $ from "jquery";
 
@@ -19,12 +28,19 @@ describe("jquery.text-markup", function () {
         return div;
     }
 
+    // The reader tools paint violations with ::highlight() pseudo-elements over Ranges rather
+    // than by inserting spans, so this is how a test sees what got marked.
+    function highlighted(highlightName) {
+        return getHighlightTexts(window, highlightName);
+    }
+
     var divTextEntry1;
     var divTextEntry2;
     var divTextEntry3;
 
     beforeEach(function () {
         document.body.innerHTML = "";
+        installHighlightPolyfill(window);
         divTextEntry1 = addDiv("text_entry1");
         divTextEntry2 = addDiv("text_entry2");
         divTextEntry3 = addDiv("text_entry3");
@@ -35,40 +51,74 @@ describe("jquery.text-markup", function () {
     });
 
     it("checkLeveledReader", function () {
+        // The hidden span is one of CKEditor's selection bookmarks, sitting in the middle of
+        // "Three". The markup must see through it: "Thr" + "ee" is one three-letter word, not two.
         var input =
             'Two-word sentence. Thr<span data-cke-bookmark="1" style="display: none;" id="cke_bm_41C">&nbsp;</span>ee <span class="bold">"word"</span> sentence. "This is a six word sentence."';
-        var out2 =
-            'Two-word sentence. <span class="sentence-too-long" data-segment="sentence">Thr<span data-cke-bookmark="1" style="display: none;" id="cke_bm_41C">&nbsp;</span>ee <span class="bold">"word"</span> sentence.</span> <span class="sentence-too-long" data-segment="sentence">"This is a six word sentence."</span>';
-        var out3 =
-            'Two-word sentence. Thr<span data-cke-bookmark="1" style="display: none;" id="cke_bm_41C">&nbsp;</span>ee <span class="bold">"word"</span> sentence. <span class="sentence-too-long" data-segment="sentence">"This is a six word sentence."</span>';
+        // A Range's text includes anything invisible inside it, so the highlight over the second
+        // sentence reads back with the bookmark's non-breaking space still in the middle of
+        // "Three". Only the visible characters are painted.
+        var nbsp = String.fromCharCode(0xa0);
+        var threeWordSentence = `Thr${nbsp}ee "word" sentence.`;
+        var sixWordSentence = '"This is a six word sentence."';
 
         // check 2 word sentences
         $("#text_entry1")
             .html(input)
             .checkLeveledReader({ maxWordsPerSentence: 2 });
-        var result = $("#text_entry1").html();
-        expect(result).toBe(out2);
+        // The DOM must be left exactly as it was; marking it up is what BL-16558 is about.
+        expect($("#text_entry1").html()).toBe(input);
+        expect(highlighted(kSentenceTooLongHighlight)).toEqual([
+            threeWordSentence,
+            sixWordSentence,
+        ]);
 
         // check 3 word sentences
         $("#text_entry1")
             .html(input)
             .checkLeveledReader({ maxWordsPerSentence: 3 });
-        result = $("#text_entry1").html();
-        expect(result).toBe(out3);
+        expect($("#text_entry1").html()).toBe(input);
+        expect(highlighted(kSentenceTooLongHighlight)).toEqual([
+            sixWordSentence,
+        ]);
     });
 
     it("checkLeveledReader.handlesDivsWithEmbeddedParas", function () {
         var input =
             '<p>Two-word sentence. Three <span class="bold">"word"</span> sentence.<br></p><p>"This is a six word sentence."</p>';
-        var out2 =
-            '<p>Two-word sentence. <span class="sentence-too-long" data-segment="sentence">Three <span class="bold">"word"</span> sentence.</span><br></p><p><span class="sentence-too-long" data-segment="sentence">"This is a six word sentence."</span></p>';
 
         // check 2 word sentences
         $("#text_entry1")
             .html(input)
             .checkLeveledReader({ maxWordsPerSentence: 2 });
-        var result = $("#text_entry1").html();
-        expect(result).toBe(out2);
+        expect($("#text_entry1").html()).toBe(input);
+        expect(highlighted(kSentenceTooLongHighlight)).toEqual([
+            'Three "word" sentence.',
+            '"This is a six word sentence."',
+        ]);
+    });
+
+    it("checkLeveledReader marks words that are too long", function () {
+        $("#text_entry1")
+            .html("<p>Cat elephant. Dog.</p>")
+            .checkLeveledReader({ maxGlyphsPerWord: 5 });
+
+        expect($("#text_entry1").html()).toBe("<p>Cat elephant. Dog.</p>");
+        expect(highlighted(kWordTooLongHighlight)).toEqual(["elephant"]);
+    });
+
+    it("checkLeveledReader marks a long word wherever it appears on the page", function () {
+        // The long-word list is cumulative over the page, so a word first seen in the second
+        // paragraph must still be marked in the first one.
+        $("#text_entry1")
+            .html("<p>An elephant.</p><p>Another elephant.</p>")
+            .checkLeveledReader({ maxGlyphsPerWord: 5 });
+
+        expect(highlighted(kWordTooLongHighlight)).toEqual([
+            "elephant",
+            "Another",
+            "elephant",
+        ]);
     });
 
     // check the bug reported in BL-10119
@@ -105,31 +155,29 @@ describe("jquery.text-markup", function () {
     });
 
     it("marks up invalid words", function () {
+        // "a" is decodable and "ae" is decodable-but-uncollected (we no longer mark those);
+        // "big" uses graphemes the reader does not know yet.
         var input = "a ae big";
-        var out =
-            'a <span class="possible-word" data-segment="word">ae</span> <span class="word-not-found" data-segment="word">big</span>';
         $("#text_entry1")
             .html(input)
             .checkDecodableReader({
                 focusWords: ["a"],
                 knownGraphemes: ["a", "e", "s"],
             });
-        var result = $("#text_entry1").html();
-        expect(result).toBe(out);
+        expect($("#text_entry1").html()).toBe(input);
+        expect(highlighted(kWordNotDecodableHighlight)).toEqual(["big"]);
     });
 
     it("handles the magic word 'word'", function () {
         var input = "a ae word";
-        var out =
-            'a <span class="possible-word" data-segment="word">ae</span> <span class="word-not-found" data-segment="word">word</span>';
         $("#text_entry1")
             .html(input)
             .checkDecodableReader({
                 focusWords: ["a"],
                 knownGraphemes: ["a", "e", "s"],
             });
-        var result = $("#text_entry1").html();
-        expect(result).toBe(out);
+        expect($("#text_entry1").html()).toBe(input);
+        expect(highlighted(kWordNotDecodableHighlight)).toEqual(["word"]);
     });
 
     it("getMaxSentenceLength", function () {
@@ -278,40 +326,37 @@ describe("jquery.text-markup", function () {
         expect($("#text_entry1").html()).toBe(input);
     });
 
-    it("checkWrapWordsExtraIgnoresEmptyItems", function () {
-        const cssWordNotFound = "word-not-found";
-        const cssPossibleWord = "possible-word";
-        const html = "<p>This is a test.</p>";
-        const notFound = ["", "test", "", "is", ""];
-        const newHtml = theOneLibSynphony.wrap_words_extra(
-            html,
-            notFound,
-            cssWordNotFound,
-            ' data-segment="word"',
-        );
-        expect(newHtml).toBe(
-            '<p>This <span class="word-not-found" data-segment="word">is</span> a <span class="word-not-found" data-segment="word">test</span>.</p>',
-        );
+    // The words find_words_extra located, as substrings of the text it searched, so a test can
+    // read its results without doing offset arithmetic.
+    function foundWords(text, words) {
+        return theOneLibSynphony
+            .find_words_extra(text, words)
+            .map((span) => text.substring(span.start, span.end));
+    }
+
+    it("find_words_extra ignores empty items in the word list", function () {
+        const text = "This is a test.";
+        expect(foundWords(text, ["", "test", "", "is", ""])).toEqual([
+            "is",
+            "test",
+        ]);
     });
 
-    it("checkWrapWordsExtraHandlesExtraWhitespace", function () {
-        const cssWordNotFound = "word-not-found";
-        const cssPossibleWord = "possible-word";
-        const html = "<p> This<em> is </em>a test.</p>";
-        const notFound = ["this", "is", ""];
-        const newHtml = theOneLibSynphony.wrap_words_extra(
-            html,
-            notFound,
-            cssWordNotFound,
-            ' data-segment="word"',
-        );
-        expect(newHtml).toBe(
-            '<p> <span class="word-not-found" data-segment="word">This</span><em> <span class="word-not-found" data-segment="word">is</span> </em>a test.</p>',
-        );
+    it("find_words_extra matches case-insensitively and around extra whitespace", function () {
+        const text = " This  is  a test.";
+        expect(foundWords(text, ["this", "is", ""])).toEqual(["This", "is"]);
+    });
+
+    it("find_words_extra reports the offsets of each occurrence", function () {
+        const text = "a cat and a cat";
+        expect(theOneLibSynphony.find_words_extra(text, ["cat"])).toEqual([
+            { start: 2, end: 5 },
+            { start: 12, end: 15 },
+        ]);
     });
 
     // The following three tests lock in that the analyzer (getWordsFromHtmlString) and the
-    // highlighter (wrap_words_extra) agree about ZERO WIDTH SPACE (U+200B) being a word
+    // highlighter (find_words_extra) agree about ZERO WIDTH SPACE (U+200B) being a word
     // boundary. They previously disagreed: the analyzer split words on U+200B while the
     // highlighter's \p{Z}/\p{P} boundaries did not match it (U+200B is Unicode category Cf,
     // not Zs), so a decodable word touching a ZWSP was left unmarked or mis-marked. See
@@ -337,46 +382,32 @@ describe("jquery.text-markup", function () {
         ]);
     });
 
-    it("wrap_words_extra matches words bounded by a ZERO WIDTH SPACE (BL-16490)", function () {
+    it("find_words_extra matches words bounded by a ZERO WIDTH SPACE (BL-16490)", function () {
         const zwsp = String.fromCharCode(0x200b);
         // A stray ZWSP sits between two words. Because the analyzer splits on it, both
-        // "cat" and "dog" end up in the word list, and the highlighter must wrap both,
-        // leaving the ZWSP in place between them.
-        const html = `<p>cat${zwsp}dog</p>`;
+        // "cat" and "dog" end up in the word list, and the highlighter must find both.
+        const text = `cat${zwsp}dog`;
         // sanity check: the invisible ZWSP really is present in the input
-        expect(html.indexOf(zwsp)).toBeGreaterThan(-1);
+        expect(text.indexOf(zwsp)).toBeGreaterThan(-1);
 
-        const newHtml = theOneLibSynphony.wrap_words_extra(
-            html,
-            ["cat", "dog"],
-            "word-not-found",
-            ' data-segment="word"',
-        );
-
-        expect(newHtml).toBe(
-            `<p><span class="word-not-found" data-segment="word">cat</span>${zwsp}` +
-                `<span class="word-not-found" data-segment="word">dog</span></p>`,
-        );
-        // the ZWSP must be preserved, not swallowed
-        expect(newHtml.indexOf(zwsp)).toBeGreaterThan(-1);
+        expect(
+            theOneLibSynphony.find_words_extra(text, ["cat", "dog"]),
+        ).toEqual([
+            { start: 0, end: 3 },
+            // 4, not 3: the highlight must not swallow the ZWSP between the two words.
+            { start: 4, end: 7 },
+        ]);
     });
 
-    it("wrap_words_extra matches a word immediately followed by a ZERO WIDTH SPACE (BL-16490)", function () {
+    it("find_words_extra matches a word immediately followed by a ZERO WIDTH SPACE (BL-16490)", function () {
         const zwsp = String.fromCharCode(0x200b);
         // "cat" is decodable; a stray ZWSP sits right after it, before a normal space.
         // Previously the afterWord boundary (\p{Z}/\p{P} only) did not see the ZWSP, so
         // "cat" was left unmarked.
-        const html = `<p>cat${zwsp} sat</p>`;
+        const text = `cat${zwsp} sat`;
 
-        const newHtml = theOneLibSynphony.wrap_words_extra(
-            html,
-            ["cat"],
-            "word-not-found",
-            ' data-segment="word"',
-        );
-
-        expect(newHtml).toBe(
-            `<p><span class="word-not-found" data-segment="word">cat</span>${zwsp} sat</p>`,
-        );
+        expect(theOneLibSynphony.find_words_extra(text, ["cat"])).toEqual([
+            { start: 0, end: 3 },
+        ]);
     });
 });

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markupSpec.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/jquery.text-markupSpec.js
@@ -134,6 +134,55 @@ describe("jquery.text-markup", function () {
         expect(highlighted(kWordTooLongHighlight)).toEqual([]);
     });
 
+    // A <br> ends a line, so each line of a stanza counts as its own sentence rather than the
+    // whole verse counting as one long one. (When the markup worked on HTML, the sentence
+    // splitter saw <br> as a paragraph-ending placeholder; now mapVisibleText gives it a
+    // newline, which that splitter also counts as paragraph-ending.)
+    it("checkLeveledReader treats each <br> line as its own sentence", function () {
+        const input = "<p>One two three<br>four five six</p>";
+        $("#text_entry1")
+            .html(input)
+            .checkLeveledReader({ maxWordsPerSentence: 4 });
+
+        expect($("#text_entry1").html()).toBe(input);
+        // Both lines are 3 words, so neither exceeds 4. Were the <br> only a space, this would
+        // be one 6-word sentence and would be marked.
+        expect(highlighted(kSentenceTooLongHighlight)).toEqual([]);
+
+        // Sanity/positive control: a limit of 2 marks each line separately.
+        $("#text_entry1")
+            .html(input)
+            .checkLeveledReader({ maxWordsPerSentence: 2 });
+        expect(highlighted(kSentenceTooLongHighlight)).toEqual([
+            "One two three",
+            "four five six",
+        ]);
+    });
+
+    // Locating sentences relies on the splitter returning the text unchanged. It rewrites a
+    // literal "<br>" the user typed as text, which would shift every following offset, so in
+    // that case we skip sentence marking rather than highlight the wrong words.
+    it("checkLeveledReader does not mis-mark when the text contains a literal <br>", function () {
+        const input =
+            "<p>Type &lt;br&gt; to break. This sentence is far too long.</p>";
+        $("#text_entry1")
+            .html(input)
+            .checkLeveledReader({ maxWordsPerSentence: 2 });
+
+        expect($("#text_entry1").html()).toBe(input);
+        expect(highlighted(kSentenceTooLongHighlight)).toEqual([]);
+
+        // Sanity/positive control: the same text without the literal "<br>" IS marked, so the
+        // assertion above is meaningful rather than passing for some unrelated reason.
+        $("#text_entry1")
+            .html("<p>Type to break. This sentence is far too long.</p>")
+            .checkLeveledReader({ maxWordsPerSentence: 2 });
+        expect(highlighted(kSentenceTooLongHighlight)).toEqual([
+            "Type to break.",
+            "This sentence is far too long.",
+        ]);
+    });
+
     // check the bug reported in BL-10119
     it("checkLeveledReader.handlesSentencesWithInitialMarkup", function () {
         const input =

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/split_sentencesSpec.js
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/split_sentencesSpec.js
@@ -333,6 +333,20 @@ describe("Splitting text into sentences", function () {
         expect(sentences[0].text).toBe("« Et toi&nbsp;?&nbsp;»&nbsp;'");
         expect(sentences[1].text).toBe("What next?");
     });
+    // The two tests around this one use the "&nbsp;" entity and the narrow NBSP. A caller that
+    // passes plain text rather than HTML - the reader tools' visible-text snapshot, or anything
+    // that went through removeAllHtmlMarkupFromString, which decodes entities - has the real
+    // NO-BREAK SPACE character instead, and it has to behave the same way. It used not to, so
+    // the closing guillemet ended up starting the next sentence.
+    it("Split into sentences, real NO-BREAK SPACE between sentence-ending punct and other punct puts other punct in previous", function () {
+        var inputText = "« Et toi\u00A0?\u00A0»\u00A0' What next?";
+        var fragments = theOneLibSynphony.stringToSentences(inputText);
+        var sentences = _.filter(fragments, function (frag) {
+            return frag.isSentence;
+        });
+        expect(sentences[0].text).toBe("« Et toi\u00A0?\u00A0»\u00A0'");
+        expect(sentences[1].text).toBe("What next?");
+    });
     it("Split into sentences, narrow NBSP between sentence-ending punct and other punct puts other punct in previous", function () {
         var inputText = "« Et toi\u202F?\u202F»\u202F'\u202F What next?";
         var fragments = theOneLibSynphony.stringToSentences(inputText);

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/synphony_lib.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/synphony_lib.ts
@@ -1057,10 +1057,19 @@ export class LibSynphony {
         // These kinds of spaces are allowed, but only before a trailingPunct; otherwise,
         // they are considered part of the inter-sentence white space.
         // \\u202F: narrow non-breaking space that our long-press inserts for non-breaking space.
+        // \\u00A0: a real NO-BREAK SPACE. nbspReplacement above only stands in for the "&nbsp;"
+        // *entity*, which is what we see when the input is HTML. Callers that pass us plain text
+        // (the reader tools' mapVisibleText, and removeAllHtmlMarkupFromString, which decodes
+        // entities) have the actual character instead, and without it here a French-style
+        // "Bonjour ! " would break the sentence before its closing guillemet.
         // Using a non-capturing group here, because it's only to allow the space+trailing
         // sequence to repeat; we don't want to use it separately in the result.
         var afterSEP =
-            "(?:[" + nbspReplacement + "\\u202F]*" + trailingPunct + ")*";
+            "(?:[" +
+            nbspReplacement +
+            "\\u00A0\\u202F]*" +
+            trailingPunct +
+            ")*";
 
         // regex to find sentence ending sequences and inter-sentence space
         // \p{SEP} is defined as a list of sentence ending punctuation characters by a call to XRegExp.addUnicodeData

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/synphony_lib.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/libSynphony/synphony_lib.ts
@@ -236,7 +236,7 @@ export function setLangData(data) {
 // (or stray inside) words without being visible.
 // This is the body of a regex character class (no enclosing brackets). It MUST be kept in
 // sync between getWordsFromHtmlString (which splits story text into words on these) and
-// wrap_words_extra (which highlights those words in the HTML): if the two disagree about
+// find_words_extra (which locates those words for highlighting): if the two disagree about
 // where a word ends, a decodable word next to one of these characters gets left unmarked
 // or mis-marked. See BL-3933, BL-7081, and BL-16490.
 // NOTE: U+200C (ZWNJ) and U+200D (ZWJ) are deliberately excluded; they are legitimate
@@ -666,7 +666,7 @@ export class LibSynphony {
         // as are ZERO WIDTH JOINER and NON JOINER (See https://issues.bloomlibrary.org/youtrack/issue/BL-7081).
         // See list at: https://www.compart.com/en/unicode/category/Cf
         // These live in the shared zeroWidthAndDirectionalSplitters constant so that
-        // wrap_words_extra bounds words at exactly the same characters we split on here
+        // find_words_extra bounds words at exactly the same characters we split on here
         // (See BL-16490).
         // split on whitespace, Control(control) and some Control(format) characters
         regex = XRegExp(
@@ -1445,26 +1445,26 @@ export class LibSynphony {
     }
 
     /**
-     * Wraps words in <code>storyHTML</code> that are contained in <code>aWords</code>
-     * @param {String} storyHTML
+     * Finds every occurrence in <code>storyText</code> of a word in <code>aWords</code>, and
+     * returns the character span of each. The reader tools use these to highlight the words with
+     * ::highlight() pseudo-elements, which is why this reports positions instead of wrapping the
+     * words in spans: wrapping them would mean rewriting the innerHTML of a contenteditable, which
+     * CKEditor turns into a permanent inline background-color style (BL-16558).
+     * @param {String} storyText plain text (not HTML), as seen by mapVisibleText()
      * @param {Array} aWords
-     * @param {String} cssClass
-     * @param {String} extra
-     * @returns {String}
+     * @returns {Array} an array of {start, end} character offsets within storyText
      */
-    public wrap_words_extra(storyHTML, aWords, cssClass, extra) {
-        if (aWords === undefined || aWords.length === 0) return storyHTML;
+    public find_words_extra(
+        storyText: string,
+        aWords: string[],
+    ): { start: number; end: number }[] {
+        if (aWords === undefined || aWords.length === 0) return [];
 
-        // Remove empty strings from the aWords array.  And if the array is then
-        // empty, return the original storyHTML.
-        aWords = aWords.filter((x) => x);
-        if (aWords.length === 0) return storyHTML;
+        // Ignore empty strings in the aWords array; they would match everywhere.
+        const words = aWords.filter((x) => x);
+        if (words.length === 0) return [];
 
-        if (storyHTML.trim().length === 0) return storyHTML;
-
-        // make sure extra starts with a space
-        if (extra.length > 0 && extra.substring(0, 1) !== " ")
-            extra = " " + extra;
+        if (storyText.trim().length === 0) return [];
 
         // Bound words at the same zero-width / directional splitters that
         // getWordsFromHtmlString splits on (via zeroWidthAndDirectionalSplitters), in
@@ -1475,51 +1475,31 @@ export class LibSynphony {
         // include them; they must be listed explicitly. See BL-16490.
         const wordBoundaryChars =
             "\\s\\p{Z}" + zeroWidthAndDirectionalSplitters;
-        var beforeWord =
-            "(^\\s*|>\\s*|[" + wordBoundaryChars + "]|\\p{P}|&nbsp;)"; // word beginning delimiter
-        var afterWord =
-            "(?=(\\s*$|\\s*<|[" +
-            wordBoundaryChars +
-            "]|\\p{P}+\\s|\\p{P}+<br|[\\s]*&nbsp;|\\p{P}+&nbsp;|\\p{P}+$))"; // word ending delimiter
+        // Working on plain text rather than HTML, we need no alternatives for tag boundaries
+        // or &nbsp; entities: a non-breaking space is a real \p{Z} character here, and where a
+        // tag used to bound a word there is now either ordinary text or the separating space
+        // that mapVisibleText() puts in for a <br> or a block boundary.
+        const beforeWord = "(^\\s*|[" + wordBoundaryChars + "]|\\p{P})"; // word beginning delimiter
+        const afterWord =
+            "(?=(\\s*$|[" + wordBoundaryChars + "]|\\p{P}+\\s|\\p{P}+$))"; // word ending delimiter
 
         // escape special characters
-        var escapedWords = aWords.map(RegExp.quote);
+        const escapedWords = words.map(RegExp.quote);
 
-        var regex = XRegExp(
+        const regex = XRegExp(
             beforeWord + "(" + escapedWords.join("|") + ")" + afterWord,
             "xgi",
         );
 
-        // We must not replace any occurrences inside <...>. For example, if html is abc <span class='word'>x</span>
-        // and we are trying to wrap 'word', we should not change anything.
-        // To prevent this we split the string into sections starting at <. If this is valid html, each except the first
-        // should have exactly one >. We strip off everything up to the > and do the wrapping within the rest.
-        // Finally we put the pieces back together.
-        var parts = storyHTML.split("<");
-        var modParts: any[] = [];
-        for (var i = 0; i < parts.length; i++) {
-            var text = parts[i];
-            var prefix = "";
-            if (i != 0) {
-                var index = text.indexOf(">");
-                prefix = text.substring(0, index + 1);
-                text = text.substring(index + 1, text.length);
-            }
-            modParts.push(
-                prefix +
-                    XRegExp.replace(
-                        text,
-                        regex,
-                        '$1<span class="' +
-                            cssClass +
-                            '"' +
-                            extra +
-                            ">$2</span>",
-                    ),
-            );
+        const spans: { start: number; end: number }[] = [];
+        let match: RegExpExecArray | null;
+        // Every match contains a non-empty word, so lastIndex always advances.
+        while ((match = regex.exec(storyText)) !== null) {
+            // Group 1 is the delimiter the match had to start with; the word itself is group 2.
+            const start = match.index + match[1].length;
+            spans.push({ start, end: start + match[2].length });
         }
-
-        return modParts.join("<");
+        return spans;
     }
 }
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerHighlights.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerHighlights.ts
@@ -22,7 +22,7 @@ export const kWordTooLongHighlight = "bloom-reader-word-too-long";
 export const kWordNotDecodableHighlight = "bloom-reader-word-not-decodable";
 export const kSightWordHighlight = "bloom-reader-sight-word";
 
-// The class we put on our hover tip. bloom-ui means Bloom strips it when saving the page.
+// The class we put on our hover tip. Accompanied by bloom-ui so the element is never saved.
 const kTipClass = "bloom-reader-highlight-tip";
 
 interface ReaderHighlightLayer {

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerHighlights.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerHighlights.ts
@@ -178,7 +178,12 @@ class ReaderHighlightManager {
             );
         });
 
-        this.ensureHoverHandler(contextNode.ownerDocument ?? undefined);
+        // Only listen for hovers while there is actually something to explain.
+        if (this.paintedRanges.size > 0) {
+            this.ensureHoverHandler(contextNode.ownerDocument ?? undefined);
+        } else {
+            this.detachHoverHandler();
+        }
     }
 
     // Remove all the reader highlights, e.g. when the user turns the tool off.
@@ -186,7 +191,7 @@ class ReaderHighlightManager {
         this.rangesInProgress = new Map<string, Range[]>();
         this.paintedRanges = new Map<string, Range[]>();
         this.highlights.clearAllManagedHighlights(contextNode);
-        this.hideTip();
+        this.detachHoverHandler();
     }
 
     private ensureHoverHandler(pageDocument: Document | undefined): void {
@@ -194,10 +199,31 @@ class ReaderHighlightManager {
             return;
         }
         // A new page means a new document; the old one is being discarded along with its handler.
+        this.detachHoverHandler();
         this.hoverDocument = pageDocument;
-        this.tipElement = undefined;
         pageDocument.addEventListener("mousemove", this.handleMouseMove);
         pageDocument.addEventListener("mouseleave", this.handleMouseLeave);
+    }
+
+    // Stop listening, and take our tip out of the page. There is nothing to hover over once the
+    // highlights are gone, and leaving the handler attached would mean doing work on every mouse
+    // move for the rest of the page's life. endPass() attaches it again when there is.
+    private detachHoverHandler(): void {
+        this.hideTip();
+        this.tipElement?.remove();
+        this.tipElement = undefined;
+        if (!this.hoverDocument) {
+            return;
+        }
+        this.hoverDocument.removeEventListener(
+            "mousemove",
+            this.handleMouseMove,
+        );
+        this.hoverDocument.removeEventListener(
+            "mouseleave",
+            this.handleMouseLeave,
+        );
+        this.hoverDocument = undefined;
     }
 
     // Since there is no element to hang a tooltip on, we hit-test the mouse against the ranges we

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerHighlights.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerHighlights.ts
@@ -72,12 +72,15 @@ const allReaderHighlightNames = readerHighlightLayers.map(
 // zero-width phrase markers. This replaces what removeAllHtmlMarkupFromString() used to strip
 // out of the HTML string.
 function shouldSkipElementForReaderText(element: Element): boolean {
+    // Covers Bloom's transient in-page UI generally, including the format cog (StyleEditor
+    // creates it as <div id="formatButton" class="bloom-ui">).
     if (element.classList.contains("bloom-ui")) {
         return true;
     }
-    if (element.id === "formatButton") {
-        return true;
-    }
+    // The Talking Book tool's phrase markers need their own case: unlike the UI above they are
+    // real saved content (invisible and zero-width), and they carry no other class - Bloom's
+    // spreadsheet export/import writes them as class="bloom-audio-split-marker" exactly, and
+    // MarkedUpText.cs matches that attribute for equality, so bloom-ui cannot be added to them.
     if (element.classList.contains("bloom-audio-split-marker")) {
         return true;
     }

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerHighlights.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerHighlights.ts
@@ -223,9 +223,22 @@ class ReaderHighlightManager {
         this.hideTip();
     };
 
+    // The layer whose tip should show for this mouse position, if any. Only layers that actually
+    // have a tip are considered: a too-long word sits inside a too-long sentence, and the word
+    // layer has nothing to say, so letting it match first would hide the sentence's explanation.
     private layerAtPoint(event: MouseEvent): ReaderHighlightLayer | undefined {
         const pageDocument = this.hoverDocument;
         if (!pageDocument) {
+            return undefined;
+        }
+        // Cheapest possible exit first. The listeners stay attached for the life of the page
+        // document, so with the tool turned off (or on a page with no violations) this runs on
+        // every mouse move and must not reach getCaretPosition(), which forces a layout.
+        const layersWithTips = readerHighlightLayers.filter(
+            (layer) =>
+                layer.tipL10nId && this.paintedRanges.get(layer.name)?.length,
+        );
+        if (layersWithTips.length === 0) {
             return undefined;
         }
         const target = event.target as Element | null;
@@ -242,9 +255,15 @@ class ReaderHighlightManager {
             return undefined;
         }
 
-        return readerHighlightLayers.find((layer) =>
+        return layersWithTips.find((layer) =>
             (this.paintedRanges.get(layer.name) ?? []).some(
                 (range) =>
+                    // Ranges whose content has been replaced since we painted are not under the
+                    // mouse, and asking isPointInRange about one whose root differs from the
+                    // caret's throws WrongDocumentError, so screen them out first.
+                    range.startContainer.isConnected &&
+                    range.startContainer.ownerDocument ===
+                        caret.node.ownerDocument &&
                     // The caret test is the cheap one, and narrows us to a single candidate
                     // range; then we confirm the mouse really is over the text it covers.
                     range.isPointInRange(caret.node, caret.offset) &&

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerHighlights.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerHighlights.ts
@@ -243,8 +243,12 @@ class ReaderHighlightManager {
         }
 
         return readerHighlightLayers.find((layer) =>
-            (this.paintedRanges.get(layer.name) ?? []).some((range) =>
-                range.isPointInRange(caret.node, caret.offset),
+            (this.paintedRanges.get(layer.name) ?? []).some(
+                (range) =>
+                    // The caret test is the cheap one, and narrows us to a single candidate
+                    // range; then we confirm the mouse really is over the text it covers.
+                    range.isPointInRange(caret.node, caret.offset) &&
+                    isPointOverRange(range, event.clientX, event.clientY),
             ),
         );
     }
@@ -271,6 +275,23 @@ class ReaderHighlightManager {
             this.tipElement.style.display = "none";
         }
     }
+}
+
+// Is the point actually inside the area the range's text occupies?
+// We have to ask, because caretPositionFromPoint() answers with the NEAREST text position even
+// when the point is nowhere near any text. Hovering the white space below the last paragraph, for
+// instance, gets you a position at the end of the last line, so a tip would appear or not
+// depending on whether that line happened to be highlighted. Exported for testing: a Range's
+// client rects need real layout, which the unit tests don't have.
+export function isPointOverRange(range: Range, x: number, y: number): boolean {
+    // A range spanning more than one line has one rect per line.
+    return Array.from(range.getClientRects()).some(
+        (rect) =>
+            x >= rect.left &&
+            x <= rect.right &&
+            y >= rect.top &&
+            y <= rect.bottom,
+    );
 }
 
 // The document position under a point, using whichever of the two spellings the browser has.

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerHighlights.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerHighlights.ts
@@ -1,0 +1,305 @@
+import {
+    makeRangeFromTextOffsets,
+    mapVisibleText,
+    TextHighlightManager,
+    TextOffsetMap,
+} from "../../js/textHighlightManager";
+import theOneLocalizationManager from "../../../lib/localizationManager/localizationManager";
+
+// The decodable and leveled reader tools mark up violations (a word that is not decodable at
+// this stage, a sentence that is too long for this level, ...). They used to do that by wrapping
+// the offending text in a styled span, which meant rewriting the innerHTML of a contenteditable
+// on every keystroke. CKEditor responds to that by copying the span's computed background-color
+// into a bare inline style of its own, which then gets saved into the book - permanently
+// (BL-16558).
+//
+// So instead we paint the violations with ::highlight() pseudo-elements over live Ranges, the
+// same technique the Talking Book tool uses (see textHighlightManager.ts). The DOM is never
+// touched, so there is nothing for CKEditor to copy.
+
+export const kSentenceTooLongHighlight = "bloom-reader-sentence-too-long";
+export const kWordTooLongHighlight = "bloom-reader-word-too-long";
+export const kWordNotDecodableHighlight = "bloom-reader-word-not-decodable";
+export const kSightWordHighlight = "bloom-reader-sight-word";
+
+// The class we put on our hover tip. bloom-ui means Bloom strips it when saving the page.
+const kTipClass = "bloom-reader-highlight-tip";
+
+interface ReaderHighlightLayer {
+    name: string;
+    // Where highlights overlap (a too-long word inside a too-long sentence) the higher priority
+    // paints on top, which is how the old nested spans behaved.
+    priority: number;
+    // Text of the hover tip for this kind of violation, if it has one.
+    tipL10nId?: string;
+    tipEnglish?: string;
+}
+
+// Ordered so that the first layer whose range contains the mouse wins the tip; word-level
+// violations are more specific than sentence-level ones, so they come first.
+const readerHighlightLayers: ReaderHighlightLayer[] = [
+    {
+        name: kSightWordHighlight,
+        priority: 3,
+        tipL10nId: "EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord",
+        tipEnglish: "Sight Word",
+    },
+    {
+        name: kWordNotDecodableHighlight,
+        priority: 2,
+        tipL10nId:
+            "EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable",
+        tipEnglish: "This word is not decodable in this stage.",
+    },
+    {
+        name: kWordTooLongHighlight,
+        priority: 2,
+    },
+    {
+        name: kSentenceTooLongHighlight,
+        priority: 1,
+        tipL10nId: "EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong",
+        tipEnglish: "This sentence is too long for this level.",
+    },
+];
+
+const allReaderHighlightNames = readerHighlightLayers.map(
+    (layer) => layer.name,
+);
+
+// True for elements inside a bloom-editable whose text the reader tools must not analyze:
+// transient Bloom UI, CKEditor's hidden selection bookmarks, and the Talking Book tool's
+// zero-width phrase markers. This replaces what removeAllHtmlMarkupFromString() used to strip
+// out of the HTML string.
+function shouldSkipElementForReaderText(element: Element): boolean {
+    if (element.classList.contains("bloom-ui")) {
+        return true;
+    }
+    if (element.id === "formatButton") {
+        return true;
+    }
+    if (element.classList.contains("bloom-audio-split-marker")) {
+        return true;
+    }
+    // CKEditor's bookmarks are hidden spans with ids like cke_bm_123S, holding a placeholder
+    // character that would otherwise break a word in two.
+    if (element.id.startsWith("cke_")) {
+        return true;
+    }
+    const style = element.getAttribute("style");
+    if (style && /display:\s*none/i.test(style)) {
+        return true;
+    }
+    return false;
+}
+
+// Snapshot the text of an element as the reader sees it, ready for analysis and for turning the
+// resulting character offsets back into Ranges.
+export function mapReaderText(element: Node): TextOffsetMap {
+    return mapVisibleText(element, shouldSkipElementForReaderText);
+}
+
+// A span of characters within a TextOffsetMap's text.
+export interface TextSpan {
+    start: number;
+    end: number;
+}
+
+// Make the Ranges for a set of character spans, dropping any that turn out to cover no real text.
+export function makeRangesForSpans(
+    map: TextOffsetMap,
+    spans: TextSpan[],
+): Range[] {
+    return spans
+        .map((span) => makeRangeFromTextOffsets(map, span.start, span.end))
+        .filter((range): range is Range => !!range);
+}
+
+// Narrow a span so it neither starts nor ends on whitespace. A sentence fragment can include the
+// space that follows it, and we don't want the highlight to extend past the visible text.
+export function trimSpan(text: string, span: TextSpan): TextSpan {
+    let { start, end } = span;
+    while (start < end && /\s/.test(text[start])) {
+        start++;
+    }
+    while (end > start && /\s/.test(text[end - 1])) {
+        end--;
+    }
+    return { start, end };
+}
+
+// Collects the Ranges found by one pass of the reader markup over the page's editable elements,
+// registers them as ::highlight() layers, and answers hover tips for them.
+class ReaderHighlightManager {
+    private highlights = new TextHighlightManager(allReaderHighlightNames);
+
+    // Ranges accumulated by the pass in progress, then the ones currently painted.
+    private rangesInProgress = new Map<string, Range[]>();
+    private paintedRanges = new Map<string, Range[]>();
+
+    // The document we have attached the hover handler to, if any.
+    private hoverDocument: Document | undefined;
+    private tipElement: HTMLElement | undefined;
+
+    // Start collecting the highlights for a new markup pass.
+    public beginPass(): void {
+        this.rangesInProgress = new Map<string, Range[]>();
+    }
+
+    // Add ranges found in one element to a layer of the pass in progress.
+    public addRanges(highlightName: string, ranges: Range[]): void {
+        if (ranges.length === 0) {
+            return;
+        }
+        const existing = this.rangesInProgress.get(highlightName);
+        if (existing) {
+            existing.push(...ranges);
+        } else {
+            this.rangesInProgress.set(highlightName, [...ranges]);
+        }
+    }
+
+    // Paint everything the pass found, replacing what was painted before. contextNode is any node
+    // in the document being highlighted.
+    public endPass(contextNode?: Node): void {
+        if (!contextNode) {
+            return;
+        }
+
+        this.paintedRanges = this.rangesInProgress;
+        this.rangesInProgress = new Map<string, Range[]>();
+
+        readerHighlightLayers.forEach((layer) => {
+            this.highlights.setHighlight(
+                layer.name,
+                this.paintedRanges.get(layer.name) ?? [],
+                contextNode,
+                layer.priority,
+            );
+        });
+
+        this.ensureHoverHandler(contextNode.ownerDocument ?? undefined);
+    }
+
+    // Remove all the reader highlights, e.g. when the user turns the tool off.
+    public clearAll(contextNode?: Node): void {
+        this.rangesInProgress = new Map<string, Range[]>();
+        this.paintedRanges = new Map<string, Range[]>();
+        this.highlights.clearAllManagedHighlights(contextNode);
+        this.hideTip();
+    }
+
+    private ensureHoverHandler(pageDocument: Document | undefined): void {
+        if (!pageDocument || this.hoverDocument === pageDocument) {
+            return;
+        }
+        // A new page means a new document; the old one is being discarded along with its handler.
+        this.hoverDocument = pageDocument;
+        this.tipElement = undefined;
+        pageDocument.addEventListener("mousemove", this.handleMouseMove);
+        pageDocument.addEventListener("mouseleave", this.handleMouseLeave);
+    }
+
+    // Since there is no element to hang a tooltip on, we hit-test the mouse against the ranges we
+    // painted and show our own tip. (This also fixes the tips for sight words and non-decodable
+    // words, which have been throwing rather than appearing: the old code called qtip() on a raw
+    // DOM element instead of on a jQuery wrapper.)
+    private handleMouseMove = (event: MouseEvent): void => {
+        const layer = this.layerAtPoint(event);
+        if (!layer?.tipL10nId) {
+            this.hideTip();
+            return;
+        }
+        this.showTip(
+            theOneLocalizationManager.getText(
+                layer.tipL10nId,
+                layer.tipEnglish ?? "",
+            ),
+            event,
+        );
+    };
+
+    private handleMouseLeave = (): void => {
+        this.hideTip();
+    };
+
+    private layerAtPoint(event: MouseEvent): ReaderHighlightLayer | undefined {
+        const pageDocument = this.hoverDocument;
+        if (!pageDocument) {
+            return undefined;
+        }
+        const target = event.target as Element | null;
+        if (!target?.closest?.(".bloom-editable")) {
+            return undefined;
+        }
+
+        const caret = getCaretPosition(
+            pageDocument,
+            event.clientX,
+            event.clientY,
+        );
+        if (!caret) {
+            return undefined;
+        }
+
+        return readerHighlightLayers.find((layer) =>
+            (this.paintedRanges.get(layer.name) ?? []).some((range) =>
+                range.isPointInRange(caret.node, caret.offset),
+            ),
+        );
+    }
+
+    private showTip(text: string, event: MouseEvent): void {
+        const pageDocument = this.hoverDocument;
+        if (!pageDocument?.body || !text) {
+            return;
+        }
+        if (!this.tipElement) {
+            this.tipElement = pageDocument.createElement("div");
+            // bloom-ui keeps it out of the saved page.
+            this.tipElement.classList.add("bloom-ui", kTipClass);
+            pageDocument.body.appendChild(this.tipElement);
+        }
+        this.tipElement.textContent = text;
+        this.tipElement.style.left = `${event.pageX + 12}px`;
+        this.tipElement.style.top = `${event.pageY + 16}px`;
+        this.tipElement.style.display = "block";
+    }
+
+    private hideTip(): void {
+        if (this.tipElement) {
+            this.tipElement.style.display = "none";
+        }
+    }
+}
+
+// The document position under a point, using whichever of the two spellings the browser has.
+function getCaretPosition(
+    pageDocument: Document,
+    x: number,
+    y: number,
+): { node: Node; offset: number } | undefined {
+    const documentWithCaretApis = pageDocument as Document & {
+        caretPositionFromPoint?: (
+            x: number,
+            y: number,
+        ) => { offsetNode: Node; offset: number } | null;
+        caretRangeFromPoint?: (x: number, y: number) => Range | null;
+    };
+
+    if (documentWithCaretApis.caretPositionFromPoint) {
+        const position = documentWithCaretApis.caretPositionFromPoint(x, y);
+        return position
+            ? { node: position.offsetNode, offset: position.offset }
+            : undefined;
+    }
+    if (documentWithCaretApis.caretRangeFromPoint) {
+        const range = documentWithCaretApis.caretRangeFromPoint(x, y);
+        return range
+            ? { node: range.startContainer, offset: range.startOffset }
+            : undefined;
+    }
+    return undefined;
+}
+
+export const theOneReaderHighlightManager = new ReaderHighlightManager();

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerHighlights.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerHighlights.ts
@@ -326,7 +326,7 @@ class ReaderHighlightManager {
 }
 
 // Is the point actually inside the area the range's text occupies?
-// We have to ask, because caretPositionFromPoint() answers with the NEAREST text position even
+// We have to ask, because getCaretPosition() answers with the NEAREST text position even
 // when the point is nowhere near any text. Hovering the white space below the last paragraph, for
 // instance, gets you a position at the end of the last line, so a tip would appear or not
 // depending on whether that line happened to be highlighted. Exported for testing: a Range's
@@ -342,33 +342,21 @@ export function isPointOverRange(range: Range, x: number, y: number): boolean {
     );
 }
 
-// The document position under a point, using whichever of the two spellings the browser has.
+// The document position under a point.
+// We use Chromium's older caretRangeFromPoint rather than the standard caretPositionFromPoint
+// because it works on every WebView2 Bloom supports: the standard one only arrived in Chromium
+// 128, and WebView2Browser.kMinimumWebView2Version is still 112, where it does not exist. (jsdom
+// has neither, which is why the hover tip cannot be unit-tested end to end.)
 function getCaretPosition(
     pageDocument: Document,
     x: number,
     y: number,
 ): { node: Node; offset: number } | undefined {
-    const documentWithCaretApis = pageDocument as Document & {
-        caretPositionFromPoint?: (
-            x: number,
-            y: number,
-        ) => { offsetNode: Node; offset: number } | null;
-        caretRangeFromPoint?: (x: number, y: number) => Range | null;
-    };
-
-    if (documentWithCaretApis.caretPositionFromPoint) {
-        const position = documentWithCaretApis.caretPositionFromPoint(x, y);
-        return position
-            ? { node: position.offsetNode, offset: position.offset }
-            : undefined;
-    }
-    if (documentWithCaretApis.caretRangeFromPoint) {
-        const range = documentWithCaretApis.caretRangeFromPoint(x, y);
-        return range
-            ? { node: range.startContainer, offset: range.startOffset }
-            : undefined;
-    }
-    return undefined;
+    // It returns null when the point is outside the document; anywhere in a text box is not.
+    const caretRange = pageDocument.caretRangeFromPoint(x, y);
+    return caretRange
+        ? { node: caretRange.startContainer, offset: caretRange.startOffset }
+        : undefined;
 }
 
 export const theOneReaderHighlightManager = new ReaderHighlightManager();

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerHighlightsSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerHighlightsSpec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { isPointOverRange, trimSpan } from "./readerHighlights";
+
+describe("readerHighlights", () => {
+    describe("isPointOverRange", () => {
+        // jsdom has no layout, so a real Range reports no client rects. These stand-ins let us
+        // test the hit test itself with known geometry.
+        function rangeWithRects(
+            rects: {
+                left: number;
+                top: number;
+                right: number;
+                bottom: number;
+            }[],
+        ): Range {
+            return {
+                getClientRects: () => rects,
+            } as unknown as Range;
+        }
+
+        // A word on one line: x 100-140, y 50-70.
+        const oneLine = rangeWithRects([
+            { left: 100, top: 50, right: 140, bottom: 70 },
+        ]);
+
+        it("is true for a point inside the text", () => {
+            expect(isPointOverRange(oneLine, 120, 60)).toBe(true);
+        });
+
+        it("is true on the edge of the text", () => {
+            expect(isPointOverRange(oneLine, 100, 50)).toBe(true);
+            expect(isPointOverRange(oneLine, 140, 70)).toBe(true);
+        });
+
+        // This is the case that used to show a tip wrongly: the mouse is in the white space
+        // below the last paragraph, but caretPositionFromPoint() still reports a position at the
+        // end of the highlighted line above it.
+        it("is false for a point below the text", () => {
+            expect(isPointOverRange(oneLine, 120, 200)).toBe(false);
+        });
+
+        it("is false for a point beside or above the text", () => {
+            expect(isPointOverRange(oneLine, 300, 60)).toBe(false);
+            expect(isPointOverRange(oneLine, 120, 10)).toBe(false);
+        });
+
+        it("checks every line of a range that wraps", () => {
+            // A sentence wrapping onto a second line gets a rect per line, and the gap to the
+            // right of the shorter second line is not over the text.
+            const twoLines = rangeWithRects([
+                { left: 100, top: 50, right: 300, bottom: 70 },
+                { left: 100, top: 70, right: 180, bottom: 90 },
+            ]);
+            expect(isPointOverRange(twoLines, 250, 60)).toBe(true);
+            expect(isPointOverRange(twoLines, 150, 80)).toBe(true);
+            expect(isPointOverRange(twoLines, 250, 80)).toBe(false);
+        });
+
+        it("is false when the range occupies nothing", () => {
+            expect(isPointOverRange(rangeWithRects([]), 120, 60)).toBe(false);
+        });
+    });
+
+    describe("trimSpan", () => {
+        it("leaves a span that is already tight alone", () => {
+            expect(trimSpan("A cat sat.", { start: 2, end: 5 })).toEqual({
+                start: 2,
+                end: 5,
+            });
+        });
+
+        it("excludes the space a sentence fragment carries with it", () => {
+            const text = "One. Two.  ";
+            expect(trimSpan(text, { start: 4, end: text.length })).toEqual({
+                start: 5,
+                end: 9,
+            });
+        });
+
+        it("collapses a span that is all whitespace", () => {
+            const span = trimSpan("a   b", { start: 1, end: 4 });
+            expect(span.end).toBe(span.start);
+        });
+    });
+});

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerHighlightsSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerHighlightsSpec.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from "vitest";
-import { isPointOverRange, trimSpan } from "./readerHighlights";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+    isPointOverRange,
+    kWordNotDecodableHighlight,
+    theOneReaderHighlightManager,
+    trimSpan,
+} from "./readerHighlights";
+import { installHighlightPolyfill } from "../../test/highlightTestSupport";
 
 describe("readerHighlights", () => {
     describe("isPointOverRange", () => {
@@ -58,6 +64,67 @@ describe("readerHighlights", () => {
 
         it("is false when the range occupies nothing", () => {
             expect(isPointOverRange(rangeWithRects([]), 120, 60)).toBe(false);
+        });
+    });
+
+    // The tip needs a mousemove handler on the page, but there is nothing to hover over once the
+    // highlights are gone, and an idle handler would do work (including forcing a layout) on
+    // every mouse move for the rest of the page's life.
+    describe("the hover handler's lifetime", () => {
+        let added: string[];
+        let removed: string[];
+        let root: HTMLElement;
+
+        beforeEach(() => {
+            document.body.innerHTML = "";
+            installHighlightPolyfill(window);
+            root = document.createElement("div");
+            document.body.appendChild(root);
+            added = [];
+            removed = [];
+            vi.spyOn(document, "addEventListener").mockImplementation(
+                (type: string) => {
+                    added.push(type);
+                },
+            );
+            vi.spyOn(document, "removeEventListener").mockImplementation(
+                (type: string) => {
+                    removed.push(type);
+                },
+            );
+        });
+
+        afterEach(() => {
+            vi.restoreAllMocks();
+            theOneReaderHighlightManager.clearAll(document.body);
+        });
+
+        // Something to hover over: one range under a layer that has a tip.
+        function paintOneHighlight(): void {
+            root.textContent = "Cat";
+            const range = document.createRange();
+            range.selectNodeContents(root);
+            theOneReaderHighlightManager.beginPass();
+            theOneReaderHighlightManager.addRanges(kWordNotDecodableHighlight, [
+                range,
+            ]);
+            theOneReaderHighlightManager.endPass(root);
+        }
+
+        it("is attached while highlights are painted and detached when they are cleared", () => {
+            paintOneHighlight();
+            expect(added).toContain("mousemove");
+            expect(removed).not.toContain("mousemove");
+
+            // The user turns the reader tool off, or moves to a page with nothing to mark.
+            theOneReaderHighlightManager.clearAll(root);
+            expect(removed).toContain("mousemove");
+        });
+
+        it("is not attached at all by a pass that finds no violations", () => {
+            theOneReaderHighlightManager.beginPass();
+            theOneReaderHighlightManager.endPass(root);
+            expect(added).not.toContain("mousemove");
         });
     });
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerTools.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerTools.ts
@@ -1,12 +1,10 @@
 /// <reference path="readerToolsModel.ts" />
 /// <reference path="directoryWatcher.ts" />
-/// <reference path="../../../typings/jquery.qtip.d.ts" />
 /// <reference path="../../../typings/jqueryui/jqueryui.d.ts" />
 import $ from "jquery";
 import jQuery from "jquery";
 import { DirectoryWatcher } from "./directoryWatcher";
 import { getTheOneReaderToolsModel } from "./readerToolsModel";
-import theOneLocalizationManager from "../../../lib/localizationManager/localizationManager";
 import {
     theOneLanguageDataInstance,
     theOneLibSynphony,
@@ -23,13 +21,6 @@ import * as _ from "underscore";
 import { renderRoot } from "../../../utils/reactRender";
 import * as React from "react";
 import { ReaderToolSwitch } from "./ReaderToolSwitch";
-
-interface textMarkup extends JQueryStatic {
-    cssSentenceTooLong(): JQuery;
-    cssSightWord(): JQuery;
-    cssWordNotFound(): JQuery;
-    cssPossibleWord(): JQuery;
-}
 
 // listen for messages sent to this page
 window.addEventListener("message", processDLRMessage, false);
@@ -191,59 +182,8 @@ function processDLRMessage(event: MessageEvent): void {
             getTheOneReaderToolsModel().setMarkupType(parseInt(params[1]));
             return;
 
-        case "Qtips": // request from toolbox to add qtips to marked-up spans
-            // We could make separate messages for these...
-            markDecodableStatus();
-            markLeveledStatus();
-
-            return;
-
         default:
     }
-}
-
-function markDecodableStatus(): void {
-    // q-tips; mark sight words and non-decodable words
-    const sightWord = theOneLocalizationManager.getText(
-        "EditTab.EditTab.Toolbox.DecodableReaderTool.SightWord",
-        "Sight Word",
-    );
-    const notDecodable = theOneLocalizationManager.getText(
-        "EditTab.EditTab.Toolbox.DecodableReaderTool.WordNotDecodable",
-        "This word is not decodable in this stage.",
-    );
-    const editableElements = $(".bloom-content1");
-    editableElements
-        .find("span." + (<textMarkup>$).cssSightWord())
-        .each(function () {
-            this.qtip({ content: sightWord });
-        });
-
-    editableElements
-        .find("span." + (<textMarkup>$).cssWordNotFound())
-        .each(function () {
-            this.qtip({ content: notDecodable });
-        });
-
-    // we're considering dropping this entirely
-    // We are disabling the "Possible Word" feature at this time.
-    //editableElements.find('span.' + $.cssPossibleWord()).each(function() {
-    //    $(this.qtip({ content: 'This word is decodable in this stage, but is not part of the collected list of words.' });
-    //});
-}
-
-function markLeveledStatus(): void {
-    // q-tips; mark sentences that are too long
-    const tooLong = theOneLocalizationManager.getText(
-        "EditTab.EditTab.Toolbox.LeveledReaderTool.SentenceTooLong",
-        "This sentence is too long for this level.",
-    );
-    const editableElements = $(".bloom-content1");
-    editableElements
-        .find("span." + (<textMarkup>$).cssSentenceTooLong())
-        .each(function () {
-            $(this).qtip({ content: tooLong });
-        });
 }
 
 export function beginInitializeDecodableReaderTool(): JQueryPromise<void> {

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
@@ -33,6 +33,7 @@ import {
     postString,
 } from "../../../utils/bloomApi";
 import { EditableDivUtils } from "../../js/editableDivUtils";
+import { theOneReaderHighlightManager } from "./readerHighlights";
 import {
     allPromiseSettled,
     setTimeoutPromise,
@@ -521,6 +522,18 @@ export class ReaderToolsModel {
         return didMarkup;
     }
 
+    /**
+     * Remove the decodable/leveled reader highlights from the page, e.g. when the tool is turned
+     * off or the page has nothing we can mark.
+     */
+    private clearReaderHighlights(): void {
+        // the contentWindow is not available during unit testing
+        const contentWindow = this.safelyGetContentWindow();
+        theOneReaderHighlightManager.clearAll(
+            contentWindow?.document.body ?? undefined,
+        );
+    }
+
     private safelyGetContentWindow(): Window | null {
         const page = parent.window.document.getElementById("page");
         if (!page) return null;
@@ -632,7 +645,10 @@ export class ReaderToolsModel {
      */
     public doMarkup(createCkEditorBookMarks: boolean = true): void {
         if (!this.readyToDoMarkup()) return;
-        if (this.currentMarkupType === MarkupType.None) return;
+        if (this.currentMarkupType === MarkupType.None) {
+            this.clearReaderHighlights();
+            return;
+        }
 
         let oldSelectionPosition = -1;
         if (this.activeElement)
@@ -646,6 +662,11 @@ export class ReaderToolsModel {
         // EditableDivUtils.logElementsInnerHtml(editableElements.toArray());
 
         let bookmarksForEachEditable: object[] = [];
+        if (editableElements.length === 0) {
+            // e.g. a cover page. There is nothing to mark, so make sure nothing is left
+            // highlighted from a page that did have something.
+            this.clearReaderHighlights();
+        }
         if (editableElements.length > 0) {
             // qtips can be orphaned if the element they belong to is deleted
             // (and so the mouse can't move off their owning element, and they never go away).
@@ -761,12 +782,6 @@ export class ReaderToolsModel {
                 offset: oldSelectionPosition,
             });
             this.redoStack = []; // ok because only referred to by this variable.
-        }
-
-        // the contentWindow is not available during unit testing
-        const contentWindow = this.safelyGetContentWindow();
-        if (contentWindow) {
-            contentWindow.postMessage("Qtips", "*");
         }
     }
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerTools_libSynphonySpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerTools_libSynphonySpec.ts
@@ -7,6 +7,14 @@ import * as _ from "underscore";
 import ReadersSynphonyWrapper from "./ReadersSynphonyWrapper";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import $ from "jquery";
+import {
+    kSightWordHighlight,
+    kWordNotDecodableHighlight,
+} from "./readerHighlights";
+import {
+    getHighlightTexts,
+    installHighlightPolyfill,
+} from "../../test/highlightTestSupport";
 
 describe("readerTools-libSynphony tests", () => {
     function generateTestData() {
@@ -75,7 +83,14 @@ describe("readerTools-libSynphony tests", () => {
     let divTextEntry2;
     let divTextEntry3;
 
+    // The reader tools paint violations with ::highlight() pseudo-elements over Ranges rather
+    // than by inserting spans, so this is how a test sees what got marked.
+    function highlighted(highlightName: string): string[] {
+        return getHighlightTexts(window, highlightName);
+    }
+
     beforeEach(() => {
+        installHighlightPolyfill(window);
         divTextEntry1 = addDiv("text_entry1");
         divTextEntry2 = addDiv("text_entry2");
         divTextEntry3 = addDiv("text_entry3");
@@ -174,34 +189,20 @@ describe("readerTools-libSynphony tests", () => {
         ];
         const text1 = $("#text_entry1");
 
-        // test empty div (just a <br>)
-        text1
-            .html("<br>")
-            .checkDecodableReader({ knownGraphemes: knownGraphemes });
-        expect(text1.html()).toEqual("<br>");
-
-        // test end of text followed by <br>
-        text1
-            .html("Cat dog.<br>")
-            .checkDecodableReader({ knownGraphemes: knownGraphemes });
-        expect(text1.html()).toEqual(
-            '<span class="possible-word" data-segment="word">Cat</span> <span class="possible-word" data-segment="word">dog</span>.<br>',
-        );
-
-        // test <br> in middle of text
-        text1
-            .html("Cat.<br>Dog.")
-            .checkDecodableReader({ knownGraphemes: knownGraphemes });
-        expect(text1.html()).toEqual(
-            '<span class="possible-word" data-segment="word">Cat</span>.<br><span class="possible-word" data-segment="word">Dog</span>.',
-        );
-
-        text1
-            .html("Cat<br>Dog.")
-            .checkDecodableReader({ knownGraphemes: knownGraphemes });
-        expect(text1.html()).toEqual(
-            '<span class="possible-word" data-segment="word">Cat</span><br><span class="possible-word" data-segment="word">Dog</span>.',
-        );
+        // Every word here is decodable with the given graphemes but was not collected from the
+        // sample texts, so nothing should be marked. (We used to mark these "possible words",
+        // but that feature has long been disabled: it had neither a color nor a tooltip.)
+        // What the original bug was about is that the markup must not disturb the HTML - and
+        // now it never does, whatever it finds.
+        const inputs = ["<br>", "Cat dog.<br>", "Cat.<br>Dog.", "Cat<br>Dog."];
+        inputs.forEach((input) => {
+            text1
+                .html(input)
+                .checkDecodableReader({ knownGraphemes: knownGraphemes });
+            expect(text1.html()).toEqual(input);
+            expect(highlighted(kWordNotDecodableHighlight)).toEqual([]);
+            expect(highlighted(kSightWordHighlight)).toEqual([]);
+        });
     });
 
     it("sightWordOnlyStages", () => {
@@ -215,28 +216,29 @@ describe("readerTools-libSynphony tests", () => {
             .html("<br>")
             .checkDecodableReader({ sightWords: ["canine", "feline"] });
         expect(text1.html()).toEqual("<br>");
+        expect(highlighted(kWordNotDecodableHighlight)).toEqual([]);
 
         // no sight words
         text1
             .html("Cat dog.")
             .checkDecodableReader({ sightWords: ["canine", "feline"] });
-        expect(text1.html()).toEqual(
-            '<span class="word-not-found" data-segment="word">Cat</span> <span class="word-not-found" data-segment="word">dog</span>.',
-        );
+        expect(text1.html()).toEqual("Cat dog.");
+        expect(highlighted(kWordNotDecodableHighlight)).toEqual(["Cat", "dog"]);
+        expect(highlighted(kSightWordHighlight)).toEqual([]);
 
         // test one sight word
         text1
             .html("Canine Dog.")
             .checkDecodableReader({ sightWords: ["canine", "feline"] });
-        expect(text1.html()).toEqual(
-            '<span class="sight-word" data-segment="word">Canine</span> <span class="word-not-found" data-segment="word">Dog</span>.',
-        );
+        expect(text1.html()).toEqual("Canine Dog.");
+        expect(highlighted(kSightWordHighlight)).toEqual(["Canine"]);
+        expect(highlighted(kWordNotDecodableHighlight)).toEqual(["Dog"]);
 
         text1
             .html("Canine feline")
             .checkDecodableReader({ sightWords: ["canine", "feline"] });
-        expect(text1.html()).toEqual(
-            '<span class="sight-word" data-segment="word">Canine</span> <span class="sight-word" data-segment="word">feline</span>',
-        );
+        expect(text1.html()).toEqual("Canine feline");
+        expect(highlighted(kSightWordHighlight)).toEqual(["Canine", "feline"]);
+        expect(highlighted(kWordNotDecodableHighlight)).toEqual([]);
     });
 });

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioHighlightManager.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioHighlightManager.ts
@@ -1,0 +1,299 @@
+import StyleEditor from "../../StyleEditor/StyleEditor";
+import {
+    makeRangeForNodeContents,
+    TextHighlightManager,
+} from "../../js/textHighlightManager";
+
+const kSegmentClass = "bloom-highlightSegment";
+const kEnableHighlightClass = "ui-enableHighlight";
+const kDisableHighlightClass = "ui-disableHighlight";
+const kPostAudioSplitClass = "bloom-postAudioSplit";
+const kTextBoxRecordingMode = "textbox";
+
+const kCurrentHighlightBackgroundCssVar =
+    "--bloom-audio-current-highlight-background";
+const kCurrentHighlightColorCssVar = "--bloom-audio-current-highlight-color";
+
+// This translates Bloom's audio-highlight classes into the CSS highlight registry and
+// ::highlight pseudo-elements (see textHighlightManager.ts for why and how).
+// The DOM still decides which pieces of text are eligible and marks them with the appropriate
+// classes, but in the Edit Tab the visible paint comes from ::highlight pseudo-elements instead
+// of the element background colors, which we continue to use in Bloom Player etc. - we will need
+// to keep the original class and css rules for a while so that old versions of Bloom player
+// display the highlights, but a next step would be to make newer versions of Bloom Player switch
+// to using pseudo-elements to display highlights like we do here.
+
+export const currentHighlightName = "bloom-audio-current";
+
+export const splitHighlightNames = [
+    "bloom-audio-split-1",
+    "bloom-audio-split-2",
+    "bloom-audio-split-3",
+] as const;
+
+const allManagedHighlightNames = [currentHighlightName, ...splitHighlightNames];
+
+// A StyleEditor instance used only to read the user's audio-highlight colors from a book's
+// userModifiedStyles sheet. We share StyleEditor's rule lookup rather than duplicating the
+// selector-matching logic, so the read and the write (StyleEditor.putAudioHiliteRulesInDom)
+// can never drift apart. supportFilesRoot is irrelevant for this read-only use.
+let styleEditorForColorLookup: StyleEditor | undefined;
+function getStyleEditorForColorLookup(): StyleEditor {
+    if (!styleEditorForColorLookup) {
+        styleEditorForColorLookup = new StyleEditor("/bloom/bookEdit");
+    }
+    return styleEditorForColorLookup;
+}
+
+function getDocumentElement(contextNode: Node): HTMLElement | undefined {
+    return contextNode.ownerDocument?.documentElement ?? undefined;
+}
+
+export class AudioHighlightManager {
+    private highlights = new TextHighlightManager(allManagedHighlightNames);
+
+    // Remove all current and split highlights from the registry for the document containing contextNode.
+    public clearAllManagedHighlights(contextNode?: Node): void {
+        this.highlights.clearAllManagedHighlights(contextNode);
+    }
+
+    // Remove only the split (blue segment) highlights from the registry, leaving the current highlight intact.
+    public clearSplitHighlights(contextNode?: Node): void {
+        this.highlights.clearHighlights(splitHighlightNames, contextNode);
+    }
+
+    // Returns true if the current highlight is still registered but no longer paints anything
+    // because the DOM under it was rewritten. See TextHighlightManager.hasDeadRanges().
+    public currentHighlightHasDeadRanges(contextNode?: Node): boolean {
+        return this.highlights.hasDeadRanges(currentHighlightName, contextNode);
+    }
+
+    // currentHighlight is the element currently selected for recording etc.
+    // It might be a span (sentence mode) or text box (text box mode).
+    // currentTextBox is either the same as currentHighlight (text box mode)
+    // or its TextBox ancestor (sentence mode).
+    // Adjust pseudo-element highlights to what they should be for this state of things.
+    public refreshHighlights(
+        currentHighlight: Element | null,
+        currentTextBox: HTMLElement | null,
+        suppressCurrentHighlight?: boolean,
+    ): void {
+        const contextNode = currentHighlight ?? currentTextBox;
+        if (!contextNode) {
+            return;
+        }
+
+        if (!this.highlights.canHighlight(contextNode)) {
+            return;
+        }
+
+        if (suppressCurrentHighlight) {
+            this.highlights.clearAllManagedHighlights(contextNode);
+            return;
+        }
+
+        // Split highlights (blue segments after a textbox recording) and the current highlight
+        // (yellow sentence) are mutually exclusive: split state replaces the yellow highlight.
+        if (this.shouldShowSplitHighlights(currentHighlight, currentTextBox)) {
+            this.highlights.clearHighlights(
+                [currentHighlightName],
+                contextNode,
+            );
+            this.refreshSplitHighlights(currentTextBox);
+        } else {
+            this.highlights.clearHighlights(splitHighlightNames, contextNode);
+            this.refreshCurrentHighlight(currentHighlight, currentTextBox);
+        }
+    }
+
+    private refreshCurrentHighlight(
+        currentHighlight: Element | null,
+        currentTextBox: HTMLElement | null,
+    ): void {
+        const contextNode = currentHighlight ?? currentTextBox;
+        if (!contextNode) {
+            return;
+        }
+
+        const highlightInfo = this.getCurrentHighlightInfo(
+            currentHighlight,
+            currentTextBox,
+        );
+        if (!highlightInfo || highlightInfo.ranges.length === 0) {
+            this.highlights.clearHighlights(
+                [currentHighlightName],
+                contextNode,
+            );
+            return;
+        }
+
+        // enhance: don't check for highlight color settings changes so often
+        this.updateCurrentHighlightColors(highlightInfo.styleSource);
+        this.highlights.setHighlight(
+            currentHighlightName,
+            highlightInfo.ranges,
+            contextNode,
+        );
+    }
+
+    private refreshSplitHighlights(currentTextBox: HTMLElement): void {
+        // Cycle through 3 colors using a page-relative index so adjacent paragraphs
+        // never share the same color at their boundary.
+        const rangesByName = new Map<string, Range[]>();
+        splitHighlightNames.forEach((name) => rangesByName.set(name, []));
+
+        Array.from(
+            currentTextBox.querySelectorAll(`span.${kSegmentClass}`),
+        ).forEach((segment, index) => {
+            const highlightName =
+                splitHighlightNames[index % splitHighlightNames.length];
+            const ranges = rangesByName.get(highlightName);
+            ranges?.push(...this.getRangesForSegment(segment));
+        });
+
+        splitHighlightNames.forEach((name) => {
+            this.highlights.setHighlight(
+                name,
+                rangesByName.get(name) ?? [],
+                currentTextBox,
+            );
+        });
+    }
+
+    private getCurrentHighlightInfo(
+        currentHighlight: Element | null,
+        currentTextBox: HTMLElement | null,
+    ):
+        | {
+              ranges: Range[];
+              styleSource: Element;
+          }
+        | undefined {
+        if (!currentHighlight) {
+            return undefined;
+        }
+
+        // copilot says: fixHighlighting() can carve the visible pieces into nested ui-enableHighlight
+        // spans so punctuation or outer whitespace stays unpainted. Prefer those exact
+        // spans whenever they exist so the pseudo-highlight matches the background-color highlight behavior
+        const enabledDescendants = Array.from(
+            currentHighlight.querySelectorAll(`span.${kEnableHighlightClass}`),
+        );
+        const enabledRanges = enabledDescendants
+            .map((enabledSpan) => makeRangeForNodeContents(enabledSpan))
+            .filter((range): range is Range => !!range);
+        if (enabledRanges.length > 0) {
+            return {
+                ranges: enabledRanges,
+                styleSource: enabledDescendants[0],
+            };
+        }
+
+        if (currentHighlight.classList.contains(kDisableHighlightClass)) {
+            return undefined;
+        }
+
+        if (currentHighlight === currentTextBox) {
+            const paragraphs = Array.from(currentTextBox.querySelectorAll("p"));
+            const paragraphRanges = paragraphs
+                .map((paragraph) => makeRangeForNodeContents(paragraph))
+                .filter((range): range is Range => !!range);
+            if (paragraphRanges.length > 0) {
+                return {
+                    ranges: paragraphRanges,
+                    styleSource: paragraphs[0],
+                };
+            }
+        }
+
+        const wholeElementRange = makeRangeForNodeContents(currentHighlight);
+        if (!wholeElementRange) {
+            return undefined;
+        }
+
+        return {
+            ranges: [wholeElementRange],
+            styleSource: currentHighlight,
+        };
+    }
+
+    // Set the CSS variables that control the ::highlight colors to match the user's chosen
+    // highlight color for the current text style, falling back to the default yellow.
+    private updateCurrentHighlightColors(styleSource: Element): void {
+        const documentElement = getDocumentElement(styleSource);
+        if (!documentElement) {
+            console.error(
+                "AudioHighlightManager.updateCurrentHighlightColors() could not find documentElement for the style source.",
+            );
+            return;
+        }
+
+        const bloomEditable = styleSource.closest(".bloom-editable");
+        const styleName = bloomEditable
+            ? Array.from(bloomEditable.classList).find((c) =>
+                  c.endsWith("-style"),
+              )
+            : undefined;
+
+        // Read the user's chosen highlight colors for this style from the same
+        // userModifiedStyles rules that StyleEditor.putAudioHiliteRulesInDom writes, by
+        // delegating to StyleEditor's own lookup (looking in the page's document, not the
+        // toolbox's). When there is no such style, fall back to the default yellow/black.
+        const userColors = styleName
+            ? getStyleEditorForColorLookup().getAudioHiliteProps(
+                  styleName,
+                  styleSource.ownerDocument,
+              )
+            : undefined;
+
+        documentElement.style.setProperty(
+            kCurrentHighlightBackgroundCssVar,
+            userColors?.hiliteBgColor ?? "#febf00",
+        );
+        documentElement.style.setProperty(
+            kCurrentHighlightColorCssVar,
+            userColors?.hiliteTextColor ?? "black",
+        );
+    }
+
+    private shouldShowSplitHighlights(
+        currentHighlight: Element | null,
+        currentTextBox: HTMLElement | null,
+    ): currentTextBox is HTMLElement {
+        if (!currentHighlight || !currentTextBox) {
+            return false;
+        }
+
+        if (currentHighlight !== currentTextBox) {
+            return false;
+        }
+
+        if (currentTextBox.classList.contains(kDisableHighlightClass)) {
+            return false;
+        }
+
+        // Split highlights are only for textbox recordings after AudioRecording has
+        // split the textbox into segment spans and marked it as post-split.
+        return (
+            currentTextBox.classList.contains(kPostAudioSplitClass) &&
+            currentTextBox
+                .getAttribute("data-audiorecordingmode")
+                ?.toLowerCase() === kTextBoxRecordingMode
+        );
+    }
+
+    private getRangesForSegment(segment: Element): Range[] {
+        const enabledRanges = Array.from(
+            segment.querySelectorAll(`span.${kEnableHighlightClass}`),
+        )
+            .map((enabledSpan) => makeRangeForNodeContents(enabledSpan))
+            .filter((range): range is Range => !!range);
+
+        if (enabledRanges.length > 0) {
+            return enabledRanges;
+        }
+
+        const wholeSegmentRange = makeRangeForNodeContents(segment);
+        return wholeSegmentRange ? [wholeSegmentRange] : [];
+    }
+}

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.less
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.less
@@ -24,7 +24,7 @@
     z-index: 1;
 }
 
-// Use pseudoelements to display TBT highlighting in the Edit tab. See audioTextHighlightManager.ts
+// Use pseudoelements to display TBT highlighting in the Edit tab. See textHighlightManager.ts
 ::highlight(bloom-audio-current) {
     // A thick underline offset upwards (the skip-ink setting allows it to be drawn right against the text)
     // does not extend upwards as far as background-color highlighting, which greatly reduces the

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -73,9 +73,9 @@ import {
 import { animateStyleName } from "../../../utils/shared";
 import jQuery from "jquery";
 import {
-    TextHighlightManager,
+    AudioHighlightManager,
     currentHighlightName,
-} from "../../js/textHighlightManager";
+} from "./audioHighlightManager";
 import { TalkingBookUiState, Status } from "./TalkingBookUiState";
 
 // ENHANCE: Replace AudioRecordingMode with this?
@@ -193,7 +193,7 @@ export default class AudioRecording implements IAudioRecorder {
     public __testonly__sentenceToIdListMap = this.sentenceToIdListMap; // Exposing it for unit tests. Not meant for public use.
 
     private playbackOrderCache: IPlaybackOrderInfo[] = [];
-    private audioTextHighlightManager = new TextHighlightManager();
+    private audioHighlightManager = new AudioHighlightManager();
 
     // Incremented each time setHighlightToAsync starts. During page setup several rounds of it
     // can overlap (newPageReady fires twice, and a quick page change can leave the previous
@@ -911,7 +911,7 @@ export default class AudioRecording implements IAudioRecorder {
             this.removeAudioCurrent(pageDocBody);
         }
 
-        this.audioTextHighlightManager.clearAllManagedHighlights(
+        this.audioHighlightManager.clearAllManagedHighlights(
             pageDocBody ?? undefined,
         );
     }
@@ -1095,7 +1095,7 @@ export default class AudioRecording implements IAudioRecorder {
             : null;
         // The manager keeps both the yellow current highlight and the blue post-split
         // highlights in sync so callers do not need separate refresh paths.
-        this.audioTextHighlightManager.refreshHighlights(
+        this.audioHighlightManager.refreshHighlights(
             activeHighlight,
             currentTextBox,
             suppressCurrentHighlight,
@@ -3057,9 +3057,7 @@ export default class AudioRecording implements IAudioRecorder {
         if (
             mustRefresh ||
             !alreadyRegistered ||
-            this.audioTextHighlightManager.currentHighlightHasDeadRanges(
-                pageBody,
-            )
+            this.audioHighlightManager.currentHighlightHasDeadRanges(pageBody)
         ) {
             this.refreshAudioTextHighlights(this.highlightedElement);
         }
@@ -4645,7 +4643,7 @@ export default class AudioRecording implements IAudioRecorder {
             currentTextBox.removeAttribute("data-audioRecordingEndTimes");
         }
 
-        this.audioTextHighlightManager.clearSplitHighlights(
+        this.audioHighlightManager.clearSplitHighlights(
             currentTextBox ?? undefined,
         );
     }

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -73,9 +73,9 @@ import {
 import { animateStyleName } from "../../../utils/shared";
 import jQuery from "jquery";
 import {
-    AudioTextHighlightManager,
+    TextHighlightManager,
     currentHighlightName,
-} from "./audioTextHighlightManager";
+} from "../../js/textHighlightManager";
 import { TalkingBookUiState, Status } from "./TalkingBookUiState";
 
 // ENHANCE: Replace AudioRecordingMode with this?
@@ -193,7 +193,7 @@ export default class AudioRecording implements IAudioRecorder {
     public __testonly__sentenceToIdListMap = this.sentenceToIdListMap; // Exposing it for unit tests. Not meant for public use.
 
     private playbackOrderCache: IPlaybackOrderInfo[] = [];
-    private audioTextHighlightManager = new AudioTextHighlightManager();
+    private audioTextHighlightManager = new TextHighlightManager();
 
     // Incremented each time setHighlightToAsync starts. During page setup several rounds of it
     // can overlap (newPageReady fires twice, and a quick page change can leave the previous

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
@@ -23,7 +23,7 @@ import { Status } from "./TalkingBookUiState";
 import {
     currentHighlightName,
     splitHighlightNames,
-} from "./audioTextHighlightManager";
+} from "../../js/textHighlightManager";
 
 // A controllable stand-in for the page-frame CanvasElementManager. By default it is DISABLED,
 // so getCanvasElementManager() returns undefined -- exactly how the real one behaves in tests

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
@@ -24,6 +24,11 @@ import {
     currentHighlightName,
     splitHighlightNames,
 } from "./audioHighlightManager";
+import {
+    FakeHighlightRegistry,
+    getHighlightRegistry,
+    installHighlightPolyfill,
+} from "../../test/highlightTestSupport";
 
 // A controllable stand-in for the page-frame CanvasElementManager. By default it is DISABLED,
 // so getCanvasElementManager() returns undefined -- exactly how the real one behaves in tests
@@ -74,36 +79,6 @@ vi.mock("../canvas/canvasElementPageBridge", async (importActual) => {
     };
 });
 
-class FakeHighlight {
-    public ranges: Range[];
-
-    public constructor(...ranges: Range[]) {
-        this.ranges = ranges;
-    }
-}
-
-type FakeHighlightRegistry = Map<string, FakeHighlight>;
-type TestCssWithHighlights = {
-    highlights?: FakeHighlightRegistry;
-};
-
-const installPseudoHighlightPolyfill = (targetWindow: Window) => {
-    const targetWindowWithCss = targetWindow as Window & {
-        CSS?: TestCssWithHighlights;
-    };
-    if (!targetWindowWithCss.CSS) {
-        targetWindowWithCss.CSS = {};
-    }
-
-    const cssWithHighlights = targetWindowWithCss.CSS;
-    cssWithHighlights.highlights = new Map<string, FakeHighlight>();
-    (
-        targetWindow as Window & {
-            Highlight?: typeof FakeHighlight;
-        }
-    ).Highlight = FakeHighlight;
-};
-
 const getPageWindow = (): Window | undefined => {
     const iframe = parent.window.document.getElementById(
         "page",
@@ -111,20 +86,9 @@ const getPageWindow = (): Window | undefined => {
     return iframe?.contentWindow ?? undefined;
 };
 
+// The audio highlights are registered in the page iframe's document when there is one.
 const getPseudoHighlightsRegistry = (): FakeHighlightRegistry => {
-    const targetWindow = getPageWindow() ?? globalThis.window;
-    const cssWithHighlights = (
-        targetWindow as Window & {
-            CSS?: TestCssWithHighlights;
-        }
-    ).CSS;
-    if (!cssWithHighlights?.highlights) {
-        throw new Error(
-            "Expected CSS.highlights test polyfill to be installed",
-        );
-    }
-
-    return cssWithHighlights.highlights;
+    return getHighlightRegistry(getPageWindow() ?? globalThis.window);
 };
 
 const getSplitHighlightTexts = (): string[][] => {
@@ -180,13 +144,13 @@ const setHighlightedElementFromDom = (recording: AudioRecording) => {
 
 describe("audio recording tests", () => {
     beforeAll(async () => {
-        installPseudoHighlightPolyfill(globalThis.window);
+        installHighlightPolyfill(globalThis.window);
 
         await setupForAudioRecordingTests();
 
         const pageWindow = getPageWindow();
         if (pageWindow) {
-            installPseudoHighlightPolyfill(pageWindow);
+            installHighlightPolyfill(pageWindow);
         }
     });
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
@@ -23,7 +23,7 @@ import { Status } from "./TalkingBookUiState";
 import {
     currentHighlightName,
     splitHighlightNames,
-} from "../../js/textHighlightManager";
+} from "./audioHighlightManager";
 
 // A controllable stand-in for the page-frame CanvasElementManager. By default it is DISABLED,
 // so getCanvasElementManager() returns undefined -- exactly how the real one behaves in tests

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -1601,6 +1601,15 @@ function handlePageEditing(
                 // While this call came before it, the reader highlights were painted and then
                 // immediately detached on every pause in typing, and nothing reappeared until
                 // some other path redid the markup (e.g. changing the level).
+                //
+                // Not covered by a unit test: the pieces are (cleanUpNbsps in toolboxSpec.ts,
+                // which now checks that it leaves the text nodes alone when it has nothing to
+                // convert; the highlight primitives in textHighlightManagerSpec.ts), but the
+                // *ordering* between them is only exercised by running handlePageEditing, and
+                // that needs a live ckeditor instance on the editable div plus the parent
+                // window's "page" iframe and a real Selection - none of which we can stand up in
+                // jsdom. So if you reorder anything in here, test it by typing in a Leveled
+                // Reader book and watching the over-long sentences stay highlighted.
                 if (activeTool && !activeTool.isUpdateMarkupAsync()) {
                     // Note, the updateMarkup routine must be sure to use the result of
                     // ckEditor's getData() method, not the raw HTML of the editableDivs.

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -1552,8 +1552,12 @@ function handlePageEditing(
                 removeCommentsFromEditableHtml(editableDiv);
 
                 // If there's no tool active, we don't need to update the markup.
-                if (currentTool && toolbox.toolboxIsShowing()) {
-                    if (currentTool.isUpdateMarkupAsync()) {
+                const activeTool =
+                    currentTool && toolbox.toolboxIsShowing()
+                        ? currentTool
+                        : undefined;
+                if (activeTool) {
+                    if (activeTool.isUpdateMarkupAsync()) {
                         // It's possible that removeCommentsFromEditableHtml moved the selection, typically
                         // to the start of the editableDiv. This doesn't matter on the synchronous branch,
                         // because we restore it at the end of this method, after the other updates, and no
@@ -1572,7 +1576,7 @@ function handlePageEditing(
                         bookmarks = ckeditorSelection.createBookmarks(true);
 
                         const actualUpdateFunc =
-                            await currentTool.updateMarkupAsync();
+                            await activeTool.updateMarkupAsync();
                         if (
                             keydownEventCounter ===
                             counterValueThatIdentifiesThisKeyDown
@@ -1583,18 +1587,29 @@ function handlePageEditing(
                             // of updating for the earlier keystroke.)
                             actualUpdateFunc();
                         }
-                    } else {
-                        // Note, the updateMarkup routine must be sure to use the result of
-                        // ckEditor's getData() method, not the raw HTML of the editableDivs.
-                        // See EditableDivUtils.doCkEditorCleanup() and .restoreSelectionFromCkEditorBookmarks().
-                        // Unfortunately, we can't easily do that in a top-level (general for all tools) way because of
-                        // our current architecture. Namely, the reader tools have a lower-level
-                        // doMarkup() which gets called more than just from here.
-                        currentTool.updateMarkup();
                     }
                 }
 
                 cleanUpNbsps(editableDiv);
+
+                // The synchronous branch is used only by the decodable and leveled reader tools,
+                // and their markup no longer changes the DOM: it paints violations with
+                // ::highlight() over live Ranges (BL-16558). Those Ranges must therefore be
+                // created AFTER the last thing that rewrites this editable's content.
+                // cleanUpNbsps() ends with an unconditional `editableDiv.innerHTML = ...`, which
+                // replaces every text node in the box, so any Range pointing into them collapses.
+                // While this call came before it, the reader highlights were painted and then
+                // immediately detached on every pause in typing, and nothing reappeared until
+                // some other path redid the markup (e.g. changing the level).
+                if (activeTool && !activeTool.isUpdateMarkupAsync()) {
+                    // Note, the updateMarkup routine must be sure to use the result of
+                    // ckEditor's getData() method, not the raw HTML of the editableDivs.
+                    // See EditableDivUtils.doCkEditorCleanup() and .restoreSelectionFromCkEditorBookmarks().
+                    // Unfortunately, we can't easily do that in a top-level (general for all tools) way because of
+                    // our current architecture. Namely, the reader tools have a lower-level
+                    // doMarkup() which gets called more than just from here.
+                    activeTool.updateMarkup();
+                }
 
                 //set the selection to wherever our bookmark node ended up
                 //NB: in BL-3900: "Decodable & Talking Book tools delete text after longpress", it was here,
@@ -1659,6 +1674,13 @@ export function cleanUpNbsps(editableDiv: HTMLElement) {
     const preserveNbspAfter = [" ", "«", "—"];
     const preserveNbspBefore = [" ", "»", ":", ";", "!", "?"];
 
+    // Whether we actually converted anything. Assigning innerHTML rebuilds every node in the box
+    // even when the string is unchanged, which loses the selection and collapses any Range
+    // pointing into the old text nodes -- and the reader tools' highlights and the Talking Book
+    // tool's audio highlights are live Ranges. Almost every keystroke leaves nothing to convert,
+    // so only write when there is something to write.
+    let replacedAnNbsp = false;
+
     let i = -1;
     let j = -1;
     // Simultaneously loop through the text and the html, finding each corresponding nbsp.
@@ -1706,9 +1728,10 @@ export function cleanUpNbsps(editableDiv: HTMLElement) {
                 editableDivText.substring(0, j) +
                 " " +
                 editableDivText.substring(j + 1);
+            replacedAnNbsp = true;
         }
     }
-    editableDiv.innerHTML = editableDivHtml;
+    if (replacedAnNbsp) editableDiv.innerHTML = editableDivHtml;
 
     // Restore the bookmarks. See comment above.
     if (originalBookMarkContent)

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolboxSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolboxSpec.ts
@@ -124,4 +124,35 @@ describe("toolbox tests", () => {
         // important thing is to do no harm.
         runNbspTest('<span data-attr="&nbsp;yuck!">A&nbsp;B</span>');
     });
+
+    // runNbspTest only compares serialized html, which cannot tell "we left the DOM alone" apart
+    // from "we rebuilt it into something that serializes the same". These two check the actual
+    // nodes, because rebuilding matters: the reader tools' violation highlights and the Talking
+    // Book tool's audio highlights are live Ranges, and replacing a text node collapses any Range
+    // pointing into it. See the note where handlePageEditing() calls cleanUpNbsps.
+    it("cleanUpNbsps keeps the same text node when there is nothing to convert", () => {
+        const div = document.createElement("div");
+        div.innerHTML = "<p>A b&nbsp;</p>"; // trailing nbsp, so nothing to convert
+        const textNodeBefore = div.querySelector("p")!.firstChild;
+        // Sanity check the setup: we mean to be watching a text node.
+        expect(textNodeBefore?.nodeType).toBe(Node.TEXT_NODE);
+
+        cleanUpNbsps(div);
+
+        expect(div.innerHTML).toBe("<p>A b&nbsp;</p>");
+        expect(div.querySelector("p")!.firstChild).toBe(textNodeBefore);
+    });
+
+    it("cleanUpNbsps does rebuild the content when there is something to convert", () => {
+        const div = document.createElement("div");
+        div.innerHTML = "<p>A&nbsp;b c</p>";
+        const textNodeBefore = div.querySelector("p")!.firstChild;
+        // Sanity check the setup: this nbsp is one we expect to be converted.
+        expect(textNodeBefore?.textContent).toBe("A b c"); // the character after the A is U+00A0, a non-breaking space
+
+        cleanUpNbsps(div);
+
+        expect(div.innerHTML).toBe("<p>A b c</p>");
+        expect(div.querySelector("p")!.firstChild).not.toBe(textNodeBefore);
+    });
 });


### PR DESCRIPTION
Fixes BL-16558: quickly replacing text in a Decodable Reader could leave inaccurate — and permanent — highlighting in the book.

## Cause

The decodable and leveled reader tools marked violations (a word that is not decodable at this stage, a sentence too long for this level, a word too long) by rewriting the `innerHTML` of the contenteditable to wrap the offending text in a styled span. CKEditor responds to that by copying the span's computed `background-color` into a bare inline style of its own, which then gets saved into the book.

## Fix

Paint the violations with `::highlight()` pseudo-elements over live `Range`s instead — the technique the Talking Book tool already uses (BL-15300). The DOM is never modified, so there is nothing for CKEditor to copy. As with the Talking Book highlight, the paint is a thick offset underline rather than a background color: drawn behind the glyphs, it covers far less of the previous line when lines are tightly spaced.

Because the analysis no longer has to *produce* HTML, it no longer has to work *in* HTML. `mapVisibleText()` snapshots an element's visible text plus where each character came from in the DOM; the word/sentence analysis runs on that plain string; and the results are highlighted by character offset. That removes the HTML reassembly, the leading-`</span>` nesting hack, the format-button stash/restore, and `removeAllHtmlMarkupFromString`'s role in markup.

## Commits

Deliberately sequenced so the mechanical parts are easy to verify:

1. **Move** the audio highlight manager to shared `bookEdit/js/textHighlightManager.ts` — pure rename, no logic change.
2. **Split** the generic highlight core out of the audio-specific half (`audioHighlightManager.ts`) — behavior-preserving; Talking Book tests pass untouched.
3. **The fix** — reader tools highlight without touching the DOM.
4. Unit tests for the shared primitives.
5. Only show a reader hover tip when the mouse is really over the text.
6. Stop removing CKEditor's selection bookmarks (converges with 323b1b6674 on master).

## Also in here

- Marking of "possible words" is gone. It has had neither a color nor a tooltip for years (both were commented out), so it only ever added noise to the DOM.
- A long word is now marked **everywhere** it appears on the page. The long-word list was always cumulative, but the old code wrapped each leaf as it went, so a word first seen in the second paragraph was left unmarked in the first.
- The hover tips move from per-span qtips to a hit test against the painted ranges. This restores two tips that were in fact broken: `markDecodableStatus` called `qtip()` on a raw DOM element rather than a jQuery wrapper, so the "Sight Word" and "not decodable" tips threw instead of appearing. No new localized strings.
- `removeSynphonyMarkup`/`removeCkEditorMarkup` are retained: existing books contain leftover spans, and CKEditor's copies of their background color, that still need cleaning out. That is what repairs already-damaged books.

## Not done here, deliberately

- `doMarkup` still does the CKEditor `getData()`/bookmark dance around the markup. It no longer has an `innerHTML` rewrite to protect a selection across, but it also strips CKEditor filling chars that would otherwise split a word, so removing it is a separate change.
- The reader tools' own undo/redo (which snapshots `innerHTML`) is untouched; it exists only because markup used to mutate the DOM. Removing it is its own behavioral risk, to be looked at after testing.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16558


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8123)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8123)
<!-- Reviewable:end -->
