### PR TITLE
Deliver the UI @font-face rules to the preview documents 93afdc5696 missed

### DIFF
--- a/src/BloomBrowserUI/bloomUIFontFaces.css
+++ b/src/BloomBrowserUI/bloomUIFontFaces.css
@@ -9,15 +9,30 @@
  * the text goes invisible for several frames while it re-loads ("FOIT"). That was the cause
  * of a visible text flicker on every page change in edit mode.
  *
+ * Equally, EVERY Bloom-managed document needs them: a document that lacks them silently falls
+ * back to whatever fonts the system happens to have, which changes text metrics and can shift
+ * the layout (that is how BL-14102's missing Andika shows up).
+ *
  * So: do NOT @import this file (or re-declare these fonts) in .less that gets compiled into
  * bundles or component styles. It is delivered in exactly two ways:
  *   1. A plain `@import (less)` in the root stylesheet of each document that contains
  *      server-rendered text (editMode.less, toolbox.less, readerSetup.less), all of which are
- *      linked in their document's <head> at parse time.
- *   2. ensureUiFontFacesInstalled() (utils/uiFontFaces.ts), which injects this file's text --
- *      only if the document doesn't already have these faces -- and is called from
- *      reactRender.tsx for every React root, covering all the WinForms-hosted React documents.
- * A unit test (uiFontFacesSingleSource.test.ts) enforces this.
+ *      linked in their document's <head> at parse time, so they are in effect before that text
+ *      first paints.
+ *   2. ensureUiFontFacesInstalled() (utils/uiFontFaces.ts), which injects the rules for the
+ *      families the document is missing. It is called from reactRender.tsx for every React
+ *      root, covering all the WinForms-hosted React documents, and from bookPreview.ts, whose
+ *      documents (the collection tab preview, single-page previews and template-page
+ *      thumbnails) have neither a stylesheet from (1) nor a React root.
+ *
+ * Note that (2) filters per family rather than injecting all or nothing, because a document may
+ * arrive already declaring some of these families and not others: Bloom prepends the served
+ * book fonts (Andika, ABeeZee, from /host/fonts/) to each book's defaultLangStyles.css, so any
+ * document that links a book's stylesheets already has an Andika face. Adding a second one late
+ * would cause exactly the blanking described above.
+ *
+ * A unit test (uiFontFacesSingleSource.test.ts) enforces both the single source and the two
+ * lists of approved delivery points.
  *
  * These were very helpful in compiling this file:
  * - google-webfonts-helper.herokuapp.com (for getting .woff2 Roboto with a maximum of charsets)

--- a/src/BloomBrowserUI/collectionsTab/collectionsTabBookPane/bookPreview.ts
+++ b/src/BloomBrowserUI/collectionsTab/collectionsTabBookPane/bookPreview.ts
@@ -2,7 +2,20 @@ import $ from "jquery";
 import "jquery.hasAttr.js"; //reviewSlog for CenterVerticallyInParent
 import "errorHandler";
 import { WireUpForWinforms } from "../../utils/WireUpWinform";
+import { ensureUiFontFacesInstalled } from "../../utils/uiFontFaces";
 import { CollectionsTabBookPane } from "./CollectionsTabBookPane";
+
+// The preview documents this bundle is loaded into (Book.AddPreviewJavascript(): the collection
+// tab's whole-book preview, single-page previews, and template-page thumbnails) are copies of the
+// book's own DOM plus previewMode.css. previewMode.less imports bloomUI.less by (reference), so
+// previewMode.css carries no @font-face at all, and the only such rules those documents do get
+// are the served book fonts (Andika, ABeeZee) that Bloom prepends to defaultLangStyles.css --
+// never Roboto/NotoSans/SymChar. No React root is mounted here either, so renderRoot()'s call
+// doesn't happen. Without this, the UI font stack falls back to whatever the system has, which
+// changes text metrics and shifts the layout. ensureUiFontFacesInstalled() adds only the
+// families the document is missing, so the Andika it already has is left alone rather than
+// duplicated. See bloomUIFontFaces.css.
+ensureUiFontFacesInstalled();
 
 $.fn.CenterVerticallyInParent = function () {
     return this.each(function () {

--- a/src/BloomBrowserUI/scripts/__tests__/uiFontFacesSingleSource.test.ts
+++ b/src/BloomBrowserUI/scripts/__tests__/uiFontFacesSingleSource.test.ts
@@ -24,8 +24,8 @@ const fontFacesFile = "bloomUIFontFaces.css";
 
 // The only files allowed to include bloomUIFontFaces.css. Each is the one source of the
 // declarations for a whole document: the three .less are compiled to css that is linked in a
-// document's <head> at parse time, and uiFontFaces.ts injects them at runtime into React
-// documents that lack such a link (guarded so it never adds a duplicate).
+// document's <head> at parse time, and uiFontFaces.ts injects them at runtime into documents
+// that lack such a link (guarded so it never adds a duplicate).
 const allowedIncluders = [
     path.join("bookEdit", "css", "editMode.less"),
     path.join("bookEdit", "toolbox", "toolbox.less"),
@@ -37,6 +37,16 @@ const allowedIncluders = [
         "readerSetup.less",
     ),
     path.join("utils", "uiFontFaces.ts"),
+];
+
+// Files allowed to import utils/uiFontFaces (i.e. to install the faces at runtime). Every
+// Bloom-managed document must end up with the UI faces; documents that neither link one of the
+// stylesheets above nor mount a React root have to ask for them explicitly, and each such
+// document's bundle root is listed here so that a new one is a deliberate decision rather than
+// an oversight (BL-15300).
+const allowedInstallCallers = [
+    path.join("utils", "reactRender.tsx"), // covers every React-rooted document
+    path.join("collectionsTab", "collectionsTabBookPane", "bookPreview.ts"), // the preview/thumbnail documents: no static link, no React root
 ];
 
 function walk(dir: string, results: string[] = []): string[] {
@@ -107,5 +117,35 @@ describe("UI @font-face single-source invariant (BL-15300)", () => {
             );
         });
         expect(realIncluders.sort()).toEqual([...allowedIncluders].sort());
+    });
+
+    it("keeps the set of uiFontFaces importers to the documented list", () => {
+        // The module itself, its own unit tests, and this file are not delivery points.
+        const notDeliveryPoints = [
+            path.join("utils", "uiFontFaces.ts"),
+            path.join("utils", "uiFontFaces.spec.ts"),
+            path.relative(browserUiRoot, __filename),
+        ];
+        // Match importing the MODULE rather than calling the function by name: that catches
+        // namespace imports, `await import(...)`, and aliased named imports, any of which
+        // would be a real fifth delivery point while a call-site-name scan looked right.
+        // It also excludes prose: bloomMaterialUITheme.ts names the function in a comment
+        // explaining why it must NOT install the faces, but imports nothing.
+        const importsTheModule =
+            /(?:from\s*|import\s*\(\s*)["'][^"']*\/uiFontFaces["']/;
+        const importers = allFiles
+            .filter(isScriptFile)
+            .map((file) => path.relative(browserUiRoot, file))
+            .filter(
+                (file) =>
+                    !notDeliveryPoints.includes(file) &&
+                    importsTheModule.test(
+                        fs.readFileSync(path.join(browserUiRoot, file), "utf8"),
+                    ),
+            );
+        // Sanity check that the scan is actually finding importers, so that moving or renaming
+        // the module can't turn this into a vacuously passing test.
+        expect(importers.length).toBeGreaterThan(0);
+        expect(importers.sort()).toEqual([...allowedInstallCallers].sort());
     });
 });

--- a/src/BloomBrowserUI/utils/uiFontFaces.spec.ts
+++ b/src/BloomBrowserUI/utils/uiFontFaces.spec.ts
@@ -1,0 +1,93 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, it, expect } from "vitest";
+import { selectMissingFontFaceRules } from "./uiFontFaces";
+
+// These cover the per-family filtering that keeps BL-15300's flicker from coming back through a
+// partially-declared document. The interesting case is the book preview documents: Bloom
+// prepends the served book fonts (Andika, ABeeZee) to each book's defaultLangStyles.css, so
+// those documents already have an Andika face but lack Roboto/NotoSans/SymChar. Injecting the
+// whole file there would add a SECOND, late Andika face and blank the already-rendered text;
+// injecting nothing would leave the UI fonts missing. Only the missing families may go in.
+//
+// We read bloomUIFontFaces.css from disk rather than importing it: vitest runs with Vite's
+// default css:false, under which `import x from "...css?raw"` yields an empty string. Reading
+// the real file also means these tests fail if its shape ever stops matching what the
+// filtering assumes.
+const uiFontFacesCss = fs.readFileSync(
+    path.resolve(__dirname, "../bloomUIFontFaces.css"),
+    "utf8",
+);
+
+const familiesIn = (rules: string[]) =>
+    new Set(
+        rules.map((rule) => {
+            const match = rule.match(/font-family:\s*([^;}]+)/);
+            if (!match) throw new Error(`no font-family in rule: ${rule}`);
+            return match[1].trim().replace(/["']/g, "");
+        }),
+    );
+
+const kAllFamilies = ["Roboto", "NotoSans", "SymChar", "Andika"];
+
+describe("selectMissingFontFaceRules", () => {
+    it("finds the real file's rules and no prose (sanity check on the source file)", () => {
+        // The file's comment block mentions "@font-face" several times in prose; those must not
+        // be picked up as rules. 15 faces: Roboto x3, NotoSans x10, SymChar, Andika.
+        const rules = selectMissingFontFaceRules(uiFontFacesCss, []);
+        expect(rules.length).toBe(15);
+        expect(familiesIn(rules)).toEqual(new Set(kAllFamilies));
+        for (const rule of rules) {
+            expect(rule.startsWith("@font-face")).toBe(true);
+        }
+    });
+
+    it("skips a family the document already declares but keeps the rest", () => {
+        // This is the book-preview shape: Andika present (from defaultLangStyles.css), the
+        // UI-only families absent. ABeeZee is declared there too and is simply irrelevant here.
+        const rules = selectMissingFontFaceRules(uiFontFacesCss, [
+            "Andika",
+            "ABeeZee",
+        ]);
+
+        expect(familiesIn(rules)).toEqual(
+            new Set(["Roboto", "NotoSans", "SymChar"]),
+        );
+        // All ten NotoSans faces must survive, not just the first.
+        expect(rules.length).toBe(14);
+    });
+
+    it("returns nothing when every family is already declared", () => {
+        // The edit page shape: editMode.css already carries the whole set, so renderRoot()'s
+        // call must add nothing at all.
+        expect(
+            selectMissingFontFaceRules(uiFontFacesCss, kAllFamilies),
+        ).toEqual([]);
+    });
+
+    it("matches family names regardless of quoting and case", () => {
+        // bloomUIFontFaces.css writes "Roboto" quoted; a document may report it unquoted and/or
+        // differently cased, and CSS family matching is case-insensitive.
+        const rules = selectMissingFontFaceRules(uiFontFacesCss, [
+            '"roboto"',
+            "NOTOSANS",
+            "symchar",
+            "  Andika  ",
+        ]);
+        expect(rules).toEqual([]);
+    });
+
+    it("keeps every rule when the document declares nothing relevant", () => {
+        const rules = selectMissingFontFaceRules(uiFontFacesCss, [
+            "Times New Roman",
+            "ABeeZee",
+        ]);
+        expect(familiesIn(rules)).toEqual(new Set(kAllFamilies));
+    });
+
+    it("throws on an @font-face rule with no font-family rather than silently dropping it", () => {
+        expect(() =>
+            selectMissingFontFaceRules("@font-face { src: url(x.woff2); }", []),
+        ).toThrow(/no font-family/);
+    });
+});

--- a/src/BloomBrowserUI/utils/uiFontFaces.ts
+++ b/src/BloomBrowserUI/utils/uiFontFaces.ts
@@ -46,10 +46,19 @@ export function selectMissingFontFaceRules(
 // would either strand those documents without the UI fonts or hand them a late duplicate
 // Andika; injecting only the missing families does neither.
 //
-// The doc.fonts check is reliable at the time we are called because pending stylesheet
-// <link>s block script execution, so any statically-linked declarations -- whether from
-// editMode.css and friends or from the book's own defaultLangStyles.css -- are already in the
-// font set before any of our code runs.
+// The doc.fonts check is reliable at the time we are called because a pending stylesheet
+// blocks script execution, so any statically-linked declarations -- whether from editMode.css
+// and friends or from the book's own defaultLangStyles.css -- are already in the font set
+// before any of our code runs.
+//
+// Note that this does NOT depend on the <link>s preceding the <script> in the document, which
+// is worth knowing because in one path they don't: Book.GetThumbnailXmlDocumentForPage() calls
+// AddPreviewJavascript() BEFORE EnsureStylesheetLinks(), and SortStyleSheetLinks() re-appends
+// every link to the end of <head> -- i.e. after the script. That ordering would matter for a
+// classic script (which only waits for stylesheets above it), but HtmlDom.AddScriptFile() gives
+// anything named *bundle.js type="module", and a module script is deferred: it runs only after
+// the whole document is parsed, by which point every stylesheet in <head> has been accounted
+// for wherever it sits.
 export function ensureUiFontFacesInstalled(doc: Document = document): void {
     if (doc.getElementById(kUiFontFacesStyleId)) return;
     // doc.fonts is undefined in jsdom (unit tests); there, treat nothing as declared and

--- a/src/BloomBrowserUI/utils/uiFontFaces.ts
+++ b/src/BloomBrowserUI/utils/uiFontFaces.ts
@@ -1,34 +1,69 @@
 import uiFontFacesCss from "../bloomUIFontFaces.css?raw";
 
+const kUiFontFacesStyleId = "bloom-ui-font-faces";
+
+// Matches one @font-face rule. Our rules never nest braces, so [^}]* is a safe body match.
+// Prose mentions of "@font-face" in the file's comment block are not followed by "{", so
+// they don't match.
+const kFontFaceRule = /@font-face\s*\{[^}]*\}/g;
+const kFamilyDeclaration = /font-family:\s*([^;}]+)/;
+
+// CSS family names are quoted inconsistently and match case-insensitively, so compare on a
+// normalized form.
+const normalizeFamily = (family: string) =>
+    family.trim().replace(/["']/g, "").toLowerCase();
+
+// Picks out the @font-face rules in cssText whose family is NOT among alreadyDeclaredFamilies.
+// Exported so the filtering can be unit tested against the real bloomUIFontFaces.css: vitest
+// runs with Vite's default css:false, under which a `?raw` import of a .css file yields an
+// EMPTY string, so a test of ensureUiFontFacesInstalled() itself could never see real rules.
+export function selectMissingFontFaceRules(
+    cssText: string,
+    alreadyDeclaredFamilies: Iterable<string>,
+): string[] {
+    const declared = new Set(
+        Array.from(alreadyDeclaredFamilies, normalizeFamily),
+    );
+    return (cssText.match(kFontFaceRule) ?? []).filter((rule) => {
+        const family = rule.match(kFamilyDeclaration);
+        if (!family)
+            throw new Error(`@font-face rule with no font-family: ${rule}`);
+        return !declared.has(normalizeFamily(family[1]));
+    });
+}
+
 // Makes sure the current document has the @font-face declarations for Bloom's UI fonts
-// (Roboto, NotoSans, SymChar, and the Andika fallback of BL-14102), installing them if --
-// and only if -- they are not already present.
+// (Roboto, NotoSans, SymChar, and the Andika fallback of BL-14102), installing the ones -- and
+// only the ones -- it is missing.
 //
-// Why the guard matters (BL-15300): if a duplicate @font-face for a family that is already
-// rendered gets added to a document, CSS font matching switches the rendered text to the new,
-// not-yet-loaded copy of the font, and the text goes blank for several frames while it
-// re-loads. The edit page, toolbox, and reader-setup documents get these declarations from a
-// stylesheet linked in their <head> (see bloomUIFontFaces.css), so for them this must be a
-// no-op; for the various WinForms-hosted React documents, which have no such static link,
-// this installs the fonts before the first React render commits.
+// Why we filter per family rather than injecting all or nothing (BL-15300): if a duplicate
+// @font-face for a family that is already rendered gets added to a document, CSS font matching
+// switches the rendered text to the new, not-yet-loaded copy of the font, and the text goes
+// blank for several frames while it re-loads. Documents can arrive here already declaring SOME
+// of our families but not others -- most importantly the book preview documents, whose
+// defaultLangStyles.css Bloom prepends the served-font faces (Andika, ABeeZee, pointing at
+// /host/fonts/) to, while still lacking Roboto/NotoSans/SymChar. An all-or-nothing check
+// would either strand those documents without the UI fonts or hand them a late duplicate
+// Andika; injecting only the missing families does neither.
 //
-// The document.fonts check is reliable at the time we are called because pending stylesheet
-// <link>s block script execution, so any statically-linked declarations are already in the
+// The doc.fonts check is reliable at the time we are called because pending stylesheet
+// <link>s block script execution, so any statically-linked declarations -- whether from
+// editMode.css and friends or from the book's own defaultLangStyles.css -- are already in the
 // font set before any of our code runs.
 export function ensureUiFontFacesInstalled(doc: Document = document): void {
     if (doc.getElementById(kUiFontFacesStyleId)) return;
-    // doc.fonts is undefined in jsdom (unit tests); there, treat the faces as not declared
-    // and fall through to injecting, which is harmless.
-    const alreadyDeclared =
-        doc.fonts &&
-        Array.from(doc.fonts).some(
-            (face) => face.family.replace(/["']/g, "") === "Roboto",
-        );
-    if (alreadyDeclared) return;
+    // doc.fonts is undefined in jsdom (unit tests); there, treat nothing as declared and
+    // fall through to injecting everything, which is harmless.
+    const declaredFamilies = doc.fonts
+        ? Array.from(doc.fonts, (face) => face.family)
+        : [];
+    const missingRules = selectMissingFontFaceRules(
+        uiFontFacesCss,
+        declaredFamilies,
+    );
+    if (missingRules.length === 0) return;
     const style = doc.createElement("style");
     style.id = kUiFontFacesStyleId;
-    style.textContent = uiFontFacesCss;
+    style.textContent = missingRules.join("\n");
     doc.head.appendChild(style);
 }
-
-const kUiFontFacesStyleId = "bloom-ui-font-faces";


### PR DESCRIPTION
Follow-up to 93afdc5696, which made `bloomUIFontFaces.css` the single source of the UI `@font-face` rules. That change's audit covered the three `.less` includers and every React root, but not documents that merely **load a bundle** — and before it, `bloomMaterialUITheme.ts` imported `bloomWebFonts.less`, so every bundle injected the declarations into whatever document loaded it.

## What was broken

The book preview documents that `Book.AddPreviewJavascript()` sets up — the collection tab's whole-book preview, single-page previews, and the template-page thumbnails behind Add Page — ended up with no UI `@font-face` at all. `previewMode.less` imports `bloomUI.less` by `(reference)`, so `previewMode.css` never carried them itself, and no React root mounts there, so `renderRoot()` never ran. The UI font stack fell back to whatever the system had, which changes text metrics and shifts the layout.

## The fix

- `bookPreview.ts` installs the faces at module scope. Linking `bloomUIFontFaces.css` from `Book.cs` instead was rejected: `previewMode.css` is copied into published BloomPUB/ePUB artifacts, where `/bloom/fonts/...` URLs don't resolve.
- `ensureUiFontFacesInstalled()` now selects **per family** instead of all-or-nothing. This was necessary, not incidental: Bloom prepends the served book fonts (Andika, ABeeZee, at `/host/fonts/`) to every book's `defaultLangStyles.css`, so a preview document already declares an Andika face while lacking Roboto/NotoSans/SymChar. The old check looked only for Roboto, so a naive fix would have injected the whole file and added a **second, late Andika face** — precisely the duplicate-arrives-after-render condition that blanks text for several frames. The filtering is factored out as `selectMissingFontFaceRules()` and unit tested against the real stylesheet, because a `?raw` css import yields an empty string under vitest's default `css:false`.
- The guard test enforced only "no duplicate declarations". Nothing enforced the other half of the invariant — that every Bloom-managed document actually gets them — which is how this was missed. It now also pins the set of files importing `utils/uiFontFaces`, matching on the module import rather than the function name so a namespace, dynamic, or aliased import can't slip a fifth delivery point past it.

## Audited and clear

All 28 Vite entry points and every document that links a stylesheet: the edit page, toolbox, and reader-setup documents are covered statically; the WinForms-hosted React documents and the workspace/app document are covered by `renderRoot()`. The page thumbnail list needed no change — its "Pages" heading is `Segoe UI` and its only `@UIFontStack` consumer is the runtime toast, both after `renderRoot()`. `spreadsheetFunctions.html` loads a bundle with no React root but is a headless utility page with no rendered text. Published ePUB/BloomPUB output correctly uses book fonts, not ours.

## Not verified

Whether restoring these faces fixes the specific layout shift originally reported on the arithmetic `numberRow`. Those `.Equation` editables are `font-family: Aileron, Arial` and Aileron is not among Bloom's served fonts, so the shift is most likely a container whose UI font changed — but that was not confirmed at the glyph level.

## Testing

- `pnpm typecheck`, `pnpm lint` (0 errors)
- front-end suite: 575 tests pass
- C# suite via `build/agent-dotnet.sh`: 2942 pass, 0 fail
- `build/agent-vite.sh` confirms the production bundles compile and `bookPreviewBundle.js` pulls in the chunk carrying the font CSS

No YouTrack card: 93afdc5696's `BL-15300` reference points at an unrelated Talking Book issue, and no card exists for this font work.


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8124)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8124)
<!-- Reviewable:end -->
