### PR TITLE
Give the preview/print DOMs the UI @font-face rules they still reference (BL-15300)

### DIFF
--- a/src/BloomBrowserUI/bloomUIFontFaces.css
+++ b/src/BloomBrowserUI/bloomUIFontFaces.css
@@ -1,6 +1,7 @@
 /*
- * The @font-face declarations for the fonts Bloom's own UI uses (the content of books gets
- * its fonts from defaultLangStyles.css and friends, not from here).
+ * The @font-face declarations for the fonts Bloom's own UI uses. Book content is supposed to get
+ * its fonts from defaultLangStyles.css and friends rather than from here, and mostly does -- but
+ * see delivery route 3 below for one place where a book document genuinely needs these.
  *
  * IMPORTANT (BL-15300): these declarations must appear EXACTLY ONCE per document, in CSS that
  * is present before the document first paints. When a stylesheet containing a duplicate
@@ -17,7 +18,16 @@
  *   2. ensureUiFontFacesInstalled() (utils/uiFontFaces.ts), which injects this file's text --
  *      only if the document doesn't already have these faces -- and is called from
  *      reactRender.tsx for every React root, covering all the WinForms-hosted React documents.
- * A unit test (uiFontFacesSingleSource.test.ts) enforces this.
+ *   3. Book.AddPreviewJavascript() links it into the preview/thumbnail/printing DOMs. Those are
+ *      book documents, so in principle they should want nothing from this file; in practice
+ *      bookPreviewBundle.js drags bloomUI.css in with it, and that stylesheet's `body` rule puts
+ *      the UI font stack on the book. Until that leak is fixed (the bundle only pulls in the UI
+ *      code because bookPreview.ts still wires up the dead "legacy" collections tab), a book
+ *      document that names these fonts has to be able to resolve them. Route 2 cannot cover it:
+ *      those documents create no React root, and their text is server-rendered, so a late
+ *      JS-injected @font-face would reintroduce the very flicker described above.
+ * Unit tests enforce routes 1 and 2 (uiFontFacesSingleSource.test.ts) and route 3
+ * (BookTests.GetPreviewHtmlFileForWholeBook_LinksUiFontFaces).
  *
  * These were very helpful in compiling this file:
  * - google-webfonts-helper.herokuapp.com (for getting .woff2 Roboto with a maximum of charsets)

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -3518,6 +3518,15 @@ namespace Bloom.Book
         internal void AddPreviewJavascript(HtmlDom dom)
         {
             dom.AddJavascriptFile("bookPreviewBundle.js".ToLocalhost());
+            // The bundle drags bloomUI.css into this document, and that stylesheet's `body` rule
+            // selects Bloom's UI font stack. The matching @font-face declarations used to ride
+            // along inside the same bundle, but BL-15300 moved them out to bloomUIFontFaces.css,
+            // leaving the font-family rule here with nothing to resolve against: any text that
+            // falls through to the body rule (e.g. a bloom-editable whose lang matches no
+            // defaultLangStyles rule) then renders in a system fallback font.
+            // Linked statically rather than injected from JS because this document's text is
+            // server-rendered, and a late-arriving @font-face is the very flicker BL-15300 fixed.
+            dom.EnsureStylesheetLinks("bloomUIFontFaces.css");
         }
 
         /// <summary>

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -41,6 +41,28 @@ namespace BloomTests.Book
             );
         }
 
+        /// <summary>
+        /// Any document we put bookPreviewBundle.js into also gets bloomUI.css, whose `body` rule
+        /// selects Bloom's UI font stack; so it must also get the @font-face declarations for that
+        /// stack. When BL-15300 moved those declarations out of the bundle and nothing replaced them
+        /// here, preview text that falls through to the body rule silently dropped to a system
+        /// fallback font (caught by the visual regression suite: the lang="*" arithmetic editables
+        /// rendered in Arial instead of Roboto).
+        /// </summary>
+        [Test]
+        public void GetPreviewHtmlFileForWholeBook_LinksUiFontFaces()
+        {
+            var dom = CreateBook().GetPreviewHtmlFileForWholeBook();
+            // Sanity check: the bundle that brings in the UI css really is there, so that a future
+            // change removing it turns this into a deliberate decision rather than a silent pass.
+            Assert.That(
+                dom.InnerXml,
+                Does.Contain("bookPreviewBundle.js"),
+                "precondition: the preview DOM should load the preview bundle"
+            );
+            Assert.That(dom.InnerXml, Does.Contain("bloomUIFontFaces.css"));
+        }
+
         [Test]
         public void GetPreviewHtmlFileForWholeBook_BookHasThreePages_ResultHasAll()
         {


### PR DESCRIPTION
**This is the minimal-fix alternative to #8122. Only one of the two should land.**

`Book.AddPreviewJavascript()` injects `bookPreviewBundle.js` into three book documents — the whole-book preview, page thumbnails, and the printing DOM. That bundle transitively pulls in `bloomUI.css`, whose `body { font-family: Roboto, NotoSans, sans-serif }` rule applies Bloom's UI font stack to the book. The matching `@font-face` declarations used to ride along in the same bundle (via `bloomMaterialUITheme.ts` importing `bloomWebFonts.less`), but BL-15300 moved them out to `bloomUIFontFaces.css`, which reaches documents only through a statically-linked root stylesheet or `ensureUiFontFacesInstalled()` from `renderRoot()`. A book preview gets neither.

So those documents were left naming Roboto with no Roboto declared, and any text falling through to the `body` rule dropped to a system font. Only the arithmetic page shows it, because its editables are `lang="*"`, which no `defaultLangStyles` rule matches; all other text has an explicit per-language font with its own FontServe `@font-face`. The visual regression suite has been failing all six A5 Portrait cases since BL-15300 landed.

This change links `bloomUIFontFaces.css` into those documents so the font resolves again — statically rather than injected from JS, because their text is server-rendered and a late-arriving `@font-face` is the very flicker BL-15300 was fixing.

**Trade-off vs #8122.** This restores the previous rendering exactly: no reference images change. It does *not* remove the underlying leak — `bloomUI.css` is still being applied to book content, which is what #8122 addresses at the source. #8122 is the deeper fix but changes how the arithmetic page renders (to the book's own Andika stack) and so updates six reference images.

Known, pre-existing and not addressed by either PR: the edit tab renders that same text in Roboto (its own `editMode.css` legitimately carries the UI body font), and the published BloomPUB renders it in Arial (the staged book's `fonts.css` is empty and its `defaultLangStyles.css` declares no `@font-face`). The root issue is that `lang="*"` content has no font specified anywhere.

Visual regression suite: 12/12, no reference images changed. Full C# and front-end suites green.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16624

Alternatives under consideration for the same bug — only one should land:
- #8124 (John Thomson) — install the faces from `bookPreview.ts`, selecting per font family
- #8125 — link `bloomUIFontFaces.css` from `Book.cs`
- #8122 — remove the leak so book documents never name the UI font at all


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8125)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8125)
<!-- Reviewable:end -->

