### PR TITLE
Correct the phrase-delimiter comment on getChecksum (BL-16586)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBookChecksum.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBookChecksum.ts
@@ -13,16 +13,23 @@ export function getChecksum(message: string): string {
         return "undefind";
     }
     // Vertical line character ("|") acts as a phrase delimiter in Talking Books.
-    // To perform phrase-level recording, the user can insert a temporary "|" character where he wants a phrase split to happen.
-    // This is now recognized in the list of sentence delimiters, so it will be broken up as an audio-sentence.
-    // Then the user records the audio.
-    // Then the user deletes the vertical line characters.
-    // Now the text should be the desired final state, and audio recordings are possible at a sub-sentence level.
-    // However, we don't want the sentence markup to be updated because the checksums differ (since a character was deleted).
+    // To perform phrase-level recording, the user inserts a "|" wherever a phrase split should
+    // happen. "|" is in the list of sentence delimiters, so each phrase becomes its own
+    // audio-sentence and can be recorded separately.
     //
-    // Thus, our checksum function needs to ignore the vertical line character when computing the checksum.
-    // Use a global replace: a single audio-sentence can contain more than one delimiter
-    // (e.g. "one | two | three."), and every one of them must be stripped (BL-16586).
+    // The bars then stay in the text; the user does not delete them (much older versions of
+    // Bloom did require that). Instead, closing the Talking Book tool replaces each bar with a
+    // zero-width <span class="bloom-audio-split-marker">, so the bars are invisible outside the
+    // tool, and reopening the tool turns them back into real "|" characters.
+    //
+    // Either way the bars are markup rather than content, so the checksum has to ignore them:
+    // adding, moving or removing a bar does not change the words that were recorded, and we
+    // don't want that to make Bloom think a recording no longer matches its text.
+    //
+    // Note the global replace. A single audio-sentence can hold more than one bar, because a run
+    // of adjacent bars is deliberately collapsed into a single split (so "Delta ||| epsilon."
+    // gives the chunks "Delta |||" and "epsilon."), and every bar in it has to be
+    // stripped (BL-16586).
     const adjustedMessage = message.replace(/\|/g, "");
     return getMd5(adjustedMessage);
 }


### PR DESCRIPTION
Comment-only follow-up to BL-16586.

The comment above `getChecksum` described a workflow Bloom hasn't had for years: it said the user inserts `|` phrase markers, records, and "then the user deletes the vertical line characters." Bloom now *hides* the bars instead — closing the Talking Book tool rewrites each one as a zero-width `<span class="bloom-audio-split-marker">`, and reopening the tool restores the literal `|` — so the bars stay in the text permanently.

That stale premise is what made the BL-16586 investigation initially conclude, wrongly, that record-by-sentence mode could never put two bars in one audio-sentence. It can. A run of adjacent bars is deliberately collapsed into a single split, so typing `Delta ||| epsilon.` in record-by-sentence mode gives the chunks `Delta |||` and `epsilon.` — verified in a running Bloom, along with the fact that recording that chunk stores md5 of the text with *all* bars removed (the current code) versus only the first (before the BL-16586 fix).

The comment now says that, and explains why the checksum ignores bars at all: they are markup, not content, so adding, moving or removing one must not make Bloom think a recording no longer matches its text.

No behavior change. `talkingBookChecksumSpec.ts` passes (3/3); prettier and the pre-commit type check are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8127)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8127)
<!-- Reviewable:end -->
