### PR TITLE
BL-16627: improve BloomBridge process-book fix-up: auto-fit origami splits (both directions, nested stacks) and shrink oversized images

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/autoFitImageOverTextSplits.ts
+++ b/src/BloomBrowserUI/bookEdit/js/autoFitImageOverTextSplits.ts
@@ -144,6 +144,13 @@ function fitImageOverTextSplitOnPage(page: HTMLElement): boolean {
         void splitPane.offsetHeight;
     };
 
+    // Undo the probing exactly, for the paths that end up declining the page — see
+    // captureSplitStyles. Writing back `originalTextPercent` instead would look equivalent but isn't:
+    // on a split with no explicit percentage (the common case, defaulting to 50%) it would leave an
+    // explicit "50%" behind on a page we decided not to touch.
+    const savedStyles = captureSplitStyles([splitConfig]);
+    const restore = () => restoreSplitStyles(savedStyles, splitPane);
+
     const textOverflows = (): boolean => textGroupOverflows(secondTextGroup);
 
     // Upper bound for the search: a text pane this tall is assumed to fit any text we'd auto-fit.
@@ -153,7 +160,7 @@ function fitImageOverTextSplitOnPage(page: HTMLElement): boolean {
     // growing the image (it's just over-full). Leave it exactly as we found it.
     setTextPercent(hiBound);
     if (textOverflows()) {
-        setTextPercent(originalTextPercent);
+        restore();
         return false;
     }
 
@@ -200,7 +207,7 @@ function fitImageOverTextSplitOnPage(page: HTMLElement): boolean {
     // Nothing worth doing (the authored split is already about right): put it back exactly as we
     // found it rather than rewriting the style with a rounding-noise difference.
     if (Math.abs(finalTextPercent - originalTextPercent) < kFitMinMovePercent) {
-        setTextPercent(originalTextPercent);
+        restore();
         return false;
     }
     setTextPercent(finalTextPercent);
@@ -349,13 +356,15 @@ export function readStackSizesPx(stack: SplitStack, totalPx: number): number[] {
 }
 
 // Remember every style attribute the fitting is about to overwrite, so a page we end up declining can
-// be put back byte-for-byte. Re-deriving the percentages instead would write an explicit "50%" onto
-// panes that had no style at all, needlessly changing the saved HTML of a page we chose not to touch.
-export function captureStackStyles(
-    stack: SplitStack,
+// be put back byte-for-byte. Measuring means laying the splits out over and over, so by the time we
+// decide a page is out of reach its styles have all been rewritten; re-deriving the percentages to
+// undo that would stamp an explicit "50%" onto panes that had no style at all, putting a page we
+// chose NOT to touch into the saved HTML's diff for nothing.
+export function captureSplitStyles(
+    configs: SplitConfig[],
 ): Array<[HTMLElement, string | null]> {
     const saved: Array<[HTMLElement, string | null]> = [];
-    for (const config of stack.splits)
+    for (const config of configs)
         for (const el of [
             config.firstComponent,
             config.divider,
@@ -365,15 +374,16 @@ export function captureStackStyles(
     return saved;
 }
 
-export function restoreStackStyles(
+export function restoreSplitStyles(
     saved: Array<[HTMLElement, string | null]>,
-    stack: SplitStack,
+    reflowFrom: HTMLElement,
 ): void {
     for (const [el, style] of saved) {
         if (style === null) el.removeAttribute("style");
         else el.setAttribute("style", style);
     }
-    void stack.splitPane.offsetHeight;
+    // Force a synchronous reflow so anything measured afterward sees the restored layout.
+    void reflowFrom.offsetHeight;
 }
 
 // The inverse of readStackSizesPx: lay the stack out with these pane sizes (px, visual order).
@@ -404,7 +414,12 @@ function computeImageFitPaneSizePx(
     const width = stack.splitPane.offsetWidth;
     if (width <= 0) return undefined;
     const scale = EditableDivUtils.getPageScale() || 1;
-    // Whatever the pane spends on padding/chrome rather than on the picture itself.
+    // Whatever the pane spends on padding/chrome rather than on the picture itself. Only this term is
+    // scale-divided, matching computeImageFitFirstPanePercent and the reference getImagePercent() in
+    // lib/split-pane/split-pane.ts. Don't "fix" the asymmetry here alone: it would put this out of
+    // step with the re-fit that runs afterward. It costs nothing in the off-screen processor (scale
+    // is 1), and even at another scale it can only skew this whitespace cap — never the no-overflow
+    // guarantee, which comes from measuring the real text.
     const extra =
         (slot.component.offsetHeight - slot.canvas!.offsetHeight) / scale;
     return width / aspectRatio + extra;
@@ -426,8 +441,8 @@ function fitImageTextStack(stack: SplitStack): boolean {
     const originalSizesPx = readStackSizesPx(stack, totalPx);
     const minPanePx = (totalPx * kFitMinTextPercent) / 100;
     const cushionPx = (totalPx * kFitTextCushionPercent) / 100;
-    const savedStyles = captureStackStyles(stack);
-    const restore = () => restoreStackStyles(savedStyles, stack);
+    const savedStyles = captureSplitStyles(stack.splits);
+    const restore = () => restoreSplitStyles(savedStyles, stack.splitPane);
 
     // Measure the illustration's cap NOW, while the stack is still laid out as it was saved. Both
     // inputs are read off the rendered boxes, and the probing below deliberately squeezes whichever

--- a/src/BloomBrowserUI/bookEdit/js/autoFitImageOverTextSplits.ts
+++ b/src/BloomBrowserUI/bookEdit/js/autoFitImageOverTextSplits.ts
@@ -9,18 +9,28 @@ import { EditableDivUtils } from "./editableDivUtils";
 // ── Auto-fit image/text origami splits (off-screen process-book only) ───────────────────────────
 //
 // A page that is a single illustration in the first pane and a single text block in the second pane
-// is usually saved at whatever ratio it was authored with (commonly 50/50). That often leaves a lot
-// of empty space after the text while the image is much smaller than it could be. This grows the
-// image pane (shrinking the text pane) as far as it can WITHOUT making the text overflow, but no
-// further than the point where the image already fills the constraining page dimension (for
-// top/bottom splits, the page width; for left/right splits, the page height). Growing past that just
-// adds whitespace around the image.
+// is usually saved at whatever ratio it was authored with (commonly 50/50) — a number that is right
+// only by accident. This moves the divider to the size the content actually calls for, in EITHER
+// direction:
 //
-// Governing rule: never leave the text overflowing. We don't estimate font/text sizes — we measure
-// the real browser layout with OverflowChecker, and bias toward a hair more text room than the
-// strict minimum. Wasted space is only a cosmetic ding; clipped text is a failure.
+//   - GROW the image pane (shrinking the text pane) when the text leaves room to spare, but no
+//     further than the point where the image already fills the constraining page dimension (for
+//     top/bottom splits, the page width; for left/right splits, the page height). Growing past that
+//     just adds whitespace around the image.
+//   - SHRINK the image pane when it is bigger than the image needs. Past the fill point the surplus
+//     is dead space, so trimming it costs the illustration NOTHING — it renders at exactly the same
+//     size — and hands the difference to the text. And when the text needs more than even that,
+//     shrink the image for real: clipped text is a failure, a smaller picture is not.
 //
-// Called by captureContentForExternalProcessing() (when process-book asks for it) so the grown
+// Governing rule: never leave the text overflowing, and never waste space to no one's benefit. We
+// don't estimate font/text sizes — we measure the real browser layout with OverflowChecker, and bias
+// toward a hair more text room than the strict minimum.
+//
+// The one thing we won't do is wreck a page we can't fix: if the text overflows even when given
+// almost the whole page, the page is simply over-full, and shrinking the image to a sliver would
+// leave it BOTH clipped and ugly. Those we leave exactly as authored.
+//
+// Called by captureContentForExternalProcessing() (when process-book asks for it) so the fitted
 // split persists into the saved HTML. Mutates the live DOM; relies on the fresh disposable browser
 // per page that the off-screen path uses.
 
@@ -28,6 +38,9 @@ import { EditableDivUtils } from "./editableDivUtils";
 const kFitTextCushionPercent = 1.5;
 // Never shrink the text pane below this percent of the split-pane height.
 const kFitMinTextPercent = 5;
+// Don't touch the divider for a move smaller than this (percent of split-pane size). Keeps
+// rounding noise from rewriting a split — and re-fitting every background image — for nothing.
+const kFitMinMovePercent = 0.5;
 
 // Auto-fit every qualifying image/text page in the document. Returns true if any page's split was
 // changed (so the caller knows to re-fit the background images afterward).
@@ -53,7 +66,7 @@ interface SplitConfig {
     secondInner: Element;
 }
 
-// Returns true if it changed this page's split (grew the image), false if it left the page alone.
+// Returns true if it changed this page's split (in either direction), false if it left it alone.
 function fitImageOverTextSplitOnPage(page: HTMLElement): boolean {
     const marginBox = page.querySelector(".marginBox");
     if (!marginBox) return false;
@@ -162,8 +175,10 @@ function fitImageOverTextSplitOnPage(page: HTMLElement): boolean {
     }
     const minTextPercent = hi;
 
-    // Cap how far the image can grow: once it fills the page width, growing the image pane further
-    // just adds whitespace around the image, so don't shrink the text below that point.
+    // The point past which the image gains nothing: once it fills the page width (or height, for a
+    // left/right split) a bigger pane only adds whitespace around it. So this is the text pane's
+    // FLOOR — the text is welcome to every percent above it, in either direction from where the page
+    // was authored, because those percents are dead space as far as the illustration is concerned.
     const imageFitFirstPanePercent = computeImageFitFirstPanePercent(
         splitPane,
         firstCanvas,
@@ -176,14 +191,17 @@ function fitImageOverTextSplitOnPage(page: HTMLElement): boolean {
         if (finalTextPercent < textFloorForImageFit)
             finalTextPercent = textFloorForImageFit;
     }
+    // Note there is no cap at the authored split: when the text needs more than the image's fill
+    // point, finalTextPercent stays at what the text needs and the image really does get smaller.
+    // That is deliberate — text the reader can't see is a failure; a smaller picture is a trade.
     finalTextPercent = Math.min(
         Math.max(finalTextPercent, kFitMinTextPercent),
         hiBound,
     );
 
-    // Only ever grow the image (shrink the text). If our computed split wouldn't enlarge the image,
-    // leave the page as authored.
-    if (finalTextPercent >= originalTextPercent) {
+    // Nothing worth doing (the authored split is already about right): put it back exactly as we
+    // found it rather than rewriting the style with a rounding-noise difference.
+    if (Math.abs(finalTextPercent - originalTextPercent) < kFitMinMovePercent) {
         setTextPercent(originalTextPercent);
         return false;
     }
@@ -311,6 +329,15 @@ function computeImageFitFirstPanePercent(
 // adjustBackgroundImageSizeToFit() (split-pane.ts getImagePercent()) uses, so our width cap agrees
 // with how the image will actually be re-fit afterward. The background canvas element keeps its
 // load-time size while we resize panes, so this aspect is stable across the binary search.
+//
+// CAVEAT for freshly imported books: this box is whatever the importer wrote, which is not
+// necessarily the picture's shape. BloomBridge, for one, emits the background element at the
+// full PANE rect, so on the first process-book pass we read the PANE's aspect and conclude the
+// image already fills its pane — i.e. the image-fit cap says "no room to reclaim" even when the
+// pane is half empty. The binary search still keeps text from overflowing (it measures real
+// text), so the guarantee holds; we just don't reclaim all the dead space until a pass where the
+// box reflects the image. Don't "fix" this by preferring naturalWidth/naturalHeight — that would
+// ignore cropping and disagree with the re-fit that follows.
 function getImageAspectRatio(bloomCanvas: HTMLElement): number | undefined {
     const bg = bloomCanvas.getElementsByClassName(
         "bloom-backgroundImage",

--- a/src/BloomBrowserUI/bookEdit/js/autoFitImageOverTextSplits.ts
+++ b/src/BloomBrowserUI/bookEdit/js/autoFitImageOverTextSplits.ts
@@ -30,6 +30,15 @@ import { EditableDivUtils } from "./editableDivUtils";
 // almost the whole page, the page is simply over-full, and shrinking the image to a sliver would
 // leave it BOTH clipped and ugly. Those we leave exactly as authored.
 //
+// We also handle one NESTED shape: a top-to-bottom STACK of panes — text above / illustration /
+// text below, and the like — where exactly one pane holds the illustration and the rest hold text.
+// That is a very common layout in scanned story books, and it needs us more than the two-pane case
+// does, because nothing ever set its dividers on purpose: an importer emits it as a right-nested
+// chain of horizontal splits, and with no explicit percentages Bloom's 50/50-per-split CSS default
+// cascades into an effective 50/25/25. Those numbers describe the nesting, not the content, so the
+// top text block gets half the page for its one line while the last (usually longest) one is
+// clipped. See fitImageTextStack() for the arithmetic.
+//
 // Called by captureContentForExternalProcessing() (when process-book asks for it) so the fitted
 // split persists into the saved HTML. Mutates the live DOM; relies on the fresh disposable browser
 // per page that the off-screen path uses.
@@ -71,13 +80,26 @@ function fitImageOverTextSplitOnPage(page: HTMLElement): boolean {
     const marginBox = page.querySelector(".marginBox");
     if (!marginBox) return false;
 
-    // We only handle the simple case: the marginBox's content is a single top-level two-pane split
-    // with no nested splits.
+    // The marginBox's content has to be a single top-level split.
     const splitPane = marginBox.querySelector(
         ":scope > .split-pane.horizontal-percent, :scope > .split-pane.vertical-percent",
     ) as HTMLElement | null;
     if (!splitPane) return false;
-    if (splitPane.querySelector(".split-pane")) return false; // nested split: too complex, skip
+
+    if (splitPane.querySelector(".split-pane")) {
+        // Nested. The one nested shape we understand is a STACK: panes in a single row along one
+        // axis, exactly one of them the illustration and the rest text (see fitImageTextStack).
+        // Anything else nested is too complex — leave it alone.
+        const stack = collectSplitStack(splitPane);
+        if (!stack) return false;
+        // Top/bottom stacks only. In a left/right stack the panes have different WIDTHS, so a text
+        // block's required height depends on how wide its own pane is; the panes stop being
+        // independent and the one-at-a-time measurement fitImageTextStack relies on doesn't hold.
+        if (stack.orientation !== "horizontal") return false;
+        if (stack.slots.filter((slot) => slot.kind === "image").length !== 1)
+            return false;
+        return fitImageTextStack(stack);
+    }
 
     const splitConfig = getSplitConfig(splitPane);
     if (!splitConfig) return false;
@@ -117,36 +139,12 @@ function fitImageOverTextSplitOnPage(page: HTMLElement): boolean {
     const originalTextPercent = readSecondPanePercent(splitConfig);
 
     const setTextPercent = (percent: number) => {
-        const value = percent + "%";
-        if (splitConfig.orientation === "horizontal") {
-            splitConfig.firstComponent.style.bottom = value;
-            splitConfig.divider.style.bottom = value;
-            splitConfig.secondComponent.style.height = value;
-        } else {
-            splitConfig.firstComponent.style.right = value;
-            splitConfig.divider.style.right = value;
-            splitConfig.secondComponent.style.width = value;
-        }
+        setSecondPanePercent(splitConfig, percent);
         // Force a synchronous reflow so the measurements below see the new layout.
         void splitPane.offsetHeight;
     };
 
-    const textEditables = () =>
-        Array.from(
-            secondTextGroup.querySelectorAll(
-                ".bloom-editable.bloom-visibility-code-on",
-            ),
-        ) as HTMLElement[];
-
-    // True if any visible text box has more text than fits in the (current) text pane. We check both
-    // kinds of overflow OverflowChecker knows about: the box overflowing itself (type 1) and the box
-    // overflowing its pane/ancestor (type 2, the usual one for auto-height origami text).
-    const textOverflows = (): boolean =>
-        textEditables().some(
-            (e) =>
-                OverflowChecker.IsOverflowingSelf(e) ||
-                OverflowChecker.overflowingAncestor(e) !== null,
-        );
+    const textOverflows = (): boolean => textGroupOverflows(secondTextGroup);
 
     // Upper bound for the search: a text pane this tall is assumed to fit any text we'd auto-fit.
     const hiBound = Math.max(originalTextPercent, 90);
@@ -206,6 +204,328 @@ function fitImageOverTextSplitOnPage(page: HTMLElement): boolean {
         return false;
     }
     setTextPercent(finalTextPercent);
+    return true;
+}
+
+// Write a split's position: the SECOND pane takes `percent` of the split's own box, and the first
+// pane and the divider are inset from the far edge by the same amount. Callers force the reflow.
+function setSecondPanePercent(config: SplitConfig, percent: number): void {
+    const value = percent + "%";
+    if (config.orientation === "horizontal") {
+        config.firstComponent.style.bottom = value;
+        config.divider.style.bottom = value;
+        config.secondComponent.style.height = value;
+    } else {
+        config.firstComponent.style.right = value;
+        config.divider.style.right = value;
+        config.secondComponent.style.width = value;
+    }
+}
+
+// True if any visible text box in this group has more text than fits. We check both kinds of overflow
+// OverflowChecker knows about: the box overflowing itself (type 1) and the box overflowing its
+// pane/ancestor (type 2, the usual one for auto-height origami text).
+function textGroupOverflows(textGroup: HTMLElement): boolean {
+    const editables = Array.from(
+        textGroup.querySelectorAll(".bloom-editable.bloom-visibility-code-on"),
+    ) as HTMLElement[];
+    return editables.some(
+        (e) =>
+            OverflowChecker.IsOverflowingSelf(e) ||
+            OverflowChecker.overflowingAncestor(e) !== null,
+    );
+}
+
+// ── Stacks of three or more panes ───────────────────────────────────────────────────────────────
+
+// One pane of a stack, and which of the two kinds of content it holds.
+interface StackSlot {
+    kind: "image" | "text";
+    component: HTMLElement; // the .split-pane-component whose size we control
+    canvas?: HTMLElement; // image slots only
+    textGroup?: HTMLElement; // text slots only
+}
+
+export interface SplitStack {
+    orientation: SplitOrientation;
+    splitPane: HTMLElement; // the OUTERMOST split pane; its box is the whole stack
+    splits: SplitConfig[]; // outermost → innermost; one fewer than slots
+    slots: StackSlot[]; // in visual order (top → bottom, or left → right)
+}
+
+// Decide what a single pane holds. A pane we can't confidently call "just an illustration" or "just
+// text" makes the whole page out of scope, so this returns undefined rather than guessing.
+function classifySlot(
+    inner: Element,
+    component: HTMLElement,
+): StackSlot | undefined {
+    const canvas = inner.querySelector(
+        kBloomCanvasSelector,
+    ) as HTMLElement | null;
+    const textGroup = inner.querySelector(
+        ".bloom-translationGroup",
+    ) as HTMLElement | null;
+    if (canvas && !textGroup) {
+        // Overlays (canvas elements other than the background image) put the page out of scope for
+        // the same reason as in the two-pane case: our math reasons only about the background
+        // image's aspect ratio, and overlays don't scale with it predictably.
+        if (
+            canvas.querySelector(
+                `${kCanvasElementSelector}:not(.${kBackgroundImageClass})`,
+            )
+        )
+            return undefined;
+        return { kind: "image", component, canvas };
+    }
+    if (textGroup && !canvas) return { kind: "text", component, textGroup };
+    return undefined;
+}
+
+// Deepest sane nesting we'll walk. Real stacks are three or four panes; anything deeper is a layout
+// we don't understand and shouldn't be rearranging.
+const kMaxStackDepth = 8;
+
+// Recognize a stack: splits of ONE axis chained down their second panes, each contributing its first
+// pane as a slot and the innermost contributing its second pane as the last slot. That right-leaning
+// chain is exactly what origami (and BloomBridge) produce for a row of panes along one axis.
+// Returns undefined for any other arrangement — a split nested in a FIRST pane, mixed axes, a second
+// pane holding a split alongside other content, or a pane whose content we can't classify.
+export function collectSplitStack(
+    splitPane: HTMLElement,
+): SplitStack | undefined {
+    const splits: SplitConfig[] = [];
+    const slots: StackSlot[] = [];
+    let current = splitPane;
+    let orientation: SplitOrientation | undefined;
+    for (;;) {
+        const config = getSplitConfig(current);
+        if (!config) return undefined;
+        if (orientation === undefined) orientation = config.orientation;
+        else if (config.orientation !== orientation) return undefined;
+
+        // A split inside the first pane means this is not a simple one-axis chain.
+        if (config.firstInner.querySelector(".split-pane")) return undefined;
+        const firstSlot = classifySlot(
+            config.firstInner,
+            config.firstComponent,
+        );
+        if (!firstSlot) return undefined;
+        splits.push(config);
+        slots.push(firstSlot);
+
+        const nested = config.secondInner.querySelector(
+            ":scope > .split-pane",
+        ) as HTMLElement | null;
+        if (!nested) {
+            const lastSlot = classifySlot(
+                config.secondInner,
+                config.secondComponent,
+            );
+            if (!lastSlot) return undefined;
+            slots.push(lastSlot);
+            return { orientation, splitPane, splits, slots };
+        }
+        // The second pane continues the chain, so it must hold the nested split and nothing else.
+        if (config.secondInner.children.length !== 1) return undefined;
+        if (splits.length >= kMaxStackDepth) return undefined;
+        current = nested;
+    }
+}
+
+// The stored percentages, turned into pane sizes in px along the stack axis. Each split's percentage
+// is relative to ITS OWN box, not the page: the outermost split sees the whole stack, the next only
+// what is left after the first pane, and so on — which is precisely why the CSS default of 50% per
+// split reads as 50/25/25 rather than thirds.
+export function readStackSizesPx(stack: SplitStack, totalPx: number): number[] {
+    const sizes: number[] = [];
+    let remaining = totalPx;
+    for (const config of stack.splits) {
+        const secondPx = (remaining * readSecondPanePercent(config)) / 100;
+        sizes.push(remaining - secondPx);
+        remaining = secondPx;
+    }
+    sizes.push(remaining);
+    return sizes;
+}
+
+// Remember every style attribute the fitting is about to overwrite, so a page we end up declining can
+// be put back byte-for-byte. Re-deriving the percentages instead would write an explicit "50%" onto
+// panes that had no style at all, needlessly changing the saved HTML of a page we chose not to touch.
+export function captureStackStyles(
+    stack: SplitStack,
+): Array<[HTMLElement, string | null]> {
+    const saved: Array<[HTMLElement, string | null]> = [];
+    for (const config of stack.splits)
+        for (const el of [
+            config.firstComponent,
+            config.divider,
+            config.secondComponent,
+        ])
+            saved.push([el, el.getAttribute("style")]);
+    return saved;
+}
+
+export function restoreStackStyles(
+    saved: Array<[HTMLElement, string | null]>,
+    stack: SplitStack,
+): void {
+    for (const [el, style] of saved) {
+        if (style === null) el.removeAttribute("style");
+        else el.setAttribute("style", style);
+    }
+    void stack.splitPane.offsetHeight;
+}
+
+// The inverse of readStackSizesPx: lay the stack out with these pane sizes (px, visual order).
+export function applyStackSizesPx(
+    stack: SplitStack,
+    sizesPx: number[],
+    totalPx: number,
+): void {
+    let remaining = totalPx;
+    for (let i = 0; i < stack.splits.length; i++) {
+        const secondPx = remaining - sizesPx[i];
+        setSecondPanePercent(stack.splits[i], (secondPx / remaining) * 100);
+        remaining = secondPx;
+    }
+    // One synchronous reflow at the end, so measurements afterward see the new layout.
+    void stack.splitPane.offsetHeight;
+}
+
+// The pane size at which the illustration already fills the stack's width, so a taller pane would
+// only add whitespace around it. The px counterpart of computeImageFitFirstPanePercent, simpler
+// because every pane in a top/bottom stack is the full width of the stack.
+function computeImageFitPaneSizePx(
+    stack: SplitStack,
+    slot: StackSlot,
+): number | undefined {
+    const aspectRatio = getImageAspectRatio(slot.canvas!);
+    if (aspectRatio === undefined) return undefined;
+    const width = stack.splitPane.offsetWidth;
+    if (width <= 0) return undefined;
+    const scale = EditableDivUtils.getPageScale() || 1;
+    // Whatever the pane spends on padding/chrome rather than on the picture itself.
+    const extra =
+        (slot.component.offsetHeight - slot.canvas!.offsetHeight) / scale;
+    return width / aspectRatio + extra;
+}
+
+// Fit a top/bottom stack of three or more panes holding exactly one illustration.
+//
+// What makes this tractable is that every pane in such a stack is the same WIDTH. A text block's
+// required height therefore doesn't depend on where any divider sits, so we can measure each text
+// pane on its own (give it a size, ask whether it overflows, binary-search the boundary) and then
+// simply add the answers up. Same measured-not-estimated rule as the two-pane case.
+//
+// Returns true if it changed the page.
+function fitImageTextStack(stack: SplitStack): boolean {
+    const totalPx = stack.splitPane.offsetHeight;
+    if (totalPx <= 0) return false;
+
+    const imageIndex = stack.slots.findIndex((slot) => slot.kind === "image");
+    const originalSizesPx = readStackSizesPx(stack, totalPx);
+    const minPanePx = (totalPx * kFitMinTextPercent) / 100;
+    const cushionPx = (totalPx * kFitTextCushionPercent) / 100;
+    const savedStyles = captureStackStyles(stack);
+    const restore = () => restoreStackStyles(savedStyles, stack);
+
+    // Measure the illustration's cap NOW, while the stack is still laid out as it was saved. Both
+    // inputs are read off the rendered boxes, and the probing below deliberately squeezes whichever
+    // panes it isn't testing — including this one — so measuring afterward would read the picture's
+    // chrome out of a pane collapsed to its minimum.
+    const imageFitPx = computeImageFitPaneSizePx(
+        stack,
+        stack.slots[imageIndex],
+    );
+
+    // Lay the stack out with one pane at `sizePx` and the rest sharing what's left equally. Only the
+    // pane under test is measured, so whatever this does to the others doesn't matter.
+    const probe = (index: number, sizePx: number) => {
+        const each = (totalPx - sizePx) / (stack.slots.length - 1);
+        applyStackSizesPx(
+            stack,
+            stack.slots.map((_, i) => (i === index ? sizePx : each)),
+            totalPx,
+        );
+    };
+
+    // The most any one pane can have while the others still keep their floor.
+    const hiPx = totalPx - minPanePx * (stack.slots.length - 1);
+
+    // Smallest height at which each text pane's text still fits.
+    const requiredPx: number[] = [];
+    for (let i = 0; i < stack.slots.length; i++) {
+        const slot = stack.slots[i];
+        if (slot.kind !== "text") {
+            requiredPx.push(0);
+            continue;
+        }
+        probe(i, hiPx);
+        if (textGroupOverflows(slot.textGroup!)) {
+            // This block doesn't fit even with nearly the whole page to itself, so the page is
+            // simply over-full. Same call as the two-pane case: leave it exactly as authored rather
+            // than shuffling dividers to produce something both clipped AND ugly.
+            restore();
+            return false;
+        }
+        let lo = minPanePx; // largest known-overflowing size as we narrow (starts as a guess)
+        let hi = hiPx; // smallest known-fitting size
+        probe(i, lo);
+        if (textGroupOverflows(slot.textGroup!)) {
+            for (let n = 0; n < 12; n++) {
+                const mid = (lo + hi) / 2;
+                probe(i, mid);
+                if (textGroupOverflows(slot.textGroup!)) lo = mid;
+                else hi = mid;
+            }
+        } else {
+            hi = lo; // even the smallest pane we'd use fits
+        }
+        requiredPx.push(hi);
+    }
+
+    // Each text pane gets what it needs plus the same hair of extra room the two-pane case allows.
+    const textTargetsPx = requiredPx.map((px, i) =>
+        stack.slots[i].kind === "text" ? px + cushionPx : 0,
+    );
+    const textTotalPx = textTargetsPx.reduce((a, b) => a + b, 0);
+
+    // Individually they all fit, but together they may still not — and then there is no arrangement
+    // of these dividers that works, so don't rearrange them.
+    if (textTotalPx > totalPx - minPanePx) {
+        restore();
+        return false;
+    }
+
+    // The illustration takes everything the text doesn't need, up to the point where it already
+    // fills the width; past that a taller pane is pure whitespace.
+    let imagePx = totalPx - textTotalPx;
+    if (imageFitPx !== undefined)
+        imagePx = Math.min(imagePx, Math.max(imageFitPx, minPanePx));
+
+    // Whatever the illustration declines goes back to the text panes rather than sitting dead,
+    // shared out in proportion to what each of them needed.
+    const targetsPx = textTargetsPx.slice();
+    targetsPx[imageIndex] = imagePx;
+    const leftoverPx = totalPx - textTotalPx - imagePx;
+    if (leftoverPx > 0 && textTotalPx > 0) {
+        for (let i = 0; i < targetsPx.length; i++)
+            if (stack.slots[i].kind === "text")
+                targetsPx[i] += (leftoverPx * textTargetsPx[i]) / textTotalPx;
+    }
+
+    // Nothing worth doing (the stack is already about right): put it back exactly as we found it
+    // rather than rewriting every split — and re-fitting the illustration — for rounding noise.
+    const minMovePx = (totalPx * kFitMinMovePercent) / 100;
+    if (
+        targetsPx.every(
+            (px, i) => Math.abs(px - originalSizesPx[i]) < minMovePx,
+        )
+    ) {
+        restore();
+        return false;
+    }
+    applyStackSizesPx(stack, targetsPx, totalPx);
     return true;
 }
 

--- a/src/BloomBrowserUI/bookEdit/js/autoFitImageOverTextSplits.ts
+++ b/src/BloomBrowserUI/bookEdit/js/autoFitImageOverTextSplits.ts
@@ -275,7 +275,9 @@ function classifySlot(
     if (canvas && !textGroup) {
         // Overlays (canvas elements other than the background image) put the page out of scope for
         // the same reason as in the two-pane case: our math reasons only about the background
-        // image's aspect ratio, and overlays don't scale with it predictably.
+        // image's aspect ratio, and overlays don't scale with it predictably. Not redundant with the
+        // `!textGroup` test above, though it looks it: that one already excludes TEXT bubbles (a
+        // bubble contains a translationGroup), so this is what excludes image/video/other overlays.
         if (
             canvas.querySelector(
                 `${kCanvasElementSelector}:not(.${kBackgroundImageClass})`,
@@ -666,12 +668,14 @@ function computeImageFitFirstPanePercent(
 // load-time size while we resize panes, so this aspect is stable across the binary search.
 //
 // CAVEAT for freshly imported books: this box is whatever the importer wrote, which is not
-// necessarily the picture's shape. BloomBridge, for one, emits the background element at the
-// full PANE rect, so on the first process-book pass we read the PANE's aspect and conclude the
-// image already fills its pane — i.e. the image-fit cap says "no room to reclaim" even when the
-// pane is half empty. The binary search still keeps text from overflowing (it measures real
-// text), so the guarantee holds; we just don't reclaim all the dead space until a pass where the
-// box reflects the image. Don't "fix" this by preferring naturalWidth/naturalHeight — that would
+// guaranteed to be the picture's shape. If an importer sizes the background element to the whole
+// PANE, we read the PANE's aspect and conclude the image already fills it — i.e. the image-fit cap
+// says "no room to reclaim" even when the pane is half empty. That only costs us whitespace: the
+// binary search still keeps text from overflowing, because it measures real text, so the guarantee
+// holds and the dead space gets reclaimed on a later pass once the box reflects the picture.
+// (Measured on BloomBridge output, 2026-07: it writes an aspect-CORRECT box — the pane's height by
+// the picture's proportional width — so this doesn't currently bite there. Don't rely on that for
+// other importers.) Don't "fix" any of this by preferring naturalWidth/naturalHeight: that would
 // ignore cropping and disagree with the re-fit that follows.
 function getImageAspectRatio(bloomCanvas: HTMLElement): number | undefined {
     const bg = bloomCanvas.getElementsByClassName(

--- a/src/BloomBrowserUI/bookEdit/js/autoFitImageOverTextSplitsSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/autoFitImageOverTextSplitsSpec.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect } from "vitest";
+import {
+    applyStackSizesPx,
+    captureStackStyles,
+    collectSplitStack,
+    readStackSizesPx,
+    restoreStackStyles,
+} from "./autoFitImageOverTextSplits";
+
+// These tests cover the two parts of the nested-stack support that don't need a real browser
+// layout: recognizing which pages are a stack we can fit, and the percentage arithmetic that
+// converts between per-split percentages and pane sizes. The measuring itself (binary-searching
+// the overflow boundary) needs real geometry, which jsdom does not provide — offsetHeight and
+// getBoundingClientRect are always 0 here — so it is verified end-to-end against a real book
+// instead. Keep that in mind before "fixing" a test by asking it about pixel sizes.
+
+const kTextPane = `<div class="bloom-translationGroup">
+    <div class="bloom-editable bloom-visibility-code-on" lang="fuv"><p>text</p></div>
+</div>`;
+
+const kImagePane = `<div class="bloom-canvas bloom-has-canvas-element">
+    <div class="bloom-canvas-element bloom-backgroundImage">
+        <div class="bloom-imageContainer"><img src="pic.png" /></div>
+    </div>
+</div>`;
+
+// An illustration with a text bubble floating on it — a canvas element that is not the background
+// image, which puts the page out of scope.
+const kImagePaneWithOverlay = `<div class="bloom-canvas bloom-has-canvas-element">
+    <div class="bloom-canvas-element bloom-backgroundImage">
+        <div class="bloom-imageContainer"><img src="pic.png" /></div>
+    </div>
+    <div class="bloom-canvas-element"><div class="bloom-translationGroup"></div></div>
+</div>`;
+
+/** One split pane: `first` in the leading pane, `second` in the trailing one. */
+function split(
+    axis: "horizontal" | "vertical",
+    first: string,
+    second: string,
+): string {
+    const leading = axis === "horizontal" ? "top" : "left";
+    const trailing = axis === "horizontal" ? "bottom" : "right";
+    return `<div class="split-pane ${axis}-percent">
+        <div class="split-pane-component position-${leading}">
+            <div class="split-pane-component-inner">${first}</div>
+        </div>
+        <div class="split-pane-divider ${axis}-divider"></div>
+        <div class="split-pane-component position-${trailing}">
+            <div class="split-pane-component-inner">${second}</div>
+        </div>
+    </div>`;
+}
+
+/** Parse a marginBox's worth of HTML and hand back its top-level split pane. */
+function topSplitOf(inner: string): HTMLElement {
+    const page = document.createElement("div");
+    page.className = "bloom-page";
+    page.innerHTML = `<div class="marginBox">${inner}</div>`;
+    document.body.appendChild(page);
+    return page.querySelector(".split-pane") as HTMLElement;
+}
+
+/** The text/image/text page this whole feature exists for, as BloomBridge emits it. */
+function textImageTextStack(): HTMLElement {
+    return topSplitOf(
+        split(
+            "horizontal",
+            kTextPane,
+            split("horizontal", kImagePane, kTextPane),
+        ),
+    );
+}
+
+describe("collectSplitStack", () => {
+    it("recognizes a text/image/text stack, in visual order", () => {
+        const stack = collectSplitStack(textImageTextStack());
+        expect(stack).toBeDefined();
+        expect(stack!.orientation).toBe("horizontal");
+        expect(stack!.slots.map((s) => s.kind)).toEqual([
+            "text",
+            "image",
+            "text",
+        ]);
+        // One split per divider: two dividers for three panes.
+        expect(stack!.splits.length).toBe(2);
+    });
+
+    it("recognizes deeper stacks and other positions for the illustration", () => {
+        const imageLast = collectSplitStack(
+            topSplitOf(
+                split(
+                    "horizontal",
+                    kTextPane,
+                    split("horizontal", kTextPane, kImagePane),
+                ),
+            ),
+        );
+        expect(imageLast!.slots.map((s) => s.kind)).toEqual([
+            "text",
+            "text",
+            "image",
+        ]);
+
+        const fourPanes = collectSplitStack(
+            topSplitOf(
+                split(
+                    "horizontal",
+                    kTextPane,
+                    split(
+                        "horizontal",
+                        kImagePane,
+                        split("horizontal", kTextPane, kTextPane),
+                    ),
+                ),
+            ),
+        );
+        expect(fourPanes!.slots.map((s) => s.kind)).toEqual([
+            "text",
+            "image",
+            "text",
+            "text",
+        ]);
+    });
+
+    it("reads a side-by-side stack but reports it as vertical, so the caller can decline it", () => {
+        const stack = collectSplitStack(
+            topSplitOf(
+                split(
+                    "vertical",
+                    kTextPane,
+                    split("vertical", kImagePane, kTextPane),
+                ),
+            ),
+        );
+        expect(stack!.orientation).toBe("vertical");
+    });
+
+    it("declines a stack whose axes are mixed", () => {
+        expect(
+            collectSplitStack(
+                topSplitOf(
+                    split(
+                        "horizontal",
+                        kTextPane,
+                        split("vertical", kImagePane, kTextPane),
+                    ),
+                ),
+            ),
+        ).toBeUndefined();
+    });
+
+    it("declines a split nested in the FIRST pane (not a one-axis chain)", () => {
+        expect(
+            collectSplitStack(
+                topSplitOf(
+                    split(
+                        "horizontal",
+                        split("horizontal", kTextPane, kImagePane),
+                        kTextPane,
+                    ),
+                ),
+            ),
+        ).toBeUndefined();
+    });
+
+    it("declines a second pane holding a nested split alongside other content", () => {
+        expect(
+            collectSplitStack(
+                topSplitOf(
+                    split(
+                        "horizontal",
+                        kTextPane,
+                        kTextPane + split("horizontal", kImagePane, kTextPane),
+                    ),
+                ),
+            ),
+        ).toBeUndefined();
+    });
+
+    it("declines a pane that holds both an illustration and text", () => {
+        expect(
+            collectSplitStack(
+                topSplitOf(
+                    split(
+                        "horizontal",
+                        kTextPane,
+                        split("horizontal", kImagePane + kTextPane, kTextPane),
+                    ),
+                ),
+            ),
+        ).toBeUndefined();
+    });
+
+    it("declines an illustration carrying an overlay", () => {
+        expect(
+            collectSplitStack(
+                topSplitOf(
+                    split(
+                        "horizontal",
+                        kTextPane,
+                        split("horizontal", kImagePaneWithOverlay, kTextPane),
+                    ),
+                ),
+            ),
+        ).toBeUndefined();
+    });
+
+    it("declines an empty pane", () => {
+        expect(
+            collectSplitStack(
+                topSplitOf(
+                    split(
+                        "horizontal",
+                        kTextPane,
+                        split("horizontal", "", kTextPane),
+                    ),
+                ),
+            ),
+        ).toBeUndefined();
+    });
+});
+
+describe("stack size arithmetic", () => {
+    it("reads unset splits as 50/25/25 — the nesting artifact this feature fixes", () => {
+        // Neither split carries a percentage, so each falls back to the CSS default of 50%. Because
+        // the inner split only divides what the outer one left over, that reads as 50/25/25 and NOT
+        // as equal thirds. This is exactly the layout that gives a one-line text block half the page.
+        const stack = collectSplitStack(textImageTextStack())!;
+        expect(readStackSizesPx(stack, 800)).toEqual([400, 200, 200]);
+    });
+
+    it("round-trips pane sizes through the nested percentages", () => {
+        const stack = collectSplitStack(textImageTextStack())!;
+        const target = [120, 460, 220];
+        applyStackSizesPx(stack, target, 800);
+        const readBack = readStackSizesPx(stack, 800);
+        readBack.forEach((px, i) => expect(px).toBeCloseTo(target[i], 6));
+    });
+
+    it("writes each split's percentage relative to that split's own box", () => {
+        const stack = collectSplitStack(textImageTextStack())!;
+        applyStackSizesPx(stack, [200, 400, 200], 800);
+        // The outer split keeps 200 of 800 for the top text, so its second pane is 600/800 = 75%.
+        expect(stack.splits[0].secondComponent.style.height).toBe("75%");
+        // The inner split divides that 600: the last text's 200 is a third of it, not a quarter of
+        // the page. Getting this wrong is the easiest way to reintroduce the bug.
+        expect(
+            parseFloat(stack.splits[1].secondComponent.style.height),
+        ).toBeCloseTo(100 / 3, 6);
+    });
+
+    it("moves the first pane's inset and the divider along with the second pane", () => {
+        const stack = collectSplitStack(textImageTextStack())!;
+        applyStackSizesPx(stack, [200, 400, 200], 800);
+        // All three of these have to agree, or the divider ends up somewhere other than the seam.
+        expect(stack.splits[0].firstComponent.style.bottom).toBe("75%");
+        expect(stack.splits[0].divider.style.bottom).toBe("75%");
+        expect(stack.splits[0].secondComponent.style.height).toBe("75%");
+    });
+
+    it("restores a declined page byte-for-byte, adding no style attributes", () => {
+        // Measuring means laying the stack out repeatedly, so by the time we decide a page is out of
+        // reach its styles have all been rewritten. Putting back the ORIGINAL attributes (rather than
+        // re-deriving 50%) is what keeps a page we chose not to touch out of the saved HTML's diff.
+        const stack = collectSplitStack(textImageTextStack())!;
+        const saved = captureStackStyles(stack);
+        applyStackSizesPx(stack, [120, 460, 220], 800);
+        expect(stack.splits[0].secondComponent.getAttribute("style")).not.toBe(
+            null,
+        );
+        restoreStackStyles(saved, stack);
+        for (const config of stack.splits)
+            for (const el of [
+                config.firstComponent,
+                config.divider,
+                config.secondComponent,
+            ])
+                expect(el.getAttribute("style")).toBe(null);
+    });
+
+    it("restores an authored split to its exact original text", () => {
+        const stack = collectSplitStack(textImageTextStack())!;
+        stack.splits[0].secondComponent.setAttribute("style", "height: 62%");
+        const saved = captureStackStyles(stack);
+        applyStackSizesPx(stack, [120, 460, 220], 800);
+        restoreStackStyles(saved, stack);
+        expect(stack.splits[0].secondComponent.getAttribute("style")).toBe(
+            "height: 62%",
+        );
+    });
+
+    it("round-trips a four-pane stack too", () => {
+        const stack = collectSplitStack(
+            topSplitOf(
+                split(
+                    "horizontal",
+                    kTextPane,
+                    split(
+                        "horizontal",
+                        kImagePane,
+                        split("horizontal", kTextPane, kTextPane),
+                    ),
+                ),
+            ),
+        )!;
+        const target = [100, 350, 150, 200];
+        applyStackSizesPx(stack, target, 800);
+        readStackSizesPx(stack, 800).forEach((px, i) =>
+            expect(px).toBeCloseTo(target[i], 6),
+        );
+    });
+});

--- a/src/BloomBrowserUI/bookEdit/js/autoFitImageOverTextSplitsSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/autoFitImageOverTextSplitsSpec.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from "vitest";
 import {
     applyStackSizesPx,
-    captureStackStyles,
+    captureSplitStyles,
     collectSplitStack,
     readStackSizesPx,
-    restoreStackStyles,
+    restoreSplitStyles,
 } from "./autoFitImageOverTextSplits";
 
 // These tests cover the two parts of the nested-stack support that don't need a real browser
@@ -264,12 +264,12 @@ describe("stack size arithmetic", () => {
         // reach its styles have all been rewritten. Putting back the ORIGINAL attributes (rather than
         // re-deriving 50%) is what keeps a page we chose not to touch out of the saved HTML's diff.
         const stack = collectSplitStack(textImageTextStack())!;
-        const saved = captureStackStyles(stack);
+        const saved = captureSplitStyles(stack.splits);
         applyStackSizesPx(stack, [120, 460, 220], 800);
         expect(stack.splits[0].secondComponent.getAttribute("style")).not.toBe(
             null,
         );
-        restoreStackStyles(saved, stack);
+        restoreSplitStyles(saved, stack.splitPane);
         for (const config of stack.splits)
             for (const el of [
                 config.firstComponent,
@@ -282,9 +282,9 @@ describe("stack size arithmetic", () => {
     it("restores an authored split to its exact original text", () => {
         const stack = collectSplitStack(textImageTextStack())!;
         stack.splits[0].secondComponent.setAttribute("style", "height: 62%");
-        const saved = captureStackStyles(stack);
+        const saved = captureSplitStyles(stack.splits);
         applyStackSizesPx(stack, [120, 460, 220], 800);
-        restoreStackStyles(saved, stack);
+        restoreSplitStyles(saved, stack.splitPane);
         expect(stack.splits[0].secondComponent.getAttribute("style")).toBe(
             "height: 62%",
         );

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -1561,16 +1561,16 @@ export function captureContentForExternalProcessing(
 ): void {
     window.__bloomExternalPageContent = undefined;
 
-    // Optionally auto-fit simple single-image/single-text origami pages so the grown split persists
+    // Optionally auto-fit simple single-image/single-text origami pages so the fitted split persists
     // into the saved HTML. This currently handles both image-above-text and image-left-of-text when
     // the image is in the first pane. We do this UP FRONT, before the delay-wait below, for two reasons:
     //  - It must run on the fully settled, real browser layout (which it now is: bootstrap() and the
     //    load-time fix-ups have run before C# calls us).
-    //  - Growing the image pane means the background image must be re-fit to the new pane size. That
+    //  - Resizing the image pane means the background image must be re-fit to the new pane size. That
     //    re-fit (adjustBackgroundImageSize) is async and registers a requestPageContent delay, so we
     //    kick it off here and let the waitForDelaysThenFinish loop below wait for it to settle before
-    //    we capture. Otherwise we'd save the new split with the OLD (too-small) image, and the image
-    //    would only get corrected later when a user opened the page in the Edit tab.
+    //    we capture. Otherwise we'd save the new split with the OLD (wrongly-sized) image, and the
+    //    image would only get corrected later when a user opened the page in the Edit tab.
     // Never throws out: a failure to fit must not block capturing/saving the page.
     if (fitImageTextSplits) {
         try {

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -1561,9 +1561,11 @@ export function captureContentForExternalProcessing(
 ): void {
     window.__bloomExternalPageContent = undefined;
 
-    // Optionally auto-fit simple single-image/single-text origami pages so the fitted split persists
-    // into the saved HTML. This currently handles both image-above-text and image-left-of-text when
-    // the image is in the first pane. We do this UP FRONT, before the delay-wait below, for two reasons:
+    // Optionally auto-fit image/text origami pages so the fitted split persists into the saved HTML.
+    // This handles two-pane image-above-text and image-left-of-text (image in the first pane), plus
+    // top-to-bottom STACKS of three or more panes holding one illustration and text in the rest —
+    // text above / picture / text below and the like.
+    // We do this UP FRONT, before the delay-wait below, for two reasons:
     //  - It must run on the fully settled, real browser layout (which it now is: bootstrap() and the
     //    load-time fix-ups have run before C# calls us).
     //  - Resizing the image pane means the background image must be re-fit to the new pane size. That

--- a/src/BloomExe/Book/BookProcessor.cs
+++ b/src/BloomExe/Book/BookProcessor.cs
@@ -43,13 +43,15 @@ namespace Bloom.Book
         /// the WebView2 it drives lives on the OffScreenBrowser's own dedicated thread, and this method just
         /// blocks on it. The book, however, must not be touched by another thread while we process it.
         ///
-        /// When <paramref name="fitImageTextSplits"/> is true, simple two-pane origami pages with a
-        /// single illustration in the first pane and a single text block in the second pane have their
-        /// split auto-fit. This currently covers both image-above-text and image-left-of-text layouts.
-        /// The image pane is grown (and the text pane shrunk) as far as it can without making the text
-        /// overflow, but no further than the image filling the relevant page dimension. This uses the
-        /// real off-screen browser layout (no font/text estimation); see fitImageOverTextSplits() in
-        /// bloomEditing.ts.
+        /// When <paramref name="fitImageTextSplits"/> is true, origami image/text pages have their
+        /// split auto-fit: two-pane pages with one illustration in the first pane and one text block in
+        /// the second (both image-above-text and image-left-of-text), plus top-to-bottom stacks of
+        /// three or more panes holding one illustration and text in the rest -- text above / picture /
+        /// text below and the like. Each divider moves to the size the content actually calls for, in
+        /// either direction, but never so far that text overflows, and never past the point where the
+        /// illustration already fills the relevant page dimension (beyond which a bigger pane is only
+        /// whitespace). This uses the real off-screen browser layout (no font/text estimation); see
+        /// fitImageOverTextSplits() in bloomEditing.ts.
         /// </summary>
         public static int ProcessBook(Book book, bool fitImageTextSplits = false)
         {


### PR DESCRIPTION
Auto-fit of image/text origami splits gets two related improvements. Both are about the same
governing rules: never leave text overflowing, never waste space to no one's benefit, and always
measure the real browser layout rather than estimating font sizes.

### 1. Let auto-fit shrink the image pane, not just grow it (`7bea4c7`)

`fitImageOverTextSplitOnPage()` computed the right split and then discarded it whenever applying it
would make the image pane smaller. On a page whose illustration is wider than 4:3 the image pane is
bigger than the picture needs, the surplus is dead space, and the text below gets clipped — even
though the page has room to spare. Replaced the one-way ratchet with a small deadband so the divider
moves whenever it is worth moving in either direction.

### 2. Handle nested text/image/text stacks (`e455270`)

The function bailed on any nested split (`// nested split: too complex, skip`), which excluded one of
the most common page shapes there is: **text above, an illustration, text below**.

Nothing ever chose those dividers on purpose. An importer emits the shape as a right-nested chain of
horizontal splits, and with no explicit percentages Bloom's 50/50-per-split CSS default cascades into
an effective **50/25/25** — so the top text block gets half the page for its one line, the
illustration is squeezed into a quarter, and the last (usually longest) block is clipped.

**What makes a top/bottom stack tractable** is that every pane in it has the same *width*, so a text
block's required height doesn't depend on where any divider sits. Each text pane can therefore be
measured on its own — give it a size, ask `OverflowChecker` whether it overflows, binary-search the
boundary — and the answers add up. The illustration takes what the text doesn't need, capped at the
size where it already fills the width; the surplus past that goes back to the text panes in
proportion to what each needed.

Left/right stacks are deliberately excluded: there the panes have different widths, so they aren't
independent and the one-at-a-time measurement doesn't hold.

Still declined, as before: a split inside a *first* pane, mixed axes, a second pane holding a split
alongside other content, a pane that isn't cleanly just-a-picture or just-text, an illustration
carrying overlays, more than one illustration, and genuinely over-full pages (text that overflows
even with nearly the whole page, or blocks that together need more than the page has).

## Measured result

`FUV_Taale_Taale_Fulbe` (Fulfulde, Nigeria; A5Portrait, marginBox 469x703), where **9 of the 11
content pages** are this shape. Every one sat at 351.5/175.75/175.75 px, and 9 pages had text
overflowing. Afterwards **none** do.

| page | before | after |
| --- | --- | --- |
| 5 | 352 / 176 / 176 (clipped) | 103 / 334 / 266 |
| 8 | 352 / 176 / 176 (clipped) | 154 / 325 / 224 |
| 9 | 352 (clipped) / 176 / 176 | 490 / 152 / 62 |
| 11 | 352 / 176 / 176 (clipped) | 238 / 101 / 364 |
| 14 | 352 / 176 / 176 (clipped) | 87 / 397 / 219 |

Page 15 is text/text with no illustration, so it is out of scope and correctly left untouched (it is
genuinely over-full).

## Testing

`autoFitImageOverTextSplitsSpec.ts` covers shape recognition and the nested percentage arithmetic —
including that unset splits read as 50/25/25 rather than thirds, which is the bug captured as an
assertion.

The measuring itself needs real geometry, which jsdom does not provide (`OverflowSpec` is skipped
there for the same reason). That half was verified by loading the real saved book, with its real
Bloom CSS, in Chromium and running `fitImageOverTextSplits()` against it — that is where the numbers
above come from.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16627

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8129)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8129)
<!-- Reviewable:end -->
