### PR TITLE
Size spreadsheet image rows from the embedded thumbnail (BL-16529)

### DIFF
--- a/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
@@ -229,6 +229,12 @@ namespace Bloom.Spreadsheet
                                 )
                             )
                             {
+                                // ResizeImageIfNecessary never enlarges an image, so when the source
+                                // is smaller than the (DPI-scaled) target the thumbnail is embedded at
+                                // its original, smaller size. Size the row from the thumbnail we actually
+                                // embedded, not from the requested finalHeight; otherwise small images
+                                // get a row that is much too tall. See BL-16529.
+                                finalHeight = thumbnail.Height;
                                 using (var ms = new MemoryStream())
                                 {
                                     thumbnail.Save(ms, ImageFormat.Jpeg);

--- a/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
@@ -229,12 +229,16 @@ namespace Bloom.Spreadsheet
                                 )
                             )
                             {
-                                // ResizeImageIfNecessary never enlarges an image, so when the source
-                                // is smaller than the (DPI-scaled) target the thumbnail is embedded at
-                                // its original, smaller size. Size the row from the thumbnail we actually
-                                // embedded, not from the requested finalHeight; otherwise small images
-                                // get a row that is much too tall. See BL-16529.
-                                finalHeight = thumbnail.Height;
+                                // Size the row from the thumbnail we actually embedded (which, since
+                                // ResizeImageIfNecessary never enlarges, may be smaller than the target
+                                // computed above), not from that target. The row's height is in points,
+                                // which the spreadsheet viewer does NOT scale for a high-DPI display even
+                                // though it scales the columns; so at >100% we divide the height back down
+                                // by the same factor so the displayed row matches the image. See BL-16529.
+                                if (scaleFactor > 100)
+                                    finalHeight = thumbnail.Height * 100 / scaleFactor;
+                                else
+                                    finalHeight = thumbnail.Height;
                                 using (var ms = new MemoryStream())
                                 {
                                     thumbnail.Save(ms, ImageFormat.Jpeg);

--- a/src/BloomTests/Spreadsheet/SpreadsheetImagesTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetImagesTests.cs
@@ -679,13 +679,19 @@ namespace BloomTests.Spreadsheet
 
         /// <summary>
         /// Regression test for BL-16529 (image cells too high). ResizeImageIfNecessary never
-        /// enlarges an image, so a source smaller than the (possibly DPI-scaled) thumbnail target
-        /// is embedded at its original size. The row height must be sized from the image we actually
-        /// embed, not from the larger target width; otherwise small images get a row that is much
-        /// too tall. This invariant holds regardless of the exporting machine's display scaling.
+        /// enlarges an image, so a source smaller than the (possibly DPI-scaled) thumbnail target is
+        /// embedded at its original size. The row must be sized from the thumbnail we actually embed,
+        /// not from the larger target; otherwise small images get a row that is much too tall.
+        ///
+        /// Note we assert only an upper bound (the row is not sized from the oversized target), not a
+        /// lower bound: the row height is in points, which the spreadsheet viewer does not scale for a
+        /// high-DPI display even though it scales the columns, so on a >100% display the exporter
+        /// deliberately makes the row's nominal height *smaller* than the embedded image (it is scaled
+        /// back up when displayed). A "row must be at least as tall as the image" assertion would be
+        /// wrong there. The upper bound holds regardless of the exporting machine's display scaling.
         /// </summary>
         [Test]
-        public void Export_SmallImage_RowNotTallerThanEmbeddedImage()
+        public void Export_SmallImage_RowNotSizedFromOversizedTarget()
         {
             using (var bookFolder = new TemporaryFolder("SmallImageRowHeight_Book"))
             using (var outputFolder = new TemporaryFolder("SmallImageRowHeight_Out"))
@@ -734,25 +740,29 @@ namespace BloomTests.Spreadsheet
                     // The image is anchored in the row where the exporter placed it (0-based From.Row).
                     var imageRow = worksheet.Row(picture.From.Row + 1);
 
-                    // Row height is in points; convert to pixels (72 points/inch, 96 px/inch). The
-                    // exporter adds a few pixels so the image isn't flush against the row edge.
+                    // Row height is in points; convert to its nominal pixels (72 points/inch,
+                    // 96 px/inch). The exporter adds a few pixels so the image isn't flush against the
+                    // row edge.
                     const double pointsToPixels = 96.0 / 72.0;
                     var rowHeightPx = imageRow.Height * pointsToPixels;
 
-                    // Sanity check: the row must be at least tall enough to show the whole image.
+                    // Sanity check: the row is a real, non-trivial height (it was actually set).
                     Assert.That(
                         rowHeightPx,
-                        Is.GreaterThanOrEqualTo(sourceImageHeightPx),
-                        "The row should be tall enough to display the embedded image."
+                        Is.GreaterThan(30),
+                        "The image row should have been given a real height."
                     );
-                    // The actual regression check: the row must not be dramatically taller than the
-                    // image it contains. Before the fix the row was sized from the (up to DPI-scaled)
-                    // target width, making it far taller than the small image embedded in it.
+                    // The regression check: the row must be sized from the embedded thumbnail, not the
+                    // oversized target. The un-enlarged thumbnail is the source image's height, so the
+                    // row's nominal height must not exceed that (plus a few px of padding). Before the
+                    // fix the row was sized from finalWidth*aspect (e.g. 150*154/118 = 195px for this
+                    // 118x154 image), far taller than the 154px image actually embedded.
                     Assert.That(
                         rowHeightPx,
                         Is.LessThanOrEqualTo(sourceImageHeightPx + 15),
-                        $"Row height ({rowHeightPx:0}px) is much taller than the embedded image "
-                            + $"({sourceImageHeightPx}px); small image rows should not be over-sized (BL-16529)."
+                        $"Row height ({rowHeightPx:0}px) is taller than the embedded image "
+                            + $"({sourceImageHeightPx}px), so it was sized from the oversized target "
+                            + "rather than the image actually embedded (BL-16529)."
                     );
                 }
             }

--- a/src/BloomTests/Spreadsheet/SpreadsheetImagesTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetImagesTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using Bloom;
@@ -8,6 +9,8 @@ using BloomTemp;
 using BloomTests.TeamCollection;
 using Moq;
 using NUnit.Framework;
+using OfficeOpenXml;
+using OfficeOpenXml.Drawing;
 using SIL.IO;
 
 namespace BloomTests.Spreadsheet
@@ -650,6 +653,108 @@ namespace BloomTests.Spreadsheet
                     Is.Empty,
                     "Exporting images with conflicting names should not report any warnings."
                 );
+            }
+        }
+
+        // A minimal book with a single small image (smaller than the thumbnail target width).
+        private const string smallImageBook =
+            @"
+<html><head></head>
+<body data-l1=""en"" data-l2="""" data-l3="""">
+    <div id=""bloomDataDiv""></div>
+    <div class=""bloom-page numberedPage customPage bloom-combinedPage A5Portrait side-right bloom-monolingual"" data-page="""" id=""aaaaaaaa-1111-1111-1111-111111111111"" data-page-number=""1"" lang="""">
+        <div class=""pageLabel"" lang=""en"">Image</div>
+        <div class=""pageDescription"" lang=""en""></div>
+        <div class=""marginBox"">
+            <div class=""bloom-canvas bloom-leadingElement bloom-has-canvas-element"">
+                <div class=""bloom-canvas-element bloom-backgroundImage"" style=""width: 100px; height: 100px"">
+                    <div class=""bloom-imageContainer"">
+                        <img src=""man.jpg"" alt="""" data-copyright="""" data-creator="""" data-license=""""></img>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</body></html>";
+
+        /// <summary>
+        /// Regression test for BL-16529 (image cells too high). ResizeImageIfNecessary never
+        /// enlarges an image, so a source smaller than the (possibly DPI-scaled) thumbnail target
+        /// is embedded at its original size. The row height must be sized from the image we actually
+        /// embed, not from the larger target width; otherwise small images get a row that is much
+        /// too tall. This invariant holds regardless of the exporting machine's display scaling.
+        /// </summary>
+        [Test]
+        public void Export_SmallImage_RowNotTallerThanEmbeddedImage()
+        {
+            using (var bookFolder = new TemporaryFolder("SmallImageRowHeight_Book"))
+            using (var outputFolder = new TemporaryFolder("SmallImageRowHeight_Out"))
+            {
+                var sourceImage = Path.Combine(
+                    SIL.IO.FileLocationUtilities.GetDirectoryDistributedWithApplication(
+                        _pathToTestImages
+                    ),
+                    "man.jpg"
+                );
+                RobustFile.Copy(sourceImage, Path.Combine(bookFolder.FolderPath, "man.jpg"));
+
+                int sourceImageHeightPx;
+                using (var img = Image.FromFile(sourceImage))
+                {
+                    // Sanity check: this test only exercises the bug if the source is small enough
+                    // that the exporter won't enlarge it (source width < the 150px thumbnail target).
+                    Assert.That(
+                        img.Width,
+                        Is.LessThan(150),
+                        "Setup sanity check: the test image must be narrower than the thumbnail target "
+                            + "so that it is embedded at its original (un-enlarged) size."
+                    );
+                    sourceImageHeightPx = img.Height;
+                }
+
+                var mockLangDisplayNameResolver = new Mock<ILanguageDisplayNameResolver>();
+                mockLangDisplayNameResolver
+                    .Setup(x => x.GetLanguageDisplayName("en"))
+                    .Returns("English");
+                var exporter = new SpreadsheetExporter(mockLangDisplayNameResolver.Object);
+
+                exporter.ExportToFolder(
+                    new HtmlDom(smallImageBook, true),
+                    bookFolder.FolderPath,
+                    outputFolder.FolderPath,
+                    out string outputPath,
+                    new ProgressSpy(),
+                    OverwriteOptions.Overwrite
+                );
+
+                using (var package = new ExcelPackage(new FileInfo(outputPath)))
+                {
+                    var worksheet = package.Workbook.Worksheets[0];
+                    var picture = worksheet.Drawings.OfType<ExcelPicture>().Single();
+                    // The image is anchored in the row where the exporter placed it (0-based From.Row).
+                    var imageRow = worksheet.Row(picture.From.Row + 1);
+
+                    // Row height is in points; convert to pixels (72 points/inch, 96 px/inch). The
+                    // exporter adds a few pixels so the image isn't flush against the row edge.
+                    const double pointsToPixels = 96.0 / 72.0;
+                    var rowHeightPx = imageRow.Height * pointsToPixels;
+
+                    // Sanity check: the row must be at least tall enough to show the whole image.
+                    Assert.That(
+                        rowHeightPx,
+                        Is.GreaterThanOrEqualTo(sourceImageHeightPx),
+                        "The row should be tall enough to display the embedded image."
+                    );
+                    // The actual regression check: the row must not be dramatically taller than the
+                    // image it contains. Before the fix the row was sized from the (up to DPI-scaled)
+                    // target width, making it far taller than the small image embedded in it.
+                    Assert.That(
+                        rowHeightPx,
+                        Is.LessThanOrEqualTo(sourceImageHeightPx + 15),
+                        $"Row height ({rowHeightPx:0}px) is much taller than the embedded image "
+                            + $"({sourceImageHeightPx}px); small image rows should not be over-sized (BL-16529)."
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
## Problem

Follow-on to the BL-16529 DPI-width fix. After that fix, spreadsheet-export **image rows came out too tall** for small images.

The exporter sized each image row from the *requested* thumbnail target (`finalWidth = defaultImageWidth`, scaled up by the monitor DPI factor, and `finalHeight` derived from it). But `ImageUtils.ResizeImageIfNecessary` never enlarges an image, so a source smaller than that target is embedded at its original, smaller size — while the row stayed sized for the larger target, leaving dead vertical space.

## Fix

Two parts, both anchored to the **actually-embedded thumbnail** rather than the requested target:

- **Size the row from the embedded thumbnail height**, not the target (which the resizer never enlarges up to for a small source).
- **Divide that height back down by the DPI scale factor when `scaleFactor > 100`.** The spreadsheet viewer scales columns *and rows* up for a high-DPI display but draws the embedded image at its absolute pixel size, so the row (whose height is in points) must be scaled down so the *displayed* row matches the image — the vertical counterpart of the width scaling that fixed the original too-narrow bug. At 100% the `else` branch sizes the row straight from the thumbnail height (without it, `finalHeight` would keep the oversized target, e.g. 195px for the 118×154 image, and 100% displays would still be too tall).

## Verification

Confirmed by exporting and reading the raw `.xlsx` on a **125%-scaled** machine (nominal = the row height stored in the file; displayed ≈ nominal × 1.25, which is what the viewer draws):

| Source image | Embedded image | Row height before | Row height after (nominal → displayed) |
|---|---|---|---|
| 118×154px (small) | 154px | 199–248px | 127px → ~159px ✓ (matches image) |
| same @300dpi | 154px | 199–248px | 127px → ~159px ✓ (source DPI irrelevant) |
| 199px → down-scaled to 187 | 187px | 191px | 152px → ~190px ✓ (matches image) |

Regression test `Export_SmallImage_RowNotSizedFromOversizedTarget` asserts (scale-independently) that the row is sized from the embedded thumbnail, not the oversized target. Full Spreadsheet suite green (385/385).

> Note: because the exporter reads the primary monitor's scale factor at runtime, the test's un-enlarge/100% branch is only exercised as a true regression catch on a 100%-scaled machine; on a >100% machine the divide branch runs instead. Both branches are covered by the arithmetic in the fix; the test guards the shared upper-bound invariant at any scale.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16529


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8130)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8130)
<!-- Reviewable:end -->
