### PR TITLE
Leveled Reader: restore orange for over-limit stats (BL-16408)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.spec.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.spec.tsx
@@ -11,6 +11,10 @@ import { LeveledReaderStats } from "./LeveledReaderToolControls";
 const kMaxWordsPerSentence = 10;
 const kMaxGlyphsPerWord = 5;
 const kMaxAverageWordsPerSentence = 9;
+// A second level, used to check that the limits are re-read when the level changes.
+// Its glyph limit is high enough that the statistic that is too large for level 1
+// is acceptable here.
+const kLevel2MaxGlyphsPerWord = 20;
 
 const bookStats = {
     levelNumber: 1,
@@ -91,6 +95,10 @@ describe("LeveledReaderStats", () => {
                     maxWordsPerSentence: kMaxWordsPerSentence,
                     maxGlyphsPerWord: kMaxGlyphsPerWord,
                     maxAverageWordsPerSentence: kMaxAverageWordsPerSentence,
+                    thingsToRemember: [""],
+                },
+                {
+                    maxGlyphsPerWord: kLevel2MaxGlyphsPerWord,
                     thingsToRemember: [""],
                 },
             ],
@@ -180,5 +188,26 @@ describe("LeveledReaderStats", () => {
         expect(
             getRow(container, "ThisPage", "PerPage").maxCell.textContent,
         ).toBe("");
+    });
+
+    it("re-reads the level's limits when the level changes", () => {
+        // The conversion dropped the tests that covered this, and the whole fix
+        // depends on the limits being current whenever we render.
+        const atLevel1 = getRow(container, "WordLengths", "MaxInBook");
+        expect(atLevel1.actualCell.classList).toContain("tooLarge");
+
+        getTheOneReaderToolsModel().setLevelNumber(2, true);
+        act(() => {
+            renderRoot(<LeveledReaderStats bookStats={bookStats} />, container);
+        });
+
+        // 6 is within level 2's much larger glyph limit, so it is no longer flagged.
+        const atLevel2 = getRow(container, "WordLengths", "MaxInBook");
+        expect(atLevel2.actualCell.textContent).toBe("6");
+        expect(atLevel2.actualCell.classList).toContain("acceptable");
+        // "this page" displays the new level's limit.
+        expect(
+            getRow(container, "WordLengths", "ThisPageLC").maxCell.textContent,
+        ).toBe(`${kLevel2MaxGlyphsPerWord}`);
     });
 });

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.spec.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.spec.tsx
@@ -6,69 +6,74 @@ import { getTheOneReaderToolsModel } from "../readerToolsModel";
 import ReadersSynphonyWrapper from "../ReadersSynphonyWrapper";
 import { LeveledReaderStats } from "./LeveledReaderToolControls";
 
-// The level we test against. Deliberately leaves most limits unset (0 = "this
-// level does not limit that statistic") so that we also cover the "no limit"
-// case, and so that the two statistics under test have limits that the book
-// stats below exceed.
+// The level we test against. It deliberately leaves most limits unset (0 means
+// "this level does not limit that statistic") so we also cover the no-limit case.
 const kMaxWordsPerSentence = 10;
 const kMaxGlyphsPerWord = 5;
 const kMaxAverageWordsPerSentence = 9;
 
-// Each value is unique so a cell can be located by its text.
 const bookStats = {
     levelNumber: 1,
     pageCount: 1,
-    actualWordsPerPage: 1,
+    actualWordsPerPage: 12, // no limit for this level
     actualWordsPerSentence: 2,
     actualWordCount: 3,
     actualWordsPerPageBook: 4,
     actualUniqueWords: 5,
     actualSentencesPerPage: 8,
     actualSentenceCount: 12,
-    actualLettersPerWord: 4.5, // reported as an integer elsewhere; kept distinct here
-    // Over kMaxWordsPerSentence: "This Book / longest sentence" must be orange (BL-16408).
+    actualLettersPerWord: 4, // under kMaxGlyphsPerWord
+    // Over kMaxWordsPerSentence: "This Book / longest sentence" (BL-16408).
     actualMaxWordsPerSentence: 16,
-    // Over kMaxGlyphsPerWord: "Word Lengths / max in book" must be orange (BL-16628).
+    // Over kMaxGlyphsPerWord: "Word Lengths / max in book" (BL-16628).
     actualMaxGlyphsPerWord: 6,
-    // Rounds to "9.0" but is really over kMaxAverageWordsPerSentence, so orange.
+    // Rounds to "9.0" but is really over kMaxAverageWordsPerSentence.
     actualAverageWordsPerSentence: 9.04,
     actualAverageWordsPerPage: 7,
     actualAverageGlyphsPerWord: 2.2,
     actualAverageSentencesPerPage: 1.5,
 };
 
-// Find the single element whose own text is exactly the given string. Used to
-// locate a stats cell by the number it displays.
-function getCellShowing(container: HTMLElement, text: string): HTMLElement {
-    const matches = Array.from(container.querySelectorAll("div")).filter(
-        (div) => div.textContent?.trim() === text,
-    );
-    if (matches.length !== 1) {
-        fail(
-            `Expected exactly one cell showing "${text}", found ${matches.length}. The test data may no longer be unique.`,
-        );
-    }
-    return matches[0] as HTMLElement;
-}
+// Row labels and section headers are localized, and in tests the localization
+// manager is mocked, so each renders as its l10n key. That makes the key the
+// most precise way to find a row.
+const kKeyPrefix = "EditTab.Toolbox.LeveledReaderTool.";
 
-// Emotion puts each css block in a class of its own, so we read the color out of
-// the stylesheet rule for the cell's class rather than from an inline style.
-function getColorOf(cell: HTMLElement): string {
-    const allCss = Array.from(document.querySelectorAll("style"))
-        .map((style) => style.textContent ?? "")
-        .join("\n");
-    for (const className of Array.from(cell.classList)) {
-        const rule = new RegExp(`\\.${className}\\s*\\{([^}]*)\\}`).exec(
-            allCss,
-        );
-        const color = rule && /color:\s*([^;}]+)/.exec(rule[1]);
-        if (color) {
-            return color[1].trim();
-        }
-    }
-    fail(
-        `Found no color rule for cell "${cell.textContent}" (classes: ${cell.className}).`,
+// Each stats grid lays its cells out as a flat list of children: one or two
+// section headers, then the Max/Actual header row, then three cells per
+// statistic (label, max, actual). Find a row by its label and return the other
+// two cells of that row.
+function getRow(
+    container: HTMLElement,
+    sectionHeaderKeySuffix: string,
+    rowLabelKeySuffix: string,
+): { maxCell: HTMLElement; actualCell: HTMLElement } {
+    const grids = Array.from(container.firstElementChild!.children);
+    const grid = grids.find((g) =>
+        // Only the leading children are section headers; a row label never is.
+        Array.from(g.children)
+            .slice(0, 2)
+            .some(
+                (child) =>
+                    child.textContent === kKeyPrefix + sectionHeaderKeySuffix,
+            ),
     );
+    if (!grid) {
+        fail(`Found no stats grid headed "${sectionHeaderKeySuffix}".`);
+    }
+    const cells = Array.from(grid.children);
+    const labelIndex = cells.findIndex(
+        (cell) => cell.textContent === kKeyPrefix + rowLabelKeySuffix,
+    );
+    if (labelIndex < 0) {
+        fail(
+            `Found no "${rowLabelKeySuffix}" row in the "${sectionHeaderKeySuffix}" grid.`,
+        );
+    }
+    return {
+        maxCell: cells[labelIndex + 1] as HTMLElement,
+        actualCell: cells[labelIndex + 2] as HTMLElement,
+    };
 }
 
 describe("LeveledReaderStats", () => {
@@ -95,8 +100,8 @@ describe("LeveledReaderStats", () => {
         api.loadSettings(settings);
         getTheOneReaderToolsModel().setLevelNumber(1, true);
 
-        // Sanity check: without these limits the color assertions below would
-        // pass for the wrong reason.
+        // Sanity check: without these limits the assertions below would pass for
+        // the wrong reason.
         expect(
             getTheOneReaderToolsModel().maxWordsPerSentenceOnThisPage(),
         ).toBe(kMaxWordsPerSentence);
@@ -116,43 +121,64 @@ describe("LeveledReaderStats", () => {
         container.remove();
     });
 
-    it("shows a statistic that is over the level's limit in orange", () => {
-        // "This Book / longest sentence" and "Word Lengths / max in book" both
-        // exceed a limit of the current level. They regressed to green in the
-        // React conversion because their limit was hardcoded to 0 (BL-16408).
-        expect(getColorOf(getCellShowing(container, "16"))).toBe("orange");
-        expect(getColorOf(getCellShowing(container, "6"))).toBe("orange");
-    });
-
-    it("shows a statistic that is within the level's limit in lightgreen", () => {
-        // "Word Lengths / this page" shares max in book's limit and is under it.
-        expect(getColorOf(getCellShowing(container, "4.5"))).toBe("lightgreen");
-    });
-
-    it("shows a statistic with no limit for this level in lightgreen", () => {
-        // Nothing limits words per page in this level, so no value is too large.
-        expect(getColorOf(getCellShowing(container, "1"))).toBe("lightgreen");
-    });
-
-    it("leaves the Max cell blank for the two rows that share the limit above them", () => {
-        // Pre-React behavior we are keeping: the limit is used for coloring but
-        // not displayed on these rows, so it appears exactly once per grid.
-        const maxCellsShowingTheSentenceLimit = Array.from(
-            container.querySelectorAll("div"),
-        ).filter(
-            (div) => div.textContent?.trim() === `${kMaxWordsPerSentence}`,
+    it("marks a statistic that is over the level's limit as too large", () => {
+        // These two rows regressed to "acceptable" in the React conversion
+        // because their limit was hardcoded to 0 (BL-16408, BL-16628).
+        const longestSentence = getRow(
+            container,
+            "ThisBook",
+            "MaxSentenceLength",
         );
-        expect(maxCellsShowingTheSentenceLimit.length).toBe(1);
-        const maxCellsShowingTheGlyphLimit = Array.from(
-            container.querySelectorAll("div"),
-        ).filter((div) => div.textContent?.trim() === `${kMaxGlyphsPerWord}`);
-        // kMaxGlyphsPerWord is also the value of actualUniqueWords, so the Max
-        // cell of "Word Lengths / this page" plus that one actual value = 2.
-        expect(maxCellsShowingTheGlyphLimit.length).toBe(2);
+        expect(longestSentence.actualCell.textContent).toBe("16");
+        expect(longestSentence.actualCell.classList).toContain("tooLarge");
+
+        const maxInBook = getRow(container, "WordLengths", "MaxInBook");
+        expect(maxInBook.actualCell.textContent).toBe("6");
+        expect(maxInBook.actualCell.classList).toContain("tooLarge");
+    });
+
+    it("marks a statistic that is within the level's limit as acceptable", () => {
+        // "Word Lengths / this page" shares max in book's limit and is under it.
+        const thisPage = getRow(container, "WordLengths", "ThisPageLC");
+        expect(thisPage.actualCell.textContent).toBe("4");
+        expect(thisPage.actualCell.classList).toContain("acceptable");
+    });
+
+    it("marks a statistic with no limit for this level as acceptable", () => {
+        // Nothing limits words per page in this level, so no value is too large.
+        const perPage = getRow(container, "ThisPage", "PerPage");
+        expect(perPage.actualCell.textContent).toBe("12");
+        expect(perPage.actualCell.classList).toContain("acceptable");
+    });
+
+    it("shows the level's limit in the Max cell, except on the two rows that share the limit above them", () => {
+        // Pre-React behavior we are keeping: on these two rows the limit decides
+        // the color but is not displayed, because the row above already shows it.
+        expect(
+            getRow(container, "WordLengths", "ThisPageLC").maxCell.textContent,
+        ).toBe(`${kMaxGlyphsPerWord}`);
+        expect(
+            getRow(container, "WordLengths", "MaxInBook").maxCell.textContent,
+        ).toBe("");
+        expect(
+            getRow(container, "ThisPage", "PerSentence").maxCell.textContent,
+        ).toBe(`${kMaxWordsPerSentence}`);
+        expect(
+            getRow(container, "ThisBook", "MaxSentenceLength").maxCell
+                .textContent,
+        ).toBe("");
     });
 
     it("compares averages at full precision, not as displayed", () => {
         // 9.04 displays as "9.0" but is over the level's average limit of 9.
-        expect(getColorOf(getCellShowing(container, "9.0"))).toBe("orange");
+        const average = getRow(container, "ThisBook", "Average");
+        expect(average.actualCell.textContent).toBe("9.0");
+        expect(average.actualCell.classList).toContain("tooLarge");
+    });
+
+    it("leaves the Max cell blank when this level has no limit for a statistic", () => {
+        expect(
+            getRow(container, "ThisPage", "PerPage").maxCell.textContent,
+        ).toBe("");
     });
 });

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.spec.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.spec.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { renderRoot, unmountRoot } from "../../../../utils/reactRender";
+import { ResetLanguageDataInstance } from "../libSynphony/synphony_lib";
+import { getTheOneReaderToolsModel } from "../readerToolsModel";
+import ReadersSynphonyWrapper from "../ReadersSynphonyWrapper";
+import { LeveledReaderStats } from "./LeveledReaderToolControls";
+
+// The level we test against. Deliberately leaves most limits unset (0 = "this
+// level does not limit that statistic") so that we also cover the "no limit"
+// case, and so that the two statistics under test have limits that the book
+// stats below exceed.
+const kMaxWordsPerSentence = 10;
+const kMaxGlyphsPerWord = 5;
+const kMaxAverageWordsPerSentence = 9;
+
+// Each value is unique so a cell can be located by its text.
+const bookStats = {
+    levelNumber: 1,
+    pageCount: 1,
+    actualWordsPerPage: 1,
+    actualWordsPerSentence: 2,
+    actualWordCount: 3,
+    actualWordsPerPageBook: 4,
+    actualUniqueWords: 5,
+    actualSentencesPerPage: 8,
+    actualSentenceCount: 12,
+    actualLettersPerWord: 4.5, // reported as an integer elsewhere; kept distinct here
+    // Over kMaxWordsPerSentence: "This Book / longest sentence" must be orange (BL-16408).
+    actualMaxWordsPerSentence: 16,
+    // Over kMaxGlyphsPerWord: "Word Lengths / max in book" must be orange (BL-16628).
+    actualMaxGlyphsPerWord: 6,
+    // Rounds to "9.0" but is really over kMaxAverageWordsPerSentence, so orange.
+    actualAverageWordsPerSentence: 9.04,
+    actualAverageWordsPerPage: 7,
+    actualAverageGlyphsPerWord: 2.2,
+    actualAverageSentencesPerPage: 1.5,
+};
+
+// Find the single element whose own text is exactly the given string. Used to
+// locate a stats cell by the number it displays.
+function getCellShowing(container: HTMLElement, text: string): HTMLElement {
+    const matches = Array.from(container.querySelectorAll("div")).filter(
+        (div) => div.textContent?.trim() === text,
+    );
+    if (matches.length !== 1) {
+        fail(
+            `Expected exactly one cell showing "${text}", found ${matches.length}. The test data may no longer be unique.`,
+        );
+    }
+    return matches[0] as HTMLElement;
+}
+
+// Emotion puts each css block in a class of its own, so we read the color out of
+// the stylesheet rule for the cell's class rather than from an inline style.
+function getColorOf(cell: HTMLElement): string {
+    const allCss = Array.from(document.querySelectorAll("style"))
+        .map((style) => style.textContent ?? "")
+        .join("\n");
+    for (const className of Array.from(cell.classList)) {
+        const rule = new RegExp(`\\.${className}\\s*\\{([^}]*)\\}`).exec(
+            allCss,
+        );
+        const color = rule && /color:\s*([^;}]+)/.exec(rule[1]);
+        if (color) {
+            return color[1].trim();
+        }
+    }
+    fail(
+        `Found no color rule for cell "${cell.textContent}" (classes: ${cell.className}).`,
+    );
+}
+
+describe("LeveledReaderStats", () => {
+    let container: HTMLDivElement;
+
+    beforeEach(() => {
+        ResetLanguageDataInstance();
+        getTheOneReaderToolsModel().clearForTest();
+
+        const settings: any = {
+            letters: "a b c d e f g h i j k l m n o p q r s t u v w x y z",
+            stages: [],
+            levels: [
+                {
+                    maxWordsPerSentence: kMaxWordsPerSentence,
+                    maxGlyphsPerWord: kMaxGlyphsPerWord,
+                    maxAverageWordsPerSentence: kMaxAverageWordsPerSentence,
+                    thingsToRemember: [""],
+                },
+            ],
+        };
+        const api = new ReadersSynphonyWrapper();
+        getTheOneReaderToolsModel().synphony = api;
+        api.loadSettings(settings);
+        getTheOneReaderToolsModel().setLevelNumber(1, true);
+
+        // Sanity check: without these limits the color assertions below would
+        // pass for the wrong reason.
+        expect(
+            getTheOneReaderToolsModel().maxWordsPerSentenceOnThisPage(),
+        ).toBe(kMaxWordsPerSentence);
+        expect(getTheOneReaderToolsModel().maxGlyphsPerWord()).toBe(
+            kMaxGlyphsPerWord,
+        );
+
+        container = document.createElement("div");
+        document.body.appendChild(container);
+        act(() => {
+            renderRoot(<LeveledReaderStats bookStats={bookStats} />, container);
+        });
+    });
+
+    afterEach(() => {
+        unmountRoot(container);
+        container.remove();
+    });
+
+    it("shows a statistic that is over the level's limit in orange", () => {
+        // "This Book / longest sentence" and "Word Lengths / max in book" both
+        // exceed a limit of the current level. They regressed to green in the
+        // React conversion because their limit was hardcoded to 0 (BL-16408).
+        expect(getColorOf(getCellShowing(container, "16"))).toBe("orange");
+        expect(getColorOf(getCellShowing(container, "6"))).toBe("orange");
+    });
+
+    it("shows a statistic that is within the level's limit in lightgreen", () => {
+        // "Word Lengths / this page" shares max in book's limit and is under it.
+        expect(getColorOf(getCellShowing(container, "4.5"))).toBe("lightgreen");
+    });
+
+    it("shows a statistic with no limit for this level in lightgreen", () => {
+        // Nothing limits words per page in this level, so no value is too large.
+        expect(getColorOf(getCellShowing(container, "1"))).toBe("lightgreen");
+    });
+
+    it("leaves the Max cell blank for the two rows that share the limit above them", () => {
+        // Pre-React behavior we are keeping: the limit is used for coloring but
+        // not displayed on these rows, so it appears exactly once per grid.
+        const maxCellsShowingTheSentenceLimit = Array.from(
+            container.querySelectorAll("div"),
+        ).filter(
+            (div) => div.textContent?.trim() === `${kMaxWordsPerSentence}`,
+        );
+        expect(maxCellsShowingTheSentenceLimit.length).toBe(1);
+        const maxCellsShowingTheGlyphLimit = Array.from(
+            container.querySelectorAll("div"),
+        ).filter((div) => div.textContent?.trim() === `${kMaxGlyphsPerWord}`);
+        // kMaxGlyphsPerWord is also the value of actualUniqueWords, so the Max
+        // cell of "Word Lengths / this page" plus that one actual value = 2.
+        expect(maxCellsShowingTheGlyphLimit.length).toBe(2);
+    });
+
+    it("compares averages at full precision, not as displayed", () => {
+        // 9.04 displays as "9.0" but is over the level's average limit of 9.
+        expect(getColorOf(getCellShowing(container, "9.0"))).toBe("orange");
+    });
+});

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.tsx
@@ -55,7 +55,17 @@ const MaxActualRow: FunctionComponent = () => {
 const StatsRow: FunctionComponent<{
     l10nKeySuffix: string;
     maxNum: number;
-    actualNum: number | string;
+    actualNum: number;
+    // When true, the Max cell is left blank, but maxNum is still used to decide
+    // whether the actual value is over the limit (and so shown in orange).
+    // Two rows have always behaved this way: "This Book / longest sentence" and
+    // "Word Lengths / max in book" share their limit with the row above them,
+    // and the pre-React version never displayed it. See BL-16408.
+    hideMaxNum?: boolean;
+    // Averages are displayed rounded to one decimal place. They are still
+    // compared to the max at full precision, so e.g. an average of 9.04 with a
+    // max of 9 counts as over the limit even though it displays as "9.0".
+    isAverage?: boolean;
     children: string;
 }> = (props) => {
     return (
@@ -80,7 +90,9 @@ const StatsRow: FunctionComponent<{
                     align-self: start;
                 `}
             >
-                {props.maxNum !== 0 && props.maxNum !== Infinity
+                {props.maxNum !== 0 &&
+                props.maxNum !== Infinity &&
+                !props.hideMaxNum
                     ? props.maxNum
                     : ""}
             </div>
@@ -92,13 +104,14 @@ const StatsRow: FunctionComponent<{
                     overflow-wrap: break-word;
                     text-align: center;
                     align-self: start;
-                    color: ${Number(props.actualNum) > props.maxNum &&
-                    props.maxNum !== 0
+                    color: ${isOverMax(props.actualNum, props.maxNum)
                         ? "orange"
                         : "lightgreen"};
                 `}
             >
-                {props.actualNum}
+                {props.isAverage
+                    ? formatAverage(props.actualNum)
+                    : props.actualNum}
             </div>
         </>
     );
@@ -154,7 +167,16 @@ function formatAverage(value: number): string {
     return value.toFixed(1);
 }
 
-const LeveledReaderStats: FunctionComponent<{
+// A statistic violates the current level when it exceeds the level's maximum.
+// A maximum of 0 means the level does not limit this statistic at all, and
+// Infinity means we don't know the limit yet (no level data loaded); neither
+// counts as a violation.
+function isOverMax(actualNum: number, maxNum: number): boolean {
+    return maxNum !== 0 && actualNum > maxNum;
+}
+
+// Exported for testing.
+export const LeveledReaderStats: FunctionComponent<{
     bookStats: { [key: string]: number };
 }> = (props) => {
     const model = getTheOneReaderToolsModel();
@@ -212,7 +234,11 @@ const LeveledReaderStats: FunctionComponent<{
                 </StatsRow>
                 <StatsRow
                     l10nKeySuffix="MaxSentenceLength"
-                    maxNum={0} // Here, maxNum is hardcoded as 0 because this stat is meant to be unlimtited.
+                    // The longest sentence in the book is measured against the same
+                    // limit as the longest sentence on this page, but (as before the
+                    // React conversion) we don't repeat the number in the Max column.
+                    maxNum={model.maxWordsPerSentenceOnThisPage()}
+                    hideMaxNum={true}
                     actualNum={props.bookStats["actualMaxWordsPerSentence"]}
                 >
                     longest sentence
@@ -220,18 +246,16 @@ const LeveledReaderStats: FunctionComponent<{
                 <StatsRow
                     l10nKeySuffix="Average"
                     maxNum={model.maxAverageWordsPerSentence()}
-                    actualNum={formatAverage(
-                        props.bookStats["actualAverageWordsPerSentence"],
-                    )}
+                    actualNum={props.bookStats["actualAverageWordsPerSentence"]}
+                    isAverage={true}
                 >
                     avg per sentence
                 </StatsRow>
                 <StatsRow
                     l10nKeySuffix="AveragePerPage"
                     maxNum={model.maxAverageWordsPerPage()}
-                    actualNum={formatAverage(
-                        props.bookStats["actualAverageWordsPerPage"],
-                    )}
+                    actualNum={props.bookStats["actualAverageWordsPerPage"]}
+                    isAverage={true}
                 >
                     avg per page
                 </StatsRow>
@@ -246,7 +270,10 @@ const LeveledReaderStats: FunctionComponent<{
                 </StatsRow>
                 <StatsRow
                     l10nKeySuffix="MaxInBook"
-                    maxNum={0} // maxNum is also hardcoded to be 0 here because the stat is intended to be unlimited
+                    // Like "longest sentence" above, this shares the limit of the row
+                    // above it ("this page"), so we don't repeat it in the Max column.
+                    maxNum={model.maxGlyphsPerWord()}
+                    hideMaxNum={true}
                     actualNum={props.bookStats["actualMaxGlyphsPerWord"]}
                 >
                     max in book
@@ -254,9 +281,8 @@ const LeveledReaderStats: FunctionComponent<{
                 <StatsRow
                     l10nKeySuffix="AverageInBook"
                     maxNum={model.maxAverageGlyphsPerWord()}
-                    actualNum={formatAverage(
-                        props.bookStats["actualAverageGlyphsPerWord"],
-                    )}
+                    actualNum={props.bookStats["actualAverageGlyphsPerWord"]}
+                    isAverage={true}
                 >
                     avg in book
                 </StatsRow>
@@ -279,9 +305,8 @@ const LeveledReaderStats: FunctionComponent<{
                 <StatsRow
                     l10nKeySuffix="AverageInBook"
                     maxNum={model.maxAverageSentencesPerPage()}
-                    actualNum={formatAverage(
-                        props.bookStats["actualAverageSentencesPerPage"],
-                    )}
+                    actualNum={props.bookStats["actualAverageSentencesPerPage"]}
+                    isAverage={true}
                 >
                     avg in book
                 </StatsRow>

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.tsx
@@ -97,6 +97,15 @@ const StatsRow: FunctionComponent<{
                     : ""}
             </div>
             <div
+                // Says whether this value violates the level's limit, so that tests
+                // (and any future styling) have something stable to look at instead of
+                // the color. These are the names the pre-React code used; as it noted,
+                // neither may be a substring of the other.
+                className={
+                    isOverMax(props.actualNum, props.maxNum)
+                        ? "tooLarge"
+                        : "acceptable"
+                }
                 css={css`
                     max-width: 40px;
                     padding-right: 3px;

--- a/src/BloomBrowserUI/vitest.setup.ts
+++ b/src/BloomBrowserUI/vitest.setup.ts
@@ -167,6 +167,10 @@ vi.mock("./lib/localizationManager/localizationManager", () => {
                 };
             },
             simpleFormat,
+            // The real one turns a little markdown into html. Tests that render
+            // localized components (e.g. the Div in l10nComponents) go through
+            // it, and none of them care about the markdown, so pass text along.
+            processSimpleMarkdown: (text: string) => text,
             loadStringsPromise: (_keys: string[], _lang: string | null) => {
                 // Return a Promise that resolves immediately
                 return Promise.resolve();


### PR DESCRIPTION
The React conversion of the Leveled Reader tool (BL-16408) hardcoded `maxNum={0}` for two statistics rows, which permanently disabled their over-the-limit test, so they always rendered lightgreen instead of orange:

- **This Book / longest sentence** (`actualMaxWordsPerSentence`)
- **Word Lengths / max in book** (`actualMaxGlyphsPerWord`)

Before the conversion, `readerToolsModel.updateActualCount` compared those two against `maxWordsPerSentenceOnThisPage()` and `maxGlyphsPerWord()` respectively and applied the `tooLarge` (orange) class. The old pug template's max cells for these rows (`maxWordsPerSentenceInBook`, `maxGlyphsPerWordInBook`) were never populated by `updateLevelLimits`, so the Max column looked empty for them — which is presumably why the conversion concluded the statistics were unlimited.

This passes the real limits again, and adds a `hideMaxNum` prop so the Max cell stays blank on those two rows, matching 6.4's appearance exactly. Each of them shares its limit with the row directly above it, which does display it.

Also: averages are now compared at full precision instead of comparing the string we display. An average of 9.04 against a max of 9 displays as "9.0" but is over the limit, and the pre-conversion code counted it as such.

### Tests

New `LeveledReaderToolControls.spec.tsx` covers the max-to-color mapping for over-limit, within-limit, no-limit-for-this-level, and rounded-average rows. Verified it fails on the pre-fix code: reinstating either `maxNum={0}` or the old rounded-string comparison turns the relevant assertions red. The conversion had removed the tests that covered level maximums (`sets level max values on init`, `updates max values when level changes`).

Rendering a localized component in a test needed `processSimpleMarkdown` added to the shared `localizationManager` mock in `vitest.setup.ts`.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16408

Also fixes BL-16628, which is the same bug reported separately with a 6.4-vs-6.5 side-by-side.


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8131)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8131)
<!-- Reviewable:end -->
