### PR TITLE
BL-16648: allow the Inside Back Cover to be a full-page image (6.4)

### DIFF
--- a/src/content/templates/xMatter/bloom-xmatter-mixins.pug
+++ b/src/content/templates/xMatter/bloom-xmatter-mixins.pug
@@ -275,7 +275,7 @@ mixin factory-insideFrontCover
 
 mixin factoryStandard-insideBackCover
 	// Inside Back Cover
-	+page-xmatter('Inside Back Cover').cover.coverColor.insideBackCover.bloom-backMatter(data-export='back-matter-inside-back-cover', data-xmatter-page='insideBackCover')&attributes(attributes)#502BE62F-A4D0-4225-A598-1A203FA73239
+	+page-xmatter('Inside Back Cover').cover.coverColor.insideBackCover.bloom-backMatter(data-export='back-matter-inside-back-cover', data-xmatter-page='insideBackCover', data-custom-layout-id='customInsideBackCover')&attributes(attributes)#502BE62F-A4D0-4225-A598-1A203FA73239
 		+back-cover-inner-contents
 
 mixin back-cover-outer-contents
@@ -310,7 +310,7 @@ mixin standard-endExtra1PageForDevice
 mixin standard-endExtra2PageForDevice
 	//- In paper books, this is the inside back cover
 	//- When making a .bloompub, Bloom will remove this if it is empty.
-	+page-xmatter("End Extra 2").cover.coverColor.insideBackCover.bloom-backMatter(data-export='back-matter-inside-back-cover', data-xmatter-page="insideBackCover")#898b6622-837b-49cd-9938-2de76f6d4b20
+	+page-xmatter("End Extra 2").cover.coverColor.insideBackCover.bloom-backMatter(data-export='back-matter-inside-back-cover', data-xmatter-page="insideBackCover", data-custom-layout-id='customInsideBackCover')#898b6622-837b-49cd-9938-2de76f6d4b20
 		+back-cover-inner-contents
 
 mixin standard-endExtra3PageForDevice


### PR DESCRIPTION
[Claude Opus 5 following a prompt from Hatton]

Card: [BL-16648](https://issues.bloomlibrary.org/youtrack/issue/BL-16648)

This adds `data-custom-layout-id='customInsideBackCover'` to both inside-back-cover mixins in `src/content/templates/xMatter/bloom-xmatter-mixins.pug`:

- `factoryStandard-insideBackCover` — the paper xmatter page
- `standard-endExtra2PageForDevice` — the device xmatter's inside back cover

Needed for the Vanuatu "Library for all" Conversion project, which is being done on 6.4. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8136)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8136)
<!-- Reviewable:end -->
