### PR TITLE
Remove two sources of nightly CI failure (auto-update modal, urlPrefix mock ordering)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
@@ -2941,16 +2941,25 @@ export async function setupForAudioRecordingTests() {
         },
     };
 
-    await initializeTalkingBookToolAsync();
-
     // Mock urlPrefix to return the correct base URL for tests
     // The real implementation constructs from iframe.src, but in tests iframe.src is "about:blank"
     // Real format: "/bloom/api/audio/wavFile?id=" + bookFolderUrl + "audio/"
     // In tests, we simulate the full path as if bookFolderUrl was "http://localhost:63315/bloom/C%23Injection/"
+    //
+    // This must go on the PROTOTYPE and BEFORE initializeTalkingBookToolAsync, not on
+    // theOneAudioRecorder afterwards. theOneAudioRecorder does not exist until that call creates
+    // it, and the call itself already sets the player's src. So a mock installed afterwards left
+    // that first src built by the REAL urlPrefix -- a relative URL, which jsdom resolves against
+    // its own base of http://localhost:3000/. Because setCurrentAudioId only refreshes the player
+    // when the audio id CHANGES, a test whose id was already current never overwrote that stale
+    // value, and then compared localhost:3000 against the mocked localhost:63315. It depended on
+    // which ids earlier work happened to leave behind, so it passed locally and failed in CI.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    vi.spyOn(theOneAudioRecorder as any, "urlPrefix").mockReturnValue(
+    vi.spyOn(AudioRecording.prototype as any, "urlPrefix").mockReturnValue(
         "http://localhost:63315/bloom/api/audio/wavFile?id=audio/",
     );
+
+    await initializeTalkingBookToolAsync();
 }
 
 export function StripPlayerSrcNoCacheSuffix(url: string): string {

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -1557,6 +1557,11 @@ window.showWorkspaceInitializationFailure = function(message) {
         {
             if (Platform.IsLinux)
                 return;
+            // An automated run has nobody to dismiss a modal dialog. This one is shown as a startup
+            // action, so it would sit on the UI thread in its own message loop for the whole run --
+            // exactly the "dialog nobody can dismiss" that Program.RunningE2eTests exists to avoid.
+            if (Program.RunningE2eTests)
+                return;
             // If Bloom is newly installed or we only had old versions before, this should be 0.
             var isShown = Settings.Default.AutoUpdateDialogShown;
             if (isShown < kCurrentAutoUpdateVersion)


### PR DESCRIPTION
Two independent fixes for things making the nightly red, found while evaluating the 2026-08-03 nightly. Neither one touches the actual visual-regression hang — that is BL-16612, whose fix is on `BL-16612-page-checks-hang` (#8110). These just remove the noise around it.

### 1. Don't show the auto-update dialog in automated runs

On a fresh CI runner `Settings.Default.AutoUpdateDialogShown` is 0, so `WorkspaceView` opened the "Auto Update" `ReactDialog` modally as a startup action. With nobody to dismiss it, it sat on the UI thread in its own nested message loop for the whole run — all three stack captures from the 08-03 nightly show the main thread parked in `Form.ShowDialog` under `ShowAutoUpdateDialogIfNeeded`.

`Program.RunningE2eTests` already exists to suppress exactly this (its own comment: "a dialog nobody can dismiss and hanging the whole run") and covers modal error dialogs and `Debug.Assert` boxes. This nag dialog was simply never included.

This was **not** the cause of that night's hang — the visual-regression step passed on other nights with this dialog up — just an independent hazard.

### 2. Install the talking-book `urlPrefix` mock before the recorder exists

`talkingBookSpec > showTool(checksum=missing, audio=missing, scenario=PreTextBox) => UPDATE` failed **every** nightly since 2026-07-29, comparing `http://localhost:3000/...` against the expected `http://localhost:63315/...`, while passing locally both in isolation and under a full-suite run with the same worker count.

`63315` is not a real port; it is a literal inside a mock of `AudioRecording.urlPrefix` that `setupForAudioRecordingTests` installed on `theOneAudioRecorder` *after* awaiting `initializeTalkingBookToolAsync`. Two things made that fragile:

- `theOneAudioRecorder` does not exist until that call creates it (it is an `export let` populated by `getAudioRecorder`), so the mock could not have gone on the instance any earlier.
- The call itself already sets the player's `src`, so that first `src` came from the **real** `urlPrefix` — a relative URL, which jsdom resolves against its own `http://localhost:3000/` base.

`setCurrentAudioId` only refreshes the player when the audio id **changes**, so a test whose id was already current never overwrote that stale pre-mock value, and compared `:3000` against the mocked `:63315`. Which ids were already current depended on what earlier work happened to leave behind — hence local pass, CI fail.

Fix: mock the **prototype**, before initializing, so even the init-time write goes through the mock and no stale value exists to inherit.

One deliberate consequence: the mock now applies to every `AudioRecording` instance rather than only the singleton. That matches the mock's intent ("in tests, `urlPrefix` returns this absolute URL") and the suite confirms it.

### Verification

- `pnpm typecheck` — passed
- `pnpm lint` — 0 errors (774 pre-existing repo-wide warnings; none in the changed files)
- `build/agent-dotnet.sh build BloomExe` — 0 errors
- Front-end suite — 578 passed / 5 skipped, unchanged from the pre-fix baseline
- C# suite — see checks

The full-suite numbers being *unchanged* is the honest reading: it confirms no regression, not that the CI failure is fixed. That test never reproduced locally, so fix 2 is justified by mechanism, and confirming it needs a nightly (or `workflow_dispatch`) run on this branch. Fix 1 likewise can only be observed in CI.

No tracker card — this branch carries no `BL-` id (small CI cleanups). Related context: BL-16612.


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8138)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8138)
<!-- Reviewable:end -->
