### PR TITLE
Fix toolbox not fully grayed out in Show Playback Order mode (BL-16630)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.tsx
@@ -76,6 +76,17 @@ const legacyToolSubPathByToolId: Record<string, string> = {
     settingsTool: "settings/Settings.html",
 };
 
+// While Show Playback Order mode is on, the Talking Book tool covers the whole toolbox with a
+// translucent overlay at this z-index.
+// cf @disablingOverlayZindex in bookEdit/toolbox/talkingBook/audioRecording.less
+const kDisablingOverlayZIndex = 1001;
+
+// The tool headers have to clear that overlay, and also the handful of controls inside the tool
+// that opt out of it at one above it (the Help link, and the Show Playback Order switch in
+// talkingBookAdvancedSection.tsx). The offset lands on 1005, which is what the pre-6.4
+// "#toolbox h3" rule in toolbox.less used, so this stays a like-for-like restoration.
+const kToolboxHeaderZIndex = kDisablingOverlayZIndex + 4;
+
 const toolboxHeaderIconStyles = css`
     width: 16px;
     height: 16px;
@@ -816,6 +827,23 @@ export const ToolboxRoot: React.FunctionComponent = () => {
                                     min-height: 32px;
                                     padding-left: 5px;
                                     padding-right: 12px;
+                                    // Keep the headers above the Talking Book tool's disabling
+                                    // overlay, so they neither look grayed out nor stop
+                                    // responding in Show Playback Order mode. Until 6.4 the
+                                    // "#toolbox h3" rule in toolbox.less did this; it stopped
+                                    // matching once the headers became MUI AccordionSummaries,
+                                    // which is BL-16630. Only works while no ancestor creates a
+                                    // stacking context -- a transform, filter, opacity or
+                                    // z-index on the Accordion, the Collapse or the tool-body
+                                    // host would trap it.
+                                    position: relative;
+                                    z-index: ${kToolboxHeaderZIndex};
+                                    // The header has to paint its own background for that to
+                                    // help. A collapsed header would otherwise be transparent
+                                    // and show the Accordion root's background, which stays
+                                    // under the overlay and so keeps being dimmed. Same colour
+                                    // the root uses, so nothing changes visually.
+                                    background-color: ${kBloomUnselectedTabBackground};
 
                                     & .MuiAccordionSummary-content {
                                         margin: 8px 0;

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.less
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.less
@@ -8,7 +8,14 @@
 @buttonColumnWidth: 40px;
 @splitAnimationTime: 300ms;
 @textOnLightBackground: black;
-@disablingOverlayZindex: 1001; // higher than #audio-devlist
+// higher than #audio-devlist; cf kDisablingOverlayZIndex in bookEdit/toolbox/ToolboxRoot.tsx
+@disablingOverlayZindex: 1001;
+// Keeps #disablingOverlay clear of the toolbox scrollbar, so the scrollbar stays undimmed
+// and draggable while the tool is disabled. This is the scrollbar's actual width, which is
+// also @toolboxContentPadding -- so when there is no scrollbar, the strip the overlay
+// leaves uncovered falls on the tool's right-hand padding instead of clipping the ends of
+// the full-width controls, which used to leave them slightly undimmed and still clickable.
+@disablingOverlayScrollbarAllowance: 15px;
 
 // See BL-7442: When low line height causes lines to overlap, the highlighting overlaps and
 // can over up the bottom of the characters in the line above. For Chrome/Safari we have
@@ -496,6 +503,9 @@ body .cursor-progress {
     display: none;
 }
 
+// Dims and blocks clicks on the toolbox while in Show Playback Order mode.
+// Anything that must remain usable (the tool headers, the Help link, the Show Playback
+// Order switch itself) gives itself a z-index above @disablingOverlayZindex.
 #disablingOverlay {
     z-index: @disablingOverlayZindex;
     opacity: 0.7;
@@ -503,5 +513,5 @@ body .cursor-progress {
     top: inherit;
     background-color: @toolboxBackgroundColor;
     height: 100%;
-    width: calc(100% - 20px);
+    width: calc(100% - @disablingOverlayScrollbarAllowance);
 }


### PR DESCRIPTION
Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16630

## The bug

With **Show playback order buttons** on (Talking Book Tool → Advanced), the "Talking Book Tool" header goes dull except for a bright teal stripe at its right-hand end, and the other tool headers are dimmed too. Reported in 6.4 and 6.5; fine in 6.3.

## Root cause

The Talking Book tool's `#disablingOverlay` has always been a `position: fixed` element covering the whole toolbox viewport at `z-index: 1001` — accordion headers included. What kept the headers looking normal was this rule in `toolbox.less`:

```less
#toolbox h3 {
    ...
    z-index: 1005; // higher than disablingOverlay in Talking Book tool
}
```

When the toolbox root became React/MUI in 6.4, the headers turned into `AccordionSummary` elements and that rule stopped matching them, so they started being painted over by the overlay. The legacy `#toolbox` is now `display: none`, making the old rule dead code.

The bright stripe is the overlay's long-standing `width: calc(100% - 20px)` becoming visible for the first time: the 20px it leaves uncovered started landing on the teal active header instead of on panel-colored tool body. The gap was there in 6.3 too — it just never fell on anything colorful.

Pixel-sampling the two screenshots on the report confirms it. The overlay composites as 0.7 × `#2E2E2E` over what's beneath, and both shots were taken with the mode on:

| element | 6.3 | 6.4 | if under the overlay |
| --- | --- | --- | --- |
| "Talking Book Tool" header | `#1D94A4` | **`#294C51`** | `#294C51` |
| header text | `#FFFFFF` | **`#6C6B6B`** | `#6C6C6C` |
| "Canvas Tool" header | `#404040` | **`#333333`** | `#333333` |
| playback-order switch | `#F3AA18` | `#F3AA18` | ≈ `#6E5A2C` |
| "Help" text | `#F2F2F2` | `#FFFFFF` | ≈ `#6C6C6C` |

The header rows sit on the composited value in 6.4 and not in 6.3 — that's the regression. The switch and Help are undimmed in *both*, showing their own `z-index` opt-outs still work while the headers' no longer did.

## The fix

`ToolboxRoot.tsx` — put the headers back above the overlay with `position: relative; z-index: 1005`, and give the header a `background-color`. The background matters because a *collapsed* header paints none of its own: the colour you see is the `Accordion` root's, and the root can't be lifted along with the header, since a `z-index` there would create a stacking context around the `AccordionDetails` too and hoist the whole tool body out from under the overlay. Without it, lifting the header moved its text but left its background dimmed — which kept the stripe on every collapsed header. It uses the same colour the root does, so nothing changes visually.

`audioRecording.less` — narrows the strip the overlay leaves uncovered on the right from `20px` to `15px`, and names it. That strip is deliberate: it keeps the toolbox scrollbar undimmed and draggable while the tool is disabled, and on a short window that scrollbar can be the only way to reach the switch that turns the mode off — which is why closing the gap altogether (`width: 100%`) was tried during this work and rejected. `15px` is the scrollbar's measured width, and it is also `@toolboxContentPadding`, so when there's no scrollbar the uncovered strip now falls on the tool's right-hand padding instead of clipping ~5px off the ends of the full-width controls, where it used to leave them slightly undimmed and still clickable.

## Deliberately not changed

- **The `✕` isn't dimmed while the bar beside it is.** Different documents: the toolbox is an `<iframe id="toolbox">`, and the `✕` is the `pure-toggle-label` beside the drawer in the parent edit-tab page (`EditTabPane.tsx`). A fixed overlay inside the iframe can't reach out of it. Predates 6.4 — the same pattern is measurable in the 6.3 screenshot.

## Testing

CSS layering, so no unit-test coverage applies; no automated tests were run (skipped at the developer's request). Verified by hand in the running app. With **Show playback order buttons** on:

1. the "Talking Book Tool" header is one even teal colour edge to edge — no bright stripe at the right end;
2. the other tool headers look normal, not dimmed, and are still clickable;
3. turning the mode off restores the tool.

Some resolved review threads below discuss a `pointer-events` approach that was tried and reverted; they don't describe the current diff.

---
[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8139)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8139)
<!-- Reviewable:end -->

