### PR TITLE
Report clipboard failures the user's own copy and paste can hit (BL-16459)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/bloomField/hyperlinks.ts
+++ b/src/BloomBrowserUI/bookEdit/bloomField/hyperlinks.ts
@@ -33,7 +33,10 @@ export function tryProcessHyperlink(
 export function getHyperlinkFromClipboard(
     callback: (url: string) => void,
 ): void {
-    get("common/clipboardText", (result) => {
+    // The availability-check read: this runs to decide whether the paste-hyperlink button should
+    // be enabled -- including during page initialization -- not because the user asked to paste,
+    // so C# must not report a momentarily unreadable clipboard as a failed paste.
+    get("common/clipboardText?checkingAvailability=true", (result) => {
         if (!result.data) {
             callback("");
         }

--- a/src/BloomBrowserUI/bookEdit/bloomField/hyperlinks.ts
+++ b/src/BloomBrowserUI/bookEdit/bloomField/hyperlinks.ts
@@ -1,4 +1,5 @@
 import { get } from "../../utils/bloomApi";
+import { readClipboardTextForAvailabilityCheck } from "../js/hostClipboard";
 
 // returns empty string if the URL is not valid.
 // returns the url as is if it is external
@@ -33,18 +34,23 @@ export function tryProcessHyperlink(
 export function getHyperlinkFromClipboard(
     callback: (url: string) => void,
 ): void {
-    // The availability-check read: this runs to decide whether the paste-hyperlink button should
-    // be enabled -- including during page initialization -- not because the user asked to paste,
-    // so C# must not report a momentarily unreadable clipboard as a failed paste.
-    get("common/clipboardText?checkingAvailability=true", (result) => {
-        if (!result.data) {
+    // The availability-check read, via hostClipboard: this runs to decide whether the
+    // paste-hyperlink button should be enabled -- including during page initialization -- not
+    // because the user asked to paste, so C# must not report a momentarily unreadable clipboard as
+    // a failed paste. Going through that helper also means the reply arrives as the text it really
+    // is: read directly, axios would turn a clipboard holding 42 into a number and the URL
+    // handling below would throw on it while a page was loading.
+    readClipboardTextForAvailabilityCheck().then((clipboardText) => {
+        if (!clipboardText) {
             callback("");
+            return;
         }
         get("app/selectedBookInfo", (bookInfo) => {
             if (!bookInfo.data) {
                 callback("");
+                return;
             }
-            callback(tryProcessHyperlink(result.data, bookInfo.data.id));
+            callback(tryProcessHyperlink(clipboardText, bookInfo.data.id));
         });
     });
 }

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -1803,31 +1803,26 @@ document.addEventListener("keydown", (e: KeyboardEvent) => {
         return;
     }
 
-    if (isKey("x", "KeyX")) {
-        // Do the cut ourselves rather than letting Chromium do it. Chromium deletes the selected
-        // text and then silently discards the failed clipboard write, so a cut from a locked
-        // clipboard loses the text outright (BL-16459). cutSelection copies through C# first and
-        // leaves the text alone if that fails -- the same thing the Cut button does. Only take
-        // over where that implementation applies; elsewhere, let the browser cut and just check.
-        const editor = CKEDITOR.currentInstance;
-        // Only plain Ctrl+X. Ctrl+Shift+X is not a cut, and preventDefaulting it would invent one.
-        if (
-            !e.shiftKey &&
-            document.activeElement?.closest(".bloom-editable") &&
-            editor
-        ) {
-            e.preventDefault();
-            cutSelection();
-        } else {
+    if (isKey("x", "KeyX") || isKey("c", "KeyC")) {
+        // Both are left to Chromium, which is the only one of us that can put the full HTML
+        // flavor -- formatting, links, inline pictures -- on the clipboard. We just check
+        // afterwards and report a failure.
+        //
+        // Ctrl+X deserves more than that, because Chromium deletes the selection and then
+        // discards a failed clipboard write, losing the text outright (BL-16459). An earlier
+        // version of this handler therefore did the cut itself through C#, the way the Cut
+        // button does. That protected the text but put only *plain* text on the clipboard, so
+        // cutting a formatted phrase or an inline picture silently dropped everything but the
+        // words -- a worse bug, and one that struck every cut rather than only failing ones.
+        // Fixing it properly means teaching the copy path to carry several clipboard formats at
+        // once; until then the honest thing is to let the browser cut and tell the user when it
+        // didn't work. See the PR discussion.
+        //
+        // Nothing selected means nothing was copied, so there is nothing to report -- checking
+        // anyway would announce the failure of an operation that never happened.
+        if (document.getSelection()?.toString()) {
             verifyBrowserCopyAfterDefault();
         }
-        return;
-    }
-
-    if (isKey("c", "KeyC")) {
-        // Left to Chromium: its copy carries the HTML flavor, which matters when pasting into
-        // other programs, and unlike cut a failure loses nothing. We just check afterwards.
-        verifyBrowserCopyAfterDefault();
     }
 });
 

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -1688,7 +1688,14 @@ async function copyImpl() {
 
 // See comment on copySelection
 export const cutSelection = () => {
-    cutSelectionImpl();
+    // Wrapped because the cut now waits for a round trip to C# before it deletes anything, and
+    // src/BloomBrowserUI/AGENTS.md requires asynchronous changes to the editable page DOM to hold
+    // off a concurrent page save; otherwise a save landing in that gap could capture the page
+    // half-cut. The paste path above does the same.
+    wrapWithRequestPageContentDelay(
+        () => cutSelectionImpl(),
+        "cutSelectionImpl",
+    );
 };
 
 async function cutSelectionImpl() {
@@ -1777,7 +1784,9 @@ document.addEventListener("paste", pasteHandler);
 document.addEventListener("keydown", (e: KeyboardEvent) => {
     // Not AltGr, which Windows reports as Ctrl+Alt: on many keyboard layouts AltGr+letter is how
     // the user types a character, and it must not be mistaken for a clipboard shortcut (least of
-    // all Ctrl+X, where we preventDefault).
+    // all Ctrl+X, where we preventDefault). This also means Ctrl+Alt+V no longer reaches
+    // pasteHandler as it used to; that is not a paste shortcut anyone documents, and letting a
+    // character key double as one is the bigger problem.
     if (!e.ctrlKey || e.altKey) return;
     const key = e.key?.toLowerCase();
     const isKey = (letter: string, code: string) =>

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -1701,9 +1701,15 @@ export const cutSelection = () => {
 async function cutSelectionImpl() {
     const sel = document.getSelection();
     if (!sel) return;
-    // Don't delete what we failed to copy: that would lose the text outright. The user has
-    // been told the copy failed and can try the cut again.
-    if (!(await copyTextToClipboard(sel.toString()))) return;
+    const selectedText = sel.toString();
+    // Don't delete text we failed to copy: that would lose it outright. The user has been told the
+    // copy failed and can try the cut again.
+    //
+    // Only when there was text, though. A selection with nothing textual in it -- a picture on its
+    // own, say -- gives us nothing to put on the clipboard, and a plain-text copy never could have
+    // carried it anyway; treating that as a failed copy would make the Cut button do nothing at
+    // all, which is not what it used to do.
+    if (selectedText && !(await copyTextToClipboard(selectedText))) return;
     // Using ckeditor here because it's the only way I've found to integrate clipboard
     // ops into an Undo stack that we can operate from an external button.
     // We do a Save before and after to make sure that the cut is distinct from

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -18,6 +18,13 @@ import {
     removeTransientVideoTimestampParams,
     SetupVideoEditing,
 } from "./bloomVideo";
+import {
+    copyTextToClipboard,
+    listenForBrowserClipboardOperations,
+    readTextFromClipboard,
+    verifyBrowserCopyAfterDefault,
+    verifyBrowserPasteAfterDefault,
+} from "./hostClipboard";
 import { SetupWidgetEditing } from "./bloomWidgets";
 import { setupOrigami, cleanupOrigami } from "./origami";
 import theOneLocalizationManager from "../../lib/localizationManager/localizationManager";
@@ -1643,11 +1650,12 @@ export function topBarButtonClick(button: { command: string }) {
     }
 }
 
-// These clipboard functions are implemented in Javascript because WebView2 doesn't seem to have
+// These clipboard functions are driven from Javascript because WebView2 doesn't seem to have
 // a C# api for doing them. I've made the exported functions synchronous because I'm not sure
 // what complications might come from calling an async function from C#. The implementations
-// mostly use clipboard API functions that are async, so those functions must be async.
-// We don't need to await them because nothing is using the result.
+// are async because they hand the actual clipboard work to C# over the API (see
+// hostClipboard.ts for why they must, rather than using navigator.clipboard), so the exported
+// functions do not await them; nothing is using the result.
 // The buttons that implement clipboard operations are currently only in Edit mode, so
 // this is a reasonable place for this code. If we support them elsewhere, we'll have to
 // find a way to share the code (and call it when not part of the workspaceBundle).
@@ -1670,12 +1678,12 @@ async function copyImpl() {
         // whitespace. But there's a greater chance they **don't** want unintended
         // trailing line breaks. This ".trimEnd()" works around an issue where multiple
         // copy/pastes can result in an extra line break being added. See BL-14051.
-        navigator.clipboard.writeText(
+        await copyTextToClipboard(
             activeCanvasElementEditable.innerText.trimEnd(),
         );
         return;
     }
-    navigator.clipboard.writeText(sel.toString());
+    await copyTextToClipboard(sel.toString());
 }
 
 // See comment on copySelection
@@ -1686,7 +1694,9 @@ export const cutSelection = () => {
 async function cutSelectionImpl() {
     const sel = document.getSelection();
     if (!sel) return;
-    await navigator.clipboard.writeText(sel.toString());
+    // Don't delete what we failed to copy: that would lose the text outright. The user has
+    // been told the copy failed and can try the cut again.
+    if (!(await copyTextToClipboard(sel.toString()))) return;
     // Using ckeditor here because it's the only way I've found to integrate clipboard
     // ops into an Undo stack that we can operate from an external button.
     // We do a Save before and after to make sure that the cut is distinct from
@@ -1761,13 +1771,63 @@ document.addEventListener("paste", pasteHandler);
 // end up pasting text into contenteditable elements twice, presumably
 // once because of our handler here and once because the other handler
 // is not looking for exactly this event and still gets called.
+// Clipboard keyboard shortcuts. These are handled from keydown rather than from the copy/cut/
+// paste events because CKEditor gets to those first inside a bloom-editable: it preventDefaults
+// copy and cut, and swallows paste before it reaches the document. keydown always arrives.
 document.addEventListener("keydown", (e: KeyboardEvent) => {
+    // Not AltGr, which Windows reports as Ctrl+Alt: on many keyboard layouts AltGr+letter is how
+    // the user types a character, and it must not be mistaken for a clipboard shortcut (least of
+    // all Ctrl+X, where we preventDefault).
+    if (!e.ctrlKey || e.altKey) return;
     const key = e.key?.toLowerCase();
-    const isCtrlV = e.ctrlKey && (key === "v" || e.code === "KeyV");
-    if (isCtrlV) {
+    const isKey = (letter: string, code: string) =>
+        key === letter || e.code === code;
+
+    if (isKey("v", "KeyV")) {
         pasteHandler(e);
+        // If pasteHandler took over (it preventDefaults when it is going to handle an image
+        // paste itself) it reports its own failures through the API. Otherwise Chromium is doing
+        // the paste, and only C# can tell us whether the clipboard was actually readable.
+        if (!e.defaultPrevented) {
+            verifyBrowserPasteAfterDefault();
+        }
+        return;
+    }
+
+    if (isKey("x", "KeyX")) {
+        // Do the cut ourselves rather than letting Chromium do it. Chromium deletes the selected
+        // text and then silently discards the failed clipboard write, so a cut from a locked
+        // clipboard loses the text outright (BL-16459). cutSelection copies through C# first and
+        // leaves the text alone if that fails -- the same thing the Cut button does. Only take
+        // over where that implementation applies; elsewhere, let the browser cut and just check.
+        const editor = CKEDITOR.currentInstance;
+        // Only plain Ctrl+X. Ctrl+Shift+X is not a cut, and preventDefaulting it would invent one.
+        if (
+            !e.shiftKey &&
+            document.activeElement?.closest(".bloom-editable") &&
+            editor
+        ) {
+            e.preventDefault();
+            cutSelection();
+        } else {
+            verifyBrowserCopyAfterDefault();
+        }
+        return;
+    }
+
+    if (isKey("c", "KeyC")) {
+        // Left to Chromium: its copy carries the HTML flavor, which matters when pasting into
+        // other programs, and unlike cut a failure loses nothing. We just check afterwards.
+        verifyBrowserCopyAfterDefault();
     }
 });
+
+// Ctrl+C, Ctrl+X and Ctrl+V in a text box are handled entirely inside Chromium, which never
+// tells us whether the clipboard worked. (For paste, note that pasteHandler above deliberately
+// bows out when focus is in a bloom-editable, so C# is not involved at all.) This gets each one
+// checked on the C# side so the user finds out, instead of pasting stale content -- or nothing
+// -- and concluding that their copy never happened (BL-16459).
+listenForBrowserClipboardOperations(document);
 
 async function pasteImpl(imageAvailable: boolean) {
     const canvasElementManager = theOneCanvasElementManager;
@@ -1785,7 +1845,7 @@ async function pasteImpl(imageAvailable: boolean) {
         "bloom-editable bloom-visibility-code-on",
     )[0] as HTMLElement;
 
-    const textToPaste = await navigator.clipboard.readText();
+    const textToPaste = await readTextFromClipboard();
     if (!textToPaste) {
         return;
     }

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementContextControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementContextControls.tsx
@@ -21,7 +21,8 @@ import { BloomTooltip } from "../../../react_components/BloomToolTip";
 import { useL10n } from "../../../react_components/l10nHooks";
 import { useGetFeatureStatus } from "../../../react_components/featureStatus";
 import { kBloomDisabledOpacity } from "../../../utils/colorUtils";
-import { getAsync, useApiObject } from "../../../utils/bloomApi";
+import { useApiObject } from "../../../utils/bloomApi";
+import { readClipboardTextForAvailabilityCheck } from "../hostClipboard";
 import { audioExistsForIdsAsync } from "../../toolbox/talkingBook/audioUtils";
 import { getAudioSentencesOfVisibleEditables } from "bloom-player";
 import { canvasElementControlRegistry } from "../../toolbox/canvas/canvasElementControlRegistry";
@@ -184,16 +185,15 @@ const CanvasElementContextControls: React.FunctionComponent<{
         let isCurrent = true;
         setHasClipboardText(false);
 
-        getAsync("common/clipboardText")
-            .then((response) => {
+        // The availability-check read, so that opening this menu while another program happens to
+        // be holding the clipboard doesn't tell the user we couldn't paste something they never
+        // asked us to paste.
+        readClipboardTextForAvailabilityCheck()
+            .then((clipboardText) => {
                 if (!isCurrent) {
                     return;
                 }
 
-                const clipboardText =
-                    typeof response.data === "string"
-                        ? response.data
-                        : (response.data?.data ?? "");
                 setHasClipboardText(clipboardText.length > 0);
             })
             .catch((error) => {

--- a/src/BloomBrowserUI/bookEdit/js/hostClipboard.test.ts
+++ b/src/BloomBrowserUI/bookEdit/js/hostClipboard.test.ts
@@ -64,7 +64,10 @@ describe("readTextFromClipboard", () => {
         mockGetAsync.mockResolvedValue({ data: "clipboard contents" } as never);
 
         expect(await readTextFromClipboard()).toBe("clipboard contents");
-        expect(mockGetAsync).toHaveBeenCalledWith("common/clipboardText");
+        expect(mockGetAsync).toHaveBeenCalledWith(
+            "common/clipboardText",
+            expect.any(Object),
+        );
     });
 
     // A failed read gets us "" from C# (it has already toasted), and so does an empty
@@ -82,6 +85,30 @@ describe("readTextFromClipboard", () => {
     });
 });
 
+// axios JSON-parses every response body by default, which turned a clipboard holding "42" into
+// the number 42 -- and the "is it a string?" check below then threw it away, so pasting a number
+// inserted nothing at all. Both reads must ask for the body untouched.
+describe.each([
+    ["readTextFromClipboard", readTextFromClipboard],
+    [
+        "readClipboardTextForAvailabilityCheck",
+        readClipboardTextForAvailabilityCheck,
+    ],
+])("%s", (_name, read) => {
+    test("asks axios not to parse the reply, so number-like clipboard text survives", async () => {
+        mockGetAsync.mockResolvedValue({ data: "42" } as never);
+
+        expect(await read()).toBe("42");
+
+        const config = mockGetAsync.mock.calls[0][1] as
+            | { transformResponse?: ((body: string) => unknown)[] }
+            | undefined;
+        expect(config?.transformResponse).toBeDefined();
+        // The transform must hand the body back exactly as it arrived.
+        expect(config!.transformResponse![0]("42")).toBe("42");
+    });
+});
+
 describe("readClipboardTextForAvailabilityCheck", () => {
     // These reads happen on their own schedule -- when a canvas element's menu opens, or while a
     // page initializes -- so they must ask C# to keep quiet. Without the flag, a clipboard held
@@ -93,6 +120,7 @@ describe("readClipboardTextForAvailabilityCheck", () => {
         expect(await readClipboardTextForAvailabilityCheck()).toBe("something");
         expect(mockGetAsync).toHaveBeenCalledWith(
             "common/clipboardText?checkingAvailability=true",
+            expect.any(Object),
         );
     });
 
@@ -102,7 +130,10 @@ describe("readClipboardTextForAvailabilityCheck", () => {
 
         await readTextFromClipboard();
 
-        expect(mockGetAsync).toHaveBeenCalledWith("common/clipboardText");
+        expect(mockGetAsync).toHaveBeenCalledWith(
+            "common/clipboardText",
+            expect.any(Object),
+        );
     });
 });
 

--- a/src/BloomBrowserUI/bookEdit/js/hostClipboard.test.ts
+++ b/src/BloomBrowserUI/bookEdit/js/hostClipboard.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+    copyTextToClipboard,
+    listenForBrowserClipboardOperations,
+    readTextFromClipboard,
+    verifyBrowserCopyAfterDefault,
+    verifyBrowserCopyReachedClipboard,
+    verifyBrowserPasteAfterDefault,
+    verifyBrowserPasteGotClipboard,
+} from "./hostClipboard";
+import { getAsync, postJson, postJsonAsync } from "../../utils/bloomApi";
+
+vi.mock("../../utils/bloomApi", () => ({
+    getAsync: vi.fn(),
+    postJson: vi.fn(),
+    postJsonAsync: vi.fn(),
+}));
+
+const mockGetAsync = vi.mocked(getAsync);
+const mockPostJson = vi.mocked(postJson);
+const mockPostJsonAsync = vi.mocked(postJsonAsync);
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+});
+
+describe("copyTextToClipboard", () => {
+    test("sends the text to C# rather than to navigator.clipboard", async () => {
+        mockPostJsonAsync.mockResolvedValue({ data: true } as never);
+
+        await copyTextToClipboard("some text");
+
+        expect(mockPostJsonAsync).toHaveBeenCalledWith("common/clipboardText", {
+            text: "some text",
+        });
+    });
+
+    test("reports success when C# says the text reached the clipboard", async () => {
+        mockPostJsonAsync.mockResolvedValue({ data: true } as never);
+
+        expect(await copyTextToClipboard("some text")).toBe(true);
+    });
+
+    // This is the whole point of returning a value: cut must not delete text it failed to
+    // copy. C# replies false when the clipboard could not be written (BL-16459).
+    test("reports failure when C# says the copy did not happen", async () => {
+        mockPostJsonAsync.mockResolvedValue({ data: false } as never);
+
+        expect(await copyTextToClipboard("some text")).toBe(false);
+    });
+
+    test("reports failure rather than a bogus success if the reply has no data", async () => {
+        mockPostJsonAsync.mockResolvedValue(undefined as never);
+
+        expect(await copyTextToClipboard("some text")).toBe(false);
+    });
+});
+
+describe("readTextFromClipboard", () => {
+    test("asks C# for the clipboard text", async () => {
+        mockGetAsync.mockResolvedValue({ data: "clipboard contents" } as never);
+
+        expect(await readTextFromClipboard()).toBe("clipboard contents");
+        expect(mockGetAsync).toHaveBeenCalledWith("common/clipboardText");
+    });
+
+    // A failed read gets us "" from C# (it has already toasted), and so does an empty
+    // clipboard; callers treat both as "nothing to paste".
+    test("yields an empty string when there is no text", async () => {
+        mockGetAsync.mockResolvedValue({ data: "" } as never);
+
+        expect(await readTextFromClipboard()).toBe("");
+    });
+
+    test("yields an empty string rather than a non-string when the reply is not text", async () => {
+        mockGetAsync.mockResolvedValue({ data: undefined } as never);
+
+        expect(await readTextFromClipboard()).toBe("");
+    });
+});
+
+describe("verify helpers", () => {
+    test("the copy check asks C# about the clipboard", () => {
+        verifyBrowserCopyReachedClipboard();
+
+        expect(mockPostJson).toHaveBeenCalledWith(
+            "common/verifyClipboardAfterBrowserCopy",
+            {},
+        );
+    });
+
+    // A separate endpoint, so the user gets "not able to paste" rather than a message about
+    // copying, which would be baffling when they were pasting.
+    test("the paste check uses the paste endpoint, not the copy one", () => {
+        verifyBrowserPasteGotClipboard();
+
+        expect(mockPostJson).toHaveBeenCalledWith(
+            "common/verifyClipboardAfterBrowserPaste",
+            {},
+        );
+    });
+
+    // The browser touches the clipboard as part of the default action, i.e. after our handler
+    // returns, so checking synchronously would look before the operation had been attempted.
+    test("the after-default variants wait for the current event to finish", () => {
+        vi.useFakeTimers();
+
+        verifyBrowserCopyAfterDefault();
+        verifyBrowserPasteAfterDefault();
+        expect(mockPostJson).not.toHaveBeenCalled();
+
+        vi.runAllTimers();
+        expect(mockPostJson).toHaveBeenCalledWith(
+            "common/verifyClipboardAfterBrowserCopy",
+            {},
+        );
+        expect(mockPostJson).toHaveBeenCalledWith(
+            "common/verifyClipboardAfterBrowserPaste",
+            {},
+        );
+    });
+});
+
+describe("listenForBrowserClipboardOperations", () => {
+    const dispatch = (type: string, cancelled = false) => {
+        const event = new Event(type, { cancelable: true });
+        if (cancelled) event.preventDefault();
+        document.dispatchEvent(event);
+    };
+
+    // Chromium touches the clipboard as part of the default action, after our handler returns,
+    // so the check has to be deferred; verifying immediately would look at the clipboard before
+    // the operation had even been attempted.
+    test("verifies a native copy, but only after the event has been handled", () => {
+        vi.useFakeTimers();
+        listenForBrowserClipboardOperations(document);
+
+        dispatch("copy");
+        expect(mockPostJson).not.toHaveBeenCalled();
+
+        vi.runAllTimers();
+        expect(mockPostJson).toHaveBeenCalledWith(
+            "common/verifyClipboardAfterBrowserCopy",
+            {},
+        );
+    });
+
+    test("verifies a native cut too", () => {
+        vi.useFakeTimers();
+        listenForBrowserClipboardOperations(document);
+
+        dispatch("cut");
+        vi.runAllTimers();
+
+        expect(mockPostJson).toHaveBeenCalledWith(
+            "common/verifyClipboardAfterBrowserCopy",
+            {},
+        );
+    });
+
+    // Ctrl+V in a text box is left to Chromium, so this check is the only way a failed paste
+    // can reach the user.
+    test("verifies a native paste, with the paste endpoint", () => {
+        vi.useFakeTimers();
+        listenForBrowserClipboardOperations(document);
+
+        dispatch("paste");
+        vi.runAllTimers();
+
+        expect(mockPostJson).toHaveBeenCalledWith(
+            "common/verifyClipboardAfterBrowserPaste",
+            {},
+        );
+    });
+
+    // Regression guard. Skipping defaultPrevented events looks like the right way to avoid
+    // double-reporting, and it silently disables the whole feature: CKEditor preventDefaults copy
+    // and cut inside a .bloom-editable, which is exactly where the user is when a clipboard
+    // failure matters. Measured in the running app: copy and cut both arrive with
+    // defaultPrevented=true, and with such a check in place nothing was ever reported.
+    test("still verifies when the event has been defaultPrevented", () => {
+        vi.useFakeTimers();
+        listenForBrowserClipboardOperations(document);
+
+        dispatch("copy", true);
+        vi.runAllTimers();
+
+        expect(mockPostJson).toHaveBeenCalledWith(
+            "common/verifyClipboardAfterBrowserCopy",
+            {},
+        );
+    });
+
+    test("does not verify anything until a clipboard event actually happens", () => {
+        vi.useFakeTimers();
+        listenForBrowserClipboardOperations(document);
+
+        dispatch("keydown");
+        vi.runAllTimers();
+
+        expect(mockPostJson).not.toHaveBeenCalled();
+    });
+});

--- a/src/BloomBrowserUI/bookEdit/js/hostClipboard.test.ts
+++ b/src/BloomBrowserUI/bookEdit/js/hostClipboard.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import {
     copyTextToClipboard,
     listenForBrowserClipboardOperations,
+    readClipboardTextForAvailabilityCheck,
     readTextFromClipboard,
     verifyBrowserCopyAfterDefault,
     verifyBrowserCopyReachedClipboard,
@@ -78,6 +79,30 @@ describe("readTextFromClipboard", () => {
         mockGetAsync.mockResolvedValue({ data: undefined } as never);
 
         expect(await readTextFromClipboard()).toBe("");
+    });
+});
+
+describe("readClipboardTextForAvailabilityCheck", () => {
+    // These reads happen on their own schedule -- when a canvas element's menu opens, or while a
+    // page initializes -- so they must ask C# to keep quiet. Without the flag, a clipboard held
+    // for a moment by another program tells the user we couldn't paste something they never asked
+    // us to paste.
+    test("asks C# not to report a failure", async () => {
+        mockGetAsync.mockResolvedValue({ data: "something" } as never);
+
+        expect(await readClipboardTextForAvailabilityCheck()).toBe("something");
+        expect(mockGetAsync).toHaveBeenCalledWith(
+            "common/clipboardText?checkingAvailability=true",
+        );
+    });
+
+    // The contrast that matters: a real paste does ask for failures to be reported.
+    test("differs from the paste read, which does want failures reported", async () => {
+        mockGetAsync.mockResolvedValue({ data: "" } as never);
+
+        await readTextFromClipboard();
+
+        expect(mockGetAsync).toHaveBeenCalledWith("common/clipboardText");
     });
 });
 

--- a/src/BloomBrowserUI/bookEdit/js/hostClipboard.ts
+++ b/src/BloomBrowserUI/bookEdit/js/hostClipboard.ts
@@ -15,19 +15,32 @@
 import { AxiosResponse } from "axios";
 import { getAsync, postJson, postJsonAsync } from "../../utils/bloomApi";
 
-// Put text on the clipboard. Resolves true if it actually got there; if not, C# has
-// already told the user, and callers that are about to destroy the original (cut) should
-// leave it alone.
+// Put text on the clipboard. Resolves true if it actually got there. False covers both "the
+// clipboard refused it" -- in which case C# has already told the user -- and "there was nothing
+// to copy", which C# reports as false without bothering anyone. Either way a caller that is
+// about to destroy the original (cut) should leave it alone.
 export async function copyTextToClipboard(text: string): Promise<boolean> {
     const response = await postJsonAsync("common/clipboardText", { text });
     return (response as AxiosResponse | undefined)?.data === true;
 }
 
-// Read text from the clipboard, or "" if there is none. If the clipboard could not be read
-// at all, C# has told the user and we get "" here too -- so callers do nothing, which is
-// the same thing they would do with an empty clipboard.
+// Read text from the clipboard on the user's behalf, i.e. for an actual paste, or "" if there
+// is none. If the clipboard could not be read at all, C# has told the user and we get "" here
+// too -- so callers do nothing, which is the same thing they would do with an empty clipboard.
 export async function readTextFromClipboard(): Promise<string> {
     const response = await getAsync("common/clipboardText");
+    return typeof response.data === "string" ? response.data : "";
+}
+
+// Read the clipboard only to find out whether there is text to paste -- to decide whether to
+// enable a menu item or a button -- rather than to paste it. C# deliberately stays silent about
+// a failure here: these checks run on their own schedule (when a canvas element's menu opens,
+// while a page initializes), and the user has not asked for anything, so a clipboard held for a
+// moment by another program must not produce an "unable to paste" message out of nowhere.
+export async function readClipboardTextForAvailabilityCheck(): Promise<string> {
+    const response = await getAsync(
+        "common/clipboardText?checkingAvailability=true",
+    );
     return typeof response.data === "string" ? response.data : "";
 }
 

--- a/src/BloomBrowserUI/bookEdit/js/hostClipboard.ts
+++ b/src/BloomBrowserUI/bookEdit/js/hostClipboard.ts
@@ -1,0 +1,74 @@
+// Clipboard operations that go through C# ("the host") instead of navigator.clipboard.
+//
+// This is not just plumbing preference: Chromium silently discards clipboard failures.
+// With the Windows clipboard held by another process (a clipboard manager, a remote-desktop
+// client, another program mid-copy), navigator.clipboard.writeText() still RESOLVES,
+// document.execCommand("copy") still returns true, and navigator.clipboard.readText()
+// resolves with an empty string -- indistinguishable from an empty clipboard. So a failed
+// copy in the browser is completely undetectable from Javascript, and the user is left
+// thinking they copied something they didn't (BL-16459).
+//
+// The WinForms clipboard C# uses does throw, so routing through C# is what lets a failure
+// be noticed. C# reports it as a toast; see BloomClipboard.cs. Nothing is lost by going
+// this way: these calls only ever handled plain text anyway.
+
+import { AxiosResponse } from "axios";
+import { getAsync, postJson, postJsonAsync } from "../../utils/bloomApi";
+
+// Put text on the clipboard. Resolves true if it actually got there; if not, C# has
+// already told the user, and callers that are about to destroy the original (cut) should
+// leave it alone.
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+    const response = await postJsonAsync("common/clipboardText", { text });
+    return (response as AxiosResponse | undefined)?.data === true;
+}
+
+// Read text from the clipboard, or "" if there is none. If the clipboard could not be read
+// at all, C# has told the user and we get "" here too -- so callers do nothing, which is
+// the same thing they would do with an empty clipboard.
+export async function readTextFromClipboard(): Promise<string> {
+    const response = await getAsync("common/clipboardText");
+    return typeof response.data === "string" ? response.data : "";
+}
+
+// Ask C# to check whether the clipboard is usable, and toast if it isn't, after the browser
+// has done a copy of its own. Deliberately fire-and-forget: there is nothing for us to do
+// with the answer, and we must not delay the editing gesture.
+export function verifyBrowserCopyReachedClipboard(): void {
+    postJson("common/verifyClipboardAfterBrowserCopy", {});
+}
+
+// The same for a browser-performed paste, differing only in which message the user gets.
+export function verifyBrowserPasteGotClipboard(): void {
+    postJson("common/verifyClipboardAfterBrowserPaste", {});
+}
+
+// The browser does its clipboard work as part of the default action, after our handler returns,
+// so a check has to wait for the next turn of the event loop. These are the right way to ask
+// "did what the browser just did actually work?".
+export function verifyBrowserCopyAfterDefault(): void {
+    window.setTimeout(verifyBrowserCopyReachedClipboard, 0);
+}
+
+export function verifyBrowserPasteAfterDefault(): void {
+    window.setTimeout(verifyBrowserPasteGotClipboard, 0);
+}
+
+// Watch for copies and cuts the browser performs itself, so each one gets verified. We do not
+// preventDefault or touch the data: Chromium's own copy is better than anything we would
+// reconstruct (it carries the HTML flavor, images, and whatever else was selected). We only look
+// afterwards to see whether it can have worked.
+//
+// Note there is deliberately no "skip it if the event was defaultPrevented" check here. That
+// seems the obvious way to avoid reporting twice when Bloom handles a clipboard event itself,
+// and it silently defeats the whole feature: CKEditor calls preventDefault on copy and cut
+// inside a .bloom-editable, which is precisely where the user is when this matters. Reporting
+// twice is harmless anyway -- both reports carry the same message, and the toast host shows one.
+//
+// These also do not cover Ctrl+V, whose event CKEditor swallows before it reaches the document
+// at all; keyboard shortcuts are handled from the keydown handler in bloomEditing.ts.
+export function listenForBrowserClipboardOperations(doc: Document): void {
+    doc.addEventListener("copy", verifyBrowserCopyAfterDefault);
+    doc.addEventListener("cut", verifyBrowserCopyAfterDefault);
+    doc.addEventListener("paste", verifyBrowserPasteAfterDefault);
+}

--- a/src/BloomBrowserUI/bookEdit/js/hostClipboard.ts
+++ b/src/BloomBrowserUI/bookEdit/js/hostClipboard.ts
@@ -24,11 +24,17 @@ export async function copyTextToClipboard(text: string): Promise<boolean> {
     return (response as AxiosResponse | undefined)?.data === true;
 }
 
+// The clipboard endpoint replies with text/plain, but axios runs JSON.parse over every response
+// body by default, so a clipboard holding 42 would arrive as a number, one holding true as a
+// boolean, and one holding {"a":1} as an object -- and then be discarded as "not a string",
+// meaning pasting a number silently inserted nothing. Ask for the body exactly as sent.
+const kReplyIsPlainText = { transformResponse: [(body: string) => body] };
+
 // Read text from the clipboard on the user's behalf, i.e. for an actual paste, or "" if there
 // is none. If the clipboard could not be read at all, C# has told the user and we get "" here
 // too -- so callers do nothing, which is the same thing they would do with an empty clipboard.
 export async function readTextFromClipboard(): Promise<string> {
-    const response = await getAsync("common/clipboardText");
+    const response = await getAsync("common/clipboardText", kReplyIsPlainText);
     return typeof response.data === "string" ? response.data : "";
 }
 
@@ -40,6 +46,7 @@ export async function readTextFromClipboard(): Promise<string> {
 export async function readClipboardTextForAvailabilityCheck(): Promise<string> {
     const response = await getAsync(
         "common/clipboardText?checkingAvailability=true",
+        kReplyIsPlainText,
     );
     return typeof response.data === "string" ? response.data : "";
 }

--- a/src/BloomBrowserUI/toast/Toast.tsx
+++ b/src/BloomBrowserUI/toast/Toast.tsx
@@ -36,6 +36,12 @@ type ToastInfoBase = {
     l10nId?: string;
     durationSeconds?: number;
     actionInfo?: ToastActionInfo;
+    // Normally a message identical to one already showing is suppressed, which keeps repeated
+    // notices from piling up. Set this when the same message arriving again means a *new* thing
+    // happened that the user needs to see reacted to -- a second failed copy, say, where silence
+    // reads as "that one worked". Such a toast is refreshed (and its time on screen restarted)
+    // instead of being dropped. Keep in sync with ToastService.ShowToast in C#.
+    showEvenIfDuplicate?: boolean;
 };
 
 export type ToastInfo = RequireAtLeastOne<ToastInfoBase, "text" | "l10nId">;

--- a/src/BloomBrowserUI/toast/ToastHost.test.tsx
+++ b/src/BloomBrowserUI/toast/ToastHost.test.tsx
@@ -1,0 +1,111 @@
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { renderRootSync, unmountRoot } from "../utils/reactRender";
+
+// react-toastify is mocked so we can see which of its calls ToastHost makes: showing a new toast,
+// or refreshing one that is already on screen. That distinction is the whole behaviour under test
+// and it cannot be seen in the DOM, because a refreshed toast looks exactly like the old one.
+const { mockToast, mockUpdate, mockDismiss } = vi.hoisted(() => ({
+    mockToast: vi.fn(),
+    mockUpdate: vi.fn(),
+    mockDismiss: vi.fn(),
+}));
+
+vi.mock("react-toastify", () => {
+    const toast = (...args: unknown[]) => mockToast(...args);
+    (toast as unknown as Record<string, unknown>).update = (
+        ...args: unknown[]
+    ) => mockUpdate(...args);
+    (toast as unknown as Record<string, unknown>).dismiss = (
+        ...args: unknown[]
+    ) => mockDismiss(...args);
+    return { toast, ToastContainer: () => <div /> };
+});
+vi.mock("react-toastify/dist/ReactToastify.css", () => ({}));
+vi.mock("../utils/bloomApi", () => ({ postJsonAsync: vi.fn() }));
+vi.mock("../utils/WebSocketManager", () => ({
+    default: { addListener: vi.fn(), removeListener: vi.fn() },
+}));
+
+import { ToastHost } from "./ToastHost";
+
+let container: HTMLDivElement;
+
+// The debug event is the same path the backend's websocket messages take into enqueueToasts.
+const send = (toastInfo: Record<string, unknown>) =>
+    act(() => {
+        window.dispatchEvent(
+            new CustomEvent("bloom-toast-debug-show", { detail: toastInfo }),
+        );
+    });
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    act(() => {
+        renderRootSync(<ToastHost />, container);
+    });
+});
+
+afterEach(() => {
+    unmountRoot(container);
+    container.remove();
+});
+
+describe("ToastHost duplicate handling", () => {
+    test("shows a message that isn't already on screen", () => {
+        send({ text: "Bloom was not able to copy that.", durationSeconds: 15 });
+
+        expect(mockToast).toHaveBeenCalledTimes(1);
+        expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    // The default, which keeps repeated notices from piling up.
+    test("suppresses an identical repeat by default", () => {
+        const message = { text: "Something happened.", durationSeconds: 15 };
+
+        send(message);
+        send(message);
+
+        expect(mockToast).toHaveBeenCalledTimes(1);
+        expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    // Clipboard failures opt out of that: a second failed copy is a new attempt by the user, and
+    // showing nothing reads as "that one worked" (BL-16459).
+    test("refreshes an identical repeat when the sender asks for it", () => {
+        const message = {
+            text: "Bloom was not able to copy that.",
+            durationSeconds: 15,
+            showEvenIfDuplicate: true,
+        };
+
+        send(message);
+        send(message);
+
+        expect(mockToast).toHaveBeenCalledTimes(1);
+        expect(mockUpdate).toHaveBeenCalledTimes(1);
+        // Same identity, and its time on screen restarted.
+        const [identity, options] = mockUpdate.mock.calls[0] as [
+            string,
+            { autoClose?: number },
+        ];
+        expect(identity).toBe("Bloom was not able to copy that.");
+        expect(options.autoClose).toBe(15000);
+    });
+
+    test("a third identical failure is shown again too", () => {
+        const message = {
+            text: "Bloom was not able to paste.",
+            durationSeconds: 15,
+            showEvenIfDuplicate: true,
+        };
+
+        send(message);
+        send(message);
+        send(message);
+
+        expect(mockUpdate).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/BloomBrowserUI/toast/ToastHost.tsx
+++ b/src/BloomBrowserUI/toast/ToastHost.tsx
@@ -126,6 +126,17 @@ export const ToastHost: React.FunctionComponent<{
                     return;
                 }
 
+                // A repeat that the sender says matters: refresh it and restart its time on
+                // screen, rather than dropping it as a duplicate. Without this, a second failed
+                // attempt produces no visible reaction at all, which reads as though it worked.
+                if (incomingToast.showEvenIfDuplicate) {
+                    updateToast({
+                        ...existingToast,
+                        ...incomingToast,
+                    });
+                    return;
+                }
+
                 if (
                     getToastLifetimeSeconds(incomingToast) >
                     getToastLifetimeSeconds(existingToast)

--- a/src/BloomBrowserUI/utils/bloomApi.ts
+++ b/src/BloomBrowserUI/utils/bloomApi.ts
@@ -201,8 +201,11 @@ export function get(
 }
 
 // This method is used to get a result from Bloom.
-export async function getAsync(urlSuffix: string) {
-    return await axios.get(getBloomApiPrefix() + urlSuffix);
+// The optional config is passed straight to axios; the one known need for it is a caller that
+// must switch off axios's default response transform, which runs JSON.parse on every body and so
+// turns a text/plain reply of "42" into a number (see kReplyIsPlainText in hostClipboard.ts).
+export async function getAsync(urlSuffix: string, config?: AxiosRequestConfig) {
+    return await axios.get(getBloomApiPrefix() + urlSuffix, config);
 }
 
 // A react hook for controlling an API-backed boolean from a React pure functional component

--- a/src/BloomExe/IBrowser.cs
+++ b/src/BloomExe/IBrowser.cs
@@ -9,8 +9,8 @@ using System.Windows.Forms;
 using Bloom.Api;
 using Bloom.Book;
 using Bloom.ToPalaso;
+using Bloom.Utils;
 using SIL.IO;
-using SIL.Windows.Forms.Miscellaneous;
 
 namespace Bloom
 {
@@ -320,8 +320,10 @@ namespace Bloom
                 "document.getElementsByClassName('bloom-page')[0]?.outerHTML"
             );
             // After the await we're back on the UI thread, so it's safe to use the clipboard.
+            // This method is 'async void', so a clipboard exception here would take the whole
+            // program down; BloomClipboard toasts instead of throwing.
             if (!string.IsNullOrEmpty(html))
-                PortableClipboard.SetText(html);
+                BloomClipboard.TrySetText(html);
         }
 
         public abstract Task<string> GetStringFromJavascriptAsync(string script);

--- a/src/BloomExe/NonFatalProblem.cs
+++ b/src/BloomExe/NonFatalProblem.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -58,7 +58,11 @@ namespace Bloom
             bool isShortMessagePreEncoded = false,
             bool skipSentryReport = false,
             bool showRequestDetails = false,
-            string[] additionalFilesToInclude = null
+            string[] additionalFilesToInclude = null,
+            // Let an identical message through when it arrives again, instead of being suppressed
+            // as a duplicate. For problems where a repeat means the user just tried again and hit
+            // the same wall, and needs to see that acknowledged. See ToastService.ShowToast.
+            bool showToastEvenIfDuplicate = false
         )
         {
             var originalException = exception;
@@ -191,7 +195,8 @@ namespace Bloom
                             exception,
                             fullDetailedMessage,
                             showSendReport,
-                            showRequestDetails
+                            showRequestDetails,
+                            showToastEvenIfDuplicate
                         );
                     }
                     finally
@@ -354,7 +359,8 @@ namespace Bloom
             Exception exception,
             string fullDetailedMessage,
             bool showSendReport = true,
-            bool showDetailsOnRequest = false
+            bool showDetailsOnRequest = false,
+            bool showEvenIfDuplicate = false
         )
         {
             ToastAction action = null;
@@ -404,7 +410,8 @@ namespace Bloom
                 ToastType.Warning,
                 text: shortUserLevelMessage,
                 durationSeconds: 15,
-                action: action
+                action: action,
+                showEvenIfDuplicate: showEvenIfDuplicate
             );
         }
 

--- a/src/BloomExe/Publish/BloomPub/PublishToBloomPubApi.cs
+++ b/src/BloomExe/Publish/BloomPub/PublishToBloomPubApi.cs
@@ -11,13 +11,13 @@ using Bloom.Properties;
 using Bloom.Publish.BloomPub.file;
 using Bloom.Publish.BloomPub.wifi;
 using Bloom.SubscriptionAndFeatures;
+using Bloom.Utils;
 using Bloom.web;
 using Bloom.web.controllers;
 using DesktopAnalytics;
 using Newtonsoft.Json;
 using SIL.IO;
 using SIL.Reporting;
-using SIL.Windows.Forms.Miscellaneous;
 #if !__MonoCS__
 using Bloom.Publish.BloomPub.usb;
 #endif
@@ -245,7 +245,9 @@ namespace Bloom.Publish.BloomPub
                 kApiUrlPart + "textToClipboard",
                 request =>
                 {
-                    PortableClipboard.SetText(request.RequiredPostString());
+                    // BloomClipboard toasts rather than throwing if the clipboard is being held
+                    // by something else at this moment (BL-16459).
+                    BloomClipboard.TrySetText(request.RequiredPostString());
                     request.PostSucceeded();
                 },
                 true

--- a/src/BloomExe/Utils/BloomClipboard.cs
+++ b/src/BloomExe/Utils/BloomClipboard.cs
@@ -1,0 +1,266 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Threading;
+using L10NSharp;
+using SIL.Windows.Forms.Miscellaneous;
+
+namespace Bloom.Utils
+{
+    /// <summary>
+    /// Clipboard access that reports its own failures, and the only clipboard API Bloom code
+    /// should use for text.
+    ///
+    /// Windows lets just one thread have the clipboard open at a time, so any clipboard
+    /// operation can fail simply because something else (a clipboard manager, a remote-desktop
+    /// client, another program in the middle of its own copy) happens to be holding it at that
+    /// instant. All the user can do about it is try again, so rather than crashing or popping a
+    /// problem-report dialog, these methods toast and return false (BL-16459).
+    ///
+    /// Writes and reads must be checked differently, because .NET reports their failure
+    /// differently -- and the read behaviour is genuinely surprising. Measured on .NET 8 with
+    /// another process holding the clipboard, comparing a process that had recently read the
+    /// clipboard (which Bloom always has: UpdateEditButtonsAsync polls it on a timer) against a
+    /// freshly started one:
+    ///
+    ///                      recently read the clipboard   fresh process
+    ///   ContainsText()     returned True                 threw ExternalException
+    ///   GetText()          returned ""                   threw ExternalException
+    ///   GetDataObject()    returned an object            threw ExternalException
+    ///   SetText()          threw ExternalException       threw ExternalException
+    ///
+    /// OLE answers a read from a data object cached by that process's own earlier read. So inside
+    /// Bloom, reading a locked clipboard silently looks like an *empty* clipboard -- worse than an
+    /// error, because "there was nothing to paste" is a plausible lie. Only writes fail honestly.
+    /// That is exactly why a failed copy from the Copy button was reported while a failed Ctrl+C
+    /// or Ctrl+V was not.
+    ///
+    /// Hence writes are checked by catching, and anything read-shaped is checked by asking the OS
+    /// directly whether the clipboard can be opened -- see TryOpenClipboardBriefly.
+    ///
+    /// Note that this is the *only* layer that can notice such a failure at all. Chromium
+    /// (and therefore anything the browser does, including navigator.clipboard and a plain
+    /// Ctrl+C) silently discards clipboard errors: with the clipboard held by another process,
+    /// navigator.clipboard.writeText() still resolves, document.execCommand("copy") still
+    /// returns true, and navigator.clipboard.readText() resolves with an empty string. So
+    /// front-end code that wants to know whether a copy worked has to come through here.
+    /// </summary>
+    public static class BloomClipboard
+    {
+        /// <summary>
+        /// Put text on the clipboard. Returns false (having told the user) if the clipboard
+        /// could not be written.
+        /// </summary>
+        public static bool TrySetText(string text)
+        {
+            var succeeded = false;
+            RunOnUiThread(() =>
+            {
+                try
+                {
+                    PortableClipboard.SetText(text);
+                    succeeded = true;
+                }
+                catch (Exception e)
+                {
+                    ReportCopyFailure(e);
+                }
+            });
+            return succeeded;
+        }
+
+        /// <summary>
+        /// Read text from the clipboard. Returns false (having told the user) if the clipboard
+        /// could not be read; note that an *empty* clipboard is a success, yielding "".
+        /// </summary>
+        public static bool TryGetText(out string text)
+        {
+            text = "";
+
+            // Ask the OS before believing the read: inside Bloom, reading a locked clipboard
+            // returns "" rather than throwing (see the class comment), so a failed paste would
+            // otherwise be indistinguishable from an empty clipboard and reported to nobody.
+            if (!TryOpenClipboardBriefly(out var lastError))
+            {
+                RunOnUiThread(() => ReportPasteFailure(new Win32Exception(lastError)));
+                return false;
+            }
+
+            // A local, because a lambda may not assign to an out parameter.
+            string result = null;
+            RunOnUiThread(() =>
+            {
+                try
+                {
+                    result = PortableClipboard.GetText() ?? "";
+                }
+                catch (Exception e)
+                {
+                    ReportPasteFailure(e);
+                }
+            });
+            text = result ?? "";
+            return result != null;
+        }
+
+        /// <summary>
+        /// Check whether the clipboard is usable right now, and if it isn't, tell the user that
+        /// a copy failed. This exists for copies the browser performs itself (a plain Ctrl+C in
+        /// a text box, which Chromium handles without telling us): the browser cannot report the
+        /// failure, so the only thing we can do is look at the clipboard immediately afterwards
+        /// and see whether it is accessible at all.
+        ///
+        /// Necessarily approximate, in both directions, because it is a second look rather than
+        /// the operation itself. A lock that is released between Chromium's attempt and ours goes
+        /// unreported; a lock that starts in that same gap makes us report a copy that actually
+        /// succeeded. Both windows are the width of one API round trip, and the probe's own
+        /// retries (see TryOpenClipboardBriefly) ride out momentary contention, so in practice
+        /// this catches the sustained locks that generate real reports (BL-16459) without crying
+        /// wolf.
+        ///
+        /// The probe does take the clipboard itself, for the microseconds between opening and
+        /// closing it. That is unavoidable in a truthful check, and it runs after the browser's
+        /// operation has completed, so it is not in a position to disturb it.
+        /// </summary>
+        public static bool VerifyUsableAfterBrowserCopy()
+        {
+            return VerifyUsable(ReportCopyFailure);
+        }
+
+        /// <summary>
+        /// The paste counterpart of VerifyUsableAfterBrowserCopy(), for a Ctrl+V that Chromium
+        /// handles itself. Same reasoning and same caveats; the difference is only which message
+        /// the user gets. This matters more than it might seem: a paste from an unreadable
+        /// clipboard puts nothing in the document, which looks exactly like "the clipboard was
+        /// empty", so without this the user is left believing they never copied anything.
+        /// </summary>
+        public static bool VerifyUsableAfterBrowserPaste()
+        {
+            return VerifyUsable(ReportPasteFailure);
+        }
+
+        private static bool VerifyUsable(Action<Exception> report)
+        {
+            if (TryOpenClipboardBriefly(out var lastError))
+                return true;
+            // Report from the UI thread: NonFatalProblem looks at open forms.
+            RunOnUiThread(() => report(new Win32Exception(lastError)));
+            return false;
+        }
+
+        /// <summary>
+        /// Whether the OS will currently hand us the clipboard, asked by opening and immediately
+        /// closing it.
+        ///
+        /// This is the raw Win32 call rather than anything in Clipboard/PortableClipboard because,
+        /// as the class comment records, a .NET clipboard read inside Bloom does not fail when the
+        /// clipboard is held by someone else -- OLE serves it from a cached data object, so we get
+        /// a cheerful "True" or an empty string. OpenClipboard asks the OS itself: only one thread
+        /// on the machine can hold the clipboard, so either we are granted it or we are not.
+        ///
+        /// Needs no UI thread: the lock belongs to whichever thread opened it, and we release it
+        /// before returning.
+        /// </summary>
+        private static bool TryOpenClipboardBriefly(out int lastError)
+        {
+            lastError = 0;
+            for (var attempt = 0; attempt < kOpenAttempts; attempt++)
+            {
+                if (OpenClipboard(IntPtr.Zero))
+                {
+                    CloseClipboard();
+                    return true;
+                }
+                lastError = Marshal.GetLastWin32Error();
+                // Something may be holding it for only an instant -- including the WebView2
+                // process finishing the very operation we are checking on. Don't cry wolf over
+                // that; we are looking for a clipboard held long enough to break the operation.
+                Thread.Sleep(kOpenRetryDelayMs);
+            }
+            return false;
+        }
+
+        private const int kOpenAttempts = 4;
+        private const int kOpenRetryDelayMs = 50;
+
+        // Note: a NULL owner is fine for *asking* whether the clipboard is available, which is all
+        // we do here. It is useless for *holding* the clipboard -- with a NULL owner the call
+        // succeeds but grants no exclusivity at all (which is how Lock-Clipboard.ps1 came to
+        // report that it had locked a clipboard that was in fact freely usable).
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool OpenClipboard(IntPtr hWndNewOwner);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool CloseClipboard();
+
+        private static void ReportCopyFailure(Exception e)
+        {
+            if (AlreadyJustReported(ref _lastCopyFailureReport))
+                return;
+            // A clipboard failure is not worth a modal problem-report dialog: whatever the
+            // cause, all the user can do is try again (BL-16459). So we just toast, which
+            // still offers a "Report" link and still tells Sentry.
+            NonFatalProblem.Report(
+                ModalIf.None,
+                PassiveIf.All,
+                LocalizationManager.GetDynamicString(
+                    "BloomLowPriority",
+                    "EditTab.CopyTextFailed",
+                    "Bloom was not able to copy that."
+                ),
+                exception: e
+            );
+        }
+
+        private static void ReportPasteFailure(Exception e)
+        {
+            if (AlreadyJustReported(ref _lastPasteFailureReport))
+                return;
+            NonFatalProblem.Report(
+                ModalIf.None,
+                PassiveIf.All,
+                LocalizationManager.GetDynamicString(
+                    "BloomLowPriority",
+                    "EditTab.PasteTextFailed",
+                    "Bloom was not able to paste."
+                ),
+                exception: e
+            );
+        }
+
+        private static DateTime _lastCopyFailureReport = DateTime.MinValue;
+        private static DateTime _lastPasteFailureReport = DateTime.MinValue;
+
+        // One keystroke can legitimately reach us twice: the browser's own clipboard event and
+        // the keydown handler both ask us to check, deliberately, because neither alone covers
+        // every case. The user sees one toast either way (the toast host collapses identical
+        // messages), but we don't want the log and Sentry to carry the same failure twice, so
+        // ignore a repeat of the same kind that arrives while the first is still in flight.
+        private static readonly TimeSpan kReportSuppressionWindow = TimeSpan.FromSeconds(1);
+
+        private static bool AlreadyJustReported(ref DateTime lastReport)
+        {
+            var now = DateTime.Now;
+            if (now - lastReport < kReportSuppressionWindow)
+                return true;
+            lastReport = now;
+            return false;
+        }
+
+        /// <summary>
+        /// The Windows clipboard has to be used from the UI thread, and most of our callers are
+        /// API handlers running on a server thread. Send() runs the action inline when we are
+        /// already on the UI thread, so this is safe from either.
+        /// </summary>
+        private static void RunOnUiThread(Action action)
+        {
+            if (Program.MainContext == null)
+            {
+                // No WinForms message loop: unit tests and console mode. Just run it here.
+                action();
+                return;
+            }
+            Program.MainContext.Send(_ => action(), null);
+        }
+    }
+}

--- a/src/BloomExe/Utils/BloomClipboard.cs
+++ b/src/BloomExe/Utils/BloomClipboard.cs
@@ -101,7 +101,11 @@ namespace Bloom.Utils
             {
                 try
                 {
-                    result = PortableClipboard.GetText() ?? "";
+                    // Windows programs put CRLF on the clipboard, and this read hands it back
+                    // verbatim -- where navigator.clipboard.readText(), which the front end used
+                    // before, normalized line endings for us. Keep doing that, so a multi-line
+                    // paste doesn't start gaining stray breaks in the editor.
+                    result = NormalizeLineEndings(PortableClipboard.GetText());
                 }
                 catch (Exception e)
                 {
@@ -211,6 +215,18 @@ namespace Bloom.Utils
 
         [DllImport("user32.dll", SetLastError = true)]
         private static extern bool CloseClipboard();
+
+        /// <summary>
+        /// Turns any CRLF or lone CR into LF, matching what the browser's own clipboard read gave
+        /// the front end before this class existed. Nothing downstream wants Windows line endings:
+        /// the text goes into the editor, where a stray CR can show up as an extra line break.
+        /// </summary>
+        internal static string NormalizeLineEndings(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+                return text ?? "";
+            return text.Replace("\r\n", "\n").Replace("\r", "\n");
+        }
 
         private static void ReportCopyFailure(Exception e)
         {

--- a/src/BloomExe/Utils/BloomClipboard.cs
+++ b/src/BloomExe/Utils/BloomClipboard.cs
@@ -129,8 +129,13 @@ namespace Bloom.Utils
         /// wolf.
         ///
         /// The probe does take the clipboard itself, for the microseconds between opening and
-        /// closing it. That is unavoidable in a truthful check, and it runs after the browser's
-        /// operation has completed, so it is not in a position to disturb it.
+        /// closing it, and that is not as harmless as it first looks. The browser defers the check
+        /// only by a zero-length timeout plus one localhost round trip, while Chromium's actual
+        /// write happens asynchronously in its own process -- so the two can in principle race,
+        /// and if the probe wins, Chromium's write fails (silently, since it discards clipboard
+        /// errors) and this check would have caused the very failure it then reports. The window
+        /// is small and unmeasured; whether it needs closing -- by delaying the probe, or by not
+        /// taking the clipboard at all -- is on the PR as an open question.
         /// </summary>
         public static bool VerifyUsableAfterBrowserCopy()
         {

--- a/src/BloomExe/Utils/BloomClipboard.cs
+++ b/src/BloomExe/Utils/BloomClipboard.cs
@@ -129,13 +129,17 @@ namespace Bloom.Utils
         /// wolf.
         ///
         /// The probe does take the clipboard itself, for the microseconds between opening and
-        /// closing it, and that is not as harmless as it first looks. The browser defers the check
-        /// only by a zero-length timeout plus one localhost round trip, while Chromium's actual
-        /// write happens asynchronously in its own process -- so the two can in principle race,
-        /// and if the probe wins, Chromium's write fails (silently, since it discards clipboard
-        /// errors) and this check would have caused the very failure it then reports. The window
-        /// is small and unmeasured; whether it needs closing -- by delaying the probe, or by not
-        /// taking the clipboard at all -- is on the PR as an open question.
+        /// closing it, which raises the fair question of whether the check could break the very
+        /// copy it is checking on -- Chromium writes asynchronously in its own process, so the two
+        /// can in principle race, and Chromium discards clipboard errors silently.
+        ///
+        /// Measured, because it is the kind of thing one should not reason about: a helper process
+        /// opened and closed the clipboard continuously -- 7.4 million times in ten seconds --
+        /// while Chromium wrote to it twenty times. All twenty writes landed. Whoever wants the
+        /// clipboard retries for it, so a hold measured in microseconds is simply ridden over, and
+        /// our real check takes it once per copy rather than millions of times. So the race exists
+        /// on paper and does not bite; that is why this stays a plain open-and-close rather than
+        /// something more elaborate.
         /// </summary>
         public static bool VerifyUsableAfterBrowserCopy()
         {
@@ -223,7 +227,10 @@ namespace Bloom.Utils
                     "EditTab.CopyTextFailed",
                     "Bloom was not able to copy that."
                 ),
-                exception: e
+                exception: e,
+                // A second failed attempt is a new attempt: show it again rather than letting it
+                // be swallowed as a duplicate, or the user reads the silence as success.
+                showToastEvenIfDuplicate: true
             );
         }
 
@@ -239,7 +246,10 @@ namespace Bloom.Utils
                     "EditTab.PasteTextFailed",
                     "Bloom was not able to paste."
                 ),
-                exception: e
+                exception: e,
+                // A second failed attempt is a new attempt: show it again rather than letting it
+                // be swallowed as a duplicate, or the user reads the silence as success.
+                showToastEvenIfDuplicate: true
             );
         }
 

--- a/src/BloomExe/Utils/BloomClipboard.cs
+++ b/src/BloomExe/Utils/BloomClipboard.cs
@@ -198,7 +198,11 @@ namespace Bloom.Utils
                 // Something may be holding it for only an instant -- including the WebView2
                 // process finishing the very operation we are checking on. Don't cry wolf over
                 // that; we are looking for a clipboard held long enough to break the operation.
-                Thread.Sleep(kOpenRetryDelayMs);
+                //
+                // Nothing to wait for after the last attempt, and this runs on the UI thread for
+                // the Paste toolbar command, so a wasted 50ms is 50ms of frozen window.
+                if (attempt < kOpenAttempts - 1)
+                    Thread.Sleep(kOpenRetryDelayMs);
             }
             return false;
         }

--- a/src/BloomExe/Utils/BloomClipboard.cs
+++ b/src/BloomExe/Utils/BloomClipboard.cs
@@ -70,10 +70,18 @@ namespace Bloom.Utils
         }
 
         /// <summary>
-        /// Read text from the clipboard. Returns false (having told the user) if the clipboard
-        /// could not be read; note that an *empty* clipboard is a success, yielding "".
+        /// Read text from the clipboard. Returns false if the clipboard could not be read; note
+        /// that an *empty* clipboard is a success, yielding "".
         /// </summary>
-        public static bool TryGetText(out string text)
+        /// <param name="reportFailure">
+        /// Whether to tell the user when the read fails. Pass false when nothing was asked of the
+        /// clipboard on the user's behalf -- code that is merely checking whether there is text to
+        /// paste, so it can enable a menu item or a button. Such a check can run at any time (when
+        /// a menu opens, or while a page loads), and a clipboard momentarily held by another
+        /// program must not put an unexplained "Bloom was not able to paste" in front of someone
+        /// who never tried to paste.
+        /// </param>
+        public static bool TryGetText(out string text, bool reportFailure = true)
         {
             text = "";
 
@@ -82,7 +90,8 @@ namespace Bloom.Utils
             // otherwise be indistinguishable from an empty clipboard and reported to nobody.
             if (!TryOpenClipboardBriefly(out var lastError))
             {
-                RunOnUiThread(() => ReportPasteFailure(new Win32Exception(lastError)));
+                if (reportFailure)
+                    RunOnUiThread(() => ReportPasteFailure(new Win32Exception(lastError)));
                 return false;
             }
 
@@ -96,7 +105,8 @@ namespace Bloom.Utils
                 }
                 catch (Exception e)
                 {
-                    ReportPasteFailure(e);
+                    if (reportFailure)
+                        ReportPasteFailure(e);
                 }
             });
             text = result ?? "";

--- a/src/BloomExe/WebView2Browser.cs
+++ b/src/BloomExe/WebView2Browser.cs
@@ -12,6 +12,7 @@ using Bloom.Api;
 using Bloom.Book;
 using Bloom.Edit;
 using Bloom.Properties;
+using Bloom.Utils;
 using Microsoft.Web.WebView2.Core;
 using Microsoft.Web.WebView2.WinForms;
 using Microsoft.Win32;
@@ -896,6 +897,15 @@ namespace Bloom
             // result (we only care about the side effects on the document).
             _pasteCommand.Implementer = () =>
             {
+                // Check that the clipboard is readable at all before deciding it holds no image.
+                // The catch below cannot tell "this isn't an image" from "the clipboard is being
+                // held by another program", and treating the latter as the former is how a failed
+                // paste came to be reported to the user as "Bloom did not find an image on your
+                // clipboard. Copy one first" -- advice about a clipboard that may be perfectly
+                // full. BloomClipboard toasts the real reason and we stop here (BL-16459).
+                if (!BloomClipboard.VerifyUsableAfterBrowserPaste())
+                    return;
+
                 PalasoImage clipboardImage = null;
                 try
                 {

--- a/src/BloomExe/web/ReadersApi.cs
+++ b/src/BloomExe/web/ReadersApi.cs
@@ -15,6 +15,7 @@ using Bloom.Properties;
 using Bloom.SafeXml;
 using Bloom.TeamCollection;
 using Bloom.ToPalaso;
+using Bloom.Utils;
 using Bloom.web.controllers;
 using Bloom.Workspace;
 using L10NSharp;
@@ -22,7 +23,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using SIL.IO;
 using SIL.PlatformUtilities;
-using SIL.Windows.Forms.Miscellaneous;
 using SIL.Xml;
 
 namespace Bloom.Api
@@ -236,7 +236,10 @@ namespace Bloom.Api
                 // It's in the json data, but not asked for in the clipboard copying.
                 var stringToSave =
                     headerBldr.ToString() + Environment.NewLine + dataBldr.ToString();
-                PortableClipboard.SetText(stringToSave);
+                // BloomClipboard, not PortableClipboard: it marshals to the UI thread (we are on
+                // a server thread here) and toasts instead of throwing if the clipboard is
+                // unavailable, which it can be at any moment (BL-16459).
+                BloomClipboard.TrySetText(stringToSave);
             }
             catch (IOException e)
             {

--- a/src/BloomExe/web/ToastService.cs
+++ b/src/BloomExe/web/ToastService.cs
@@ -56,13 +56,21 @@ namespace Bloom.web
         /// Do not use toastId for unrelated toasts that merely happen to have similar text; those
         /// should remain independent so each one can carry its own lifecycle and action.
         /// </summary>
+        /// <param name="showEvenIfDuplicate">
+        /// By default the browser suppresses a message identical to one already showing, which
+        /// stops repeated notices piling up. Pass true when a repeat means something new happened
+        /// that the user must see acknowledged -- a second failed copy, for instance, where showing
+        /// nothing reads as "that one worked". Such a toast is refreshed, and its time on screen
+        /// restarted, rather than dropped. Keep in sync with ToastInfo in src/BloomBrowserUI/toast.
+        /// </param>
         public static void ShowToast(
             string type = ToastType.Notice,
             string text = null,
             string l10nId = null,
             int? durationSeconds = null,
             ToastAction action = null,
-            string toastId = null
+            string toastId = null,
+            bool showEvenIfDuplicate = false
         )
         {
             CleanupExpiredCallbacks();
@@ -76,6 +84,8 @@ namespace Bloom.web
                 bundle.l10nId = l10nId;
             if (durationSeconds.HasValue)
                 bundle.durationSeconds = durationSeconds.Value;
+            if (showEvenIfDuplicate)
+                bundle.showEvenIfDuplicate = true;
 
             if (action != null)
             {

--- a/src/BloomExe/web/controllers/CommonApi.cs
+++ b/src/BloomExe/web/controllers/CommonApi.cs
@@ -117,10 +117,19 @@ namespace Bloom.web.controllers
                 {
                     if (request.HttpMethod == HttpMethods.Get)
                     {
-                        // BloomClipboard toasts if the clipboard can't be read, and gives us ""
-                        // in that case, which is also what an empty clipboard gives us. The
-                        // caller wants text either way.
-                        BloomClipboard.TryGetText(out var result);
+                        // Two quite different callers share this GET: an actual paste, and code
+                        // merely asking whether there is any text to paste so it can enable a
+                        // menu item or button (which happens when a canvas element's menu opens,
+                        // and while a page initializes -- see the note above). Only a real paste
+                        // may tell the user about a failure; a background availability check must
+                        // stay quiet, or a clipboard briefly held by another program produces an
+                        // "unable to paste" message the user did nothing to provoke.
+                        var isAvailabilityCheck =
+                            request.GetParamOrNull("checkingAvailability") == "true";
+                        // Either way we reply with the text we managed to get, which is "" when
+                        // the clipboard was unreadable -- the same as an empty clipboard, and all
+                        // the caller can act on.
+                        BloomClipboard.TryGetText(out var result, !isAvailabilityCheck);
                         request.ReplyWithText(result);
                     }
                     else

--- a/src/BloomExe/web/controllers/CommonApi.cs
+++ b/src/BloomExe/web/controllers/CommonApi.cs
@@ -11,13 +11,13 @@ using Bloom.Book;
 using Bloom.Collection;
 using Bloom.Edit;
 using Bloom.MiscUI;
+using Bloom.Utils;
 using Bloom.web;
 using Bloom.Workspace;
 using L10NSharp;
 using Newtonsoft.Json;
 using SIL.PlatformUtilities;
 using SIL.Reporting;
-using SIL.Windows.Forms.Miscellaneous;
 using Timer = System.Windows.Forms.Timer;
 
 namespace Bloom.web.controllers
@@ -117,36 +117,10 @@ namespace Bloom.web.controllers
                 {
                     if (request.HttpMethod == HttpMethods.Get)
                     {
-                        string result = ""; // initial value is not used, delegate will set it.
-                        Program.MainContext.Send(
-                            o =>
-                            {
-                                try
-                                {
-                                    result = PortableClipboard.GetText();
-                                }
-                                catch (Exception e)
-                                {
-                                    // Need to make sure to handle exceptions.
-                                    // If the worker thread dies with an unhandled exception,
-                                    // it causes the whole program to immediately crash without opportunity for error reporting
-                                    // A clipboard failure is not worth a modal problem-report dialog: whatever the
-                                    // cause, all the user can do is try again (BL-16459). So we just toast, which
-                                    // still offers a "Report" link and still tells Sentry.
-                                    NonFatalProblem.Report(
-                                        ModalIf.None,
-                                        PassiveIf.All,
-                                        LocalizationManager.GetDynamicString(
-                                            "BloomLowPriority",
-                                            "EditTab.PasteTextFailed",
-                                            "Bloom was not able to paste."
-                                        ),
-                                        exception: e
-                                    );
-                                }
-                            },
-                            null
-                        );
+                        // BloomClipboard toasts if the clipboard can't be read, and gives us ""
+                        // in that case, which is also what an empty clipboard gives us. The
+                        // caller wants text either way.
+                        BloomClipboard.TryGetText(out var result);
                         request.ReplyWithText(result);
                     }
                     else
@@ -154,40 +128,40 @@ namespace Bloom.web.controllers
                         // post
                         var requestData = DynamicJson.Parse(request.RequiredPostJson());
                         string content = requestData.text;
-                        if (!string.IsNullOrEmpty(content))
-                        {
-                            Program.MainContext.Post(
-                                o =>
-                                {
-                                    try
-                                    {
-                                        PortableClipboard.SetText(content);
-                                    }
-                                    catch (Exception e)
-                                    {
-                                        // Need to make sure to handle exceptions.
-                                        // If the worker thread dies with an unhandled exception,
-                                        // it causes the whole program to immediately crash without opportunity for error reporting
-                                        // A clipboard failure is not worth a modal problem-report dialog: whatever the
-                                        // cause, all the user can do is try again (BL-16459). So we just toast, which
-                                        // still offers a "Report" link and still tells Sentry.
-                                        NonFatalProblem.Report(
-                                            ModalIf.None,
-                                            PassiveIf.All,
-                                            LocalizationManager.GetDynamicString(
-                                                "BloomLowPriority",
-                                                "EditTab.CopyTextFailed",
-                                                "Bloom was not able to copy that."
-                                            ),
-                                            exception: e
-                                        );
-                                    }
-                                },
-                                null
-                            );
-                        }
-                        request.PostSucceeded();
+                        // We reply with whether the copy actually happened (BloomClipboard has
+                        // already toasted if it didn't) so that callers who are about to destroy
+                        // the original -- cut, as opposed to copy -- can leave it alone.
+                        var succeeded =
+                            !string.IsNullOrEmpty(content) && BloomClipboard.TrySetText(content);
+                        request.ReplyWithBoolean(succeeded);
                     }
+                },
+                false,
+                false
+            );
+            // Called by the browser just after it has done a copy itself (a plain Ctrl+C or
+            // Ctrl+X in a text box, which Chromium handles internally). Chromium discards
+            // clipboard errors without telling Javascript, so this is the only way such a
+            // failure can reach the user: we look at the clipboard right afterwards and toast
+            // if it turns out not to be usable. See BloomClipboard for the details and limits.
+            apiHandler.RegisterEndpointHandler(
+                "common/verifyClipboardAfterBrowserCopy",
+                request =>
+                {
+                    request.ReplyWithBoolean(BloomClipboard.VerifyUsableAfterBrowserCopy());
+                },
+                false,
+                false
+            );
+            // The same, for a paste the browser performs itself. Ctrl+V in a text box is
+            // deliberately left to Chromium (see pasteHandler in bloomEditing.ts), so this is the
+            // only thing standing between a failed paste and the user concluding that whatever
+            // they copied earlier never made it to the clipboard.
+            apiHandler.RegisterEndpointHandler(
+                "common/verifyClipboardAfterBrowserPaste",
+                request =>
+                {
+                    request.ReplyWithBoolean(BloomClipboard.VerifyUsableAfterBrowserPaste());
                 },
                 false,
                 false

--- a/src/BloomTests/Utils/BloomClipboardTests.cs
+++ b/src/BloomTests/Utils/BloomClipboardTests.cs
@@ -1,0 +1,44 @@
+using Bloom.Utils;
+using NUnit.Framework;
+
+namespace BloomTests.Utils
+{
+    [TestFixture]
+    public class BloomClipboardTests
+    {
+        // Windows programs put CRLF on the clipboard, and the .NET read hands it back verbatim --
+        // unlike the browser's own clipboard read, which the front end used before BloomClipboard
+        // existed and which normalized line endings. Pasted text goes straight into the editor,
+        // where a stray CR can surface as an extra line break, so this normalizing is what keeps a
+        // multi-line paste looking the way it did.
+        [TestCase("one\r\ntwo", "one\ntwo", TestName = "NormalizeLineEndings_Crlf_BecomesLf")]
+        [TestCase("one\rtwo", "one\ntwo", TestName = "NormalizeLineEndings_LoneCr_BecomesLf")]
+        [TestCase("one\ntwo", "one\ntwo", TestName = "NormalizeLineEndings_AlreadyLf_Unchanged")]
+        [TestCase(
+            "a\r\nb\rc\nd",
+            "a\nb\nc\nd",
+            TestName = "NormalizeLineEndings_Mixed_AllBecomeLf"
+        )]
+        [TestCase("no breaks", "no breaks", TestName = "NormalizeLineEndings_NoBreaks_Unchanged")]
+        [TestCase("", "", TestName = "NormalizeLineEndings_Empty_StaysEmpty")]
+        public void NormalizeLineEndings_ProducesLfOnly(string input, string expected)
+        {
+            Assert.That(BloomClipboard.NormalizeLineEndings(input), Is.EqualTo(expected));
+        }
+
+        // An unreadable clipboard is reported by returning false, and callers then treat the text
+        // as empty; a null must not escape as null and trip them up.
+        [Test]
+        public void NormalizeLineEndings_Null_GivesEmptyString()
+        {
+            Assert.That(BloomClipboard.NormalizeLineEndings(null), Is.EqualTo(""));
+        }
+
+        // Guards the CRLF pair against being turned into two breaks by a naive fix.
+        [Test]
+        public void NormalizeLineEndings_CrlfPair_DoesNotBecomeTwoBreaks()
+        {
+            Assert.That(BloomClipboard.NormalizeLineEndings("a\r\n\r\nb"), Is.EqualTo("a\n\nb"));
+        }
+    }
+}


### PR DESCRIPTION
The earlier fix for BL-16459 made the `common/clipboardText` endpoint toast instead of popping a problem-report dialog. That covered a handful of buttons, but not the ways a user actually copies and pastes: a plain **Ctrl+C, Ctrl+X or Ctrl+V**, the canvas element's **Copy Text** command, and the **Cut/Copy toolbar buttons** all failed in complete silence. Worse:

- **Ctrl+X deleted the selected text it had failed to copy**, losing it outright.
- A locked clipboard was reported to the user as *"Bloom did not find an image on your clipboard. Copy one first"* — advice about a clipboard that may be perfectly full.

## Two measured facts shaped the fix

Both are counter-intuitive enough that they are recorded in `BloomClipboard`'s comments, so they don't get "corrected" back out.

**1. Chromium never tells Javascript that a clipboard operation failed.** With another process holding the clipboard:

| call | clipboard free | clipboard locked |
|---|---|---|
| `navigator.clipboard.writeText()` | resolves | **resolves** |
| `document.execCommand("copy")` | `true` | **`true`** |
| `navigator.clipboard.readText()` | resolves with text | **resolves with `""`** |

So adding `.catch()` to the front-end calls would accomplish nothing — the work has to go through C#.

**2. A .NET clipboard *read* inside Bloom does not fail either.** OLE answers it from a data object cached by that process's own earlier read, and Bloom is always reading (`UpdateEditButtonsAsync` polls the clipboard on a timer). Measured on .NET 8 with the clipboard locked:

| | process that recently read the clipboard | fresh process |
|---|---|---|
| `ContainsText()` | **returned True** | threw `ExternalException` |
| `GetText()` | **returned `""`** | threw `ExternalException` |
| `SetText()` | threw | threw |

Only writes fail honestly. That asymmetry is exactly why the Copy button reported failures and Ctrl+C did not, and why a failed paste looked to the user like an empty clipboard.

## The change

- **`BloomClipboard`** (new) owns clipboard text access: write failures detected by catching, anything read-shaped by asking the OS directly via `OpenClipboard`. Marshals to the UI thread, so API handlers can call it. Reports via a toast (with Report link + Sentry), deduped so one keystroke logs once.
- **`hostClipboard.ts`** (new) routes the front end's clipboard work through C# instead of `navigator.clipboard`. Nothing is lost — those calls were plain-text only.
- **Keyboard shortcuts are checked from `keydown`**, because CKEditor `preventDefault`s copy and cut inside a `.bloom-editable` and swallows paste before it reaches the document. There is deliberately *no* "skip defaultPrevented events" check; a regression test guards that, since adding one silently disables the whole feature.
- **Ctrl+X is left to the browser**, and only checked afterwards. An earlier revision of this branch took the cut over so it could copy first and not delete on failure — but Bloom's own cut can only put *plain* text on the clipboard, so that lost formatting, links and inline pictures on **every** cut rather than only failing ones. So a failed cut still loses the text (Chromium's long-standing behaviour); what is new is that the user is told, and can press Ctrl+Z. Fixing it properly needs the copy path to carry several clipboard formats at once — see the open discussion. AltGr (reported as Ctrl+Alt) is excluded so international layouts can still type.
- Brought the other unguarded C# clipboard writes in: reader stats, BloomPub text-to-clipboard, and copy-page-HTML (an `async void` that a clipboard exception would have crashed the program from).

## Verification

Against a **genuinely locked clipboard** in a running Bloom (verified with a self-testing locker, after discovering that `OpenClipboard(NULL)` reports success while granting no exclusivity at all):

- Ctrl+C → "Bloom was not able to copy that."
- Ctrl+V → "Bloom was not able to paste."
- Ctrl+X → toast (the text is removed by the browser as always; Ctrl+Z restores it)
- Copy/Cut/Paste buttons → toast
- the false "no image on your clipboard" message → gone

597 front-end tests pass (19 new, covering the endpoints, the cut-abort contract, and the defaultPrevented regression). `BloomExe`/`BloomTests` build clean; typecheck, eslint, prettier, csharpier clean.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16459


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8140)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8140)
<!-- Reviewable:end -->

