### PR TITLE
Fix the LeveledReaderStats tests broken by the UI redesign (BL-16585)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.spec.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.spec.tsx
@@ -43,6 +43,9 @@ const bookStats = {
 // most precise way to find a row.
 const kKeyPrefix = "EditTab.Toolbox.LeveledReaderTool.";
 
+// What a Max cell shows when it has no number to display (BL-16585).
+const kNoMaxShown = "—";
+
 // Each stats grid lays its cells out as a flat list of children: one or two
 // section headers, then the Max/Actual header row, then three cells per
 // statistic (label, max, actual). Find a row by its label and return the other
@@ -162,19 +165,20 @@ describe("LeveledReaderStats", () => {
     it("shows the level's limit in the Max cell, except on the two rows that share the limit above them", () => {
         // Pre-React behavior we are keeping: on these two rows the limit decides
         // the color but is not displayed, because the row above already shows it.
+        // They get the same em dash as a row with no limit at all.
         expect(
             getRow(container, "WordLengths", "ThisPageLC").maxCell.textContent,
         ).toBe(`${kMaxGlyphsPerWord}`);
         expect(
             getRow(container, "WordLengths", "MaxInBook").maxCell.textContent,
-        ).toBe("");
+        ).toBe(kNoMaxShown);
         expect(
             getRow(container, "ThisPage", "PerSentence").maxCell.textContent,
         ).toBe(`${kMaxWordsPerSentence}`);
         expect(
             getRow(container, "ThisBook", "MaxSentenceLength").maxCell
                 .textContent,
-        ).toBe("");
+        ).toBe(kNoMaxShown);
     });
 
     it("compares averages at full precision, not as displayed", () => {
@@ -184,10 +188,10 @@ describe("LeveledReaderStats", () => {
         expect(average.actualCell.classList).toContain("tooLarge");
     });
 
-    it("leaves the Max cell blank when this level has no limit for a statistic", () => {
+    it("shows an em dash in the Max cell when this level has no limit for a statistic", () => {
         expect(
             getRow(container, "ThisPage", "PerPage").maxCell.textContent,
-        ).toBe("");
+        ).toBe(kNoMaxShown);
     });
 
     it("re-reads the level's limits when the level changes", () => {

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.tsx
@@ -346,7 +346,8 @@ function isBookOverLevel(
     });
 }
 
-const LeveledReaderStats: FunctionComponent<{
+// Exported for testing.
+export const LeveledReaderStats: FunctionComponent<{
     bookStats: { [key: string]: number };
 }> = (props) => {
     const model = getTheOneReaderToolsModel();


### PR DESCRIPTION
All 7 tests in LeveledReaderToolControls.spec.tsx were failing, for two
reasons, both introduced by "Improve Leveled Reader tool UI (BL-16585)".

That commit dropped the `export` keyword (and its "Exported for testing"
comment) from LeveledReaderStats, so the spec's named import resolved to
undefined and every test died in beforeEach with React's "Element type is
invalid ... got: undefined". Restored the export. Note that the typecheck
gate does not catch this: the resulting TS2305 is not one of the
blunder-class errors it reports, so only the tests see it.

The same commit also intentionally changed no-limit Max cells to show an
em dash instead of nothing ("em dash for no-limit Max cells" in its
message), which left three max-cell assertions expecting "". Updated
those to the new display via a kNoMaxShown constant, and renamed the
"leaves the Max cell blank" test accordingly. The component's behavior is
unchanged here; only the stale expectations moved.

pnpm test: 578 passed, 5 skipped, 0 failed. typecheck and lint clean.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8142)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8142)
<!-- Reviewable:end -->
