### PR TITLE
BL-16648: fix margins, branding CSS, and localization for custom layout pages

### DIFF
--- a/DistFiles/localization/en/BloomLowPriority.xlf
+++ b/DistFiles/localization/en/BloomLowPriority.xlf
@@ -353,6 +353,16 @@
         <note>ID: CollectionTab.BookMenu.MoveToCurrentCollection</note>
         <note>{0} will be replaced with the name of the collection that the user currently has open for editing.</note>
       </trans-unit>
+      <trans-unit id="EditTab.CustomCover.FieldType.BookTitle">
+        <source xml:lang="en">Book Title</source>
+        <note>ID: EditTab.CustomCover.FieldType.BookTitle</note>
+        <note>One choice in the "Field Type:" menu of a text block on a custom layout page. Choosing it makes that block hold the title of the book.</note>
+      </trans-unit>
+      <trans-unit id="EditTab.CustomCover.FieldType.CoverCredits">
+        <source xml:lang="en">Cover Credits</source>
+        <note>ID: EditTab.CustomCover.FieldType.CoverCredits</note>
+        <note>One choice in the "Field Type:" menu of a text block on a custom layout page. Choosing it makes that block hold the credits (author, illustrator, etc.) that are shown on the cover.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/BloomBrowserUI/bookEdit/js/CanvasElementContextControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/js/CanvasElementContextControls.tsx
@@ -1246,10 +1246,14 @@ function makeLanguageMenuItem(
     });
 }
 
+// The labelL10nId of each of these is used to localize its item in the "Field Type:" menu.
+// Two of them reuse strings that were created for other purposes but say exactly the right
+// thing; the other two have ids of their own in BloomLowPriority.xlf.
 const fieldTypeData: Array<{
     dataBook: string;
     dataDerived: string;
     label: string;
+    labelL10nId: string;
     readOnly: boolean;
     editableClasses: string[];
     classes: string[];
@@ -1260,6 +1264,7 @@ const fieldTypeData: Array<{
         dataBook: "bookTitle",
         dataDerived: "",
         label: "Book Title",
+        labelL10nId: "EditTab.CustomCover.FieldType.BookTitle",
         readOnly: false,
         editableClasses: ["Title-On-Cover-style", "bloom-padForOverflow"],
         classes: ["bookTitle"],
@@ -1268,6 +1273,7 @@ const fieldTypeData: Array<{
         dataBook: "smallCoverCredits",
         dataDerived: "",
         label: "Cover Credits",
+        labelL10nId: "EditTab.CustomCover.FieldType.CoverCredits",
         readOnly: false,
         editableClasses: ["smallCoverCredits", "Cover-Default-style"],
         classes: [],
@@ -1276,6 +1282,7 @@ const fieldTypeData: Array<{
         dataBook: "",
         dataDerived: "languagesOfBook",
         label: "Languages",
+        labelL10nId: "BookSettings.LanguagesGroupLabel",
         readOnly: true,
         editableClasses: [],
         classes: ["coverBottomLangName", "Cover-Default-style"],
@@ -1284,6 +1291,7 @@ const fieldTypeData: Array<{
         dataBook: "",
         dataDerived: "topic",
         label: "Topic",
+        labelL10nId: "Topic",
         readOnly: true,
         editableClasses: [],
         classes: [
@@ -1395,7 +1403,7 @@ function makeFieldTypeMenuItem(
     ];
     for (const fieldType of fieldTypeData) {
         subMenu.push({
-            l10nId: null,
+            l10nId: fieldType.labelL10nId,
             english: fieldType.label,
             onClick: () => {
                 clearFieldTypeClasses();

--- a/src/BloomTests/Book/XMatterHelperTests.cs
+++ b/src/BloomTests/Book/XMatterHelperTests.cs
@@ -75,6 +75,61 @@ namespace BloomTests.Book
             Assert.AreEqual(expectedXMatterName, actual, "XMatterName did not match.");
         }
 
+        /// <summary>
+        /// The Inside Back Cover is opted in to custom layout by carrying data-custom-layout-id
+        /// (BL-16648). The paper version of the page (Factory xmatter) and the device version
+        /// (Device xmatter's "End Extra 2") must use the SAME id, so that a book keeps its
+        /// customized inside back cover when it moves between paper and device xmatter. The two
+        /// pages come from different pug mixins and nothing else enforces the match, so it would be
+        /// easy to break silently.
+        /// </summary>
+        [Test]
+        public void InsideBackCover_PaperAndDeviceXMatter_ShareOneCustomLayoutId()
+        {
+            var paperId = GetInsideBackCoverCustomLayoutId("Factory");
+            var deviceId = GetInsideBackCoverCustomLayoutId("Device");
+
+            Assert.That(
+                paperId,
+                Is.EqualTo("customInsideBackCover"),
+                "paper (Factory) xmatter inside back cover"
+            );
+            Assert.That(
+                deviceId,
+                Is.EqualTo("customInsideBackCover"),
+                "device xmatter inside back cover"
+            );
+            Assert.That(
+                deviceId,
+                Is.EqualTo(paperId),
+                "paper and device inside back covers must share one custom layout id, or a book loses its custom inside back cover when it changes xmatter"
+            );
+        }
+
+        /// <summary>
+        /// Returns the data-custom-layout-id of the inside back cover page of the given xmatter pack.
+        /// </summary>
+        private string GetInsideBackCoverCustomLayoutId(string xmatterName)
+        {
+            var helper = new XMatterHelper(
+                _dom,
+                xmatterName,
+                new FileLocator(new[] { _factoryXMatter })
+            );
+            var pages = helper.XMatterDom.SafeSelectNodes(
+                "//div[contains(@class,'bloom-page') and @data-xmatter-page='insideBackCover']"
+            );
+            // Sanity check: without this, an xmatter pack that had no inside back cover at all
+            // would make the test above fail in a confusing way (or, if we returned "", look like
+            // a missing attribute rather than a missing page).
+            Assert.That(
+                pages.Length,
+                Is.EqualTo(1),
+                $"{xmatterName} xmatter should have exactly one inside back cover page"
+            );
+            return ((SafeXmlElement)pages[0]).GetAttribute("data-custom-layout-id");
+        }
+
         [Test]
         public void InjectXMatter_AllDefaults_Inserts3PagesBetweenDataDivAndFirstPage()
         {

--- a/src/content/bookLayout/canvasElement.less
+++ b/src/content/bookLayout/canvasElement.less
@@ -345,6 +345,19 @@
     --cover-margin-left: 0px;
     --cover-margin-right: 0px;
     --cover-margin-side: 0px;
+    // Only the outside front and back covers actually consume the --cover-margin-*
+    // variables (see basePage.less); the inside covers get the ordinary page margins and
+    // gutter like any other page. So we have to zero those too, or a "full page" canvas on
+    // a custom inside back cover stops short of the page edges, and is off-centre as well,
+    // because the inside back cover is a side-left page and so picks up the gutter.
+    // (No need to do anything about the page-number allowance that basePage.less adds to
+    // padding-bottom: --pageNumber-extra-height is only ever non-zero on .numberedPage, and
+    // xmatter pages are never numbered.)
+    --page-margin-top: 0px;
+    --page-margin-bottom: 0px;
+    --page-margin-left: 0px;
+    --page-margin-right: 0px;
+    --page-gutter: 0px;
     .bloom-canvas {
         margin: 0;
     }

--- a/src/content/branding/branding-base.less
+++ b/src/content/branding/branding-base.less
@@ -127,10 +127,22 @@ Rules that format the branding go in branding-base.less, or in the branding.less
     }
 }
 
-// Allow all custom back cover pages to use text canvas elements, even when the branding
-// prevents customized text in the normal places by hiding the .bloom-translationGroup. (BL-16106)
+// Allow any custom-layout xmatter page to use text canvas elements, even when the branding
+// prevents customized text in the normal places by hiding the .bloom-translationGroup.
+// (BL-16106 for the outside back cover; generalized to any such page for BL-16648, which
+// enables custom layout on the inside back cover.)
 // (But, we don't want to force any image description to be visible!)
-.outsideBackCover.bloom-customLayout[data-custom-layout-id="customOutsideBackCover"]
+//
+// About the !important and the specificity: brandings hide these groups in their own
+// branding.less files, each of which @imports this file first, so on a tie the branding
+// wins. Almost every branding hides the group without !important, so it loses to the
+// !important here whatever its specificity. The one exception is RobotsMali, which hides
+// the inside back cover's group with !important at (0,3,0)
+// (.insideBackCover .marginBox .bloom-translationGroup); it is the only reason we need both
+// !important and a selector above (0,4,0). This selector is (0,6,0) -- the same as the
+// outside-back-cover-only rule it replaced -- which leaves headroom if some branding ever
+// gets more specific still.
+.bloom-page.bloom-customLayout[data-custom-layout-id]
     .marginBox
     .bloom-translationGroup:not(.bloom-imageDescription) {
     display: flex !important; // flex is the default set in basePage.less for .bloom-translationGroup


### PR DESCRIPTION
Fixes several problems in Bloom's **custom layout** support. These showed up on the Inside Back Cover — because #8136 just enabled Custom Layout there — but none of them is specific to that page, so the fixes are written for custom layout pages generally.

**This PR adds no new capability.** The Inside Back Cover opt-in itself landed in #8136; the pug is untouched here.

Relates to [BL-16648](https://issues.bloomlibrary.org/youtrack/issue/BL-16648). Targets `Version6.4`.

## What's fixed

**1. Margins and gutter aren't zeroed on custom layout pages that aren't outside covers** (`canvasElement.less`)

A "full page" canvas element on a custom Inside Back Cover did not reach the page edges, and was off-centre as well. The existing `.bloom-page.bloom-customLayout` override zeroes only the `--cover-margin-*` variables, but those are consumed just by the outside front/back covers (`basePage.less`). Every other page falls through to the ordinary `--page-margin-*` padding, and also picks up `--page-gutter` when it's a `side-left` page — as the Inside Back Cover is. So this zeroes those five variables too.

Only pages already in custom layout are affected, so no standard-layout book changes appearance. No `!important` needed, and the page-number allowance needs no attention (`--pageNumber-extra-height` is non-zero only on `.numberedPage`, and xmatter pages are never numbered).

**2. Branding CSS hides text canvas elements on custom xmatter pages** (`branding-base.less`)

Generalizes the BL-16106 un-hide rule from the outside back cover to any custom-layout xmatter page. Kept at specificity **(0,6,0)** — identical to the selector it replaces — deliberately: RobotsMali hides the inside back cover's translation group with `!important` at (0,3,0), and since every `branding.less` imports `branding-base.less` first, a branding wins any specificity tie on source order. A shorter selector would have left RobotsMali's case still broken.

**3. "Field Type:" menu labels were not localizable** (`CanvasElementContextControls.tsx`, `BloomLowPriority.xlf`)

All four submenu entries were built with `l10nId: null`, so they were English-only even though the parent "Field Type:" item is localized. Adds `labelL10nId` to `fieldTypeData`. `Topic` and `BookSettings.LanguagesGroupLabel` reuse existing strings whose English matches exactly; `Book Title` and `Cover Credits` get new ids.

The two new XLF entries are deliberately **without** `translate="no"`, overriding the general rule in AGENTS.md, because 6.4 is a public beta and we want these translated.

## Test

`InsideBackCover_PaperAndDeviceXMatter_ShareOneCustomLayoutId` asserts that the Factory (paper) and Device inside back cover pages both carry `data-custom-layout-id` **and that the value is the same on both**. They come from different pug mixins with nothing else enforcing the match; if they diverged, a book would silently lose its custom inside back cover when it changed xmatter.

## Verification done

- `yarn build` and `dotnet build Bloom.sln` clean (0 errors).
- `XMatterHelperTests`: 28 pass (27 before this branch's test).
- Compiled xmatter confirmed: `data-custom-layout-id="customInsideBackCover"` present on the `insideBackCover` page of **both** `Factory-XMatter.html` and `Device-XMatter.html`, same value.
- eslint clean on the changed `.tsx`; committed through the real pre-commit hook (pretty-quick, lint-staged/eslint, the three C# checks, csharpier) with no `--no-verify`.
- **Measured against the compiled CSS** in Chromium, using Bloom's actual stylesheet order from `StyleSheetLinkSorter` (basePage → xmatter → branding → appearance), with controls:
  - A4 side-left custom page, before: `56.7px` left padding vs `94.5px` right (the 10mm gutter, i.e. the off-centre bug). After: `0` on all four sides.
  - A5 standard control still shows `45.3px`, confirming the harness detects margins.
  - RobotsMali branding: translation group on a custom-layout inside back cover goes from `display:none` (standard-layout control — the bug) to `display:flex`.

### Verified interactively in the running app

Driven through the real UI (page thumbnail → the above-page **Custom Layout** menu) on an A4Portrait book, measuring the live edit-page DOM:

| | Standard layout | Custom layout |
| --- | --- | --- |
| page padding T\|R\|B\|L | `56.7 \| 56.7 \| 56.7 \| **94.5**` | `0 \| 0 \| 0 \| 0` |
| `--page-gutter` | `10mm` | `0px` |
| `.bloom-canvas` inset | — | `L0 T0 R0 B0` |
| background canvas element | — | `794x1123` = exactly the full page |

The standard-layout column is the bug this fixes: the inside back cover is a `side-right` page here, so it picked up the 10mm gutter on the left (94.5px vs 56.7px) and a "full page" image was both inset and **off-centre by 37.8px**. In custom layout the canvas now reaches all four page edges. Confirmed visually as well: the `coverColor` runs edge to edge with no margin band.

Also confirmed: an **existing** book picks up `data-custom-layout-id="customInsideBackCover"` when opened for editing (xmatter re-injection), so this is not limited to newly created books.

**Expected behaviour to note for QA:** converting the Inside Back Cover to Custom Layout produces a large, near-page-sized empty text box (measured 643x1009 on a 794x1123 page), because `.insideBackCover .bloom-translationGroup` is `height: 100%`. Resizing or deleting it is the user's first move. This is a deliberate decision, not a bug — please don't file it.

## Known limitation (pre-existing, not addressed here)

A project-specific xmatter that sets `--page-margin-*`/`--cover-margin-*` with specificity of at least (0,2,0) still defeats this zeroing, because xmatter CSS is linked *after* `basePage.css`. Measured: **Kyrgyzstan2020** (a (0,5,0) selector — keeps 15mm margins and the 10mm gutter) and **ABC-Reader** (`.HalfLetterPortrait.bloom-page`, ties at (0,2,0) and wins on source order — keeps 0.5in).

This is a limitation of the existing approach rather than something introduced here: ABC-Reader's **outside front cover** custom layout, which shipped before this change, is already affected the same way (measured: `padding-top: 48px` despite the zeroing). Factory and Device xmatter — including the Vanuatu "Library for all" case that drove BL-16648 — are unaffected.

**Decision: leave these alone.** If an xmatter has its own margin overrides we don't want to fight them, and these xmatters/brandings are considered obsolete for new work, so they won't be used with custom layout. We can revisit if that turns out to be wrong.

## Full-bleed case

Checked by John: a custom-layout Inside Back Cover in a full-bleed book behaves correctly. That was the last item with no evidence behind it, so nothing about this change is now unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8143)
<!-- Reviewable:end -->

---
[Devin review](https://app.devin.ai/review/BloomBooks/BloomDesktop/pull/8143)
