### PR TITLE
Way to turn off indenting & don't insert <p> before headers (BL-16649)

### DIFF
--- a/DistFiles/localization/en/BloomMediumPriority.xlf
+++ b/DistFiles/localization/en/BloomMediumPriority.xlf
@@ -14,6 +14,11 @@
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.AppBuilder</note>
         <note>This checkbox enables the experimental publish-to-apps workflow.</note>
       </trans-unit>
+      <trans-unit id="EditTab.TextContextMenu.NoIndent" translate="no">
+        <source xml:lang="en">No Indent</source>
+        <note>ID: EditTab.TextContextMenu.NoIndent</note>
+        <note>Item on the menu you get by right-clicking a paragraph of text in the Edit tab. It is a checkable on/off command that removes the first-line indent from just that one paragraph, overriding the indent that the paragraph's style gives it. Typically used on a paragraph continued from the previous page.</note>
+      </trans-unit>
       <!-- Drag Activity Tool -->
       <trans-unit id="EditTab.Toolbox.DragActivity.ChooseSound">
         <source xml:lang="en">Choose...</source>

--- a/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
+++ b/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
@@ -9,6 +9,7 @@ import { EditableDivUtils } from "../js/editableDivUtils";
 import $ from "jquery";
 import { showLinkTargetChooserDialog } from "../../react_components/LinkTargetChooser/LinkTargetChooserDialogLauncher";
 import { getLocalization } from "../../react_components/l10n";
+import { kNoIndentClass } from "../textContextMenu/noIndent";
 
 // This class is actually just a group of static functions with a single public method. It does whatever we need to to make Firefox's contenteditable
 // element have the behavior we need.
@@ -258,11 +259,36 @@ export default class BloomField {
                 }
             });
         }
+        // BL-16649: "No Indent" (see the text context menu) marks one
+        // paragraph as the continuation of a paragraph on the previous page. Pressing Enter
+        // in such a paragraph makes a genuinely new paragraph, which should indent normally
+        // -- but ckeditor builds it by shallow-cloning the paragraph it split, so it would
+        // inherit the class. We note which paragraphs existed just before the Enter, then
+        // take the class off any that the split created. Only paragraphs are considered:
+        // the class is only ever put on a <p>, never on a heading (see kBlockElementSelector).
+        let paragraphsBeforeEnter: HTMLParagraphElement[] | undefined;
         ckeditor.on("key", (event) => {
             if (event.data.keyCode === CKEDITOR.SHIFT + 13) {
                 BloomField.InsertLineBreak();
                 event.cancel();
+            } else if (event.data.keyCode === 13) {
+                paragraphsBeforeEnter = Array.from(
+                    bloomEditableDiv.getElementsByTagName("p"),
+                );
             }
+        });
+        ckeditor.on("afterCommandExec", (event) => {
+            if (event.data.name !== "enter") return;
+            const paragraphsBefore = paragraphsBeforeEnter;
+            paragraphsBeforeEnter = undefined;
+            if (!paragraphsBefore) return;
+            Array.from(bloomEditableDiv.getElementsByTagName("p")).forEach(
+                (paragraph) => {
+                    if (!paragraphsBefore.includes(paragraph)) {
+                        paragraph.classList.remove(kNoIndentClass);
+                    }
+                },
+            );
         });
         ckeditor.on("selectionChange", () => {
             this.EnsureCaretNotInsideLineBreakSpan();

--- a/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
+++ b/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
@@ -28,6 +28,14 @@ import { getLocalization } from "../../react_components/l10n";
 // Next, we have to keep you from accidentally losing the image placeholder when you do ctrl+a DEL. We prevent this deletion
 // for any element marked with a 'bloom-preventRemoval' class.
 
+// The block-level elements we tolerate as direct children of a bloom-editable. Bloom's own
+// editing UI only ever makes paragraphs, but content converted from other formats (e.g. by
+// BloomBridge) can legitimately arrive with real heading elements, and a box that leads with
+// one must not have an empty paragraph pushed in above it. Several places below ask "which
+// block am I in?" or "does this box have any blocks yet?"; they all consult this rather than
+// looking for a <p> specifically, so a heading counts as a block everywhere or nowhere.
+const kBlockElementSelector = "p,h1,h2,h3,h4,h5,h6";
+
 export default class BloomField {
     public static ManageField(bloomEditableDiv: HTMLElement) {
         BloomField.PreventRemovalOfSomeElements(bloomEditableDiv);
@@ -657,7 +665,7 @@ export default class BloomField {
                     //see if it is one those. Anything marked with bloom-preventRemoval is probably not something we want to
                     //be merging with.
                     const previousElement = $(sel.anchorNode)
-                        .closest("P")
+                        .closest(kBlockElementSelector)
                         .prev();
                     if (
                         previousElement.length > 0 &&
@@ -693,10 +701,24 @@ export default class BloomField {
         });
     }
 
+    // True if the element is one of the block elements we allow as a direct child of a
+    // bloom-editable, i.e. a paragraph or a heading.
+    private static IsBlockElement(element: Element | undefined): boolean {
+        return (
+            !!element &&
+            kBlockElementSelector
+                .split(",")
+                .includes(element.tagName.toLowerCase())
+        );
+    }
+
     private static EnsureStartsWithParagraphElement(field: HTMLElement) {
+        // A heading counts: a box that starts with <h1> already starts with a block, and
+        // prepending an empty paragraph above it would give the reader a blank first line
+        // (and, once the page is saved, keep it).
         if (
             $(field).children().length > 0 &&
-            $(field).children().first().prop("tagName").toLowerCase() === "p"
+            BloomField.IsBlockElement($(field).children().first()[0])
         ) {
             return;
         }
@@ -705,6 +727,10 @@ export default class BloomField {
 
     private static EnsureEndsWithParagraphElement(field: HTMLElement) {
         //Enhance: move any errant paragraphs to after the bloom-canvas
+        // Deliberately still requires a paragraph rather than accepting any block: this is
+        // only used for the embedded-image case below, where the trailing paragraph is there
+        // to give the user somewhere to type text that wraps around the image. A heading is
+        // not that.
         if (
             $(field).children().length > 0 &&
             $(field).children().last().prop("tagName").toLowerCase() === "p"
@@ -773,10 +799,13 @@ export default class BloomField {
         position: CursorPosition,
     ) {
         const range = document.createRange();
+        // Any block will do, and it has to be any block: a box holding only a heading has no
+        // paragraph, and selectNodeContents(undefined) throws.
+        const blocks = $(field).find(kBlockElementSelector);
         if (position === CursorPosition.start) {
-            range.selectNodeContents($(field).find("p").first()[0]);
+            range.selectNodeContents(blocks.first()[0]);
         } else {
-            range.selectNodeContents($(field).find("p").last()[0]);
+            range.selectNodeContents(blocks.last()[0]);
         }
         range.collapse(position === CursorPosition.start); //true puts it at the start
         const sel = window.getSelection();
@@ -791,7 +820,9 @@ export default class BloomField {
         // if the user types (ctrl+a, 'blah'), then we get blah outside of any paragraph
 
         $(field).keyup((e) => {
-            if ($(field).find("p").length === 0) {
+            // Note that a heading counts as a block here, so this does not fire on every
+            // keystroke in a box that holds only a heading (which has no paragraph at all).
+            if ($(field).find(kBlockElementSelector).length === 0) {
                 BloomField.EnsureParagraphsPresent(field);
 
                 // Now put the cursor in the paragraph, *after* the character they may have just typed or the
@@ -931,7 +962,12 @@ export default class BloomField {
 
                 //Are we in the first paragraph?
                 //FYI: Nested paragraphs don't seem to be allowed. So don't need to worry about that possibility.
-                const closestP = $(sel.anchorNode).closest("P");
+                // A heading counts as a block here too. Looking only for a "P" would find
+                // nothing when the caret is in a heading, and the code below would then fall
+                // through and block the backspace even in a heading that has blocks before it.
+                const closestP = $(sel.anchorNode).closest(
+                    kBlockElementSelector,
+                );
                 const previousElement = closestP.prev();
 
                 if (previousElement.length !== 0) {

--- a/src/BloomBrowserUI/bookEdit/bloomField/bloomFieldSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/bloomField/bloomFieldSpec.ts
@@ -264,6 +264,54 @@ describe("BloomField", () => {
         expect($("div p").length).toBeGreaterThan(0);
     });
 
+    // Content converted from other formats can arrive with a real heading as the first thing
+    // in the box. Prepending an empty paragraph above it would show the reader a blank first
+    // line, and saving the page would make that permanent.
+    it("bloom-editable div starting with a heading does not get a paragraph prepended", () => {
+        const editable = document.getElementById("simple");
+        if (!editable) {
+            throw new Error("Test setup error: expected #simple to exist.");
+        }
+        editable.innerHTML = "<h1>The Heading</h1><p>The body.</p>";
+        // Sanity check on the setup: the heading really is first before we do anything.
+        expect(editable.firstElementChild!.tagName).toBe("H1");
+
+        WireUp();
+
+        expect(editable.firstElementChild!.tagName).toBe("H1");
+        expect(editable.getElementsByTagName("p").length).toBe(1);
+    });
+
+    // A heading is a block, so a box holding nothing else needs no paragraph added. This is
+    // also the case that used to make MoveCursorToEdgeOfField throw, since it looked for a
+    // paragraph and found none.
+    it("bloom-editable div holding only a heading is left alone", () => {
+        const editable = document.getElementById("simple");
+        if (!editable) {
+            throw new Error("Test setup error: expected #simple to exist.");
+        }
+        editable.innerHTML = "<h2>Only a heading</h2>";
+
+        WireUp();
+
+        expect(editable.innerHTML).toBe("<h2>Only a heading</h2>");
+    });
+
+    // The other half of the rule: a box with no block element at all still gets a paragraph,
+    // which is what everything from styling to the Talking Book tool assumes.
+    it("bloom-editable div with only bare text still gets a paragraph", () => {
+        const editable = document.getElementById("simple");
+        if (!editable) {
+            throw new Error("Test setup error: expected #simple to exist.");
+        }
+        editable.innerHTML = "loose text";
+        expect(editable.getElementsByTagName("p").length).toBe(0); // sanity check
+
+        WireUp();
+
+        expect(editable.getElementsByTagName("p").length).toBe(1);
+    });
+
     describe("backspacePreventionTests", () => {
         it("backspace prevented at start of paragraph", () => {
             const shouldBeCanceled = true;

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -77,6 +77,7 @@ import PlaceholderProvider from "./PlaceholderProvider";
 import { initChoiceWidgetsForEditing } from "./simpleComprehensionQuiz";
 import { handleUndo } from "../workspaceRoot";
 import { setupPageLayoutMenu } from "../toolbox/canvas/customXmatterPage";
+import { setupTextContextMenu } from "../textContextMenu/TextContextMenu";
 import { resetAbovePageControls } from "./AbovePageControls";
 
 // Allows toolbox code to make an element properly in the context of this iframe.
@@ -1092,6 +1093,7 @@ function OneTimeSetup() {
     hookupLinkHandler();
     setupDragActivityTabControl();
     setupPageLayoutMenu();
+    setupTextContextMenu();
 }
 
 function isTextSelected(): boolean {

--- a/src/BloomBrowserUI/bookEdit/textContextMenu/TextContextMenu.tsx
+++ b/src/BloomBrowserUI/bookEdit/textContextMenu/TextContextMenu.tsx
@@ -81,8 +81,10 @@ function renderTextContextMenu(
     if (!root) {
         root = pageDocument.createElement("div");
         root.setAttribute("id", kTextContextMenuRootId);
-        // We don't have to worry about removing this before saving because it is above the
-        // level of the bloom-page, the only part of the body that gets saved.
+        // We don't have to worry about removing this before saving. Saving posts the whole
+        // body (getBodyContentForSavePage), but the C# side keeps only the div.bloom-page out
+        // of it, and this sits outside that -- as does the menu markup itself, which MUI
+        // portals into the body while it is open.
         pageDocument.body.appendChild(root);
     }
     ReactDOM.render(

--- a/src/BloomBrowserUI/bookEdit/textContextMenu/TextContextMenu.tsx
+++ b/src/BloomBrowserUI/bookEdit/textContextMenu/TextContextMenu.tsx
@@ -4,9 +4,8 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import Menu from "@mui/material/Menu";
 import { ThemeProvider } from "@mui/material/styles";
-import { default as NoIndentIcon } from "@mui/icons-material/FormatIndentDecreaseSharp";
 import { lightTheme } from "../../bloomMaterialUITheme";
-import { LocalizableMenuItem } from "../../react_components/localizableMenuItem";
+import { LocalizableSelectableMenuItem } from "../../react_components/localizableMenuItem";
 import {
     canToggleNoIndent,
     findParagraphForTextContextMenu,
@@ -55,11 +54,10 @@ const TextContextMenu: React.FunctionComponent<{
                     }
                 `}
             >
-                <LocalizableMenuItem
+                <LocalizableSelectableMenuItem
                     english="No Indent"
                     l10nId="EditTab.TextContextMenu.NoIndent"
-                    icon={<NoIndentIcon />}
-                    checked={noIndentIsOn}
+                    selected={noIndentIsOn}
                     disabled={!canToggleNoIndent(props.paragraph)}
                     onClick={handleNoIndentClick}
                 />

--- a/src/BloomBrowserUI/bookEdit/textContextMenu/TextContextMenu.tsx
+++ b/src/BloomBrowserUI/bookEdit/textContextMenu/TextContextMenu.tsx
@@ -1,0 +1,119 @@
+import { css } from "@emotion/react";
+
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import Menu from "@mui/material/Menu";
+import { ThemeProvider } from "@mui/material/styles";
+import { default as NoIndentIcon } from "@mui/icons-material/FormatIndentDecreaseSharp";
+import { lightTheme } from "../../bloomMaterialUITheme";
+import { LocalizableMenuItem } from "../../react_components/localizableMenuItem";
+import {
+    canToggleNoIndent,
+    findParagraphForTextContextMenu,
+    isNoIndentOn,
+    toggleNoIndent,
+} from "./noIndent";
+
+// The context menu for a right-click on the text of an ordinary text box in the edit view
+// (BL-16649). Text inside a canvas element gets CanvasElementContextControls' menu instead;
+// see findParagraphForTextContextMenu.
+//
+// The menu is a controlled MUI Menu anchored at the mouse position, in the style of
+// CanvasElementContextControls. Open state lives in renderTextContextMenu (below) rather
+// than in the component, so that the component can be re-rendered for a new paragraph
+// without carrying over stale state.
+const TextContextMenu: React.FunctionComponent<{
+    paragraph: HTMLElement;
+    open: boolean;
+    setOpen: (open: boolean) => void;
+    anchorPosition: { left: number; top: number };
+}> = (props) => {
+    const noIndentIsOn = isNoIndentOn(props.paragraph);
+
+    const handleNoIndentClick = () => {
+        toggleNoIndent(props.paragraph);
+        props.setOpen(false);
+    };
+
+    return (
+        <ThemeProvider theme={lightTheme}>
+            <Menu
+                open={props.open}
+                anchorReference="anchorPosition"
+                anchorPosition={props.anchorPosition}
+                onClose={() => props.setOpen(false)}
+                // The page has its own focus concerns (the caret in the text we right-clicked on),
+                // and we don't want opening the menu to disturb them.
+                disableAutoFocus={true}
+                disableEnforceFocus={true}
+                css={css`
+                    ul li {
+                        color: #4d4d4d;
+                        svg {
+                            color: inherit !important;
+                        }
+                    }
+                `}
+            >
+                <LocalizableMenuItem
+                    english="No Indent"
+                    l10nId="EditTab.TextContextMenu.NoIndent"
+                    icon={<NoIndentIcon />}
+                    checked={noIndentIsOn}
+                    disabled={!canToggleNoIndent(props.paragraph)}
+                    onClick={handleNoIndentClick}
+                />
+            </Menu>
+        </ThemeProvider>
+    );
+};
+
+const kTextContextMenuRootId = "text-context-menu";
+
+// Renders (or re-renders) the text context menu into a root div of the page document.
+function renderTextContextMenu(
+    paragraph: HTMLElement,
+    open: boolean,
+    anchorPosition: { left: number; top: number },
+) {
+    const pageDocument = paragraph.ownerDocument;
+    let root = pageDocument.getElementById(kTextContextMenuRootId);
+    if (!root) {
+        root = pageDocument.createElement("div");
+        root.setAttribute("id", kTextContextMenuRootId);
+        // We don't have to worry about removing this before saving because it is above the
+        // level of the bloom-page, the only part of the body that gets saved.
+        pageDocument.body.appendChild(root);
+    }
+    ReactDOM.render(
+        <TextContextMenu
+            paragraph={paragraph}
+            open={open}
+            anchorPosition={anchorPosition}
+            setOpen={(newOpen: boolean) =>
+                renderTextContextMenu(paragraph, newOpen, anchorPosition)
+            }
+        />,
+        root,
+    );
+}
+
+/**
+ * Makes a right-click on the text of an ordinary text box put up our own context menu.
+ * Call once per page document, from the edit-mode page setup.
+ */
+export function setupTextContextMenu(): void {
+    document.addEventListener("contextmenu", (event: MouseEvent) => {
+        // Ctrl+right-click is reserved for the WebView2 developer menu; see
+        // WebView2Browser.ContextMenuRequested.
+        if (event.ctrlKey) return;
+        const paragraph = findParagraphForTextContextMenu(event.target);
+        if (!paragraph) return;
+        event.preventDefault();
+        event.stopPropagation();
+        renderTextContextMenu(paragraph, true, {
+            left: event.clientX,
+            top: event.clientY,
+        });
+    });
+}

--- a/src/BloomBrowserUI/bookEdit/textContextMenu/noIndent.ts
+++ b/src/BloomBrowserUI/bookEdit/textContextMenu/noIndent.ts
@@ -1,0 +1,52 @@
+// The logic behind the "No Indent" command on the text context menu (BL-16649).
+// Kept separate from the React component so it can be unit tested against a plain DOM.
+
+import { kCanvasElementSelector } from "../toolbox/canvas/canvasElementUtils";
+
+// Put on an individual <p> to cancel the first-line indent that the paragraph's style
+// (see the Format dialog) would otherwise give it. The matching CSS rule is in
+// basePage-sharedRules.less (and a copy in basePage-legacy-5-6.less).
+export const kNoIndentClass = "bloom-noIndent";
+
+/**
+ * Find the paragraph that a right-click should act on, or undefined if this is not a click
+ * the text context menu should handle. We only want paragraphs of ordinary text boxes:
+ * text inside a canvas element has its own context menu, which the canvas code puts up.
+ */
+export function findParagraphForTextContextMenu(
+    target: EventTarget | null,
+): HTMLElement | undefined {
+    if (!(target instanceof Element)) return undefined;
+    const paragraph = target.closest("p");
+    if (!paragraph) return undefined;
+    if (!paragraph.closest(".bloom-editable")) return undefined;
+    if (paragraph.closest(kCanvasElementSelector)) return undefined;
+    return paragraph;
+}
+
+/** Is "No Indent" currently turned on for this paragraph? */
+export function isNoIndentOn(paragraph: HTMLElement): boolean {
+    return paragraph.classList.contains(kNoIndentClass);
+}
+
+/**
+ * "No Indent" is worth offering only if it is already on (so the user can turn it back off),
+ * or if something is actually indenting the paragraph, so that turning it on would do
+ * something visible. A paragraph whose style has no first-line indent gets a disabled item.
+ */
+export function canToggleNoIndent(paragraph: HTMLElement): boolean {
+    if (isNoIndentOn(paragraph)) return true;
+    const indent =
+        paragraph.ownerDocument.defaultView?.getComputedStyle(
+            paragraph,
+        ).textIndent;
+    // A computed text-indent is an absolute length ("0px", "26.6667px") or a percentage.
+    return !!indent && parseFloat(indent) !== 0;
+}
+
+/** Turn "No Indent" on or off for this one paragraph. */
+export function toggleNoIndent(paragraph: HTMLElement): void {
+    paragraph.classList.toggle(kNoIndentClass);
+    // The class is plain content markup inside the bloom-editable, so it is saved with the
+    // page the next time Bloom asks the browser for the page content; nothing to post here.
+}

--- a/src/BloomBrowserUI/bookEdit/textContextMenu/noIndentSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/textContextMenu/noIndentSpec.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+    canToggleNoIndent,
+    findParagraphForTextContextMenu,
+    isNoIndentOn,
+    kNoIndentClass,
+    toggleNoIndent,
+} from "./noIndent";
+
+// Builds a page with an ordinary text box (two paragraphs) and a canvas element that also
+// contains text, so we can check which right-clicks the text context menu claims.
+function setupPage(): void {
+    document.body.innerHTML = `
+        <div class="bloom-page">
+            <div class="bloom-translationGroup normal-style">
+                <div class="bloom-editable normal-style" id="ordinaryText">
+                    <p id="first">First paragraph <em id="emphasis">with emphasis</em></p>
+                    <p id="second">Second paragraph</p>
+                </div>
+            </div>
+            <div class="bloom-canvas">
+                <div class="bloom-canvas-element">
+                    <div class="bloom-translationGroup">
+                        <div class="bloom-editable">
+                            <p id="canvasParagraph">Canvas text</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div id="notText">Not in a text box at all</div>
+        </div>`;
+}
+
+function element(id: string): HTMLElement {
+    const result = document.getElementById(id);
+    if (!result)
+        throw new Error(`test setup is broken: no element with id ${id}`);
+    return result;
+}
+
+describe("findParagraphForTextContextMenu", () => {
+    beforeEach(setupPage);
+    afterEach(() => (document.body.innerHTML = ""));
+
+    it("finds the paragraph when the click is on the paragraph itself", () => {
+        expect(findParagraphForTextContextMenu(element("first"))).toBe(
+            element("first"),
+        );
+    });
+
+    it("finds the enclosing paragraph when the click is on something inside it", () => {
+        expect(findParagraphForTextContextMenu(element("emphasis"))).toBe(
+            element("first"),
+        );
+    });
+
+    it("ignores a click on a paragraph inside a canvas element", () => {
+        // sanity check: it really is a paragraph of a bloom-editable, so only the
+        // canvas-element test can be what rejects it
+        expect(
+            element("canvasParagraph").closest(".bloom-editable"),
+        ).toBeTruthy();
+        expect(
+            findParagraphForTextContextMenu(element("canvasParagraph")),
+        ).toBeUndefined();
+    });
+
+    it("ignores a click that is not in a paragraph of a bloom-editable", () => {
+        expect(
+            findParagraphForTextContextMenu(element("notText")),
+        ).toBeUndefined();
+        expect(
+            findParagraphForTextContextMenu(element("ordinaryText")),
+        ).toBeUndefined();
+    });
+
+    it("ignores a non-element target", () => {
+        expect(findParagraphForTextContextMenu(null)).toBeUndefined();
+        expect(findParagraphForTextContextMenu(document)).toBeUndefined();
+    });
+});
+
+describe("toggleNoIndent", () => {
+    beforeEach(setupPage);
+    afterEach(() => (document.body.innerHTML = ""));
+
+    it("adds and removes the class on just the one paragraph", () => {
+        const first = element("first");
+        const second = element("second");
+        expect(isNoIndentOn(first)).toBe(false); // sanity check
+
+        toggleNoIndent(first);
+        expect(first.classList.contains(kNoIndentClass)).toBe(true);
+        expect(isNoIndentOn(first)).toBe(true);
+        expect(isNoIndentOn(second)).toBe(false);
+
+        toggleNoIndent(first);
+        expect(first.classList.contains(kNoIndentClass)).toBe(false);
+        expect(isNoIndentOn(first)).toBe(false);
+    });
+});
+
+describe("canToggleNoIndent", () => {
+    beforeEach(setupPage);
+    afterEach(() => (document.body.innerHTML = ""));
+
+    it("is false for a paragraph that is not indented and not marked", () => {
+        expect(canToggleNoIndent(element("first"))).toBe(false);
+    });
+
+    it("is true for an indented paragraph, so that it can be turned on", () => {
+        const first = element("first");
+        first.style.textIndent = "20pt";
+        expect(canToggleNoIndent(first)).toBe(true);
+    });
+
+    it("is false for a paragraph whose indent is explicitly zero", () => {
+        const first = element("first");
+        first.style.textIndent = "0pt";
+        expect(canToggleNoIndent(first)).toBe(false);
+    });
+
+    it("is true for a hanging indent, which the command also cancels", () => {
+        const first = element("first");
+        first.style.textIndent = "-20pt";
+        expect(canToggleNoIndent(first)).toBe(true);
+    });
+
+    it("is true for an already-marked paragraph, so that it can be turned off", () => {
+        const first = element("first");
+        // Once the class is on, the computed indent is zero (the real rule lives in
+        // basePage-sharedRules.less); the item must stay enabled anyway.
+        first.classList.add(kNoIndentClass);
+        expect(canToggleNoIndent(first)).toBe(true);
+    });
+});

--- a/src/BloomBrowserUI/react_components/localizableMenuItem.tsx
+++ b/src/BloomBrowserUI/react_components/localizableMenuItem.tsx
@@ -72,10 +72,6 @@ export interface ILocalizableMenuItemProps
     // override MUI's inline-flex and allow the item to size vertically to its content.
     labelCss?: SerializedStyles;
     value?: string | number | readonly string[];
-    // For an item that toggles something on and off: shows a check at the end of the row when
-    // the thing is on, while leaving the leading icon slot free for the command's own icon.
-    // (Contrast LocalizableSelectableMenuItem below, which puts the check in the icon slot.)
-    checked?: boolean;
 }
 
 export interface ILocalizableSelectableMenuItemProps
@@ -177,16 +173,6 @@ export const LocalizableMenuItem: React.FunctionComponent<
         />
     );
 
-    const checkElement = props.checked ? (
-        <CheckIcon
-            css={css`
-                color: ${menuItemColor};
-                font-size: 1.3rem;
-                margin-left: 10px;
-            `}
-        />
-    ) : null;
-
     const localizedSubLabel = useL10n("", props.subLabelL10nId ?? null);
     const subLabel =
         props.subLabel ?? props.generatedSubLabel ?? localizedSubLabel;
@@ -227,7 +213,6 @@ export const LocalizableMenuItem: React.FunctionComponent<
                         primary={label + ellipsis}
                         secondary={subLabel !== "" ? subLabel : null} // null is needed to not leave an empty row
                     ></ListItemText>
-                    {checkElement}
                     {subscriptionElement}
                 </React.Fragment>
             </MenuItem>

--- a/src/BloomBrowserUI/react_components/localizableMenuItem.tsx
+++ b/src/BloomBrowserUI/react_components/localizableMenuItem.tsx
@@ -72,6 +72,10 @@ export interface ILocalizableMenuItemProps
     // override MUI's inline-flex and allow the item to size vertically to its content.
     labelCss?: SerializedStyles;
     value?: string | number | readonly string[];
+    // For an item that toggles something on and off: shows a check at the end of the row when
+    // the thing is on, while leaving the leading icon slot free for the command's own icon.
+    // (Contrast LocalizableSelectableMenuItem below, which puts the check in the icon slot.)
+    checked?: boolean;
 }
 
 export interface ILocalizableSelectableMenuItemProps
@@ -173,6 +177,16 @@ export const LocalizableMenuItem: React.FunctionComponent<
         />
     );
 
+    const checkElement = props.checked ? (
+        <CheckIcon
+            css={css`
+                color: ${menuItemColor};
+                font-size: 1.3rem;
+                margin-left: 10px;
+            `}
+        />
+    ) : null;
+
     const localizedSubLabel = useL10n("", props.subLabelL10nId ?? null);
     const subLabel =
         props.subLabel ?? props.generatedSubLabel ?? localizedSubLabel;
@@ -213,6 +227,7 @@ export const LocalizableMenuItem: React.FunctionComponent<
                         primary={label + ellipsis}
                         secondary={subLabel !== "" ? subLabel : null} // null is needed to not leave an empty row
                     ></ListItemText>
+                    {checkElement}
                     {subscriptionElement}
                 </React.Fragment>
             </MenuItem>

--- a/src/content/bookLayout/basePage-legacy-5-6.less
+++ b/src/content/bookLayout/basePage-legacy-5-6.less
@@ -124,9 +124,9 @@ span.bloom-linebreak {
     text-indent: 0;
 }
 // added from basePage-sharedRules.less (which this file does not import) so that the
-// "No Indent" command works in legacy books too. See BL-16649 and the fuller
-// comment on the original rule.
-.bloom-page p.bloom-noIndent {
+// "No Indent" command works in legacy books too. See BL-16649 and the fuller comment on
+// the original rule, including why the selector is this long.
+.bloom-page .bloom-editable p.bloom-noIndent {
     text-indent: 0 !important;
 }
 .pdfPublishMode .bloom-page.Device16x9Portrait {

--- a/src/content/bookLayout/basePage-legacy-5-6.less
+++ b/src/content/bookLayout/basePage-legacy-5-6.less
@@ -123,6 +123,12 @@ span.bloom-linebreak {
     display: block;
     text-indent: 0;
 }
+// added from basePage-sharedRules.less (which this file does not import) so that the
+// "No Indent" command works in legacy books too. See BL-16649 and the fuller
+// comment on the original rule.
+.bloom-page p.bloom-noIndent {
+    text-indent: 0 !important;
+}
 .pdfPublishMode .bloom-page.Device16x9Portrait {
     min-width: 99.74791667mm;
     max-width: 99.74791667mm;

--- a/src/content/bookLayout/basePage-sharedRules.less
+++ b/src/content/bookLayout/basePage-sharedRules.less
@@ -190,6 +190,18 @@ span.bloom-linebreak {
     text-indent: 0;
 }
 
+// BL-16649: the user can put this on an individual paragraph with the "No Indent" command
+// on the right-click menu of a text box. It is for continuation paragraphs, e.g. where the
+// author has manually split a paragraph across two pages and the part at the top of the
+// second page should not get the style's first-line indent.
+// The Format dialog writes rules like `.mystyle-style > p {text-indent: 20pt !important}`
+// into userModifiedStyles, so this has to be !important too; it wins because its specificity
+// (0-2-1) beats that of the style rule (0-1-1).
+// NB: there is a copy of this rule in basePage-legacy-5-6.less, which does not import this file.
+.bloom-page p.bloom-noIndent {
+    text-indent: 0 !important;
+}
+
 // Text wrapping algorithms.
 .bloom-page .bloom-editable.bloom-visibility-code-on {
     // Very long words should just allow themselves to be broken at the end of a line if they're

--- a/src/content/bookLayout/basePage-sharedRules.less
+++ b/src/content/bookLayout/basePage-sharedRules.less
@@ -194,11 +194,19 @@ span.bloom-linebreak {
 // on the right-click menu of a text box. It is for continuation paragraphs, e.g. where the
 // author has manually split a paragraph across two pages and the part at the top of the
 // second page should not get the style's first-line indent.
+//
 // The Format dialog writes rules like `.mystyle-style > p {text-indent: 20pt !important}`
-// into userModifiedStyles, so this has to be !important too; it wins because its specificity
-// (0-2-1) beats that of the style rule (0-1-1).
+// into userModifiedStyles, so this has to be !important too. It also has to out-specify
+// hand-written rules in customBookStyles/customCollectionStyles, which we cannot win on
+// source order: StyleSheetLinkSorter puts basePage *before* those, so among equally
+// specific !important rules theirs would win. Hence the deliberately long selector
+// (0-3-1) rather than just `.bloom-page p.bloom-noIndent` (0-2-1), which a custom
+// `.bloom-page .mystyle-style p` (also 0-2-1, but loaded later) would have beaten.
+// The marked paragraph is always inside a .bloom-editable -- that is the only place the
+// command is offered -- so requiring it here costs us no matches.
+//
 // NB: there is a copy of this rule in basePage-legacy-5-6.less, which does not import this file.
-.bloom-page p.bloom-noIndent {
+.bloom-page .bloom-editable p.bloom-noIndent {
     text-indent: 0 !important;
 }
 


### PR DESCRIPTION
Two changes for BL-16649, one per problem on the card.

### Problem 1: you don't always want indenting

When a paragraph style has a first-line indent and the author manually splits a paragraph
across two pages, the continuation paragraph at the top of the second page gets an indent it
should not have.

Right-clicking a paragraph of an ordinary text box in the edit view now opens a small context
menu. Plain right-click there was previously unused (the C# side strips the native WebView2
items), ctrl+right-click still reaches the developer menu, and text inside a canvas element
keeps the canvas element's own menu.

The menu's one item, **No Indent**, toggles a `bloom-noIndent` class on that one paragraph. It
shows a check when on, and is disabled when the paragraph has no indent for it to remove.

The class is cancelled by a rule in `basePage-sharedRules.less`. It has to out-specify two
things: the `.foo-style > p {text-indent: … !important}` rule the Format dialog writes into
userModifiedStyles (0-1-1), and any hand-written rule in `customBookStyles.css` /
`customCollectionStyles.css` — which we cannot win on source order, because
`StyleSheetLinkSorter` deliberately sorts `basePage` *before* those files. So the selector is
`.bloom-page .bloom-editable p.bloom-noIndent` (0-3-1) rather than the shorter 0-2-1 form, which
a custom `.bloom-page .foo-style p` (equally specific, loaded later) would have beaten. The rule
is copied into `basePage-legacy-5-6.less`, which does not import the shared rules;
`baseEPUB.less` does import them, so it works in published ePubs too.

Note that the rule deliberately leaves `margin-left` alone. For a hanging-indent style (which
is `text-indent: -20pt` plus `margin-left: 20pt`) that makes a marked paragraph line up with
the body lines of a hanging paragraph, which is what a continuation should do; for an ordinary
first-line indent it sits flush.

Also here:

- `LocalizableMenuItem` gains a `checked` prop, which puts the check at the *end* of the row so
  the leading icon slot stays free for the command's own icon.
- Pressing Enter inside a marked paragraph no longer gives the new paragraph the class:
  ckeditor builds the second half by cloning the paragraph it split, so `BloomField` now strips
  the class from whichever paragraphs the split created.

### Problem 2: you don't always want to start with a `<p>`

The earlier commit on this branch: don't auto-insert a paragraph above a heading.

### Testing

`noIndentSpec.ts` covers the click-targeting (including that clicks inside canvas elements are
ignored) and the enabled/checked/toggle logic, including the hanging-indent and
already-marked cases.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16649


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8144)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8144)
<!-- Reviewable:end -->

---
[Devin review](https://app.devin.ai/review/BloomBooks/BloomDesktop/pull/8144)
