### PR TITLE
Run AI-editor images through Bloom's import processing (BL-16645)

### DIFF
--- a/src/BloomExe/web/controllers/AiImageEditorApi.cs
+++ b/src/BloomExe/web/controllers/AiImageEditorApi.cs
@@ -16,6 +16,7 @@ using SIL.IO;
 using SIL.Progress;
 using SIL.Reporting;
 using SIL.Windows.Forms.ClearShare;
+using SIL.Windows.Forms.ImageToolbox;
 
 namespace Bloom.web.controllers
 {
@@ -111,6 +112,20 @@ namespace Bloom.web.controllers
             ".jpg",
             ".jpeg",
             ".webp",
+        };
+
+        // The subset of AllowedImageExtensions that Bloom's import processing can actually
+        // open. PalasoImage decodes through GDI+, which has no WebP codec, so handing it a
+        // .webp throws every time — those are copied verbatim instead (see
+        // ImportImageIntoBookFolder). Kept as its own list rather than "everything but webp"
+        // so that adding a format above is a deliberate decision here too.
+        private static readonly HashSet<string> ProcessableImageExtensions = new HashSet<string>(
+            StringComparer.OrdinalIgnoreCase
+        )
+        {
+            ".png",
+            ".jpg",
+            ".jpeg",
         };
 
         // Regex alternation of the allowed extensions without the leading dot
@@ -890,8 +905,9 @@ namespace Bloom.web.controllers
 
         /// <summary>
         /// Applies one replacement to the slot named by incomingId ("{pageId}:{ordinal}"),
-        /// copying the new image bytes (from history or a reused book file) into the book
-        /// folder under a fresh name. An off-page slot is edited here in the storage DOM
+        /// bringing the new image bytes (from history or a reused book file) into the book
+        /// folder under a fresh name via <see cref="ImportImageIntoBookFolder"/>, which also
+        /// applies Bloom's normal import processing. An off-page slot is edited here in the storage DOM
         /// (caller saves); a current-page slot is left untouched — we return oldSrc/newSrc and
         /// the new file's <paramref name="creditAttributes"/> (via the out params) for the
         /// front-end to apply to the live DOM. Returns false with <paramref name="error"/> set
@@ -1009,15 +1025,9 @@ namespace Bloom.web.controllers
                 return false;
             }
 
-            // Write the new image under a fresh name (preserving the source extension) so
-            // we never clobber a file shared by another slot or serve stale cached bytes.
-            // GetUnusedFilename guarantees fresh while keeping the name human-readable
-            // (filenames surface in image metadata and problem reports).
-            var extension = Path.GetExtension(sourceBytesPath);
-            if (string.IsNullOrEmpty(extension))
-                extension = ".png";
-            var newFileName = ImageUtils.GetUnusedFilename(book.FolderPath, "ai-image", extension);
-            RobustFile.Copy(sourceBytesPath, Path.Combine(book.FolderPath, newFileName), true);
+            // Bring the bytes into the book folder, import-processed and under a fresh
+            // "ai-image*" name.
+            var newFileName = ImportImageIntoBookFolder(sourceBytesPath, book.FolderPath);
             newSrc = newFileName;
 
             // A generated result arrives with no intellectual-property metadata of its own, so
@@ -1061,6 +1071,77 @@ namespace Bloom.web.controllers
                 pageForDataDivSync = page;
 
             return true;
+        }
+
+        /// <summary>
+        /// Brings the bytes for a replacement into the book folder under a fresh "ai-image*"
+        /// name, running the same import processing a user-added image gets — downscale
+        /// anything oversized, convert a non-web format to PNG — instead of the verbatim copy
+        /// this used to do (BL-16645). AI services can return very large PNGs, and an
+        /// unprocessed one bloats the book folder for every sync, upload and backup.
+        ///
+        /// The NAME matters as much as the bytes: <see cref="DeleteSupersededAiImageFiles"/>
+        /// reclaims our old files by their "ai-image" prefix, but ProcessAndSaveImageIntoFolder
+        /// names its output after the SOURCE file, which for us is an opaque history id. So we
+        /// let it write, then rename onto the name we reserved. Passing isSameFile:false
+        /// guarantees it wrote a brand-new file (GetUnusedFilename picked that name), so the
+        /// rename can never disturb a file another slot shares. Processing may change the
+        /// extension (a non-web format becomes .png, .jpeg becomes .jpg), so the reserved name
+        /// takes its extension from what was actually produced rather than from the source.
+        ///
+        /// Anything we can't process is copied verbatim rather than lost — unprocessed but
+        /// intact, which is what this code did for every format before BL-16645. That covers
+        /// .webp (see <see cref="ProcessableImageExtensions"/>), a placeholder (which
+        /// ProcessAndSaveImageIntoFolder deliberately short-circuits on, writing nothing), and
+        /// an image that fails to process at all. Internal for testing.
+        /// </summary>
+        /// <returns>The name (no path) of the new file in the book folder.</returns>
+        internal static string ImportImageIntoBookFolder(
+            string sourceBytesPath,
+            string bookFolderPath
+        )
+        {
+            string processedName = null;
+            if (
+                ProcessableImageExtensions.Contains(Path.GetExtension(sourceBytesPath))
+                && !ImageUtils.IsPlaceholderImageFilename(sourceBytesPath)
+            )
+            {
+                try
+                {
+                    using (var imageInfo = PalasoImage.FromFileRobustly(sourceBytesPath))
+                    {
+                        processedName = ImageUtils.ProcessAndSaveImageIntoFolder(
+                            imageInfo,
+                            bookFolderPath,
+                            isSameFile: false
+                        );
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // Corrupt bytes, or an image too big for us to process at all. Falling
+                    // through to the plain copy keeps the user's image, just unprocessed.
+                    Logger.WriteError(
+                        $"AiImageEditorApi: could not import-process {sourceBytesPath}; copying it unchanged",
+                        ex
+                    );
+                }
+            }
+
+            var producedPath =
+                processedName == null ? null : Path.Combine(bookFolderPath, processedName);
+            var extension = Path.GetExtension(producedPath ?? sourceBytesPath);
+            if (string.IsNullOrEmpty(extension))
+                extension = ".png";
+            var newFileName = ImageUtils.GetUnusedFilename(bookFolderPath, "ai-image", extension);
+            var newPath = Path.Combine(bookFolderPath, newFileName);
+            // producedPath may not exist if processing bailed out early; fall back to the copy.
+            if (producedPath != null && RobustFile.Exists(producedPath))
+                RobustFile.Move(producedPath, newPath, true); // true: overwrite
+            else
+                RobustFile.Copy(sourceBytesPath, newPath, true);
+            return newFileName;
         }
 
         /// <summary>

--- a/src/BloomExe/web/controllers/AiImageEditorApi.cs
+++ b/src/BloomExe/web/controllers/AiImageEditorApi.cs
@@ -1027,7 +1027,17 @@ namespace Bloom.web.controllers
 
             // Bring the bytes into the book folder, import-processed and under a fresh
             // "ai-image*" name.
-            var newFileName = ImportImageIntoBookFolder(sourceBytesPath, book.FolderPath);
+            var newFileName = ImportImageIntoBookFolder(
+                sourceBytesPath,
+                book.FolderPath,
+                // Only a freshly generated/uploaded result needs resizing. A REUSED book image
+                // was already import-processed on its own way in, so there is nothing to gain
+                // by shrinking it again — and resizing rewrites the file through
+                // GraphicsMagick, which can drop the credits embedded in it. This path
+                // deliberately doesn't re-write credits (see EmbedCreditsInNewImageFile below),
+                // so there would be nothing to put them back.
+                resizeIfNeeded: !string.IsNullOrEmpty(replacement.resultId)
+            );
             newSrc = newFileName;
 
             // A generated result arrives with no intellectual-property metadata of its own, so
@@ -1095,10 +1105,17 @@ namespace Bloom.web.controllers
         /// ProcessAndSaveImageIntoFolder deliberately short-circuits on, writing nothing), and
         /// an image that fails to process at all. Internal for testing.
         /// </summary>
+        /// <param name="resizeIfNeeded">
+        /// False for a reused book image, which was already import-processed on its own way in.
+        /// Resizing it again would gain nothing and would rewrite the file through
+        /// GraphicsMagick, which can drop the credits embedded in it — and the reuse path
+        /// deliberately doesn't re-write credits, so they would simply be lost.
+        /// </param>
         /// <returns>The name (no path) of the new file in the book folder.</returns>
         internal static string ImportImageIntoBookFolder(
             string sourceBytesPath,
-            string bookFolderPath
+            string bookFolderPath,
+            bool resizeIfNeeded = true
         )
         {
             string processedName = null;
@@ -1114,7 +1131,8 @@ namespace Bloom.web.controllers
                         processedName = ImageUtils.ProcessAndSaveImageIntoFolder(
                             imageInfo,
                             bookFolderPath,
-                            isSameFile: false
+                            isSameFile: false,
+                            resizeFileIfNeeded: resizeIfNeeded
                         );
                     }
                 }

--- a/src/BloomTests/web/controllers/AiImageEditorApiTests.cs
+++ b/src/BloomTests/web/controllers/AiImageEditorApiTests.cs
@@ -162,6 +162,143 @@ namespace BloomTests.web.controllers
         }
 
         // ------------------------------------------------------------------
+        // ImportImageIntoBookFolder: brings a committed image into the book folder with
+        // Bloom's normal import processing (BL-16645). The "ai-image" name it produces is
+        // load-bearing — DeleteSupersededAiImageFiles reclaims old files by that prefix —
+        // and the processing must never be able to lose the image.
+        // ------------------------------------------------------------------
+
+        // Writes a PNG of the given size into a "source" folder OUTSIDE the book folder,
+        // standing in for the AI editor's history folder, and returns its full path.
+        private string MakeSourcePng(string name, int width, int height)
+        {
+            var sourceFolder = Path.Combine(_bookFolder.Path, "source");
+            Directory.CreateDirectory(sourceFolder);
+            var path = Path.Combine(sourceFolder, name);
+            using (var bitmap = new Bitmap(width, height))
+            {
+                RobustImageIO.SaveImage(bitmap, path, ImageFormat.Png);
+            }
+            return path;
+        }
+
+        [Test]
+        public void ImportImageIntoBookFolder_NamesTheFileAiImage_NotAfterTheSource()
+        {
+            // The source is named like an AI history result (an opaque id). The old code
+            // reserved an "ai-image*" name; ProcessAndSaveImageIntoFolder would instead name
+            // the file after the source, silently taking it out of reach of
+            // DeleteSupersededAiImageFiles.
+            var source = MakeSourcePng("a1b2c3d4.png", 10, 10);
+            Assert.That(File.Exists(source), Is.True, "setup: the source image should exist");
+
+            var newName = AiImageEditorApi.ImportImageIntoBookFolder(source, _bookFolder.Path);
+
+            Assert.That(
+                newName,
+                Does.StartWith("ai-image"),
+                "DeleteSupersededAiImageFiles reclaims our files by this prefix"
+            );
+            Assert.That(
+                newName,
+                Does.Not.Contain("a1b2c3d4"),
+                "the opaque history id must not become the book's file name"
+            );
+            Assert.That(
+                File.Exists(Path.Combine(_bookFolder.Path, newName)),
+                Is.True,
+                "the bytes must actually land in the book folder"
+            );
+        }
+
+        [Test]
+        public void ImportImageIntoBookFolder_CalledTwice_ProducesDistinctFiles()
+        {
+            // Two slots committed in one go must not collapse onto one file name.
+            var source = MakeSourcePng("result.png", 10, 10);
+
+            var first = AiImageEditorApi.ImportImageIntoBookFolder(source, _bookFolder.Path);
+            var second = AiImageEditorApi.ImportImageIntoBookFolder(source, _bookFolder.Path);
+
+            Assert.That(second, Is.Not.EqualTo(first), "each import needs its own file");
+            Assert.That(File.Exists(Path.Combine(_bookFolder.Path, first)), Is.True);
+            Assert.That(File.Exists(Path.Combine(_bookFolder.Path, second)), Is.True);
+        }
+
+        [Test]
+        public void ImportImageIntoBookFolder_OversizedImage_IsDownscaled()
+        {
+            // The point of BL-16645: an AI service can hand back a huge PNG, and copying it
+            // verbatim bloats the book folder for every sync, upload and backup.
+            var source = MakeSourcePng("huge.png", 5000, 4000);
+            using (var before = Image.FromFile(source))
+            {
+                Assert.That(
+                    before.Width,
+                    Is.EqualTo(5000),
+                    "setup: the source really is oversized"
+                );
+            }
+
+            var newName = AiImageEditorApi.ImportImageIntoBookFolder(source, _bookFolder.Path);
+
+            using (var after = Image.FromFile(Path.Combine(_bookFolder.Path, newName)))
+            {
+                Assert.That(
+                    after.Width,
+                    Is.LessThan(5000),
+                    "an oversized image should have been downscaled on the way in"
+                );
+            }
+        }
+
+        [Test]
+        public void ImportImageIntoBookFolder_UnprocessableFormat_IsCopiedVerbatim()
+        {
+            // PalasoImage decodes through GDI+, which has no WebP codec. We must still get
+            // the user's image into the book (unprocessed but intact), under our own name.
+            var sourceFolder = Path.Combine(_bookFolder.Path, "source");
+            Directory.CreateDirectory(sourceFolder);
+            var source = Path.Combine(sourceFolder, "generated.webp");
+            var bytes = new byte[] { 1, 2, 3, 4, 5 };
+            File.WriteAllBytes(source, bytes);
+
+            var newName = AiImageEditorApi.ImportImageIntoBookFolder(source, _bookFolder.Path);
+
+            Assert.That(newName, Does.StartWith("ai-image"));
+            Assert.That(
+                Path.GetExtension(newName),
+                Is.EqualTo(".webp"),
+                "a format we can't process keeps its own extension"
+            );
+            Assert.That(
+                File.ReadAllBytes(Path.Combine(_bookFolder.Path, newName)),
+                Is.EqualTo(bytes),
+                "the bytes must survive unchanged"
+            );
+        }
+
+        [Test]
+        public void ImportImageIntoBookFolder_CorruptImage_StillLandsInTheBookFolder()
+        {
+            // Processing must never be able to lose the image: a .png that isn't really a PNG
+            // throws inside PalasoImage, and we fall back to the plain copy.
+            var sourceFolder = Path.Combine(_bookFolder.Path, "source");
+            Directory.CreateDirectory(sourceFolder);
+            var source = Path.Combine(sourceFolder, "broken.png");
+            File.WriteAllText(source, "this is not a png");
+
+            var newName = AiImageEditorApi.ImportImageIntoBookFolder(source, _bookFolder.Path);
+
+            Assert.That(newName, Does.StartWith("ai-image"));
+            Assert.That(
+                File.Exists(Path.Combine(_bookFolder.Path, newName)),
+                Is.True,
+                "a corrupt image must still be copied rather than silently dropped"
+            );
+        }
+
+        // ------------------------------------------------------------------
         // TryResolveServedUrlToBookFile: the path-traversal guard that stops a
         // reused-image URL from resolving to anything outside the book folder.
         // servedUrl is passed as a plain book-folder path (FromLocalhost leaves a

--- a/src/BloomTests/web/controllers/AiImageEditorApiTests.cs
+++ b/src/BloomTests/web/controllers/AiImageEditorApiTests.cs
@@ -253,6 +253,56 @@ namespace BloomTests.web.controllers
         }
 
         [Test]
+        public void ImportImageIntoBookFolder_ReusedImage_IsNotResized()
+        {
+            // A reused book image was already import-processed on its own way in, so we
+            // deliberately don't resize it again: resizing rewrites the file through
+            // GraphicsMagick, and the reuse path doesn't re-write credits afterwards, so
+            // anything embedded in the original would simply be lost.
+            var source = MakeSourcePng("already-in-book.png", 5000, 4000);
+
+            var newName = AiImageEditorApi.ImportImageIntoBookFolder(
+                source,
+                _bookFolder.Path,
+                resizeIfNeeded: false
+            );
+
+            using (var after = Image.FromFile(Path.Combine(_bookFolder.Path, newName)))
+            {
+                Assert.That(
+                    after.Width,
+                    Is.EqualTo(5000),
+                    "a reused image must come through at its original size"
+                );
+                Assert.That(after.Height, Is.EqualTo(4000));
+            }
+        }
+
+        [Test]
+        public void ImportImageIntoBookFolder_ReusedImage_KeepsItsCredits()
+        {
+            // The credits live inside the image file. Nothing re-writes them on the reuse
+            // path, so whatever import processing does to the file has to leave them alone.
+            var name = MakePngWithCredits("reused.png", "Jane Doe", "Copyright 2020 Jane Doe");
+            var source = Path.Combine(_bookFolder.Path, name);
+
+            // Sanity: the credits really are in the source file, so a match below is not
+            // just two empty values agreeing.
+            var before = Metadata.FromFile(source);
+            Assert.That(before.Creator, Is.EqualTo("Jane Doe"), "setup");
+
+            var newName = AiImageEditorApi.ImportImageIntoBookFolder(
+                source,
+                _bookFolder.Path,
+                resizeIfNeeded: false
+            );
+
+            var after = Metadata.FromFile(Path.Combine(_bookFolder.Path, newName));
+            Assert.That(after.Creator, Is.EqualTo("Jane Doe"));
+            Assert.That(after.CopyrightNotice, Is.EqualTo("Copyright 2020 Jane Doe"));
+        }
+
+        [Test]
         public void ImportImageIntoBookFolder_UnprocessableFormat_IsCopiedVerbatim()
         {
             // PalasoImage decodes through GDI+, which has no WebP codec. We must still get


### PR DESCRIPTION
When the AI Image Editor committed an image back into the book, `AiImageEditorApi` did a plain `RobustFile.Copy` into the book folder, so none of the processing a user-added image gets was applied. AI services can return very large PNGs, and an unprocessed one bloats the book folder for every sync, upload and backup.

This routes the commit through `ImageUtils.ProcessAndSaveImageIntoFolder` (the same path the image-gallery and paste flows already use), via a new `ImportImageIntoBookFolder` helper.

Two things the helper has to protect:

- **The `ai-image` file name.** `DeleteSupersededAiImageFiles` reclaims the files we generate by that prefix, but `ProcessAndSaveImageIntoFolder` names its output after the *source* file, which for us is an opaque history id. So we let it write and then rename onto the name we reserved. `isSameFile: false` guarantees it wrote a brand-new file, so the rename can never disturb a file another slot shares. The reserved name takes its extension from what was actually produced, since processing can turn a `.jpeg` into `.jpg`.
- **The image itself.** Anything we can't process is copied verbatim rather than lost: `.webp` (PalasoImage decodes through GDI+, which has no WebP codec), a placeholder (`ProcessAndSaveImageIntoFolder` deliberately writes nothing for one), and images that fail to process at all.

Adds tests for the naming invariant, which was previously untested — nothing in the suite went through this path, so a silent rename would not have been caught.

### Known gaps (deliberate, flagged for review)

- A `.webp` result is still copied verbatim, so an oversized `.webp` is not downscaled. Bloom has no WebP decoder.
- A *reused* existing book image now also goes through processing. In practice that's a straight copy (it was already import-processed on its own way in), but if one were oversized enough to be resized, its embedded credits could be lost — the reuse path deliberately does not re-embed credits.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16645


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8146)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8146)
<!-- Reviewable:end -->
