### PR TITLE
Fix "By Sentence" left disabled on a text box with no recording (BL-16632)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -4126,6 +4126,19 @@ export default class AudioRecording implements IAudioRecorder {
         );
 
         this.updateButtonStateHelper(expectedVerb, response);
+
+        // The helper just recomputed this.haveAudio from the server, for whatever element is
+        // current now. The Advanced section's Recording Mode radio buttons are driven by values
+        // derived from it (uiState.hasAudio and uiState.haveACurrentTextboxModeRecording), and
+        // only updateDisplay() recomputes those. Several paths that change which box is current
+        // (clicking in another text box, Next/Back, typing new text) refresh the buttons through
+        // here without otherwise calling updateDisplay, which left the radio buttons describing
+        // the *previous* box. That is BL-16632: after recording By Whole Text Box and then
+        // clicking a box with no recording, "By Sentence" stayed disabled, saying to use Clear
+        // first, even though Clear itself was (correctly) disabled because that box has no audio.
+        // Pass false because refreshing what the UI shows must not have the side effect of
+        // choosing a new current element.
+        this.updateDisplay(false);
     }
 
     private updateButtonStateHelper(

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -4129,19 +4129,13 @@ export default class AudioRecording implements IAudioRecorder {
 
         // The helper just recomputed this.haveAudio from the server, for whatever element is
         // current now. The Advanced section's Recording Mode radio buttons are driven by values
-        // derived from it (uiState.hasAudio and uiState.haveACurrentTextboxModeRecording), and
-        // only updateDisplay() recomputes those. Several paths that change which box is current
-        // (clicking in another text box, Next/Back, typing new text) refresh the buttons through
-        // here without otherwise calling updateDisplay, which left the radio buttons describing
-        // the *previous* box. That is BL-16632: after recording By Whole Text Box and then
-        // clicking a box with no recording, "By Sentence" stayed disabled, saying to use Clear
-        // first, even though Clear itself was (correctly) disabled because that box has no audio.
-        // Both arguments are false because this refresh must only *report* state, never change
-        // it: choosing a new current element (maySetHighlight) would recurse back into here via
-        // getCurrentTextBox, and switching the recording mode (maySwitchToSentenceMode) would
-        // change it out from under the button statuses we just computed for the mode we read at
-        // the top of this method.
-        this.updateDisplay(false, false);
+        // derived from it, so they have to be recomputed here too. Several paths that change which
+        // box is current (clicking in another text box, Next/Back, typing new text) refresh the
+        // buttons through here and nothing else, which left the radio buttons describing the
+        // *previous* box. That is BL-16632: after recording By Whole Text Box and then clicking a
+        // box with no recording, "By Sentence" stayed disabled, saying to use Clear first, even
+        // though Clear itself was (correctly) disabled because that box has no audio.
+        this.updateAudioStateInDisplay();
     }
 
     private updateButtonStateHelper(
@@ -4500,6 +4494,13 @@ export default class AudioRecording implements IAudioRecorder {
         // 1- When calling changeStateAndSetExpected() with expectedVerb = ""
         // 2- While doing auto segmenting
         // 3- An unrecoverable error has occurred
+        // Every path that gets here has nothing recordable selected: the page has no editable
+        // text, the click landed on something that can't be recorded, or we could not work out
+        // what is current. So the current selection has no audio, by definition. Saying so keeps
+        // the Advanced section honest -- otherwise it goes on reporting the audio of the box we
+        // were on before, which is the BL-16632 mismatch ("By Sentence" disabled telling you to
+        // press Clear, while Clear is disabled because there is nothing to clear).
+        this.haveAudio = false;
         this.setStatus("record", Status.Disabled);
         this.setStatus("play", Status.Disabled);
         this.setStatus("split", Status.Disabled);
@@ -4509,11 +4510,10 @@ export default class AudioRecording implements IAudioRecorder {
         this.setStatus("listen", Status.Disabled);
 
         // The Advanced section's controls (the Recording Mode radio buttons, Insert Segment
-        // Marker) are driven by derived values in uiState that only updateDisplay recomputes, so
-        // they have to be refreshed here too. Otherwise deleting all the text on a page disables
-        // every button but leaves those controls enabled, still describing the text that used to
-        // be there (BL-16632). Report only: never move the highlight or switch the mode from here.
-        this.updateDisplay(false, false);
+        // Marker) are driven by derived values that have to be refreshed here too. Otherwise
+        // deleting all the text on a page disables every button but leaves those controls enabled,
+        // still describing the text that used to be there (BL-16632).
+        this.updateAudioStateInDisplay();
     }
 
     private showBusy(): void {
@@ -4761,15 +4761,31 @@ export default class AudioRecording implements IAudioRecorder {
         await this.setShowPlaybackOrderMode(isOn);
     }
 
-    // maySwitchToSentenceMode: whether this refresh may *change* this.recordingMode, via the
-    // subscription downgrade below. A caller that has already computed something from
-    // this.recordingMode must pass false, so the mode cannot change underneath what it computed;
-    // the downgrade then happens at the next ordinary updateDisplay, just as it did before the
-    // button-state refresh started calling this at all (BL-16632).
-    private updateDisplay(
-        maySetHighlight = true,
-        maySwitchToSentenceMode = true,
-    ): void {
+    // Recompute just the parts of the display that depend on the current audio state: whether the
+    // current selection has a recording, whether that recording is a whole-text-box one, and
+    // whether the page has anything recordable. This is what the button-state refresh invalidates
+    // when it recomputes this.haveAudio, so that refresh calls this rather than the whole of
+    // updateDisplay (BL-16632). Deliberately narrow in two ways:
+    //  - It does not publish the *mode* fields (recordingMode, inShowPlaybackOrderMode,
+    //    showingImageDescriptions). Those belong to the code that changes those modes, and
+    //    republishing them from a button refresh fights it -- e.g. it would undo the uiState reset
+    //    removePlaybackOrderUi deliberately makes on page change while leaving its own field set.
+    //  - It never *changes* anything, so it can't disturb a caller further up the stack: no
+    //    highlight is chosen (which would recurse back here via getCurrentTextBox), and
+    //    this.recordingMode is left alone -- updateDisplay's subscription downgrade could
+    //    otherwise switch the mode out from under button statuses just computed for the old one.
+    private updateAudioStateInDisplay(): void {
+        const hasRecordableDivs =
+            this.getRecordableDivs(true, false).length > 0;
+        const currentPlaybackMode = this.getCurrentPlaybackMode(false);
+        this.uiState.haveACurrentTextboxModeRecording =
+            this.haveAudio && currentPlaybackMode === RecordingMode.TextBox;
+        this.uiState.hasAudio = this.haveAudio;
+        this.uiState.hasRecordableDivs = hasRecordableDivs;
+        this.notifyStateChanged();
+    }
+
+    private updateDisplay(maySetHighlight = true): void {
         // It's a bit expensive to do the test for text present, but without it,
         // Import Recording will be improperly enabled on an empty page.
         const hasRecordableDivs =
@@ -4779,7 +4795,6 @@ export default class AudioRecording implements IAudioRecorder {
         let haveACurrentTextboxModeRecording =
             this.haveAudio && currentPlaybackMode === RecordingMode.TextBox;
         if (
-            maySwitchToSentenceMode &&
             this.wholeTextBoxAudioFeatureStatus &&
             !this.wholeTextBoxAudioFeatureStatus.enabled &&
             this.recordingMode === RecordingMode.TextBox

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -4136,9 +4136,12 @@ export default class AudioRecording implements IAudioRecorder {
         // the *previous* box. That is BL-16632: after recording By Whole Text Box and then
         // clicking a box with no recording, "By Sentence" stayed disabled, saying to use Clear
         // first, even though Clear itself was (correctly) disabled because that box has no audio.
-        // Pass false because refreshing what the UI shows must not have the side effect of
-        // choosing a new current element.
-        this.updateDisplay(false);
+        // Both arguments are false because this refresh must only *report* state, never change
+        // it: choosing a new current element (maySetHighlight) would recurse back into here via
+        // getCurrentTextBox, and switching the recording mode (maySwitchToSentenceMode) would
+        // change it out from under the button statuses we just computed for the mode we read at
+        // the top of this method.
+        this.updateDisplay(false, false);
     }
 
     private updateButtonStateHelper(
@@ -4504,6 +4507,13 @@ export default class AudioRecording implements IAudioRecorder {
         this.setStatus("prev", Status.Disabled);
         this.setStatus("clear", Status.Disabled);
         this.setStatus("listen", Status.Disabled);
+
+        // The Advanced section's controls (the Recording Mode radio buttons, Insert Segment
+        // Marker) are driven by derived values in uiState that only updateDisplay recomputes, so
+        // they have to be refreshed here too. Otherwise deleting all the text on a page disables
+        // every button but leaves those controls enabled, still describing the text that used to
+        // be there (BL-16632). Report only: never move the highlight or switch the mode from here.
+        this.updateDisplay(false, false);
     }
 
     private showBusy(): void {
@@ -4751,7 +4761,15 @@ export default class AudioRecording implements IAudioRecorder {
         await this.setShowPlaybackOrderMode(isOn);
     }
 
-    private updateDisplay(maySetHighlight = true): void {
+    // maySwitchToSentenceMode: whether this refresh may *change* this.recordingMode, via the
+    // subscription downgrade below. A caller that has already computed something from
+    // this.recordingMode must pass false, so the mode cannot change underneath what it computed;
+    // the downgrade then happens at the next ordinary updateDisplay, just as it did before the
+    // button-state refresh started calling this at all (BL-16632).
+    private updateDisplay(
+        maySetHighlight = true,
+        maySwitchToSentenceMode = true,
+    ): void {
         // It's a bit expensive to do the test for text present, but without it,
         // Import Recording will be improperly enabled on an empty page.
         const hasRecordableDivs =
@@ -4761,6 +4779,7 @@ export default class AudioRecording implements IAudioRecorder {
         let haveACurrentTextboxModeRecording =
             this.haveAudio && currentPlaybackMode === RecordingMode.TextBox;
         if (
+            maySwitchToSentenceMode &&
             this.wholeTextBoxAudioFeatureStatus &&
             !this.wholeTextBoxAudioFeatureStatus.enabled &&
             this.recordingMode === RecordingMode.TextBox

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
@@ -1870,6 +1870,34 @@ describe("audio recording tests", () => {
 
             expect(recording.uiState.hasRecordableDivs).toBe(true);
         });
+
+        // The mirror image: when the last of the text goes away, the tool disables every button
+        // (the empty expected verb), and the Advanced section's controls have to follow. They used
+        // to stay enabled, still describing the text that had just been deleted.
+        it("disables the recording modes once the last of the text is deleted", async () => {
+            setupDefaultApiResponses();
+            SetupIFrameFromHtml(
+                '<div id="page1"><div class="bloom-translationGroup"><div id="box1" class="bloom-editable audio-sentence bloom-visibility-code-on" data-test-preselect="true" lang="en" data-audiorecordingmode="TextBox"><p>Text that is about to be deleted.</p></div></div></div>',
+            );
+
+            const recording = new AudioRecording();
+            (recording as unknown as { isShowing: boolean }).isShowing = true;
+            recording.recordingMode = RecordingMode.TextBox;
+
+            await recording.handleNewPageReady();
+            expect(
+                recording.uiState.hasRecordableDivs,
+                "Setup problem: the box starts out with text to record",
+            ).toBe(true);
+
+            // The user deletes all of it. The markup update that follows finds nothing recordable
+            // left on the page, which disables the buttons with the empty expected verb.
+            getFrameElementById("page", "box1")!.innerHTML = "<p></p>";
+
+            await recording.changeStateAndSetExpectedAsync("");
+
+            expect(recording.uiState.hasRecordableDivs).toBe(false);
+        });
     });
 
     describe("- initializeAudioRecordingMode()", () => {

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
@@ -1898,6 +1898,46 @@ describe("audio recording tests", () => {
 
             expect(recording.uiState.hasRecordableDivs).toBe(false);
         });
+
+        // Clicking something that can't be recorded (a picture, say) deselects everything and
+        // disables all the buttons. The Advanced section has to stop claiming the recording of the
+        // box we were on, or we are back to "By Sentence" disabled telling you to press a Clear
+        // button that is itself disabled.
+        it("stops claiming a recording when the click lands on something that cannot be recorded", async () => {
+            setupApiResponsesWithRecordingForBox1();
+            const box1 =
+                '<div id="box1" class="bloom-editable audio-sentence bloom-visibility-code-on" data-test-preselect="true" lang="en" data-audiorecordingmode="TextBox"><p>This box has been recorded.</p></div>';
+            SetupIFrameFromHtml(
+                `<div id="page1"><div class="bloom-translationGroup">${box1}</div><div id="justAPicture"><img src="picture.png" /></div></div>`,
+            );
+
+            const recording = new AudioRecording();
+            (recording as unknown as { isShowing: boolean }).isShowing = true;
+            recording.recordingMode = RecordingMode.TextBox;
+            await recording.handleNewPageReady();
+            expect(
+                recording.uiState.hasAudio,
+                "Setup problem: box1's recording should have been found",
+            ).toBe(true);
+
+            const moveRecordingHighlightToElement = (
+                recording as unknown as {
+                    moveRecordingHighlightToElement(
+                        target: HTMLElement,
+                    ): Promise<boolean>;
+                }
+            ).moveRecordingHighlightToElement.bind(recording);
+            await moveRecordingHighlightToElement(
+                getFrameElementById("page", "justAPicture")!,
+            );
+
+            // Sanity check: nothing is selected, so every button is disabled.
+            expect(recording.uiState.buttons.clear).toBe(Status.Disabled);
+            expect(recording.uiState.hasAudio).toBe(false);
+            expect(recording.uiState.haveACurrentTextboxModeRecording).toBe(
+                false,
+            );
+        });
     });
 
     describe("- initializeAudioRecordingMode()", () => {

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
@@ -1763,6 +1763,115 @@ describe("audio recording tests", () => {
         });
     });
 
+    // BL-16632: The Recording Mode radio buttons are driven by uiState.hasAudio and
+    // uiState.haveACurrentTextboxModeRecording, which are derived from this.haveAudio. The
+    // button-state refresh recomputes this.haveAudio from the server whenever the current
+    // element changes, so anything that refreshes the buttons must also refresh those derived
+    // flags. Otherwise "By Sentence" keeps saying 'first use the "Clear" button to remove your
+    // recording' about a box that has no recording (and whose Clear button is disabled).
+    describe("- recording mode enablement when the current box changes (BL-16632)", () => {
+        // Only box1 has a recording.
+        function setupApiResponsesWithRecordingForBox1() {
+            vi.spyOn(axios, "get").mockImplementation((url: string) => {
+                if (url.includes(kAnyRecordingApiUrl)) {
+                    return Promise.resolve({ data: url.includes("box1") });
+                } else {
+                    return Promise.reject("Fake 404 error 16632.");
+                }
+            });
+        }
+
+        // A page where box1 has been recorded By Whole Text Box and box2 has text the user
+        // just typed but has never recorded. Both are marked up for TextBox recording, which
+        // is what the tool does to a newly typed box while that mode is selected.
+        function setupPageWithRecordedBox1AndUnrecordedBox2() {
+            const box1 =
+                '<div id="box1" class="bloom-editable audio-sentence bloom-visibility-code-on" data-test-preselect="true" lang="en" data-audiorecordingmode="TextBox"><p>This box has been recorded.</p></div>';
+            const box2 =
+                '<div id="box2" class="bloom-editable audio-sentence bloom-visibility-code-on" lang="en" data-audiorecordingmode="TextBox"><p>This box has never been recorded.</p></div>';
+            SetupIFrameFromHtml(
+                `<div id="page1"><div class="bloom-translationGroup">${box1}</div><div class="bloom-translationGroup">${box2}</div></div>`,
+            );
+        }
+
+        it("stops claiming a whole-text-box recording after the highlight moves to a box with no recording", async () => {
+            setupApiResponsesWithRecordingForBox1();
+            setupPageWithRecordedBox1AndUnrecordedBox2();
+
+            const recording = new AudioRecording();
+            (recording as unknown as { isShowing: boolean }).isShowing = true;
+            recording.recordingMode = RecordingMode.TextBox;
+
+            // Arrive on the page with box1 (which has a whole-text-box recording) current.
+            await recording.handleNewPageReady();
+
+            // Sanity check the starting state: with box1 current we really do have a
+            // whole-text-box recording, so "By Sentence" is correctly disabled here.
+            expect(
+                recording.uiState.buttons.clear,
+                "Setup problem: Clear should be enabled for the recorded box",
+            ).toBe(Status.Enabled);
+            expect(recording.uiState.hasAudio).toBe(true);
+            expect(recording.uiState.haveACurrentTextboxModeRecording).toBe(
+                true,
+            );
+
+            // The user clicks in box2, which has text but no recording.
+            const moveRecordingHighlightToElement = (
+                recording as unknown as {
+                    moveRecordingHighlightToElement(
+                        target: HTMLElement,
+                    ): Promise<boolean>;
+                }
+            ).moveRecordingHighlightToElement.bind(recording);
+            await moveRecordingHighlightToElement(
+                getFrameElementById("page", "box2")!,
+            );
+
+            // Sanity check that the engine did notice box2 has no recording.
+            expect(
+                recording.uiState.buttons.clear,
+                "Setup problem: Clear should be disabled for the unrecorded box",
+            ).toBe(Status.Disabled);
+            // ...so the radio buttons must agree: no audio, no whole-text-box recording,
+            // hence "By Sentence" is available again.
+            expect(recording.uiState.hasAudio).toBe(false);
+            expect(recording.uiState.haveACurrentTextboxModeRecording).toBe(
+                false,
+            );
+        });
+
+        // The other half of BL-16632: add a page and type into its empty text box. Nothing
+        // recomputed hasRecordableDivs after the page was found to be empty, so both Recording
+        // Mode radio buttons stayed disabled even though the box now had text to record.
+        it("enables the recording modes once text is typed into a page that started out empty", async () => {
+            setupDefaultApiResponses();
+            SetupIFrameFromHtml(
+                '<div id="page1"><div class="bloom-translationGroup"><div id="box1" class="bloom-editable bloom-visibility-code-on" lang="en" data-audiorecordingmode="TextBox"><p></p></div></div></div>',
+            );
+
+            const recording = new AudioRecording();
+            (recording as unknown as { isShowing: boolean }).isShowing = true;
+            recording.recordingMode = RecordingMode.TextBox;
+
+            // A newly added page: it has a text box, but no text yet, so there is nothing to record.
+            await recording.handleNewPageReady();
+            expect(recording.uiState.hasRecordableDivs).toBe(false);
+
+            // The user types. The markup update that follows ends by refreshing the button state.
+            const box1 = getFrameElementById("page", "box1")!;
+            box1.innerHTML = "<p>Text the user just typed.</p>";
+            box1.classList.add("audio-sentence");
+            (
+                recording as unknown as { highlightedElement: HTMLElement }
+            ).highlightedElement = box1;
+
+            await recording.changeStateAndSetExpectedAsync("record");
+
+            expect(recording.uiState.hasRecordableDivs).toBe(true);
+        });
+    });
+
     describe("- initializeAudioRecordingMode()", () => {
         it("initializeAudioRecordingMode gets mode from current div if available (synchronous) (Text Box)", () => {
             SetupIFrameFromHtml(


### PR DESCRIPTION
The Talking Book tool's Recording Mode radio buttons are driven by values derived from whether the
current text box has a recording (`hasAudio`, `haveACurrentTextboxModeRecording`,
`hasRecordableDivs`). Only a full `updateDisplay()` recomputed those, while the buttons (Record,
Play, Clear …) were refreshed every time the current box changed — so the radio buttons went on
describing the box you were on before.

After recording By Whole Text Box and then clicking a box with no recording — or typing into a
newly added page — "By Sentence" stayed disabled, its tooltip telling you to use Clear first, while
the Clear button itself was correctly disabled because the current box has no audio.

**The fix.** The button-state refresh now ends by calling a new, deliberately narrow
`updateAudioStateInDisplay()`, which publishes just those three audio-derived values and changes
nothing else. It is narrow in two ways that matter:

- it does **not** publish the mode fields (`recordingMode`, `inShowPlaybackOrderMode`,
  `showingImageDescriptions`) — those belong to the code that changes those modes, and
  republishing them from a button refresh fights it;
- it never *changes* anything: no highlight is chosen (which would recurse back in via
  `getCurrentTextBox`), and `this.recordingMode` is left alone, so `updateDisplay`'s
  subscription downgrade can't move the mode out from under button statuses just computed.

Two related holes found in review are fixed too:

- `disableInteraction()` published the derived values without refreshing `haveAudio` first, so the
  Advanced section could still report the audio of the box we had just left. Every path that gets
  there has nothing recordable selected, so it now says so.
- Deleting the last of the text on a page disabled every button but left the Recording Mode radios
  and Insert Segment Marker enabled, still describing text that was gone.

**Tests.** Five regression tests in `audioRecordingSpec.ts`, each confirmed to fail without its
fix: the highlight moving to an unrecorded box; typing into a page that started out empty;
deleting the last of the text; clicking something that cannot be recorded; and (on the branch
below) a stale server answer arriving after a page change.

**Not in this PR:** the related race — a `checkForAnyRecording` answer about the *previous* box
arriving after the page changed — which is why the card's own repro steps ("record By Whole Text
Box, add a new page, type") only sometimes show the problem. That is a separate, pre-existing
defect; the guard for it (each refresh takes a generation number; only the most recent may apply
what it hears back) is held on the branch `BL-16632-stale-button-state-answers` pending a decision
about whether it ships with this regression fix.

Not verified live in Bloom: reproducing by hand needs an actual microphone recording. QA test ideas
are on the card.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16632

---
[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8147)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8147)
<!-- Reviewable:end -->
