### PR TITLE
Only claim the background image when it is still a placeholder (BL-16542)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementClipboard.test.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementClipboard.test.ts
@@ -56,7 +56,10 @@ vi.mock("../../toolbox/canvas/CanvasElementItem", () => ({
 }));
 
 import { SetupMetadataButton } from "../bloomImages";
-import { changeImageInfo } from "../bloomEditing";
+import {
+    changeImageInfo,
+    wrapWithRequestPageContentDelay,
+} from "../bloomEditing";
 import {
     CanvasElementClipboard,
     ICanvasElementClipboardHost,
@@ -201,5 +204,69 @@ describe("CanvasElementClipboard paste refreshes the metadata button (BL-16605)"
         expect(host.adjustContainerAspectRatio).toHaveBeenCalledTimes(1);
         expect(host.adjustBackgroundImageSize).not.toHaveBeenCalled();
         expect(SetupMetadataButton).not.toHaveBeenCalled();
+    });
+});
+
+describe("CanvasElementClipboard only claims a placeholder background (BL-16542)", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        vi.mocked(SetupMetadataButton).mockReset();
+        vi.mocked(changeImageInfo).mockClear();
+        vi.mocked(wrapWithRequestPageContentDelay).mockClear();
+    });
+
+    test("a canvas whose only content is a placeholder background takes the pasted image as its background", () => {
+        const { bloomCanvas, img } = makeCanvasWithPlaceholder(true);
+        const host = makeHost(bloomCanvas, undefined);
+
+        expect(img.getAttribute("src")).toBe("placeHolder.png");
+
+        makeClipboard(host).finishPasteImageFromClipboard(pastedImageInfo);
+
+        expect(img.getAttribute("src")).toBe("pasted.png");
+        expect(host.adjustBackgroundImageSize).toHaveBeenCalledTimes(1);
+        // We handled it here, so we never reached the add-a-new-element branch.
+        expect(wrapWithRequestPageContentDelay).not.toHaveBeenCalled();
+    });
+
+    test("a background that already holds a real image is left alone; the paste becomes a new canvas element", () => {
+        // Nothing is selected (the state right after the page is displayed), so the only way
+        // this paste could replace the background is the empty-canvas branch. That branch must
+        // not fire once the background holds a real image: replacing the picture the user can
+        // see needs them to select it first. See BL-16542.
+        const { bloomCanvas, img } = makeCanvasWithPlaceholder(true);
+        img.setAttribute("src", "realBackground.png");
+        const host = makeHost(bloomCanvas, undefined);
+
+        // Sanity check: one canvas element, and it IS the background, so the only thing
+        // keeping us out of that branch is the non-placeholder src.
+        expect(
+            bloomCanvas.getElementsByClassName(kCanvasElementClass).length,
+        ).toBe(1);
+        expect(
+            bloomCanvas
+                .getElementsByClassName(kCanvasElementClass)[0]
+                .classList.contains(kBackgroundImageClass),
+        ).toBe(true);
+
+        makeClipboard(host).finishPasteImageFromClipboard(pastedImageInfo);
+
+        expect(img.getAttribute("src")).toBe("realBackground.png");
+        expect(changeImageInfo).not.toHaveBeenCalled();
+        expect(host.adjustBackgroundImageSize).not.toHaveBeenCalled();
+        expect(SetupMetadataButton).not.toHaveBeenCalled();
+        // Instead we fell through to the branch that adds a new canvas element.
+        expect(wrapWithRequestPageContentDelay).toHaveBeenCalledTimes(1);
+    });
+
+    test("a background whose src is missing counts as empty", () => {
+        const { bloomCanvas, img } = makeCanvasWithPlaceholder(true);
+        img.removeAttribute("src");
+        const host = makeHost(bloomCanvas, undefined);
+
+        makeClipboard(host).finishPasteImageFromClipboard(pastedImageInfo);
+
+        expect(img.getAttribute("src")).toBe("pasted.png");
+        expect(host.adjustBackgroundImageSize).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementClipboard.test.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementClipboard.test.ts
@@ -11,8 +11,11 @@ import {
 // this suite exists because the Ctrl+V path used to skip it (BL-16605).
 vi.mock("../bloomImages", () => ({
     kImageContainerClass: "bloom-imageContainer",
+    // Mirror the real helper's semantics (bloomImages.ts): case-insensitive, and it wants the
+    // whole "placeholder.png", not just the stem. The empty-canvas branch now leans on this
+    // predicate, so a looser stub here would let the tests pass on behavior we don't ship.
     isPlaceHolderImage: (src: string | null) =>
-        !!src && src.includes("placeHolder"),
+        !!src && src.toLowerCase().includes("placeholder.png"),
     SetupMetadataButton: vi.fn(),
 }));
 

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementClipboard.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementClipboard.ts
@@ -11,6 +11,7 @@ import {
     wrapWithRequestPageContentDelay,
 } from "../bloomEditing";
 import {
+    isPlaceHolderImage,
     kImageContainerClass,
     SetupMetadataButton,
 } from "../bloomImages";
@@ -164,7 +165,9 @@ export class CanvasElementClipboard {
     // Otherwise, if there is a bloom canvas on the page, it will pick the one that has the active element
     // or the first one if none has an active element.
     // (If there is no canvas, it returns false.)
-    // If the canvas is empty (including the background), set the background to the image.
+    // If the canvas holds nothing but a background that is still a placeholder, set that
+    // background to the image. (A background that already holds a real image is left alone;
+    // select it first if you want to replace it.)
     // Else if canvas is allowed by the subscription tier, add the image as a canvas/game item.
     // Make it up to 1/3 width and 1/3 height of the canvas, roughly centered on the canvas.
     // Is it a draggable item? Yes, if we are in the "Start" mode of a game.
@@ -240,7 +243,7 @@ export class CanvasElementClipboard {
         const canvasElements =
             bloomCanvas.getElementsByClassName(kCanvasElementClass);
         // If it's an empty canvas, make this its background image.  An empty canvas may already
-        // have a background image, but no other content.  See BL-16542.
+        // have a background placeholder image, but no other content.  See BL-16542.
         // A possible special case is the custom game page, where the only canvas element is the
         // header. But that works out to our advantage, since we think a background is unlikely
         // in games, and would prefer to interpret the pasted image as a game item.
@@ -249,7 +252,12 @@ export class CanvasElementClipboard {
             canvasElements[0].classList.contains(kBackgroundImageClass)
         ) {
             const bgimg = canvasElements[0].getElementsByTagName("img")[0];
-            if (bgimg) {
+            // Use the shared placeholder test rather than an exact match on the src: at
+            // runtime a placeholder src is not always the bare "placeHolder.png" we write
+            // into the templates, and every other place in the code that asks "is this
+            // still empty?" goes through isPlaceHolderImage().
+            const src = bgimg?.getAttribute("src");
+            if (bgimg && (!src?.trim() || isPlaceHolderImage(src))) {
                 this.replaceImageInCanvasElement(
                     bloomCanvas,
                     canvasElements[0] as HTMLElement,

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementManager.ts
@@ -2631,7 +2631,9 @@ export class CanvasElementManager {
     // Otherwise, if there is a bloom canvas on the page, it will pick the one that has the active element
     // or the first one if none has an active element.
     // (If there is no canvas, it returns false.)
-    // If the canvas is empty (including the background), set the background to the image.
+    // If the canvas holds nothing but a background that is still a placeholder, set that
+    // background to the image. (A background that already holds a real image is left alone;
+    // select it first if you want to replace it.)
     // Else if canvas is allowed by the subscription tier, add the image as a canvas/game item.
     // Make it up to 1/3 width and 1/3 height of the canvas, roughly centered on the canvas.
     // Is it a draggable item? Yes, if we are in the "Start" mode of a game.


### PR DESCRIPTION
With nothing selected, pasting an image into a `bloom-canvas` whose only canvas element is the background used to overwrite that background's image file outright — even when it already held a real picture the user could see.

This restricts that "empty canvas" branch of `CanvasElementClipboard.finishPasteImageFromClipboard()` to a background that is still a placeholder (or has no `src` at all). A background holding a real image is now left alone, and the pasted image arrives as a new canvas element instead — which is already what happens on a custom front cover, whose single canvas holds several canvas elements and no background image at all.

Replacing a real background still works: select it first, and the selected-image branch handles it (the BL-16542 behavior added earlier).

Also in here:

- Use the shared `isPlaceHolderImage()` helper rather than an exact match against `"placeholder.png"`. A runtime `src` is not always the bare value we write into the templates, and every other "is this still empty?" test in the code goes through that helper.
- Update the two doc comments (on `CanvasElementClipboard.finishPasteImageFromClipboard` and `CanvasElementManager.pasteImageFromClipboard`) that described the old rule.
- Three unit tests covering the new rule: placeholder background is claimed, real background is left alone and routes to the add-a-new-element branch, missing `src` counts as empty.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16542


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8149)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8149)
<!-- Reviewable:end -->
