### PR TITLE
Run the C# suite with dotnet test, so CI and developers run the same thing (BL-16656)

### DIFF
--- a/build/Bloom.proj
+++ b/build/Bloom.proj
@@ -59,7 +59,6 @@
   <UsingTask TaskName="MakeWixForDirTree" AssemblyFile="$(BuildTasksDll)" Condition="Exists('$(BuildTasksDll)')" />
   <UsingTask TaskName="Split" AssemblyFile="$(BuildTasksDll)" Condition="Exists('$(BuildTasksDll)')" />
   <UsingTask TaskName="FileUpdate" AssemblyFile="$(BuildTasksDll)" Condition="Exists('$(BuildTasksDll)')" />
-  <UsingTask TaskName="NUnit3" AssemblyFile="$(BuildTasksDll)" Condition="Exists('$(BuildTasksDll)')" />
   <UsingTask TaskName="S3BuildPublisher" AssemblyFile="$(BuildTasksAwsDll)" Condition="Exists('$(BuildTasksAwsDll)')" />
   <Import Project="$(MSBuildCommunityTasksPath)/MSBuild.Community.Tasks.Targets"/>
   <UsingTask TaskName="WebDownload" AssemblyFile="$(MSBuildCommunityTasksPath)/MSBuild.Community.Tasks.dll"/>
@@ -193,21 +192,71 @@
     <CallTarget Targets="TestOnly"/>
   </Target>
   <Target Name="TestOnly" DependsOnTargets="RunNUnit"/>
+  <!--
+	Runs the C# suite with `dotnet test` (the same runner developers use) rather than with the
+	nunit3-console that the SIL.BuildTasks NUnit3 task wraps.
+
+	The console runner launches a per-framework agent process that asks the host only for
+	Microsoft.NETCore.App, never Microsoft.WindowsDesktop.App. Managed WPF assemblies still
+	resolve through our deps.json, but the native search path is derived from what the process
+	asked for, so anything calling into WPF's native code dies with "Unable to load DLL
+	'wpfgfx_cor3.dll'". `dotnet test` starts the host from BloomTests.runtimeconfig.json, which
+	does ask for WindowsDesktop. That gap is why ImageGalleryApi's tests passed every local run
+	and turned TeamCity red the moment they merged (BL-16597). The build and the developers were
+	not running the same thing. This makes them the same thing.
+
+	We deliberately point dotnet test at the already-built assembly rather than at the csproj:
+	several tests locate content by walking up from the assembly's own folder (see
+	BloomFileLocatorTests.kRelativePathToBrowserFolder), so letting dotnet test rebuild into
+	its default bin folder would quietly change what those paths resolve to.
+
+	Note we do NOT rely on the runner to report to TeamCity. We write NUnit3 xml (the format that
+	both TeamCity's importData and the nightly's publish action already understand) and hand
+	TeamCity the file. The Exec must not abort the target on failure, or a failing run would
+	skip the import and TeamCity would lose exactly the results worth looking at; so we capture
+	the exit code, import, and only then fail.
+  -->
   <Target Name="RunNUnit">
     <PropertyGroup>
-      <TestResultsXmlFile Condition="$(isOnTeamCity) == false">$(RootDir)/output/Tests/$(Configuration)/x64/TestResults.xml</TestResultsXmlFile>
-      <ExtraExcludeCategories Condition="'$(teamcity_version)' != ''">SkipOnTeamCity,$(ExtraExcludeCategories)</ExtraExcludeCategories>
+      <TestResultsXmlFile>$(RootDir)/output/Tests/$(Configuration)/x64/TestResults.xml</TestResultsXmlFile>
+      <!-- Categories to leave out, semicolon separated, which is what MSBuild splits an Include
+	       on. Callers pass one: TeamCity /p:excludedCategories=Integration (the tests that talk
+	       to the live S3 bucket), the nightly /p:excludedCategories=SkipOnTeamCity. TeamCity
+	       additionally always wants SkipOnTeamCity, so add it there rather than making the build
+	       configuration repeat it. Note the name must differ from excludedCategories by more
+	       than case: MSBuild property names are case insensitive, so a property "ExcludedCategories"
+	       reading "$(excludedCategories)" would be reading itself. -->
+      <CategoriesToExclude>$(excludedCategories)</CategoriesToExclude>
+      <CategoriesToExclude Condition="'$(teamcity_version)' != ''">SkipOnTeamCity;$(excludedCategories)</CategoriesToExclude>
     </PropertyGroup>
-    <NUnit3
-			Assemblies="@(TestAssemblies)"
-			ToolPath="$(NuGetPackageDir)/nunit.consolerunner/3.20.1/tools"
-			ExcludeCategory="$(ExtraExcludeCategories)$(excludedCategories)"
-			WorkingDirectory="$(RootDir)/output/Tests/$(Configuration)/x64"
-			Trace="Debug"
-			Verbose="true"
-			OutputXmlFile="$(TestResultsXmlFile)"
-			UseNUnit3Xml="true"
-			TeamCity="$(isOnTeamCity)"/>
+    <!-- A comma would survive as part of a category name and yield "TestCategory!=A,B", which
+	     matches nothing and so silently excludes nothing, running a suite nobody asked for. Only
+	     reachable by setting the property in the environment: on the command line MSBuild reads a
+	     comma as its own separator between properties, so /p:excludedCategories=A,B never gets
+	     this far. Worth catching anyway, since the failure it prevents is a silent one. -->
+    <Error Condition="$(CategoriesToExclude.Contains(','))"
+		   Text="excludedCategories is semicolon separated, but got '$(CategoriesToExclude)'"/>
+    <ItemGroup>
+      <ExcludedCategory Include="$(CategoriesToExclude)"/>
+    </ItemGroup>
+    <PropertyGroup>
+      <TestFilterArgument Condition="'@(ExcludedCategory)' != ''">--filter "@(ExcludedCategory->'TestCategory!=%(Identity)', '&amp;')"</TestFilterArgument>
+    </PropertyGroup>
+    <Message Importance="high" Text="Running C# tests: @(TestAssemblies) $(TestFilterArgument)"/>
+    <!-- The logger only writes the results file once a run completes, so a run that dies before
+	     that (crashed test host, a filter dotnet test rejects, no dotnet on PATH) would leave
+	     the previous run's file sitting there for importData to hand the build server. The build
+	     still goes red on the exit code, but the report it shows would be a different run's, and
+	     plausibly all green. Delete it first so a missing report reads as missing. TeamCity
+	     checkouts persist between builds, which is what makes this reachable. -->
+    <Delete Files="$(TestResultsXmlFile)"/>
+    <Exec Command='dotnet test "@(TestAssemblies)" --nologo $(TestFilterArgument) --logger:"nunit;LogFilePath=$(TestResultsXmlFile)"'
+		  WorkingDirectory="$(RootDir)/output/Tests/$(Configuration)/x64"
+		  ContinueOnError="true">
+      <Output TaskParameter="ExitCode" PropertyName="TestExitCode"/>
+    </Exec>
+    <Message Condition="$(isOnTeamCity) == true" Importance="high" Text="##teamcity[importData type='nunit' path='$(TestResultsXmlFile)']"/>
+    <Error Condition="'$(TestExitCode)' != '0'" Text="C# tests failed (dotnet test returned $(TestExitCode)). Results: $(TestResultsXmlFile)"/>
   </Target>
   <Target Name="MakeDownloadPointers" DependsOnTargets="VersionNumbers"
 		Condition="'$(OS)'=='Windows_NT'">

--- a/src/BloomTests/BloomTests.csproj
+++ b/src/BloomTests/BloomTests.csproj
@@ -106,9 +106,11 @@
 		<PackageReference Include="Moq" Version="4.14.7" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="NUnit" Version="3.14.0" />
-		<PackageReference Include="NUnit.ConsoleRunner" Version="3.20.1" />
-		<PackageReference Include="NUnit.Extension.TeamCityEventListener" Version="1.0.10" />
 		<PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
+		<!-- Lets `dotnet test` write its results as NUnit3 xml, which is what both TeamCity's
+		     importData and the nightly's publish action already read. Keeping the format means
+		     moving off nunit3-console costs no changes downstream of the build. -->
+		<PackageReference Include="NunitXml.TestLogger" Version="6.1.0" />
 		<PackageReference Include="RestSharp" Version="106.12.0" />
 		<PackageReference Include="SharpZipLib" Version="1.3.3" />
 		<PackageReference Include="SIL.Core" Version="18.0.0-beta0028" />

--- a/src/BloomTests/SetUpFixture.cs
+++ b/src/BloomTests/SetUpFixture.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Runtime.InteropServices;
-using System.Windows.Media.Imaging;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 
 namespace BloomTests
 {
@@ -17,54 +13,6 @@ namespace BloomTests
         public void Setup()
         {
             L10NSharp.LocalizationManager.StrictInitializationMode = false;
-            MakeWpfNativeCodeLoadable();
-        }
-
-        /// <summary>
-        /// Lets WPF's imaging code find its own native library when we are run by the NUnit
-        /// console runner, which is how the build does it (see the NUnit3 task in Bloom.proj).
-        ///
-        /// The production code that needs this is Bloom.web.controllers.ImageGalleryApi, which
-        /// is the one place in Bloom that uses WPF's WIC-backed imaging
-        /// (System.Windows.Media.Imaging: BitmapDecoder to read an image's header, BitmapImage
-        /// and JpegBitmapEncoder to build the downscaled preview the image chooser shows for a
-        /// file the browser cannot display). Its tests — ImageGalleryApiTests — are therefore
-        /// the only ones this affects today, and if that usage ever goes away, so can this.
-        ///
-        /// That runner launches a per-framework agent process whose runtimeconfig.json asks
-        /// only for Microsoft.NETCore.App, never Microsoft.WindowsDesktop.App. The managed WPF
-        /// assemblies still load — NUnit resolves those through our deps.json — but the
-        /// runtime's native search path is built from what the *process* asked for, so it holds
-        /// the NETCore.App folder alone. The first WPF imaging call then dies with
-        /// "Unable to load DLL 'wpfgfx_cor3.dll'", which is next door in the WindowsDesktop
-        /// folder that nobody put on the path. Both agent versions we have shipped (3.20.1 and
-        /// 3.22.0) are built this way, so this is not something a runner upgrade fixes.
-        ///
-        /// Nothing is wrong with Bloom itself: Bloom.exe sets UseWPF and so is a genuine
-        /// WindowsDesktop app, whose native path includes that folder. Nor is anything wrong
-        /// under `dotnet test`, which starts the host from BloomTests.runtimeconfig.json — and
-        /// that one does ask for WindowsDesktop. So a test that needs WPF passes locally and
-        /// fails on the build machine, which is how those tests came to be merged green and
-        /// then turn TeamCity red (BL-16597).
-        ///
-        /// PresentationCore is loaded out of the very folder its native library lives in, so
-        /// that folder is simply where the assembly already is. Returning zero for anything not
-        /// found there leaves normal resolution — and its normal error — untouched.
-        /// </summary>
-        private static void MakeWpfNativeCodeLoadable()
-        {
-            var presentationCore = typeof(BitmapDecoder).Assembly;
-            var windowsDesktopFolder = Path.GetDirectoryName(presentationCore.Location);
-            NativeLibrary.SetDllImportResolver(
-                presentationCore,
-                (libraryName, assembly, searchPath) =>
-                    NativeLibrary.TryLoad(
-                        Path.Combine(windowsDesktopFolder, libraryName),
-                        out var library
-                    )
-                        ? library
-                        : IntPtr.Zero
-            );
         }
     }
 }


### PR DESCRIPTION
CI and developers did not run the C# suite the same way, so a test could be green everywhere locally and red the moment it merged.

`build/Bloom.proj` ran the suite through the **NUnit3 MSBuild task** from SIL.BuildTasks, which wraps `nunit3-console`. That runner launches a per-framework agent process whose `runtimeconfig.json` asks the host only for `Microsoft.NETCore.App`, never `Microsoft.WindowsDesktop.App`. Managed WPF assemblies still resolve (NUnit finds them via our `deps.json`), but the runtime's **native** search path is derived from what the process asked for, so any call into WPF's native code fails with `Unable to load DLL 'wpfgfx_cor3.dll'`. `dotnet test` starts the host from `BloomTests.runtimeconfig.json`, which *does* ask for WindowsDesktop, so the same tests pass.

That is exactly how BL-16597's `ImageGalleryApiTests` passed on every developer machine and produced 15 failures on TeamCity the moment they merged.

## What changed

- `RunNUnit` now runs `dotnet test` against the already-built assembly (not the csproj: several tests locate content by walking up from the assembly's own folder, e.g. `BloomFileLocatorTests.kRelativePathToBrowserFolder`).
- Results stay **NUnit3 xml at the same path** via `NunitXml.TestLogger`, so `nightly.yml` is untouched and there is **no TeamCity server-side change** — results go over `##teamcity[importData type='nunit']`.
- The `Exec` deliberately does not abort the target: it captures the exit code, emits `importData`, and only then fails. Otherwise a failing run would skip the import and TeamCity would lose exactly the results worth looking at.
- Category exclusion simplified to semicolons (what MSBuild already splits an `Include` on), dropping the comma conversion and the `Unescape` it forced.
- Drops the WPF `DllImportResolver` added to `SetUpFixture.cs` on master, which existed only to work around the console runner. It goes in this commit so reverting the switch restores it too.
- SIL.BuildTasks is left alone — the `NUnit3` task wraps one specific runner and Bloom was its only caller here.

## Verification

- **The real target, end to end**: `msbuild Bloom.proj /t:TestOnly` → 3027 tests, 0 failures, 12 skipped, 5m10s, exit 0, valid NUnit3 xml written to the path `nightly.yml` publishes.
- Filter construction checked for every caller shape: TeamCity with `Integration`, the nightly with `SkipOnTeamCity`, TeamCity with nothing passed, nothing passed at all, and the comma guard firing.
- vstest confirmed to honour the two-clause form: `BloomS3ClientTests` runs 31 tests without the `Integration` exclusion and 30 with it.
- `ImageGalleryApiTests` 23/23 with the resolver removed.

## Still to prove on CI

TeamCity reports **3687** C# test occurrences where only **3027** run locally. Sampling the TeamCity results confirms the difference is C#, not front-end vitest — most likely `TestCaseSource` data that only exists on a build agent. Their behaviour under VSTest is unconfirmed, so this wants one TeamCity run and one dispatched C#-only nightly before merge.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16656


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8152)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8152)
<!-- Reviewable:end -->
