### PR TITLE
Make reporting a blocked server worker always top up the pool (BL-16612)

### DIFF
--- a/src/BloomExe/ErrorReporter/HtmlErrorReporter.cs
+++ b/src/BloomExe/ErrorReporter/HtmlErrorReporter.cs
@@ -474,41 +474,41 @@ namespace Bloom.ErrorReporter
                             }
 
                             // ShowDialog will cause this thread to be blocked (because it spins up a modal) until the dialog is closed.
-                            BloomServer.RegisterThreadBlocking();
-
-                            try
+                            using (BloomServer.ReportThreadBlocking())
                             {
-                                dlg.ShowDialog();
-                                Logger.WriteMinorEvent("closing error report dialog");
-
-                                // Take action if the user clicked a button other than Close
-                                if (
-                                    dlg.CloseSource == "closedByAlternateButton"
-                                    && onExtraButtonClicked != null
-                                )
+                                try
                                 {
-                                    onExtraButtonClicked(message, exception);
-                                }
-                                else if (dlg.CloseSource == "closedByReportButton")
-                                {
-                                    var onClicked =
-                                        onReportButtonClicked != null
-                                            ? onReportButtonClicked
-                                            : DefaultOnReportClicked;
-                                    onClicked(message, exception);
-                                }
+                                    dlg.ShowDialog();
+                                    Logger.WriteMinorEvent("closing error report dialog");
 
-                                // Note: With the way LibPalaso's ErrorReport is designed,
-                                // its intention is that after OnShowDetails is invoked and closed, you will not come back to the Notify Dialog
-                                // This code has been implemented to follow that model
-                                //
-                                // But now that we have more options, it might be nice to come back to this dialog.
-                                // If so, you'd need to add/update some code in this section.
-                            }
-                            finally
-                            {
-                                ResetToDefaults();
-                                BloomServer.RegisterThreadUnblocked();
+                                    // Take action if the user clicked a button other than Close
+                                    if (
+                                        dlg.CloseSource == "closedByAlternateButton"
+                                        && onExtraButtonClicked != null
+                                    )
+                                    {
+                                        onExtraButtonClicked(message, exception);
+                                    }
+                                    else if (dlg.CloseSource == "closedByReportButton")
+                                    {
+                                        var onClicked =
+                                            onReportButtonClicked != null
+                                                ? onReportButtonClicked
+                                                : DefaultOnReportClicked;
+                                        onClicked(message, exception);
+                                    }
+
+                                    // Note: With the way LibPalaso's ErrorReport is designed,
+                                    // its intention is that after OnShowDetails is invoked and closed, you will not come back to the Notify Dialog
+                                    // This code has been implemented to follow that model
+                                    //
+                                    // But now that we have more options, it might be nice to come back to this dialog.
+                                    // If so, you'd need to add/update some code in this section.
+                                }
+                                finally
+                                {
+                                    ResetToDefaults();
+                                }
                             }
                         }
                     }

--- a/src/BloomExe/Publish/OffScreenBrowser.cs
+++ b/src/BloomExe/Publish/OffScreenBrowser.cs
@@ -286,7 +286,25 @@ namespace Bloom.Publish
                 },
                 null
             );
-            return tcs.Task.GetAwaiter().GetResult();
+
+            // We are about to block, and publishing runs as an api request, so the thread we block is
+            // usually a BloomServer worker. Tell the server, so that it keeps a worker free to serve the
+            // requests this browser is about to make -- including the very page we navigate to, which
+            // BloomServer serves from memory.
+            //
+            // Without this the server could not tell that its whole pool was blocked. Reporting a block is
+            // opt-in, and neither of the two existing reports covers us. BloomApiHandler's covers ACQUIRING
+            // the api lock, not the long stretch while publishing holds it. ApiRequest's covers marshalling
+            // a handler onto the UI thread, which the publish endpoints deliberately opt out of (they
+            // register with handleOnUiThread: false), so it never runs on this path -- and that opt-out is
+            // also why the thread we block here is a server worker rather than the UI thread, which is what
+            // makes reporting it worth doing at all. So every other worker could be waiting for that lock,
+            // and this one waiting here, with the server believing a worker was still free. That is
+            // BL-16612.
+            using (BloomServer._theOneInstance?.ReportThreadBlocking())
+            {
+                return tcs.Task.GetAwaiter().GetResult();
+            }
         }
 
         /// <summary>

--- a/src/BloomExe/web/BloomApiHandler.cs
+++ b/src/BloomExe/web/BloomApiHandler.cs
@@ -393,22 +393,18 @@ namespace Bloom.Api
                 else if (localPathLc.StartsWith("api/i18n/"))
                     syncOn = I18NLock;
 
-                // We wrap RegisterThreadBlocking/Unblocked around acquiring the lock.
+                // We report the thread as blocked around ACQUIRING the lock -- not around holding it, since
+                // once we have it we are working rather than waiting.
                 // SemaphoreSlim is used instead of Monitor so we can safely await while the lock is held.
                 // See BL-15586.
                 bool lockAcquired = false;
                 try
                 {
                     // Try to acquire lock
-                    BloomServer._theOneInstance.RegisterThreadBlocking();
-                    try
+                    using (BloomServer._theOneInstance.ReportThreadBlocking())
                     {
                         syncOn.Wait();
                         lockAcquired = true;
-                    }
-                    finally
-                    {
-                        BloomServer._theOneInstance.RegisterThreadUnblocked();
                     }
 
                     // Lock has been acquired.

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -44,8 +44,11 @@ namespace Bloom.Api
     // when it doesn't want to spin up a real one.
     public interface IBloomServer
     {
-        void RegisterThreadBlocking();
-        void RegisterThreadUnblocked();
+        /// <summary>
+        /// See BloomServer.ReportThreadBlocking. Dispose the result when the blocking work is done;
+        /// there is deliberately no separate "unblocked" call to forget or to get wrong.
+        /// </summary>
+        IDisposable ReportThreadBlocking();
 
         // ENHANCE: Add other methods as needed
     }
@@ -136,6 +139,15 @@ namespace Bloom.Api
         /// Pool of threads that pull a request from the _queue and processes it.
         /// This is a ConcurrentDictionary (ManagedThreadId to thread) just so we can add and remove
         /// things from it without worrying about locking (or deadlocking).
+        ///
+        /// Two properties of this collection that other code relies on, so take care before changing
+        /// either. Additions are made only under lock (_queue) (see SpinUpAWorker), which is what lets a
+        /// caller re-check a count and act on it without another thread adding a worker underneath it. And
+        /// an entry is only ever REMOVED for a thread that has already died (see the pruning in
+        /// EnqueueIncomingRequests) -- nothing removes a live worker. That second property is what makes it
+        /// safe for EnsureAWorkerCanStillTakeWork to count live workers WITHOUT the lock: a concurrent
+        /// removal can only take away something that was not going to be counted as live anyway, so it
+        /// cannot inflate the answer.
         /// </summary>
         private readonly ConcurrentDictionary<int, Thread> _workers = new();
 
@@ -151,7 +163,7 @@ namespace Bloom.Api
 
         /// <summary>
         /// Keeps track of the number of worker threads that are blocked
-        /// Note: This is NOT automatically computed. Other code should call RegisterThreadAboutToBlock() and RegisterThreadUnblocked()
+        /// Note: This is NOT automatically computed. Other code should call ReportThreadBlocking() and dispose the scope it returns
         ///        whenever it causes a thread which is or potentially is a server worker thread to block.
         /// Note: This is different than _busyThreads, because a thread may be busy but not blocked.
         /// </summary>
@@ -1928,14 +1940,10 @@ namespace Bloom.Api
                 // Deal with a situation where all the workers are blocked,
                 // but there is a request in the queue that would unblock the current workers
                 // but that request can't run because it's stuck in queue
-                // and none of the existing worker threads are able to make progress anymore
-                if (_countBlockedThreads >= _workers.Count)
-                {
-                    // The worker should be spun up such that it can receive _ready.Set()
-                    SpinUpAWorker();
-
-                    // Note: Currently these workers are never stopped, so as not to complicate the code any further
-                }
+                // and none of the existing worker threads are able to make progress anymore.
+                // Any worker added here is added before the _ready.Set() below, so it receives it.
+                // (Monitor is reentrant, so it is fine that we already hold this lock.)
+                EnsureAWorkerCanStillTakeWork();
 
                 _ready.Set();
             }
@@ -2397,44 +2405,222 @@ namespace Bloom.Api
         }
 
         /// <summary>
-        /// Registers that the current thread is about to block.
-        /// This function should be called immediately before any server thread blocks
-        /// (e.g. waits for a lock, wait for a modal dialog to close, etc.)
-        /// Must be paired with RegisterThreadUnblocked() when done.
+        /// Reports that the calling thread is about to block -- waiting for a lock, for a modal dialog to
+        /// close, for an off-screen browser, and so on. Call it immediately before the blocking work and
+        /// dispose the result as soon as that work is done, normally with a `using` block.
         ///
-        /// This can be called by any code that at least sometimes (if not always)
-        /// is called by a BloomServer worker thread. The caller need not guarantee that
-        /// the current thread is a server thread. This method will check for that.
+        /// Any code that is *sometimes* run by a server worker may call this; it need not know whether the
+        /// current thread is one. Blocks reported by other threads are ignored, since they are not using up
+        /// a worker.
+        ///
+        /// Why this returns a scope instead of having a matching "unblocked" method: whether a block counts
+        /// depends on whether the caller is one of our workers, and that answer has to be REMEMBERED rather
+        /// than worked out again at the end. Blocking work that contains an await can resume on a different
+        /// thread -- a worker carries no synchronization context, so continuations land on the thread pool --
+        /// and asking "am I a worker?" there would answer no and silently skip the decrement, inflating the
+        /// count for the life of the process. The scope closes over the answer, so it cannot drift, and it
+        /// releases on every exit path including an exception. Both bugs were real: see BL-16612.
         /// </summary>
-        public void RegisterThreadBlocking()
+        public IDisposable ReportThreadBlocking()
         {
-            // Check if the current thread looks like a Server Worker
-            // If not, we can just ignore this request.
-            // Notably, ProblemReportApi can be invoked by both server and non-server code
-            if (IsWorkerThread(Thread.CurrentThread))
+            // Notably, ProblemReportApi can be invoked by both server and non-server code.
+            if (!IsWorkerThread(Thread.CurrentThread))
+                return NotBlockingAWorker;
+
+            Interlocked.Increment(ref _countBlockedThreads);
+            // Must not throw; if it did, the caller would never receive the scope that undoes the
+            // increment above. See the guarantee inside it.
+            EnsureAWorkerCanStillTakeWork();
+            return new BlockedWorkerScope(this);
+        }
+
+        // Shared, stateless scope handed to callers whose thread is not one of our workers, so those
+        // callers still get something disposable and need no special case.
+        private static readonly IDisposable NotBlockingAWorker = new DoNothingScope();
+
+        private sealed class DoNothingScope : IDisposable
+        {
+            public void Dispose() { }
+        }
+
+        /// <summary>
+        /// Undoes exactly one counted block, once. Holding the server (rather than re-deriving anything
+        /// from the current thread) is the whole point -- see ReportThreadBlocking.
+        /// </summary>
+        private sealed class BlockedWorkerScope : IDisposable
+        {
+            private BloomServer _server;
+
+            public BlockedWorkerScope(BloomServer server)
             {
-                // Note: So far only BloomApiHandler and problem report dialog have been analyzed to call this when needed.
-                Interlocked.Increment(ref _countBlockedThreads);
+                _server = server;
+            }
+
+            public void Dispose()
+            {
+                // Taking the reference away atomically makes a second Dispose -- e.g. a `using` inside a
+                // method whose caller also disposes -- harmless instead of double-decrementing.
+                var server = Interlocked.Exchange(ref _server, null);
+                if (server != null)
+                    Interlocked.Decrement(ref server._countBlockedThreads);
             }
         }
 
         /// <summary>
-        /// Registers that the current thread is no longer blocked.
-        /// Should be called as a pair with RegisterThreadBlocking(), after any blocking work returns.
+        /// If every worker is now blocked, add one, so that some worker is still able to take a request off
+        /// the queue. This matters because the request that would let the blocked workers finish is often
+        /// itself sitting in the queue: in BL-16612 a publish held an api lock while every other worker
+        /// waited for that same lock, so no worker was left to serve the page the publish was waiting for,
+        /// and the whole server deadlocked.
+        ///
+        /// This is called from ReportThreadBlocking rather than being offered as a separate method for
+        /// callers to remember, so that every caller which correctly reports that it is blocking gets the
+        /// top-up automatically. There is deliberately no way to register a block WITHOUT it -- reporting
+        /// the block is the only thing a caller has to get right.
+        ///
+        /// QueueRequest makes the same check as a request ARRIVES, which is not sufficient by itself: if
+        /// the request that would break the deadlock is already in the queue, no new request need ever
+        /// arrive to trigger the check. Checking here covers the other moment the pool can run out -- when
+        /// a worker becomes blocked.
+        ///
+        /// Deliberately has no shutdown guard, unlike QueueRequest, which gives up once the listener has
+        /// closed. A worker can therefore add one more worker while Dispose is joining threads. That is safe
+        /// only because Dispose signals _stop without disposing it or _ready, so the new worker wakes
+        /// immediately and exits -- see the note in Dispose, which must stay true for this to remain safe.
         /// </summary>
-        public void RegisterThreadUnblocked()
+        private void EnsureAWorkerCanStillTakeWork()
         {
-            // Check if the current thread looks like a Server Worker
-            // If not, we can just ignore this request.
-            // Notably, ProblemReportApi can be invoked by both server and non-server code
-            if (IsWorkerThread(Thread.CurrentThread))
+            // NOTHING in this method may throw, logging and the fast-path reads alike. The caller increments
+            // the blocked count and only receives the scope that undoes it AFTER this returns, so an
+            // exception escaping here would leak that count for the life of the process -- which would then
+            // make every later block add yet another worker. Adding a worker is a safety net; neither
+            // failing to add one nor failing to log it may turn into a failed request. The fast path is
+            // inside the try so that guarantee is structural, rather than resting on an argument about what
+            // ConcurrentDictionary.Count can do.
+            //
+            // REVIEWED DECISION (BL-16612): catching everything here, including around the logging in the
+            // catch below, is a deliberate exception to this repo's "fail fast, don't be defensive"
+            // guidance in AGENTS.md. Do not "clean this up" into a narrower catch without reading the rest
+            // of this comment, because the obvious objection to it has already been raised and answered.
+            //
+            // The immediate reason: the caller increments the blocked count and only receives the scope
+            // that undoes it after this returns, so an exception escaping here would leave that count
+            // permanently high -- the very condition this method exists to relieve.
+            //
+            // That is not the only way to arrange things, and a cheaper alternative than we first thought
+            // does exist: hand the caller its scope BEFORE calling this, dispose it and rethrow if this
+            // throws, and then this method would be free to fail fast. That touches only
+            // ReportThreadBlocking, not every call site. It was considered and declined, and the reason is
+            // a judgement rather than a constraint: topping up the pool is an opportunistic safety net, and
+            // a safety net failing is not itself a reason to fail the user's request that happened to
+            // trigger it. Publishing a book should not die because the server could not create a spare
+            // thread it may well not need. If you disagree with that trade, the restructure above is the
+            // way to change it -- but change it deliberately, not by narrowing this catch and reintroducing
+            // the leak.
+            try
             {
-                Interlocked.Decrement(ref _countBlockedThreads);
+                // Fast path that avoids _queue's lock, which the listener (enqueuing) and the workers
+                // (dequeuing) are already contending for; this runs on every api request that waits for a
+                // lock. Walking the workers to count the live ones is not free, but it is far cheaper than
+                // joining the queue behind those two.
+                //
+                // Why this counts LIVE workers even out here, where a cheap approximation would normally be
+                // fine: the only thing this test can do is SKIP the more careful check below, so the two
+                // directions of error are not symmetric.
+                //   Too LOW (say we race a SpinUpAWorker that has not added its thread yet): we decline to
+                //     return, take the lock, and get the better answer. Self-correcting -- and the reason
+                //     reading this unsynchronized is acceptable at all.
+                //   Too HIGH: we return here and the check below never runs. The raw entry count is
+                //     SYSTEMATICALLY too high, because a dead thread keeps its entry until the listener
+                //     prunes it, so using it here left the careful check unreachable.
+                // A concurrent removal cannot push us into that dangerous direction, because entries are
+                // only removed for threads that are already dead; see the note on _workers.
+                //
+                // Be clear about what a live count does NOT buy, though. It is a fact about the instant it
+                // was taken, and a worker can die immediately afterwards. The re-check under the lock is no
+                // better in that respect: the lock covers changes to _workers, not thread liveness. So
+                // neither reading is authoritative about how many workers are still alive by the time we
+                // act on it. What counting live workers removes is the systematic over-count from lingering
+                // dead entries -- not that race.
+                //
+                // Staleness in the blocked count is harmless: Interlocked.Increment gives the increments a
+                // total order, so whichever thread performs the last one reads a count including every
+                // earlier block. The worker that exhausts the pool therefore always sees the shortage, even
+                // if the ones before it did not.
+                if (Volatile.Read(ref _countBlockedThreads) < LiveWorkerCount())
+                    return;
+
+                var addedWorker = false;
+                // SpinUpAWorker requires this lock, since it modifies _workers. Re-checking here means we
+                // decide against a count taken after any concurrent add, rather than the one above -- but
+                // per the note above, not against a count guaranteed still true when we act on it.
+                lock (_queue)
+                {
+                    if (_countBlockedThreads >= LiveWorkerCount())
+                    {
+                        // REVIEWED DECISION (BL-16612): workers are never retired -- that predates this
+                        // code -- and we accepted that the pool can therefore end a session larger than it
+                        // started. During a long publish, several requests can queue behind the same lock
+                        // and each one can add a worker, so growth is bounded by how many are actually
+                        // waiting, not unbounded. We judged that a fair price for not deadlocking, but it
+                        // is why thread counts in a diagnostic may look higher than you expect. Retiring
+                        // idle workers would be the real fix and is a much larger change.
+                        SpinUpAWorker();
+                        addedWorker = true;
+                    }
+                }
+                // Logged after releasing our own lock (QueueRequest's caller may still hold it), since
+                // logging can be slow. This is the event to look for in a log when investigating a freeze,
+                // so it is worth a line even though it is not an error.
+                if (addedWorker)
+                    Logger.WriteEvent(
+                        "BloomServer: every worker was blocked, so added one to keep requests moving "
+                            + $"({_workers.Count} workers, {_countBlockedThreads} blocked)."
+                    );
+            }
+            catch (Exception e)
+            {
+                // This last attempt to record what went wrong could itself fail, and nothing may escape
+                // (see above), so it is deliberately allowed to fail silently.
+                try
+                {
+                    Logger.WriteEvent(
+                        "BloomServer: trouble adding a worker while one was blocking: " + e.Message
+                    );
+                }
+                catch { }
             }
         }
 
+        /// <summary>
+        /// How many workers are actually alive and so could still take a request off the queue. Bloom has
+        /// seen worker threads die (see the pruning in EnqueueIncomingRequests), and a dead one leaves its
+        /// entry in _workers until that pruning runs, so _workers.Count can overstate the pool.
+        ///
+        /// Counts the dictionary itself rather than its Values, which on a ConcurrentDictionary materialises
+        /// a snapshot list -- worth avoiding on something EnsureAWorkerCanStillTakeWork calls for every api
+        /// request that waits for a lock. Callers may hold lock (_queue) or not; see that method for why
+        /// counting without it is safe.
+        /// </summary>
+        private int LiveWorkerCount() => _workers.Count(kvp => kvp.Value?.IsAlive == true);
+
+        /// <summary>
+        /// The number of worker threads in the pool, alive or not. For tests, which need to observe that a
+        /// worker was added when they made every existing worker report itself blocked.
+        /// </summary>
+        internal int WorkerCount => _workers.Count;
+
+        /// <summary>
+        /// How many workers currently report themselves blocked. For tests, which need to prove that a
+        /// reported block is undone even when the scope is disposed on a different thread than reported it.
+        /// </summary>
+        internal int BlockedWorkerCount => _countBlockedThreads;
+
+        // Ordinal deliberately: the default overloads of both StartsWith and IndexOf(string) are
+        // culture-sensitive, which is the wrong kind of comparison for a thread name we generated
+        // ourselves -- and slower.
         private bool IsWorkerThread(Thread thread) =>
-            thread?.Name?.IndexOf(WorkerThreadNamePrefix) == 0;
+            thread?.Name?.StartsWith(WorkerThreadNamePrefix, StringComparison.Ordinal) == true;
 
         private string GetHtmlForRootOfBloomUI()
         {
@@ -2551,6 +2737,23 @@ namespace Bloom.Api
                         // tell _listenerThread and the worker threads they should stop
                         _stop.Set();
 
+                        // Note (BL-16612): a worker part-way through a request can still report a block while
+                        // we are joining threads below, and EnsureAWorkerCanStillTakeWork has no shutdown
+                        // guard, so that can add a worker after the join has passed it. Two things make that
+                        // survivable, and BOTH have to stay true:
+                        //   1. We only SIGNAL _stop here and never dispose it or _ready, so a late worker's
+                        //      WaitAny returns at once and it exits. Dispose those handles and it would die
+                        //      instead of an ObjectDisposedException on a background thread, taking the
+                        //      process with it.
+                        //   2. We actually reach this line. Note that it is inside `if (_listener != null)`,
+                        //      so if CloseListener() ran first -- it is public, nulls _listener, and its own
+                        //      comment mentions the shutdown timer -- _stop is never signalled at all.
+                        // Caveat worth knowing about (2): workers are FOREGROUND threads, so a worker still
+                        // waiting on _ready/_stop keeps the process alive. Pre-existing workers have always
+                        // been exposed to that; what the top-up adds is the chance of creating a NEW one
+                        // during that window. Devin raised it; it is recorded rather than fixed here because
+                        // the fix (guard the top-up on shutdown, or make added workers background threads)
+                        // changes behaviour and was left for the developer to decide.
                         var secondsToWait = 2.0;
                         // wait for _listenerThread to stop
                         if (_listenerThread.ThreadState != ThreadState.Unstarted)

--- a/src/BloomExe/web/controllers/ApiRequest.cs
+++ b/src/BloomExe/web/controllers/ApiRequest.cs
@@ -339,39 +339,44 @@ namespace Bloom.Api
         {
             Exception handlerException = null;
 
-            BloomServer._theOneInstance.RegisterThreadBlocking();
-
-            try
+            // The scope is what ends the reported block, and it has to be, for two reasons that both used
+            // to bite here (BL-16612). First, the await below can resume on a different thread than the one
+            // that reported the block -- a server worker has no synchronization context, so the
+            // continuation lands on the thread pool -- and the old code decided whether to decrement by
+            // looking at the thread it happened to be running on, so it silently skipped it and left the
+            // count permanently high. Second, disposal covers every exit: previously an exception out of
+            // Invoke other than ObjectDisposedException left the block reported forever.
+            using (BloomServer._theOneInstance.ReportThreadBlocking())
             {
-                // This will block until the UI thread is done invoking this.
-                await (Task)
-                    formForSynchronizing.Invoke(
-                        new Func<ApiRequest, Task>(
-                            async (req) =>
-                            {
-                                try
+                try
+                {
+                    // This will block until the UI thread is done invoking this.
+                    await (Task)
+                        formForSynchronizing.Invoke(
+                            new Func<ApiRequest, Task>(
+                                async (req) =>
                                 {
-                                    await endpointRegistration.Handle(req);
+                                    try
+                                    {
+                                        await endpointRegistration.Handle(req);
+                                    }
+                                    catch (Exception error)
+                                    {
+                                        handlerException = error;
+                                    }
                                 }
-                                catch (Exception error)
-                                {
-                                    handlerException = error;
-                                }
-                            }
-                        ),
-                        request
-                    );
+                            ),
+                            request
+                        );
+                }
+                catch (ObjectDisposedException)
+                {
+                    // The form was disposed between the IsDisposed check and the actual Invoke call.
+                    // This can happen when Bloom reloads after a UI language change. Fail silently.
+                    request.Failed("Shell disposed during API request handling");
+                    return false;
+                }
             }
-            catch (ObjectDisposedException)
-            {
-                // The form was disposed between the IsDisposed check and the actual Invoke call.
-                // This can happen when Bloom reloads after a UI language change. Fail silently.
-                BloomServer._theOneInstance.RegisterThreadUnblocked();
-                request.Failed("Shell disposed during API request handling");
-                return false;
-            }
-
-            BloomServer._theOneInstance.RegisterThreadUnblocked();
 
             if (handlerException != null)
             {

--- a/src/BloomExe/web/controllers/ProblemReportApi.cs
+++ b/src/BloomExe/web/controllers/ProblemReportApi.cs
@@ -725,16 +725,17 @@ namespace Bloom.web.controllers
                             dlg.SetScaledSize(731, height);
 
                             // ShowDialog will cause this thread to be blocked (because it spins up a modal) until the dialog is closed.
-                            BloomServer._theOneInstance.RegisterThreadBlocking();
-                            try
+                            using (BloomServer._theOneInstance.ReportThreadBlocking())
                             {
-                                // Keep dialog on top of program window if possible.  See https://issues.bloomlibrary.org/youtrack/issue/BL-10292.
-                                dlg.ShowDialog(owner);
-                            }
-                            finally
-                            {
-                                BloomServer._theOneInstance.RegisterThreadUnblocked();
-                                _additionalPathsToInclude = null;
+                                try
+                                {
+                                    // Keep dialog on top of program window if possible.  See https://issues.bloomlibrary.org/youtrack/issue/BL-10292.
+                                    dlg.ShowDialog(owner);
+                                }
+                                finally
+                                {
+                                    _additionalPathsToInclude = null;
+                                }
                             }
                         }
                     }

--- a/src/BloomTests/web/BloomServerWorkerPoolTests.cs
+++ b/src/BloomTests/web/BloomServerWorkerPoolTests.cs
@@ -1,0 +1,291 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Bloom.Api;
+using Bloom.Book;
+using NUnit.Framework;
+
+namespace BloomTests.web
+{
+    /// <summary>
+    /// Tests for BloomServer's worker pool keeping a worker able to take work while others are blocked.
+    ///
+    /// Deliberately a separate fixture from BloomServerTests, which needs a collection, a localization
+    /// manager, and a BloomFileLocator; none of that is relevant here, and a real listening server is
+    /// (unlike in those tests) exactly what we need, since the workers only exist once it is listening.
+    /// </summary>
+    [TestFixture]
+    public class BloomServerWorkerPoolTests
+    {
+        /// <summary>
+        /// The whole point of reporting a block (BL-16612): once every worker is blocked, no worker is left
+        /// to take a request off the queue -- including the request that would let the blocked workers
+        /// finish. So the server has to add one.
+        /// </summary>
+        [Test]
+        public void ReportThreadBlocking_WhenTheLastFreeWorkerBlocks_AddsAWorker()
+        {
+            using (var server = new BloomServer(new BookSelection()))
+            {
+                server.EnsureListening();
+                var workersAtStart = server.WorkerCount;
+                Assert.That(
+                    workersAtStart,
+                    Is.GreaterThan(1),
+                    "SANITY: the pool should start out with several workers"
+                );
+
+                // The server only counts blocks reported by its own worker threads, so we have to report
+                // from a thread that looks like one.
+                RunOnAPretendWorkerThread(() =>
+                {
+                    var scopes = new List<IDisposable>();
+                    try
+                    {
+                        // One short of all of them: a worker is still free, so leave the pool alone.
+                        for (var i = 0; i < workersAtStart - 1; i++)
+                            scopes.Add(server.ReportThreadBlocking());
+                        Assert.That(
+                            server.WorkerCount,
+                            Is.EqualTo(workersAtStart),
+                            "should not have added a worker while one was still free"
+                        );
+
+                        // Now the last free worker blocks too.
+                        scopes.Add(server.ReportThreadBlocking());
+                        Assert.That(
+                            server.WorkerCount,
+                            Is.EqualTo(workersAtStart + 1),
+                            "should have added a worker once every worker was blocked"
+                        );
+                    }
+                    finally
+                    {
+                        foreach (var scope in scopes)
+                            scope.Dispose();
+                    }
+                });
+            }
+        }
+
+        /// <summary>
+        /// Blocks reported by threads that are not server workers must be ignored: they are not consuming a
+        /// worker, so adding one would be pointless. (ProblemReportApi, for instance, reports a block from
+        /// both server and non-server code.)
+        /// </summary>
+        [Test]
+        public void ReportThreadBlocking_FromAThreadThatIsNotAWorker_DoesNotAddAWorker()
+        {
+            using (var server = new BloomServer(new BookSelection()))
+            {
+                server.EnsureListening();
+                var workersAtStart = server.WorkerCount;
+
+                // Report far more blocks than there are workers -- from this thread, which is not one.
+                for (var i = 0; i < workersAtStart * 3; i++)
+                    server.ReportThreadBlocking();
+
+                Assert.That(
+                    server.WorkerCount,
+                    Is.EqualTo(workersAtStart),
+                    "blocks reported by a non-worker thread should not grow the pool"
+                );
+                Assert.That(
+                    server.BlockedWorkerCount,
+                    Is.EqualTo(0),
+                    "blocks reported by a non-worker thread should not be counted at all"
+                );
+            }
+        }
+
+        /// <summary>
+        /// The bug this contract exists to prevent (BL-16612). Blocking work that contains an await resumes
+        /// on a different thread than it started on, because a server worker carries no synchronization
+        /// context. The old design decided whether to decrement by asking "am I on a worker thread?" at the
+        /// END of the block, so on that path it answered no, skipped the decrement, and left the count
+        /// permanently high -- which, now that the count drives adding workers, would grow the pool on every
+        /// later block. Disposing the scope has to work wherever it happens.
+        /// </summary>
+        [Test]
+        public void ReportThreadBlocking_WhenTheScopeIsDisposedOnAnotherThread_StillUndoesTheBlock()
+        {
+            using (var server = new BloomServer(new BookSelection()))
+            {
+                server.EnsureListening();
+                Assert.That(
+                    server.BlockedWorkerCount,
+                    Is.EqualTo(0),
+                    "SANITY: nothing should be blocked on a fresh server"
+                );
+
+                IDisposable scope = null;
+                RunOnAPretendWorkerThread(() =>
+                {
+                    scope = server.ReportThreadBlocking();
+                });
+                Assert.That(
+                    server.BlockedWorkerCount,
+                    Is.EqualTo(1),
+                    "SANITY: reporting from a worker thread should have counted the block"
+                );
+
+                // Dispose from a plain thread-pool thread -- which is exactly where an await's continuation
+                // lands, and which is NOT named like a worker.
+                Task.Run(() => scope.Dispose()).Wait(10000);
+
+                Assert.That(
+                    server.BlockedWorkerCount,
+                    Is.EqualTo(0),
+                    "disposing the scope on a different thread must still undo the block"
+                );
+            }
+        }
+
+        /// <summary>
+        /// Disposal has to be idempotent, since a scope can be disposed by a `using` whose caller also
+        /// disposes it; double-counting downwards would make the server believe workers were free when they
+        /// were not, which is the opposite of the deadlock but just as wrong.
+        /// </summary>
+        [Test]
+        public void ReportThreadBlocking_WhenTheScopeIsDisposedTwice_OnlyUndoesTheBlockOnce()
+        {
+            using (var server = new BloomServer(new BookSelection()))
+            {
+                server.EnsureListening();
+                IDisposable first = null,
+                    second = null;
+                RunOnAPretendWorkerThread(() =>
+                {
+                    first = server.ReportThreadBlocking();
+                    second = server.ReportThreadBlocking();
+                });
+                Assert.That(
+                    server.BlockedWorkerCount,
+                    Is.EqualTo(2),
+                    "SANITY: two reported blocks should count as two"
+                );
+
+                first.Dispose();
+                first.Dispose();
+
+                Assert.That(
+                    server.BlockedWorkerCount,
+                    Is.EqualTo(1),
+                    "a second Dispose of the same scope must not decrement again"
+                );
+                second.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// A worker thread that has died leaves its entry behind until the listener prunes it, so the raw
+        /// entry count can claim a worker is available when nothing of it remains but the entry. The shortage
+        /// check has to count only LIVE workers, or it declines to add one in exactly the situation it exists
+        /// for. Devin raised this on BL-16612.
+        ///
+        /// Reaches into the private worker collection to plant a dead entry, because there is no honest way
+        /// to make a real worker die on cue. The alternative -- adding a production seam only tests use --
+        /// seemed worse than a reflective poke that fails loudly if the field is ever renamed.
+        /// </summary>
+        [Test]
+        public void ReportThreadBlocking_WhenAnEntryIsForADeadThread_StillAddsAWorker()
+        {
+            using (var server = new BloomServer(new BookSelection()))
+            {
+                server.EnsureListening();
+                var liveWorkers = server.WorkerCount;
+
+                var field = typeof(BloomServer).GetField(
+                    "_workers",
+                    BindingFlags.NonPublic | BindingFlags.Instance
+                );
+                Assert.That(
+                    field,
+                    Is.Not.Null,
+                    "BloomServer._workers was not found; this test needs updating to match the field name"
+                );
+                var workers = (ConcurrentDictionary<int, Thread>)field.GetValue(server);
+
+                // A thread that has already finished: alive is false, but the entry is present.
+                var deadThread = new Thread(() => { }) { IsBackground = true };
+                deadThread.Start();
+                Assert.That(
+                    deadThread.Join(10000),
+                    Is.True,
+                    "SANITY: the throwaway thread should finish"
+                );
+                Assert.That(
+                    workers.TryAdd(deadThread.ManagedThreadId, deadThread),
+                    Is.True,
+                    "SANITY: should have been able to plant the dead entry"
+                );
+                Assert.That(
+                    server.WorkerCount,
+                    Is.EqualTo(liveWorkers + 1),
+                    "SANITY: the dead entry should now be inflating the raw worker count"
+                );
+
+                // Block every LIVE worker -- one fewer than the raw count. Judged on the raw count this
+                // looks like a worker is still free, and no worker gets added; judged on live workers the
+                // pool is exhausted and one must be.
+                RunOnAPretendWorkerThread(() =>
+                {
+                    var scopes = new List<IDisposable>();
+                    try
+                    {
+                        for (var i = 0; i < liveWorkers; i++)
+                            scopes.Add(server.ReportThreadBlocking());
+
+                        Assert.That(
+                            server.WorkerCount,
+                            Is.EqualTo(liveWorkers + 2),
+                            "a dead entry must not be counted as a worker that could take the request"
+                        );
+                    }
+                    finally
+                    {
+                        foreach (var scope in scopes)
+                            scope.Dispose();
+                    }
+                });
+            }
+        }
+
+        /// <summary>
+        /// Runs the action on a thread named the way BloomServer names its workers, since the name is how
+        /// ReportThreadBlocking recognizes one of its own workers. Rethrows whatever the action threw, so
+        /// that an assertion failure inside it fails the test instead of being swallowed on that thread.
+        /// </summary>
+        private static void RunOnAPretendWorkerThread(Action action)
+        {
+            Exception failure = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    action();
+                }
+                catch (Exception e)
+                {
+                    failure = e;
+                }
+            })
+            {
+                Name = BloomServer.WorkerThreadNamePrefix + "pretend",
+                IsBackground = true,
+            };
+            thread.Start();
+            Assert.That(
+                thread.Join(10000),
+                Is.True,
+                "the pretend worker thread should have finished"
+            );
+            if (failure != null)
+                ExceptionDispatchInfo.Capture(failure).Throw();
+        }
+    }
+}


### PR DESCRIPTION
Fixes the BL-16612 deadlock by repairing BloomServer's blocked-worker bookkeeping, and does nothing else.

## The problem

BloomServer counts workers that report themselves blocked and adds one when they are all blocked, so that somebody is still able to take the request which would let the others finish — that request is often itself sitting in the queue.

Stacks captured at the moment of failure on CI showed four workers and **none idle**: three parked on the api lock a publish held for minutes, and the publish itself blocked in the off-screen browser waiting for a page only a worker could serve. The safeguard evaluated `3 >= 4`, concluded a worker was free, and publishing waited forever — taking every later publish in the session with it, until Bloom was restarted.

## Four things were wrong with that mechanism

1. **The check ran only as a request ARRIVED** (in `QueueRequest`). That cannot be sufficient on its own: when the request that would break the deadlock is already queued, no new one need ever arrive. It now also runs at the other moment the pool can run out — when a worker becomes blocked — because the check moved *into* the reporting method itself. `QueueRequest` calls the same helper, so the rule lives in exactly one place.

2. **`OffScreenBrowser.RunAndBlock` never reported its block at all**, though publishing runs as an api request and blocks a worker there for as long as the browser takes. That is why the count read 3 rather than 4.

3. **A reported block could leak permanently.** Both halves decided whether to count by inspecting the *current thread's name*, so the pair only balanced when both ran on the same worker. In `ApiRequest.InvokeWithErrorHandling` they do not: the second half runs after an `await`, and a worker carries no synchronization context, so the continuation resumes on a thread-pool thread and the decrement was silently skipped — permanently inflating the count, which (given fix 1) would then grow the pool on every later block. The same method leaked again whenever anything other than `ObjectDisposedException` came out of `Invoke`, since that path skipped both halves.

   Reporting a block now returns an `IDisposable` scope that closes over whether it counted. Disposing it undoes exactly that block, from any thread, on every exit path. Disposal is idempotent, so a nested `using` cannot decrement twice and leave the server believing workers are free when they are not. `RegisterThreadUnblocked` is **deleted** rather than kept alongside — a second way to end a block is the same trap as a second way to report one. `IBloomServer` changes with it, so **BloomHarvester needs the same one-line update if it calls these.**

4. **The shortage was judged against workers that may already be dead.** `_workers` keeps an entry for a thread that has died until the listener prunes it, so the count could claim a worker was available when nothing of it remained but the entry. Both the fast path and the under-lock check now count live workers — it has to be both, because the fast path exists only to avoid taking the queue lock, so while it over-counted it returned early and made the accurate check unreachable.

## Where to look, and what to be sceptical about

- **The hot path.** The check now runs on every api request that waits for a lock, and it walks the workers (four to ten, one `IsAlive` each) rather than reading a count. Still far cheaper than joining the queue behind the listener and the workers, which is the only thing that path avoids — but it is not free, and that was a deliberate trade.
- **It must not throw.** A caller increments the count and only receives the scope that undoes it after `EnsureAWorkerCanStillTakeWork` returns, so anything escaping there would leak the count for the life of the process. Hence the catch-all, including around its own logging — a documented, deliberate exception to `AGENTS.md`'s fail-fast guidance, with the reasoning in a `REVIEWED DECISION` comment.
- **Detection still happens at report time.** Whether a block counts depends on the reporting thread being a worker. Verified for the publish path both ways: the two `updatePreview` endpoints register *synchronous* handlers, so nothing yields between the worker entering the handler and the browser call; and the captured stacks show a `Server Worker Thread` inside `RunAndBlock`. It is not structurally guaranteed for a future caller, though — see the review threads.
- **Lock safety.** `EnsureAWorkerCanStillTakeWork` takes `lock (_queue)`. Request handlers run outside that lock, and no BloomServer-internal code reports a block, so it cannot self-deadlock; in `QueueRequest` the lock is already held, which is fine since `Monitor` is reentrant. Devin checked for a lock-order inversion independently and found none.

## What this deliberately does NOT do

No time limit on how long publishing waits for the browser, no retry, and no refusal to publish. Those were considered at length and dropped: the starvation is fixed at its source, and a bound sized anywhere near real working time would convert a correct-but-slow book into a silently wrong one. Apart from no longer deadlocking, **there is no user-visible change** — no new message, no new failure mode.

Consequently the long-standing "silently degraded BloomPUB" path (page checks yielding no data ⇒ nothing stripped, no fonts embedded, success reported) is **untouched**, and still needs its own card.

## Tests

Five, in `BloomServerWorkerPoolTests`, driving a real listening server. Two were confirmed to fail without their fix rather than passing for the wrong reason:

- a worker is added when the last free one blocks — and *not* while one is still free;
- **disposing the scope on another thread still undoes the block** (fails if the thread-identity check is restored);
- disposing twice only undoes it once;
- **a dead worker's entry does not suppress the top-up** (fails if the live count is applied in only one of the two places — which is how that gap was found);
- blocks reported by non-worker threads are ignored entirely.

Full C# suite green apart from `RabRealBuildTests`, which needs Reading App Builder's `buildapp.bat` on the PATH and fails identically on unmodified `master`.

## Known gaps, recorded rather than fixed

In code comments and on the review threads, so they are not rediscovered as bugs: a worker added late during shutdown is only harmless while `Dispose` signals `_stop` without disposing the wait handles — and reaching that signal is itself conditional on `_listener != null`, which `CloseListener()` can have already cleared; and workers are never retired, so the pool can end a session larger than it started.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16612

---
[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8155)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8155)
<!-- Reviewable:end -->
