### PR TITLE
Don't require eSpeak to apply a timings file (BL-16640)

### DIFF
--- a/src/BloomExe/web/controllers/AudioSegmentationApi.cs
+++ b/src/BloomExe/web/controllers/AudioSegmentationApi.cs
@@ -229,8 +229,9 @@ namespace Bloom.web.controllers
             );
         }
 
-        // Returns true if the command returned with an error
-        protected bool DoesCommandCauseError(
+        // Returns true if the command returned with an error.
+        // Virtual so that tests can verify that a code path runs no external commands at all.
+        protected virtual bool DoesCommandCauseError(
             string commandString,
             string workingDirectory,
             out string standardOutput,
@@ -363,10 +364,17 @@ namespace Bloom.web.controllers
                 warningMessage = "",
             };
 
+            // "Apply Timings File..." just reads the times out of a file the user already has,
+            // so none of the forced-alignment machinery (Python, Aeneas, eSpeak, FFMPEG) is involved.
+            var usingManualTimings = !string.IsNullOrEmpty(requestParameters.manualTimingsPath);
+
             // The client was supposed to validate this already, but double-check in case something strange happened.
             string directoryName = GetAudioDirectory();
 
-            if (!Platform.IsLinux)
+            // Aeneas runs under Python, which can't cope with a UNC path, so we refuse up front rather
+            // than fail obscurely later. That's a limitation of the forced-alignment tooling, though, so
+            // it doesn't apply when we're only reading times out of a file the user chose.
+            if (!usingManualTimings && !Platform.IsLinux)
             {
                 if (directoryName.StartsWith("\\"))
                 {
@@ -406,10 +414,7 @@ namespace Bloom.web.controllers
             // contain a hot link here. That code is in Typescript.
             // If we're just trying to read a manual timings file, we don't need to check the Aeneas installation.
             string message;
-            if (
-                string.IsNullOrEmpty(requestParameters.manualTimingsPath)
-                && !AreAutoSegmentDependenciesMet(out message)
-            )
+            if (!usingManualTimings && !AreAutoSegmentDependenciesMet(out message))
             {
                 var localizedFormatString = L10NSharp.LocalizationManager.GetString(
                     "EditTab.Toolbox.TalkingBook.MissingDependency",
@@ -422,24 +427,32 @@ namespace Bloom.web.controllers
                 return null;
             }
 
-            // When using TTS overrides, there's no Aeneas error message that tells us if the language is unsupported.
-            // Therefore, we explicitly test if the language is supported by the dependency (eSpeak) before getting started.
-            string stdOut;
-            string stdErr;
-            string langCode = GetBestSupportedLanguage(requestedLangCode, out stdOut, out stdErr);
-
-            if (string.IsNullOrEmpty(langCode))
+            // The language actually spoken to Aeneas' TTS engine. It only differs from the requested
+            // one if eSpeak can't handle the requested one and we fall back to another language
+            // (possibly along with an orthography conversion). Applying a manual timings file involves
+            // no TTS at all, so we leave it as requested and never ask eSpeak anything.
+            string langCode = requestedLangCode;
+            if (!usingManualTimings)
             {
-                // FYI: The error message is expected to be in stdError with an empty stdOut, but I included both just in case.
-                Logger.WriteEvent("AudioSegmentationApi.GetAeneasTimings(): eSpeak error.");
-                ErrorReport.ReportNonFatalMessageWithStackTrace(
-                    $"eSpeak error: {stdOut}\n{stdErr}"
+                // When using TTS overrides, there's no Aeneas error message that tells us if the language is unsupported.
+                // Therefore, we explicitly test if the language is supported by the dependency (eSpeak) before getting started.
+                string stdOut;
+                string stdErr;
+                langCode = GetBestSupportedLanguage(requestedLangCode, out stdOut, out stdErr);
+
+                if (string.IsNullOrEmpty(langCode))
+                {
+                    // FYI: The error message is expected to be in stdError with an empty stdOut, but I included both just in case.
+                    Logger.WriteEvent("AudioSegmentationApi.GetAeneasTimings(): eSpeak error.");
+                    ErrorReport.ReportNonFatalMessageWithStackTrace(
+                        $"eSpeak error: {stdOut}\n{stdErr}"
+                    );
+                    return null;
+                }
+                Logger.WriteMinorEvent(
+                    $"AudioSegmentationApi.GetAeneasTimings(): Attempting to segment with langCode={langCode}"
                 );
-                return null;
             }
-            Logger.WriteMinorEvent(
-                $"AudioSegmentationApi.GetAeneasTimings(): Attempting to segment with langCode={langCode}"
-            );
 
             string textFragmentsFilename = Path.Combine(
                 directoryName,
@@ -478,9 +491,7 @@ namespace Bloom.web.controllers
             List<Tuple<string, string>> timingStartEndRangeList = null;
             try
             {
-                RobustFile.WriteAllLines(textFragmentsFilename, fragmentList);
-
-                if (!string.IsNullOrEmpty(requestParameters.manualTimingsPath))
+                if (usingManualTimings)
                 {
                     response.timingsFilePath = Path.Combine(
                         directoryName,
@@ -503,6 +514,8 @@ namespace Bloom.web.controllers
                 }
                 else
                 {
+                    // Aeneas reads the text it is aligning from this file.
+                    RobustFile.WriteAllLines(textFragmentsFilename, fragmentList);
                     response.timingsFilePath = Path.Combine(
                         directoryName,
                         $"{requestParameters.audioFilenameBase}_timings.txt"

--- a/src/BloomTests/web/controllers/AudioSegmentationApiTests.cs
+++ b/src/BloomTests/web/controllers/AudioSegmentationApiTests.cs
@@ -3,7 +3,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Bloom.Book;
 using Bloom.web.controllers;
+using BloomTemp;
+using Moq;
 using NUnit.Framework;
 using Assert = NUnit.Framework.Assert;
 
@@ -268,6 +271,157 @@ namespace BloomTests.web.controllers
 
             // Assert
             CollectionAssert.AreEqual(expectedOutput, output);
+        }
+
+        /// <summary>
+        /// "Apply Timings File..." must work on machines that have none of the forced-alignment
+        /// dependencies installed. In particular it used to ask eSpeak which language to use, which
+        /// failed when eSpeak was missing.
+        /// </summary>
+        [Test]
+        public void GetAeneasTimings_ManualTimingsFile_RunsNoExternalCommands()
+        {
+            using (var bookFolder = new TemporaryFolder("AudioSegmentationApiTests"))
+            {
+                var audioFolder = Directory.CreateDirectory(
+                    Path.Combine(bookFolder.FolderPath, "audio")
+                );
+                // GetAeneasTimings insists on an audio file to apply the timings to; it doesn't read it.
+                File.WriteAllText(Path.Combine(audioFolder.FullName, "textBoxId.mp3"), "");
+                var timingsPath = Path.Combine(audioFolder.FullName, "textBoxId_timings.txt");
+                File.WriteAllLines(
+                    timingsPath,
+                    new[] { "0.000\t1.500\tSentence 1.", "1.500\t4.250\tSentence 2." }
+                );
+
+                var api = new NoExternalCommandsAudioSegmentationApi(
+                    SelectionOf(bookFolder.FolderPath)
+                );
+
+                var request = new AutoSegmentRequest
+                {
+                    audioFilenameBase = "textBoxId",
+                    audioTextFragments = new[]
+                    {
+                        new AudioTextFragment { fragmentText = "Sentence 1.", id = "id1" },
+                        new AudioTextFragment { fragmentText = "Sentence 2.", id = "id2" },
+                    },
+                    // A language eSpeak would certainly reject, to prove we never consult it.
+                    lang = "qaa",
+                    manualTimingsPath = timingsPath,
+                };
+
+                var response = api.GetAeneasTimings(request);
+
+                Assert.That(response, Is.Not.Null, "Should have applied the timings file");
+                Assert.That(response.allEndTimesString, Is.EqualTo("1.500 4.250"));
+                Assert.That(response.warningMessage, Is.Empty);
+                Assert.That(response.successMessage, Is.EqualTo("Applied 2 manual timings."));
+            }
+        }
+
+        /// <summary>
+        /// Aeneas runs under Python, which can't cope with a path that doesn't start with a drive
+        /// letter, so Bloom refuses forced alignment outright for one (BL-9959) -- typically a
+        /// collection on a network share. That is a limitation of the forced-alignment tooling, so it
+        /// must not block "Apply Timings File...", which only reads numbers out of a file.
+        /// </summary>
+        [Test]
+        [Platform(
+            Exclude = "Linux",
+            Reason = "The drive-letter guard being tested only runs on Windows"
+        )]
+        public void GetAeneasTimings_ManualTimingsOnNonDriveLetterPath_AppliesThemAnyway()
+        {
+            using (var realFolder = new TemporaryFolder("AudioSegmentationApiTests"))
+            {
+                var audioFolder = Directory.CreateDirectory(
+                    Path.Combine(realFolder.FolderPath, "audio")
+                );
+                File.WriteAllText(Path.Combine(audioFolder.FullName, "textBoxId.mp3"), "");
+                var timingsPath = Path.Combine(audioFolder.FullName, "textBoxId_timings.txt");
+                File.WriteAllLines(
+                    timingsPath,
+                    new[] { "0.000\t1.500\tSentence 1.", "1.500\t4.250\tSentence 2." }
+                );
+
+                // The guard trips on any path starting with a backslash instead of a drive letter. We
+                // use the Win32 "extended-length" \\?\ form of a real local folder rather than a
+                // genuine \\server\share path, so the test exercises that branch without depending on
+                // network name resolution -- which would make it slow, and flaky on a build agent with
+                // an unusual DNS or WINS setup.
+                var bookFolder = @"\\?\" + realFolder.FolderPath;
+                Assert.That(
+                    bookFolder.StartsWith("\\"),
+                    "Sanity check: the path has to trip the guard or this test proves nothing"
+                );
+
+                var api = new NoExternalCommandsAudioSegmentationApi(SelectionOf(bookFolder));
+
+                var request = new AutoSegmentRequest
+                {
+                    audioFilenameBase = "textBoxId",
+                    audioTextFragments = new[]
+                    {
+                        new AudioTextFragment { fragmentText = "Sentence 1.", id = "id1" },
+                        new AudioTextFragment { fragmentText = "Sentence 2.", id = "id2" },
+                    },
+                    lang = "qaa",
+                    manualTimingsPath = timingsPath,
+                };
+
+                var response = api.GetAeneasTimings(request);
+
+                Assert.That(
+                    response,
+                    Is.Not.Null,
+                    "Applying a timings file must not be refused by the Aeneas-only drive-letter guard"
+                );
+                Assert.That(response.allEndTimesString, Is.EqualTo("1.500 4.250"));
+                Assert.That(response.successMessage, Is.EqualTo("Applied 2 manual timings."));
+            }
+        }
+
+        /// <summary>
+        /// A BookSelection reporting a book in the given folder, which is all GetAeneasTimings needs
+        /// from it.
+        ///
+        /// Deliberately a mock rather than a real BookSelection with SelectBook() called on it:
+        /// SelectBook writes the folder into Settings.Default.CurrentBookPath and saves it, which is
+        /// process-wide state that outlives the test. Doing that here made 47 unrelated tests fail
+        /// (the spreadsheet import ones), so don't reintroduce it.
+        /// </summary>
+        private static BookSelection SelectionOf(string bookFolderPath)
+        {
+            var book = new Mock<Bloom.Book.Book>();
+            book.SetupGet(b => b.FolderPath).Returns(bookFolderPath);
+            var selection = new Mock<BookSelection>();
+            selection.SetupGet(s => s.CurrentSelection).Returns(book.Object);
+            return selection.Object;
+        }
+
+        /// <summary>
+        /// An AudioSegmentationApi that fails the test if anything tries to run an external
+        /// command (python, aeneas, espeak, ffmpeg).
+        /// </summary>
+        private class NoExternalCommandsAudioSegmentationApi : AudioSegmentationApi
+        {
+            public NoExternalCommandsAudioSegmentationApi(BookSelection bookSelection)
+                : base(bookSelection) { }
+
+            protected override bool DoesCommandCauseError(
+                string commandString,
+                string workingDirectory,
+                out string standardOutput,
+                out string standardError,
+                params int[] errorCodesToIgnore
+            )
+            {
+                Assert.Fail($"Should not have run an external command: {commandString}");
+                standardOutput = "";
+                standardError = "";
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
## The problem

Bloom's Talking Book "Adjust Timings" dialog has two menu items that both hit the same C# endpoint, `AudioSegmentationApi.GetAeneasTimings`:

- **Use Aeneas to guess timings** — runs forced alignment (Python + Aeneas + eSpeak + FFMPEG).
- **Apply timings file...** — just reads start/end times out of a tab-separated file the user picked.

The second one was still shelling out to `espeak -v <lang> -q "hello world"` (via `GetBestSupportedLanguage`) to choose a TTS language code. eSpeak only arrives as an Aeneas dependency, so most users don't have it; for them the probe returned null and Bloom reported

```
eSpeak error:
'espeak' is not recognized as an internal or external command
```

and applied nothing. That also accounts for the card's second symptom — edits to the timings file "not being applied" — because we aborted before applying anything.

## The fix

There's nothing on this path that needs eSpeak; the question it was answering doesn't arise. The TTS language code exists purely to tell Aeneas' engine which voice to synthesize with (and, on fallback, which orthography conversion to apply) — meaningless when we're just reading numbers out of a file.

- Gate the eSpeak language probe on `!usingManualTimings`. `langCode` then stays the requested code, so the `langCode != requestedLangCode` orthography branch falls through naturally.
- Move `WriteAllLines(textFragmentsFilename, ...)` into the Aeneas-only branch. Only Aeneas reads that file; the manual path was writing it into the book's `audio` folder and immediately deleting it.
- Name the condition `usingManualTimings` once instead of re-testing the path string.

Net effect: **"Apply Timings File..." now runs no external process at all.**

## Test

`GetAeneasTimings_ManualTimingsFile_RunsNoExternalCommands` subclasses the API with an override that fails if *any* external command is attempted — so it guards against python/aeneas/ffmpeg creeping back in too, not just eSpeak. That required making the five-arg `DoesCommandCauseError` `virtual` (it was already `protected`; the other overloads funnel through it).

Verified it's a real guard: with the fix reverted it fails with `Should not have run an external command: espeak -v qaa -q "hello world"` — the exact reported failure.

## Also fixed: network-share collections

`GetAeneasTimings` additionally refuses to proceed at all if the collection path doesn't start with a drive letter — typically a collection on a network share. That's another Python/Aeneas limitation (BL-9959) that has no business applying to manual timings, so a second commit moves it under the same `usingManualTimings` guard. Without it, a user working off a network share still couldn't apply a timings file even after the eSpeak fix.

The test for it asserts the manual path gets *past* the guard and applies the timings. It uses the Win32 extended-length `\\?\` form of a real local folder rather than a genuine `\\server\share` path, so it exercises that branch without depending on network name resolution — which would make it slow and flaky on a build agent with an unusual DNS/WINS setup.

(An earlier revision of this description said this was deliberately left out of scope. That's no longer true — thanks to Devin for catching the contradiction.)

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16640


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8156)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8156)
<!-- Reviewable:end -->

