### PR TITLE
Subscription badge click no longer makes the toolbox jump (BL-16533)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.tsx
@@ -891,10 +891,23 @@ export const ToolboxRoot: React.FunctionComponent = () => {
                             `}
                             disableGutters
                             expanded={expandedSectionId === section.id}
-                            onChange={(_event, expanded) => {
-                                setActiveSection(
-                                    expanded ? section.id : undefined,
-                                );
+                            // MUI reports the state the accordion is heading TO, not the state
+                            // it is in: it calls onChange(event, !expanded). So clicking a
+                            // closed tool's header arrives here as true, and clicking the open
+                            // one's arrives as false. (MUI's own name for the parameter is just
+                            // "expanded", which reads like "this one is the active tool" and is
+                            // the opposite of what it means -- hence the name used here.)
+                            onChange={(_event, willBeExpanded) => {
+                                if (!willBeExpanded) {
+                                    // Clicking the open tool's header can't close it: the
+                                    // toolbox always has an active tool, and the effect that
+                                    // syncs us with the legacy toolbox re-expands whatever
+                                    // legacy still thinks is current. Honoring the collapse
+                                    // therefore only produced a flash, in which the tools
+                                    // below jumped up and back down. (BL-16533)
+                                    return;
+                                }
+                                setActiveSection(section.id);
                             }}
                         >
                             <AccordionSummary

--- a/src/BloomBrowserUI/react_components/requiresSubscription.tsx
+++ b/src/BloomBrowserUI/react_components/requiresSubscription.tsx
@@ -156,7 +156,13 @@ export const SubscriptionBadgeWithTooltipAndDialog: React.FunctionComponent<{
                     cursor: ${featureStatus?.enabled ? "default" : "pointer"};
                 `}
                 src={badgeUrl}
-                onClick={() => {
+                onClick={(event) => {
+                    // Clicking the badge must do nothing beyond (possibly) showing the
+                    // dialog. In the toolbox, the badge sits inside the accordion header,
+                    // which toggles the tool open/closed when clicked, so letting the click
+                    // bubble collapsed the active tool (and the toolbox then immediately
+                    // re-expanded it), making everything below it jump. (BL-16533)
+                    event.stopPropagation();
                     if (!featureStatus?.enabled) {
                         showRequiresSubscriptionDialogInAnyView(
                             props.featureName,
@@ -457,7 +463,13 @@ export function showRequiresSubscriptionDialogInEditView(featureName: string) {
 }
 
 export function showRequiresSubscriptionDialogInAnyView(featureName: string) {
-    if (getPageIframeBody()?.ownerDocument ?? document !== document) {
+    // The parentheses matter: !== binds tighter than ??, so without them this asked
+    // "is there a page iframe body?" instead of "is it in some other document than
+    // mine?". Harmless for today's callers -- they are either in the toolbox iframe
+    // (where both readings say yes) or in a top-level window like a publish screen
+    // (where there is no page iframe, so both say no) -- but it would have quietly
+    // sent a future caller inside the page iframe itself down the wrong branch.
+    if ((getPageIframeBody()?.ownerDocument ?? document) !== document) {
         // We're in edit mode, but executing from the toolbox. We want the dialog to
         // show in the edit view, where there is room for it, so we have to
         // use a function in that iframe's code to show it. (It's not enough


### PR DESCRIPTION
Clicking a tool's subscription badge in the Edit tab toolbox made the closed tools and "More..." briefly jump upward. The badge sits inside the tool header's MUI `AccordionSummary`, whose root toggles the tool open/closed on click, and the badge's handler never stopped the click from bubbling. So clicking the active tool's badge also collapsed that tool; `ToolboxRoot`'s legacy-sync effect then saw nothing expanded, read the legacy toolbox's (unchanged) current tool and re-expanded it. Hence the brief jump. Without a subscription the dialog covered the flash, which is why only subscribers reported it. Clicking a *closed* tool's badge had the mirror problem: it expanded that tool.

Three commits:

1. **The fix** — the badge's `onClick` stops propagation before anything else, so with a subscription clicking the badge does nothing at all, and without one it shows only the dialog.
2. **The same flash by another route** — clicking the header of the tool that is already open produced the identical collapse-then-re-expand. The toolbox always has an active tool, so there was never a state to land in; the Accordion's `onChange` now ignores the collapse instead of undoing it after the fact.
3. **An operator-precedence fix** in `showRequiresSubscriptionDialogInAnyView`, noticed on the way past: `a?.b ?? document !== document` parsed as `a?.b ?? (document !== document)` because `!==` binds tighter than `??`, so the test asked "is there a page iframe body?" instead of "is it in another document?". No behavior change for any current caller — they are either in the toolbox iframe (both readings say yes) or in a top-level publish screen with no `#page` in `parent.document` (both say no, so the `else if`/`else` branches those screens rely on still run). It would only have misrouted a future caller running inside the page iframe itself.

**Testing:** `pnpm typecheck` passed; `pnpm lint` reports 0 errors (only the repo's pre-existing warnings); `pnpm vitest run bookEdit/toolbox/ToolboxRoot.spec.tsx` — 2 passed; full front-end Vitest suite run in preflight. No new unit test: at the developer's direction, these are one-line event-propagation changes with no logic to regress and are quick to verify by hand.

**To verify by hand** (subscription active, Music/Canvas/Motion open): clicking the badge should do nothing and not move anything; clicking the open tool's header should also do nothing, with no jump; without a subscription the dialog should still appear from both the tool header and the "More..." list; and the badges on the PDF print-shop-ready and bulk BloomPub publish screens should still open their dialog — that is the path commit 3 touches.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16533


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8157)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8157)
<!-- Reviewable:end -->
