### PR TITLE
Skip the front-end pre-commit checks when no front-end file is staged

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -36,6 +36,50 @@ ships:
 2. else if a husky hook exists in `.git/hooks/pre-commit` → run that;
 3. else → **fail loudly** with instructions, instead of skipping silently.
 
+## What the vite-plus hook runs
+
+Routing aside, `src/BloomBrowserUI/.vite-hooks/pre-commit` runs three groups of checks,
+and the thing worth knowing before editing it is that they have deliberately different
+reach:
+
+- **Formatting** — `pretty-quick`, on **every commit, whatever it touches**. Despite living
+  in the front-end folder, it is not scoped to it: `pretty-quick --staged` resolves the git
+  root and formats every staged file prettier understands anywhere in the tree, filtered by
+  `.prettierignore`. That is why the repo root has its own `.prettierignore`. The hook still
+  runs it from `src/BloomBrowserUI`, because that is what applies *both* ignore files —
+  including the front-end one that keeps prettier off vendored third-party code.
+- **Lint and typecheck** — `lint-staged` (eslint) and a whole-project typecheck, **only when
+  the commit stages a front-end source file** (`.ts`/`.tsx`/`.mts`/`.cts` and, since the
+  tsconfig sets `allowJs`, `.js`/`.jsx`/`.mjs`/`.cjs` under `src/BloomBrowserUI/`), **or one
+  of the four config files that change what the typecheck means** — `tsconfig.json`, and
+  `package.json` / `pnpm-lock.yaml` / `pnpm-workspace.yaml`, which decide the typings
+  everything resolves against. These two tools genuinely are confined to that directory, so a
+  commit of only workflows, docs or C# gives them nothing to do.
+- **C#** — the `build/check-csharp-*.sh` scripts and `build/run-csharpier.sh`. Every commit;
+  they need only dotnet, never the front-end dependencies.
+
+**Committing without `pnpm install`.** A worktree used only for workflow, docs or C# work can
+commit without ever installing the front-end dependencies. Formatting still happens there: if
+`node_modules` is absent the hook falls back to `pnpm dlx` at the exact prettier and
+pretty-quick versions pinned in `package.json` (read from the file, so the fallback cannot
+drift from what the project uses). An installed worktree always prefers its own
+lockfile-verified binaries, so the normal case needs no network and works offline.
+
+**Nothing here is skippable.** That fallback removes the need for the install; it does not make
+the checks optional. A check that cannot run **blocks the commit**, and says which fix it
+wants:
+
+- Front-end sources staged with no `node_modules` → blocked. There is no fallback for this
+  case and there cannot easily be one: eslint and tsgo need the project's whole dependency
+  graph, not a single tool.
+- Formatting unable to run at all — no `node_modules` *and* no working `pnpm dlx` (no pnpm on
+  PATH, no network on the first use) → blocked. That is a setup problem, and a setup problem
+  should be fixed rather than worked around.
+
+So the only skip in the whole design is the deliberate one: lint and typecheck do not run when
+the commit stages nothing they could look at. That is not the silent skip this dispatcher
+exists to prevent — that one is "a hook system was configured but nothing ran".
+
 ## How to enable it (per clone)
 
 `core.hooksPath` is git config, not a tracked file, so each clone sets it once:

--- a/src/BloomBrowserUI/.vite-hooks/pre-commit
+++ b/src/BloomBrowserUI/.vite-hooks/pre-commit
@@ -12,20 +12,178 @@
 # vite/rolldown/oxc toolchain instead of this project's pinned eslint/prettier/tsgo,
 # and would not match how we lint and type-check everywhere else. Instead we invoke
 # the project's own tools directly.
+#
+# The two groups of checks below have deliberately different reach, which is the thing
+# to understand before editing either:
+#
+#   formatting      repo-wide, and runs on EVERY commit
+#   lint+typecheck  front-end only, and runs only when a front-end source file is staged
+#
+# What they have in common: NOTHING here is skippable. A check that cannot run blocks the
+# commit. The `pnpm dlx` fallback exists so that a worktree which never ran `pnpm install`
+# can still commit workflow, docs and C# changes -- it removes the need for the install, it
+# does not make the checks optional. (Only formatting has such a fallback: eslint and tsgo
+# need the project's whole dependency graph, not one tool, so there is nothing to fall back
+# to for them.)
 
 # The dispatcher runs us from the repo root; put the front-end's node_modules/.bin
 # on PATH (as an absolute path, before we cd) so its bins resolve.
-export PATH="$(pwd)/src/BloomBrowserUI/node_modules/.bin:$PATH"
+repo_root=$(pwd)
+export PATH="$repo_root/src/BloomBrowserUI/node_modules/.bin:$PATH"
 
-# JavaScript/TypeScript checks (run from the front-end project)
+# ---------------------------------------------------------------------------
+# Formatting -- every commit, whatever it touches
+# ---------------------------------------------------------------------------
+# `pretty-quick --staged` is NOT scoped to the directory it runs in: it resolves the
+# git root and formats every staged file prettier understands, anywhere in the tree,
+# filtered by .prettierignore. That is why it runs unconditionally. Gating it on
+# "was a front-end file staged" silently stopped formatting ~350 tracked files --
+# .github/workflows/*.yml, scripts/*.mjs, DistFiles/**/*.json, src/content, and so on.
+# The repo-root .prettierignore is the tell: everything it lists lives outside the
+# front-end folder, which would be pointless if prettier only ever looked inside.
+#
+# We still cd into src/BloomBrowserUI to run it, because that is what applies BOTH
+# ignore files -- the repo-root one and the front-end one that keeps prettier off
+# vendored third-party code (lib, Readium, modified_libraries, bookEdit/iconfont,
+# font-awesome). Running it from the repo root would reformat all of that.
+
+# Read a pinned version out of the front-end package.json, so the dlx fallback below
+# can never drift from the prettier the project actually uses -- a different prettier
+# would reformat files differently and produce churn. Prints nothing if not found;
+# note this must NOT exit on failure, because a bare `exit` inside $( ) would only
+# leave the subshell and the hook would sail on.
+pinned_version() {
+    sed -n 's/^[[:space:]]*"'"$1"'"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+        "$repo_root/src/BloomBrowserUI/package.json" | head -1
+}
+
+# A version is usable by dlx as long as it is something npm can resolve -- an exact pin,
+# but equally "^3.6.2" or ">=3". What it cannot resolve is a pnpm indirection such as
+# "catalog:", "workspace:*" or "link:../x", all of which are recognisable by their colon.
+# Note this deliberately does NOT reject anything else: an earlier revision demanded a
+# leading digit, which would have blocked EVERY commit the day someone wrote a caret range
+# -- an absurd price for a formatting concern.
+version_usable() {
+    case "$1" in
+        "" | *:*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+# Local install first: it is lockfile-verified, costs no network, and so still works
+# offline. `pnpm dlx` is the fallback that lets a worktree which has never run
+# `pnpm install` -- one used only for workflows, docs or C# -- still commit properly
+# formatted code.
+#
+# The versions are read lazily, inside this branch, precisely so that an unreadable
+# package.json can never affect an installed worktree, which does not need them at all.
+#
+# Because we run from src/BloomBrowserUI (see below for why -- the .prettierignore files),
+# dlx also picks up that directory's pnpm-workspace.yaml, and with it minimumReleaseAge.
+# That is a feature: the same 7-day quarantine that protects a normal install protects this
+# path too. It does mean that for a week after someone bumps prettier, the fallback cannot
+# resolve the new version and uninstalled worktrees are blocked until they install or the
+# week elapses. That is the correct end of the trade -- refusing beats reaching for a
+# package too new to have been vetted -- and the failure message below names it.
+run_pretty_quick() {
+    if [ -x "$repo_root/src/BloomBrowserUI/node_modules/.bin/pretty-quick" ]; then
+        pretty-quick "$@"
+        return $?
+    fi
+
+    prettier_version=$(pinned_version prettier)
+    pretty_quick_version=$(pinned_version pretty-quick)
+    if ! version_usable "$prettier_version" || ! version_usable "$pretty_quick_version"; then
+        echo "pre-commit: cannot resolve the prettier/pretty-quick versions in" >&2
+        echo "            src/BloomBrowserUI/package.json ('$prettier_version' /" >&2
+        echo "            '$pretty_quick_version'). If they moved to a pnpm catalog or" >&2
+        echo "            similar indirection, this hook needs teaching to resolve it." >&2
+        return 1
+    fi
+
+    # Say so before doing it. On a machine whose pnpm store is cold this fetches from the
+    # registry, and an unexplained multi-second pause during `git commit` reads as a hang.
+    echo "pre-commit: src/BloomBrowserUI/node_modules not found; running prettier" >&2
+    echo "            $prettier_version via 'pnpm dlx' (first use may download)." >&2
+    pnpm dlx --package="prettier@$prettier_version" \
+             --package="pretty-quick@$pretty_quick_version" pretty-quick "$@"
+}
+
+# No path here lets a commit through unchecked. The point of the dlx fallback is to remove
+# the need for `pnpm install`, NOT to make the checks optional: if neither the local tool nor
+# the fallback can run -- no pnpm, no network, a registry outage, an unresolvable version --
+# this is a setup problem, and a setup problem stops the commit rather than quietly shipping
+# unformatted code. Each branch above has already said which one it hit.
 cd src/BloomBrowserUI || exit 1
-pretty-quick --staged || exit 1
-# --no-stash keeps linting fast and is safe because lint-staged doesn't modify files here.
-lint-staged --no-stash || exit 1
-node scripts/typecheck.js || exit 1
+if ! run_pretty_quick --staged; then
+    echo "pre-commit: staged files could not be formatted, so the commit is blocked." >&2
+    echo "            Install the front-end dependencies ('pnpm install' in" >&2
+    echo "            src/BloomBrowserUI, or './init.sh'). That is also the fix if" >&2
+    echo "            prettier was bumped within the last 7 days: pnpm's minimumReleaseAge" >&2
+    echo "            quarantine deliberately keeps the dlx fallback off a version that" >&2
+    echo "            new. Otherwise 'pnpm dlx' just needs pnpm on PATH and, the first" >&2
+    echo "            time, network access." >&2
+    exit 1
+fi
+cd "$repo_root" || exit 1
+
+# ---------------------------------------------------------------------------
+# Lint and typecheck -- only when front-end sources are staged
+# ---------------------------------------------------------------------------
+# Unlike formatting, these two genuinely are confined to src/BloomBrowserUI: eslint is
+# configured for its .ts/.tsx, and the tsconfig has no "include", so the typecheck's
+# program is that directory. A commit staging none of those files gives them nothing to
+# do, and skipping them is what lets such a commit proceed without `pnpm install`.
+#
+# The extensions are the ones those two tools actually consume: TypeScript, plus JS
+# because the tsconfig sets "allowJs": true. Not .json in general (resolveJsonModule is
+# commented out, so JSON files are not in the program), and not .css/.less/.html/.yml,
+# which neither tool reads -- matching those would only force needless whole-project
+# typechecks. .pug is out for the same reason: no prettier pug plugin is installed and pug
+# is not in the program.
+#
+# Four config files are named explicitly, because they change what the typecheck MEANS
+# without being sources themselves: tsconfig.json (the compiler options and the shape of
+# the program), and package.json / pnpm-lock.yaml / pnpm-workspace.yaml (which versions of
+# the typings everything resolves against). Bumping a @types dependency and breaking the
+# build is an easy thing to do and an annoying one to discover in CI instead of here.
+#
+# Deletions count (hence D alongside ACM): removing a .ts is the change most likely to
+# break another module's imports, so it is exactly when the typecheck is worth running.
+#
+# --no-renames is what makes that cover a file moved OUT of the front-end, which is the
+# same event wearing a disguise. With rename detection on, --name-only prints only the
+# destination, so moving src/BloomBrowserUI/foo.ts to src/content/foo.ts would produce no
+# path under src/BloomBrowserUI and skip the typecheck. Off, the move is reported as its
+# two halves -- a delete of the old path and an add of the new -- and the delete matches.
+#
+# core.quotePath=false plus -z stops git C-quoting a non-ASCII path ("caf\303\251.ts"),
+# whose added surrounding quotes would defeat both anchors of the regex below and so
+# silently skip the checks for that file.
+staged_frontend=$(git -c core.quotePath=false diff --cached --no-renames --name-only -z --diff-filter=ACMD |
+    tr '\0' '\n' |
+    grep -E '^src/BloomBrowserUI/(.*\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)|tsconfig\.json|package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml)$')
+
+if [ -n "$staged_frontend" ]; then
+    # Front-end sources are staged, so these must run. There is no dlx fallback here:
+    # eslint and tsgo need the project's whole dependency graph, not one tool, so a
+    # missing install has to fail loudly -- silently skipping is how an unchecked
+    # front-end commit would get through.
+    if [ ! -x "$repo_root/src/BloomBrowserUI/node_modules/.bin/lint-staged" ]; then
+        echo "pre-commit: front-end sources are staged, but src/BloomBrowserUI/node_modules" >&2
+        echo "            is missing, so lint and typecheck cannot run. Run 'pnpm install'" >&2
+        echo "            in src/BloomBrowserUI (or './init.sh' for the whole worktree)." >&2
+        exit 1
+    fi
+
+    cd src/BloomBrowserUI || exit 1
+    # --no-stash keeps linting fast and is safe because lint-staged doesn't modify files here.
+    lint-staged --no-stash || exit 1
+    node scripts/typecheck.js || exit 1
+    cd "$repo_root" || exit 1
+fi
 
 # C# checks (run from the repo root)
-cd ../.. || exit 1
 build/check-csharp-robustfile.sh || exit 1
 build/check-csharp-xmlclasses.sh || exit 1
 build/check-csharp-ApplicationExit.sh || exit 1


### PR DESCRIPTION
The front-end pre-commit hook ran `pretty-quick`, `lint-staged` and a whole-project
typecheck unconditionally. That meant a worktree which had never had `pnpm install` run in
it could not commit **at all** — the hook died on `pretty-quick: command not found` even for
a commit touching only a GitHub workflow or a markdown file.

That is a real scenario rather than a hypothetical: worktrees created for CI / tooling /
docs work never need the front-end dependencies, and installing them purely to satisfy a
hook that has nothing to look at is pure overhead. The escape hatch developers reach for,
`--no-verify`, skips the C# checks too — so the status quo quietly pushes people toward
running *fewer* checks than they should.

## What changed

- The front-end block now runs only when the commit stages a file those tools could act on.
  The match is on **extension**, not merely the `src/BloomBrowserUI/` directory, so a staged
  image, a prettier-ignored `README`, or the hook script itself doesn't trigger a
  whole-project typecheck.
- When front-end files **are** staged and `node_modules` is missing, the hook fails loudly
  and names the fix, rather than skipping. Silently skipping in that case is exactly how an
  unchecked front-end commit would slip through.
- The C# checks are untouched and still run on every commit; they need only dotnet. They
  dedent one level because the front-end block now returns to the repo root itself.
- `.githooks/README.md` gains a short section on what the vite-plus hook actually runs —
  `package.json` already points at that README "for how hooks are installed and what else
  they run", and it didn't cover it. It also draws the distinction the README's
  never-skip-silently theme otherwise makes this change look like it violates: the
  dispatcher's loud failure is for "a hook system was configured but nothing ran"; this skip
  is for "these tools have nothing staged to look at".

## Verification

Both paths were exercised for real, not just by inspection:

- Both commits on this branch were made with the new hook active and **no** `--no-verify`:
  the front-end block skipped, and all four C# checks ran and passed (csharpier included).
- Staging a throwaway `.ts` file made the hook fail with the intended "run `pnpm install`"
  message, confirming the guard is not simply always-skipping. The probe file was removed.
- The script parses under `dash` as well as `bash`, checked against the committed (LF) blob,
  so it is not relying on bash-only syntax.

No tracker card: this is tooling work, which `AGENTS.md` notes is a normal case for going
without one.


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8158)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8158)
<!-- Reviewable:end -->
