### PR TITLE
Keep the Leveled Reader control block visible while the stats scroll (BL-16585)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.tsx
@@ -631,53 +631,87 @@ export const LeveledReaderToolControls: FunctionComponent = () => {
                 >
                     {showTool && (
                         <>
+                            {/* "Level x of y" and its arrows stay pinned at the top,
+                                outside the scrolling region below, just as the
+                                Decodable Reader's stage nav does. (BL-16585) */}
                             <ReaderToolNav
                                 isForLeveled={true}
                                 changeFunction={changeLevel}
                             />
-                            {/* The over-level warning banner and the within/over
-                                legend only make sense when at least one measure is
-                                actually over the current level's limit. */}
-                            {isBookOverLevel(model, bookStats) && (
-                                <>
-                                    <OverLevelBanner
-                                        levelNumber={model.levelNumber}
+                            {/* The stats and lists scroll here, inside the panel,
+                                rather than letting the whole panel scroll. That
+                                keeps the nav above and the control block below (the
+                                "Book is Leveled" toggle and Set Up Levels) always
+                                visible, the way the Decodable Reader's word lists
+                                scroll between its fixed nav and control block. */}
+                            <div
+                                css={css`
+                                    display: flex;
+                                    flex-direction: column;
+                                    flex: 1 1 auto;
+                                    // A floor, not min-height:0, for the same reason
+                                    // the Decodable Reader's sections have one: with
+                                    // nothing to stop it, this region is the only
+                                    // shrinkable thing in the column, so in a short
+                                    // panel it would shrink to 0 and the stats would
+                                    // be invisible AND unscrollable. Kept short so it
+                                    // rarely forces the panel to scroll; when the
+                                    // panel is too short even for this, the panel
+                                    // scrolls as a whole (as it did before) and
+                                    // everything stays reachable.
+                                    min-height: 120px;
+                                    overflow-y: auto;
+                                    overflow-x: hidden;
+                                    // Reserve space for the vertical scrollbar so
+                                    // its appearance (when the stats grow tall)
+                                    // doesn't shrink/reflow the content, matching
+                                    // the Decodable Reader's word grids.
+                                    scrollbar-gutter: stable;
+                                `}
+                            >
+                                {/* The over-level warning banner and the within/over
+                                    legend only make sense when at least one measure
+                                    is actually over the current level's limit. */}
+                                {isBookOverLevel(model, bookStats) && (
+                                    <>
+                                        <OverLevelBanner
+                                            levelNumber={model.levelNumber}
+                                        />
+                                        <StatsLegend />
+                                    </>
+                                )}
+                                <LeveledReaderStats bookStats={bookStats} />
+                                {levelReminders.length > 0 && (
+                                    <LeveledReaderList
+                                        l10nKeySuffix="FoThisLevel"
+                                        listHeaderText="For this Level"
+                                        listItems={levelReminders}
                                     />
-                                    <StatsLegend />
-                                </>
-                            )}
-                            <LeveledReaderStats bookStats={bookStats} />
-                            {levelReminders.length > 0 && (
+                                )}
                                 <LeveledReaderList
-                                    l10nKeySuffix="FoThisLevel"
-                                    listHeaderText="For this Level"
-                                    listItems={levelReminders}
+                                    l10nKeySuffix="KeepInMind"
+                                    listHeaderText="Keep in mind"
+                                    listItems={getKeepInMindLinks()}
                                 />
-                            )}
-                            <LeveledReaderList
-                                l10nKeySuffix="KeepInMind"
-                                listHeaderText="Keep in mind"
-                                listItems={getKeepInMindLinks()}
-                            />
+                            </div>
                         </>
                     )}
                     {/* Bottom group, top to bottom: Copy Book Stats, the "Book is
-                        Leveled" toggle, then the Set Up Levels button last. When
-                        the tool content is showing, margin-top:auto pushes the
-                        group to the bottom; it scrolls with the content when the
-                        panel overflows. The toggle stays mounted even when the
-                        content is hidden so the user can turn the book back into a
-                        leveled reader. */}
+                        Leveled" toggle, then the Set Up Levels button last. It
+                        never shrinks or scrolls: the scrolling region above takes
+                        all the leftover height, so this group stays parked at the
+                        bottom of the panel however tall the stats get. The toggle
+                        stays mounted even when the content is hidden so the user
+                        can turn the book back into a leveled reader. */}
                     <div
                         css={css`
                             display: flex;
                             flex-direction: column;
                             align-items: flex-start;
+                            flex: 0 0 auto;
                             gap: 8px;
                             margin-bottom: 10px;
-                            ${showTool
-                                ? "margin-top: auto; padding-top: 12px;"
-                                : ""}
+                            ${showTool ? "padding-top: 12px;" : ""}
                         `}
                     >
                         {showTool && (

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/leveledReader/LeveledReaderToolControls.tsx
@@ -623,6 +623,14 @@ export const LeveledReaderToolControls: FunctionComponent = () => {
                         flex: 1 1 auto;
                         min-height: 0;
                         overflow-x: hidden;
+                        // Stated rather than left implicit: this is what keeps
+                        // everything reachable in a panel too short for the nav,
+                        // the scrolling region's floor and the control block —
+                        // the whole tool scrolls. (It is what overflow-x: hidden
+                        // alone already computes to, since a non-visible axis
+                        // forces the other to auto, but the fallback matters
+                        // enough not to leave it as a side effect.)
+                        overflow-y: auto;
                         // A single horizontal padding on the whole panel keeps
                         // every row (including "Level x of y") on one left edge,
                         // instead of each section supplying its own left margin.


### PR DESCRIPTION
The Decodable Reader tool keeps its stage nav pinned at the top and its "Book is Decodable" / "Set Up Stages" control block pinned at the bottom, letting only the word lists scroll. The Leveled Reader had no internal scrolling region, so a tall stats panel made the whole tool overflow: the accordion panel scrolled and the "Book is Leveled" toggle and "Set Up Levels" button scrolled out of sight.

This gives the Leveled Reader the same three-band layout:

| | pinned top | scrolls | pinned bottom |
|---|---|---|---|
| Decodable | Stage *n* of *m* | grapheme + word grids | Generate Report / toggle / Set Up Stages |
| Leveled | Level *n* of *m* | banner, legend, stats, "For this Level", "Keep in mind" | Copy Book Stats / toggle / Set Up Levels |

The scrolling region carries a `min-height` floor (as the Decodable Reader's sections do) rather than `min-height: 0`. Without a floor it is the only shrinkable item in the column, so in a short panel it collapsed to zero height, leaving the stats both invisible and unscrollable. With the floor, a panel too short even for that overflows and scrolls as a whole — what it did before this change, and what the Decodable Reader does today.

CSS only; no behavior or API changes.

### Verified in a running Bloom

Measured over CDP in the Edit tab with a leveled book, at several forced panel heights:

- Normal height: the stats region scrolls internally; nav and control block stay put.
- Squeezed to 220 / 170 / 140 px: the stats region floors instead of collapsing, the panel scrolls as a whole, and every control (including "Set Up Levels") remains reachable — the same numbers the Decodable Reader produces under the identical squeeze.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16585


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8160)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8160)
<!-- Reviewable:end -->
