### PR TITLE
Keep the back-cover logo on the page for World Vision brandings (BL-16370)

### DIFF
--- a/src/content/branding/Local-Community/branding.less
+++ b/src/content/branding/Local-Community/branding.less
@@ -6,17 +6,10 @@
 
 // The outside back cover's marginBox is a flex column: [badge] [editable "more info" text box]
 // [Bloom Local logo + text]. We want the badge at the top and the Bloom Local block anchored to
-// the bottom of the page, with the flexible space between them. The middle box
-// (.bloom-translationGroup) growing (flex:1) is what pushes the Bloom Local block down to the
-// bottom, so we keep that. But its shared default also sets min-height:30%, and on short
-// (landscape) back covers that floor can't shrink, forcing the bottom block off the page. We
-// drop the floor to 0 so on a short page the gap simply collapses and everything fits, while on
-// a tall page the box still expands to hold the badge at the top and the local block at the
-// bottom. (The box still grows to fit any text the user actually types there.)
-.outsideBackCover .marginBox .bloom-translationGroup {
-    min-height: 0;
-    flex: 1; // grow to fill the space between the top badge and the bottom-anchored local block
-}
+// the bottom, with the flexible space between them — which means the middle box must be free to
+// give up its 30% floor on a short (landscape) page. See the mixin's comment in
+// branding-base.less.
+.allow-back-cover-text-box-to-squeeze();
 
 [data-book="outside-back-cover-branding-bottom-html"] {
     display: flex;

--- a/src/content/branding/World-Vision-International/branding.less
+++ b/src/content/branding/World-Vision-International/branding.less
@@ -3,6 +3,13 @@
 // which sizes and centers itself via branding-base.less. We deliberately do NOT set a
 // width on the images here: a rule like `img { width: 20% }` would override the wrapper's
 // own logo (4.7cm) and QR code (2.8cm) sizes and break the badge layout.
+
+// The badge is in the top slot and the World Vision logo in the bottom one, so the middle text
+// box has to be able to give up its 30% floor when the badge's caption wraps onto a third line;
+// otherwise the logo is pushed off the bottom of a short page such as Device16x9Landscape
+// (BL-16370). See the mixin's comment in branding-base.less.
+.allow-back-cover-text-box-to-squeeze();
+
 [data-book="outside-back-cover-branding-bottom-html"] img {
     width: 60%;
 }

--- a/src/content/branding/WorldVision/branding.less
+++ b/src/content/branding/WorldVision/branding.less
@@ -3,6 +3,13 @@
 // which sizes and centers itself via branding-base.less. We deliberately do NOT set a
 // width on the images here: a rule like `img { width: 20% }` would override the wrapper's
 // own logo (4.7cm) and QR code (2.8cm) sizes and break the badge layout.
+
+// The badge is in the top slot and the World Vision logo in the bottom one, so the middle text
+// box has to be able to give up its 30% floor when the badge's caption wraps onto a third line;
+// otherwise the logo is pushed off the bottom of a short page such as Device16x9Landscape
+// (BL-16370). See the mixin's comment in branding-base.less.
+.allow-back-cover-text-box-to-squeeze();
+
 [data-book="outside-back-cover-branding-bottom-html"] img {
     width: 60%;
 }

--- a/src/content/branding/branding-base.less
+++ b/src/content/branding/branding-base.less
@@ -34,6 +34,32 @@ Rules that format the branding go in branding-base.less, or in the branding.less
     // the height.   img {   height: 20mm;  }
 }
 
+// Opt-in mixin for brandings that put the tall "Made with Bloom" QR badge in the back cover's
+// TOP slot and their own logo in the BOTTOM slot.
+//
+// The back cover's marginBox is a flex column: [top slot] [editable "more info" text box]
+// [bottom slot]. The shared rule in bloom-xmatter-common.less gives the text box
+// `min-height: 30%; flex: 1`. The `flex: 1` is what pushes the bottom slot down to the bottom of
+// the page, and it already fills whatever space is going spare, so the 30% floor only ever comes
+// into play when there ISN'T that much space — and then, being a floor, it can't yield. The
+// column overflows instead, and since .bloom-page clips, the bottom logo loses its lower edge.
+// That is BL-16370: on Device16x9Landscape the marginBox is only ~94.7mm tall, so 30% is ~28.4mm,
+// and once the badge's caption wraps to a third line the badge + 28.4mm + gap + logo no longer
+// fit. Dropping the floor to 0 lets the gap simply collapse on a short page; on a tall page
+// `flex: 1` still expands the box, so the badge stays at the top and the logo at the bottom.
+// (The box still grows to hold whatever text the user actually types.)
+//
+// This is a mixin rather than a plain rule because it must NOT apply to every branding: the
+// ~70 existing packs were laid out against the 30% floor, and changing it for all of them is
+// too much risk (the same reasoning as the note in FCH/branding.less). Call it from the
+// branding.less of any pack that stacks the badge above a bottom-slot logo.
+.allow-back-cover-text-box-to-squeeze() {
+    .outsideBackCover .marginBox .bloom-translationGroup {
+        min-height: 0;
+        flex: 1; // grow to fill the space between the top badge and the bottom-anchored logo
+    }
+}
+
 /*  these rules allow different branding insertions depending on orientation */
 .portraitOnly,
 .landscapeOnly {


### PR DESCRIPTION
Fixes [BL-16370](https://issues.bloomlibrary.org/youtrack/issue/BL-16370).

## The problem

The outside back cover's `marginBox` is a flex column: **top slot** / editable "more info" text box / **bottom slot**. The shared rule in `bloom-xmatter-common.less` gives that middle text box `min-height: 30%; flex: 1`.

`flex: 1` already fills whatever space is going spare, so the 30% floor only bites when there *isn't* that much space — and then, being a floor, it can't yield. The column overflows, and since `.bloom-page` clips, the bottom-slot logo loses its lower edge.

On `Device16x9Landscape` the marginBox is only ~94.7mm tall, so 30% is ~28.4mm. Once the "Made with Bloom" badge's caption wraps onto a third line, badge + 28.4mm + gap + logo no longer fit.

## The fix

A new opt-in mixin in `branding-base.less`:

```less
.allow-back-cover-text-box-to-squeeze() {
    .outsideBackCover .marginBox .bloom-translationGroup {
        min-height: 0;
        flex: 1;
    }
}
```

Dropping the floor to 0 lets the gap collapse on a short page; on a tall page `flex: 1` still expands the box, so the badge stays at the top and the logo at the bottom. The box still grows to hold whatever text the user actually types.

It's a **mixin rather than a blanket rule** because the ~70 existing branding packs were laid out against the 30% floor, and changing it for all of them is more risk than this fix warrants (same reasoning as the note in `FCH/branding.less`).

Called from `WorldVision` and `World-Vision-International`. `Local-Community` already had this rule inline and now calls the shared mixin instead, so the explanation lives in one place.

## Testing

- `lessc` compiles all three branding packs and emits the expected `min-height: 0; flex: 1`.
- Worth eyeballing the World Vision back cover in `Device16x9Landscape` (the reported case) and in a tall layout such as A5Portrait, to confirm the logo stays bottom-anchored in both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8162)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8162)
<!-- Reviewable:end -->
