### PR TITLE
Merge Version6.4 into master (brings the BL-16370 back-cover fix)

### DIFF
--- a/src/content/branding/Local-Community/branding.less
+++ b/src/content/branding/Local-Community/branding.less
@@ -6,17 +6,10 @@
 
 // The outside back cover's marginBox is a flex column: [badge] [editable "more info" text box]
 // [Bloom Local logo + text]. We want the badge at the top and the Bloom Local block anchored to
-// the bottom of the page, with the flexible space between them. The middle box
-// (.bloom-translationGroup) growing (flex:1) is what pushes the Bloom Local block down to the
-// bottom, so we keep that. But its shared default also sets min-height:30%, and on short
-// (landscape) back covers that floor can't shrink, forcing the bottom block off the page. We
-// drop the floor to 0 so on a short page the gap simply collapses and everything fits, while on
-// a tall page the box still expands to hold the badge at the top and the local block at the
-// bottom. (The box still grows to fit any text the user actually types there.)
-.outsideBackCover .marginBox .bloom-translationGroup {
-    min-height: 0;
-    flex: 1; // grow to fill the space between the top badge and the bottom-anchored local block
-}
+// the bottom, with the flexible space between them — which means the middle box must be free to
+// give up its 30% floor on a short (landscape) page. See the mixin's comment in
+// branding-base.less.
+.allow-back-cover-text-box-to-squeeze();
 
 [data-book="outside-back-cover-branding-bottom-html"] {
     display: flex;

--- a/src/content/branding/World-Vision-International/branding.less
+++ b/src/content/branding/World-Vision-International/branding.less
@@ -3,6 +3,13 @@
 // which sizes and centers itself via branding-base.less. We deliberately do NOT set a
 // width on the images here: a rule like `img { width: 20% }` would override the wrapper's
 // own logo (4.7cm) and QR code (2.8cm) sizes and break the badge layout.
+
+// The badge is in the top slot and the World Vision logo in the bottom one, so the middle text
+// box has to be able to give up its 30% floor when the badge's caption wraps onto a third line;
+// otherwise the logo is pushed off the bottom of a short page such as Device16x9Landscape
+// (BL-16370). See the mixin's comment in branding-base.less.
+.allow-back-cover-text-box-to-squeeze();
+
 [data-book="outside-back-cover-branding-bottom-html"] img {
     width: 60%;
 }

--- a/src/content/branding/WorldVision/branding.less
+++ b/src/content/branding/WorldVision/branding.less
@@ -3,6 +3,13 @@
 // which sizes and centers itself via branding-base.less. We deliberately do NOT set a
 // width on the images here: a rule like `img { width: 20% }` would override the wrapper's
 // own logo (4.7cm) and QR code (2.8cm) sizes and break the badge layout.
+
+// The badge is in the top slot and the World Vision logo in the bottom one, so the middle text
+// box has to be able to give up its 30% floor when the badge's caption wraps onto a third line;
+// otherwise the logo is pushed off the bottom of a short page such as Device16x9Landscape
+// (BL-16370). See the mixin's comment in branding-base.less.
+.allow-back-cover-text-box-to-squeeze();
+
 [data-book="outside-back-cover-branding-bottom-html"] img {
     width: 60%;
 }

--- a/src/content/branding/branding-base.less
+++ b/src/content/branding/branding-base.less
@@ -34,6 +34,32 @@ Rules that format the branding go in branding-base.less, or in the branding.less
     // the height.   img {   height: 20mm;  }
 }
 
+// Opt-in mixin for brandings that put the tall "Made with Bloom" QR badge in the back cover's
+// TOP slot and their own logo in the BOTTOM slot.
+//
+// The back cover's marginBox is a flex column: [top slot] [editable "more info" text box]
+// [bottom slot]. The shared rule in bloom-xmatter-common.less gives the text box
+// `min-height: 30%; flex: 1`. The `flex: 1` is what pushes the bottom slot down to the bottom of
+// the page, and it already fills whatever space is going spare, so the 30% floor only ever comes
+// into play when there ISN'T that much space — and then, being a floor, it can't yield. The
+// column overflows instead, and since .bloom-page clips, the bottom logo loses its lower edge.
+// That is BL-16370: on Device16x9Landscape the marginBox is only ~94.7mm tall, so 30% is ~28.4mm,
+// and once the badge's caption wraps to a third line the badge + 28.4mm + gap + logo no longer
+// fit. Dropping the floor to 0 lets the gap simply collapse on a short page; on a tall page
+// `flex: 1` still expands the box, so the badge stays at the top and the logo at the bottom.
+// (The box still grows to hold whatever text the user actually types.)
+//
+// This is a mixin rather than a plain rule because it must NOT apply to every branding: the
+// ~70 existing packs were laid out against the 30% floor, and changing it for all of them is
+// too much risk (the same reasoning as the note in FCH/branding.less). Call it from the
+// branding.less of any pack that stacks the badge above a bottom-slot logo.
+.allow-back-cover-text-box-to-squeeze() {
+    .outsideBackCover .marginBox .bloom-translationGroup {
+        min-height: 0;
+        flex: 1; // grow to fill the space between the top badge and the bottom-anchored logo
+    }
+}
+
 /*  these rules allow different branding insertions depending on orientation */
 .portraitOnly,
 .landscapeOnly {


### PR DESCRIPTION
Forward-merges `Version6.4` into `master`. Clean merge, no conflicts, four LESS files.

## Why

The two branches share no commits: 6.4 is 2 commits ahead of master and master is 879 ahead of 6.4, so nothing flows between them automatically. The BL-16370 back-cover fix landed on 6.4 in #8162, which means **master still has the bug**: `WorldVision/branding.less` and `World-Vision-International/branding.less` have no `min-height` override, while `bloom-xmatter-common.less` still gives the back cover's middle text box a `min-height: 30%` floor. On a short page such as Device16x9Landscape, once the QR badge caption wraps to a third line, the bottom-slot logo is pushed off the page and clipped.

## What it brings

```
src/content/branding/Local-Community/branding.less          | 15 +++---------
src/content/branding/World-Vision-International/branding.less |  7 ++++++
src/content/branding/WorldVision/branding.less             |  7 ++++++
src/content/branding/branding-base.less                    | 26 ++++++++++++++++
```

Nothing else. The two commits are `79a5cf352b` (the fix) and `613d950665` (its merge).

## Please merge with a merge commit, not a squash

Squashing discards the ancestry link, so git stops knowing `Version6.4` is contained in `master`. Every future forward-merge would re-offer these same commits, and any deliberate null-merge (`-s ours`) of a 6.4-only change depends on that ancestry existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8163)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8163)
<!-- Reviewable:end -->
