### PR TITLE
Keep a long collection title clear of the card's "..." menu button (BL-16548)

### DIFF
--- a/src/BloomBrowserUI/collection/CollectionCard.tsx
+++ b/src/BloomBrowserUI/collection/CollectionCard.tsx
@@ -236,7 +236,12 @@ export const CollectionCard: React.FunctionComponent<ICollectionInfo> = (
                                 align-items: center;
                                 width: 100%;
                                 margin-bottom: 10px;
-                                // Keep the title clear of the top-right "..." button.
+                                // Keep the title clear of the top-right "..."
+                                // button. border-box makes the padding count
+                                // inside the 100% width; without it the row is
+                                // 34px wider than the card and the ellipsis
+                                // lands under the button anyway.
+                                box-sizing: border-box;
                                 padding-right: ${kMoreButtonReservedSpace};
                             `}
                         >


### PR DESCRIPTION
Follow-up to #8062 / #8072 on the Open / Create Collections dialog.

The collection card's title row is `width: 100%` with
`padding-right: 34px` reserved for the hover "..." menu button. Without
`box-sizing: border-box` the padding is added *outside* the 100%, so the row is
34px wider than the card and a long title's ellipsis still lands under the
button — the reserved space did nothing.

Adding `box-sizing: border-box` makes the padding count inside the width, so a
long name truncates before it reaches the button.

Six lines in `CollectionCard.tsx`: one CSS declaration plus a comment
explaining why `border-box` is load-bearing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8164)
<!-- Reviewable:end -->
