### PR TITLE
Keep the slow test categories out of developers' and the harvester's runs

### DIFF
--- a/.github/workflows/harvester-artifacts.yml
+++ b/.github/workflows/harvester-artifacts.yml
@@ -172,6 +172,19 @@ jobs:
 
             # TestOnly runs the suite with `dotnet test` (see Bloom.proj's RunNUnit) and writes
             # NUnit3 xml to output/Tests/Release/x64/TestResults.xml.
+            #
+            # This workflow's job is to produce harvester artifacts, so it wants a fast, reliable
+            # gate rather than full coverage: Integration (talks to the live S3 bucket) and Nightly
+            # (reserved for the long tests only the nightly should pay for) are both left out. The
+            # nightly is where those run.
+            #
+            # The %3B are escaped semicolons, and they are load-bearing: a raw semicolon would
+            # break this step. pwsh reads it as a statement separator, so only "Integration" would
+            # reach msbuild and the rest would be run as a command (which fails the step, since
+            # Actions sets $ErrorActionPreference = 'stop' for pwsh); and a semicolon that did
+            # arrive intact would be split by MSBuild into separate /p: assignments, failing with
+            # "MSB1006: Property is not valid". Both are loud, but neither runs any tests. See the
+            # comment on CategoriesToExclude in Bloom.proj for the two forms that do work.
             - name: Run C# tests
               id: csharp_tests
               working-directory: build
@@ -179,7 +192,7 @@ jobs:
               run: |
                   msbuild Bloom.proj /t:TestOnly `
                     /p:BUILD_NUMBER=$env:BUILD_NUMBER `
-                    /p:excludedCategories=SkipOnTeamCity
+                    /p:excludedCategories=Integration%3BNightly%3BSkipOnTeamCity
 
             # ----- Test reports, one per suite -----
             # Each suite gets its OWN invocation of the publish action, and therefore its own

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -196,6 +196,11 @@ jobs:
               shell: pwsh
               run: msbuild Bloom.proj /t:Build /m /p:BUILD_NUMBER=$env:BUILD_NUMBER
 
+            # The nightly is the run that pays for the slow tests, so it excludes as little as
+            # possible: only SkipOnTeamCity. It deliberately keeps Integration (the tests that
+            # talk to the live S3 bucket) and Nightly, both of which the harvester workflow and
+            # developers' local runs leave out. Don't "align" this list with theirs
+            # — if the nightly skips these too, nothing runs them at all.
             - name: Run C# tests
               id: csharp_tests
               if: ${{ !cancelled() && steps.build_csharp.outcome == 'success' && env.RUN_CSHARP_TESTS == 'true' }}

--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -150,6 +150,20 @@ House rules:
   environmental failures that used to accompany them. Not evidence against this cut: intermittent
   is intermittent. Recorded because it removes the nine-failure baseline the original wording
   leaned on.
+- **2026-08-06 — seen again, and the shared state this Idea line asks for is now identified:**
+  a different pair (`BookWithUnknownLayout_GetsUpdatedToA5Portrait`,
+  `CompressBookForDevice_MakesThumbnailFromCoverPicture`) failed on one full run and passed on the
+  next at the identical commit, and the exceptions name the culprit directly: an
+  `UnauthorizedAccessException` on `%TEMP%\BookTests\test\colorPalettes.json` and a
+  `DirectoryNotFoundException` on `%TEMP%\BookTests\book\basePage.css`. That path is a **fixed,
+  machine-wide** folder, so it is shared by every worktree — another worktree was running the suite
+  at the same time, and the two runs deleted each other's files mid-test. So this is not only "under
+  load": `build/agent-dotnet.sh` isolates *build* output per terminal, but the tests themselves still
+  share one scratch directory, which means two agents in two worktrees can never trust a red result.
+  Fix is narrower than the original Idea suggests: give the test scratch root a per-process suffix
+  (e.g. include the pid or the `BLOOM_AGENT_BUILD_DIR` key in the `BookTests` folder name).
+- **Context (2026-08-06):** BloomDesktop, `/preflight` of PR #8166, while another worktree ran its
+  own suite.
 
 
 ## 2026-07-24 — agent-dotnet.sh test exits 0 even when tests fail

--- a/build/Bloom.proj
+++ b/build/Bloom.proj
@@ -220,25 +220,69 @@
     <PropertyGroup>
       <TestResultsXmlFile>$(RootDir)/output/Tests/$(Configuration)/x64/TestResults.xml</TestResultsXmlFile>
       <!-- Categories to leave out, semicolon separated, which is what MSBuild splits an Include
-	       on. Callers pass one: TeamCity /p:excludedCategories=Integration (the tests that talk
-	       to the live S3 bucket), the nightly /p:excludedCategories=SkipOnTeamCity. TeamCity
+	       on. Each caller passes what it wants left out: TeamCity /p:excludedCategories=Integration
+	       (the tests that talk to the live S3 bucket); the harvester-artifacts workflow that plus
+	       Nightly, since it only wants a fast gate; the nightly just SkipOnTeamCity, because it is
+	       the run that deliberately does pay for the Integration and Nightly tests. Developers get
+	       their own default from
+	       src/BloomTests/BloomTests.runsettings, which this path never reads (we run dotnet test
+	       against the built assembly, not the project — see above). TeamCity
 	       additionally always wants SkipOnTeamCity, so add it there rather than making the build
 	       configuration repeat it. Note the name must differ from excludedCategories by more
 	       than case: MSBuild property names are case insensitive, so a property "ExcludedCategories"
-	       reading "$(excludedCategories)" would be reading itself. -->
+	       reading "$(excludedCategories)" would be reading itself.
+
+	       PASSING MORE THAN ONE CATEGORY ON A COMMAND LINE. The obstacle is that MSBuild reads a
+	       raw semicolon in a /p: switch as a separator between property assignments, so a bare
+	       /p:excludedCategories=A;B does not set this property to "A;B"; it fails with
+	       "MSB1006: Property is not valid. Switch: B". Two forms get around that, and both work:
+
+	         /p:"excludedCategories=A;B"  works only if those quotes survive to MSBuild.exe, which
+	         they do when the caller spawns it directly (TeamCity's MSBuild runner does, and its
+	         build configuration uses this form) or from cmd, but NOT from PowerShell, which strips
+	         them and leaves MSBuild splitting the value again.
+
+	         /p:excludedCategories=A%3BB  works from any shell, since there is nothing for a shell
+	         to strip or split. It needs the Unescape below to turn the escape back into a real
+	         separator. The GitHub Actions workflows use this form because they run in pwsh.
+
+	       So do not "fix" TeamCity's quoted form to match the workflows, or vice versa: each is
+	       correct for how it invokes MSBuild. -->
+
       <CategoriesToExclude>$(excludedCategories)</CategoriesToExclude>
       <CategoriesToExclude Condition="'$(teamcity_version)' != ''">SkipOnTeamCity;$(excludedCategories)</CategoriesToExclude>
+      <!-- Unescape so that a %3B-escaped separator (see above) becomes a real one and splits into
+	       one item per category below. Without this the whole list arrives as a SINGLE item and the
+	       filter becomes "TestCategory!=A;B", which matches nothing and therefore excludes nothing:
+	       the build would quietly run the very tests it was told to skip. A raw semicolon (reachable
+	       when the property is set in the environment rather than on a command line) is unaffected,
+	       and so is a single category. Everything downstream uses this unescaped form, so that the
+	       comma guard below inspects the same string the filter is actually built from. -->
+      <UnescapedCategoriesToExclude>$([MSBuild]::Unescape($(CategoriesToExclude)))</UnescapedCategoriesToExclude>
     </PropertyGroup>
     <!-- A comma would survive as part of a category name and yield "TestCategory!=A,B", which
-	     matches nothing and so silently excludes nothing, running a suite nobody asked for. Only
-	     reachable by setting the property in the environment: on the command line MSBuild reads a
-	     comma as its own separator between properties, so /p:excludedCategories=A,B never gets
-	     this far. Worth catching anyway, since the failure it prevents is a silent one. -->
-    <Error Condition="$(CategoriesToExclude.Contains(','))"
-		   Text="excludedCategories is semicolon separated, but got '$(CategoriesToExclude)'"/>
+	     matches nothing and so silently excludes nothing, running a suite nobody asked for. Reachable
+	     by setting the property in the environment, or by escaping it as %2C on a command line: an
+	     unescaped comma never gets this far, because MSBuild reads it as its own separator between
+	     properties, so /p:excludedCategories=A,B fails outright. Worth catching, since the failure it
+	     prevents is a silent one — and note it tests the UNESCAPED value, or a %2C would slip past
+	     the guard and then be turned into the very comma the guard exists to reject. -->
+    <Error Condition="$(UnescapedCategoriesToExclude.Contains(','))"
+		   Text="excludedCategories is semicolon separated, but got '$(UnescapedCategoriesToExclude)'"/>
     <ItemGroup>
-      <ExcludedCategory Include="$(CategoriesToExclude)"/>
+      <ExcludedCategory Include="$(UnescapedCategoriesToExclude)"/>
+      <!-- Every identity should now be a bare category name. One that still contains a separator
+	       means the list did not split, which is not a failure that announces itself: the filter
+	       becomes the single term "TestCategory!=A;B", matches no test, excludes nothing, and the
+	       build goes green having run exactly what it was told to skip. The unescaping above is what
+	       prevents that today, so this asserts the result rather than trusting it to keep working
+	       across MSBuild versions and future edits. Nothing to check when only one category was
+	       passed — there is no split to get wrong. -->
+      <MalformedExcludedCategory Include="@(ExcludedCategory)"
+			   Condition="$([System.String]::Copy('%(Identity)').Contains(';'))"/>
     </ItemGroup>
+    <Error Condition="'@(MalformedExcludedCategory)' != ''"
+		   Text="excludedCategories did not split into separate categories: got '@(MalformedExcludedCategory)' as one category. The filter would have excluded nothing. See the comment on CategoriesToExclude for how to pass several categories."/>
     <PropertyGroup>
       <TestFilterArgument Condition="'@(ExcludedCategory)' != ''">--filter "@(ExcludedCategory->'TestCategory!=%(Identity)', '&amp;')"</TestFilterArgument>
     </PropertyGroup>

--- a/src/BloomTests/BloomTests.csproj
+++ b/src/BloomTests/BloomTests.csproj
@@ -20,6 +20,24 @@
 		<SatelliteResourceLanguages>en</SatelliteResourceLanguages>
 		<IsTestProject>true</IsTestProject>
 		<Platforms>x64;ARM64</Platforms>
+		<!-- Gives `dotnet test <this project>` and the IDE test runners a default filter that
+		     leaves out the Integration and Nightly categories; see BloomTests.runsettings for why.
+
+		     The condition is what makes opting back in possible. VSTest ANDs a runsettings
+		     TestCaseFilter with any filter given on the command line (it does not replace it),
+		     so an unconditional setting here would make "TestCategory=Integration" resolve to
+		     "(TestCategory!=Integration)&(TestCategory=Integration)" and match nothing at all,
+		     making the Integration tests unrunnable. dotnet test surfaces its filter
+		     argument as the VSTestTestCaseFilter property, so when the caller asks for specific
+		     tests we hand VSTest no runsettings and let their filter stand alone.
+
+		     Consequence worth knowing: this is all-or-nothing, so ANY filter drops the whole
+		     default, not just the part you were overriding. A run narrowed by name (a filter of
+		     "FullyQualifiedName~BloomS3ClientTests", say) is therefore back to including that
+		     fixture's Integration tests, live S3 bucket and all. Add TestCategory!=Integration to
+		     such a filter yourself if you want it. (Leading hyphens are omitted throughout this
+		     comment on purpose: a double hyphen would make the XML unparseable.) -->
+		<RunSettingsFilePath Condition="'$(VSTestTestCaseFilter)' == ''">$(MSBuildProjectDirectory)\BloomTests.runsettings</RunSettingsFilePath>
 	</PropertyGroup>
 	<ItemGroup>
 		<AssemblyAttribute Include="System.Runtime.InteropServices.ComVisible">

--- a/src/BloomTests/BloomTests.runsettings
+++ b/src/BloomTests/BloomTests.runsettings
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+	Default settings for `dotnet test` (and Visual Studio's Test Explorer) on this project.
+	Wired in by BloomTests.csproj's RunSettingsFilePath, so a developer or agent gets this
+	without having to remember a flag; see the comment there for how opting back in works.
+
+	Careful: an XML comment cannot contain a double hyphen, so command-line switches are
+	written here without their leading hyphens. A stray "- -filter" in a comment makes VSTest
+	reject the whole file with "Settings file provided does not conform to required format".
+-->
+<RunSettings>
+	<RunConfiguration>
+		<!--
+			What a developer's plain `dotnet test` leaves out:
+
+			Integration: the WebLibraryIntegration tests upload to and download from the live
+			unit-test S3 bucket, so they are slow, need internet access, and need credentials for
+			that bucket.
+
+			Nightly: too slow or too environment-dependent to belong in the run a developer does
+			before every commit. S3RetryBudgetTests carries it (2 tests that wait on real socket
+			timeouts); tagging another test is all it takes to keep that one out of local runs too.
+
+			The nightly workflow is what runs all of the above, so anything you tag still gets
+			run by something. Ask for a category when you want it, by passing
+			`filter TestCategory=Integration` (with the usual leading hyphens), which suppresses
+			this file entirely.
+
+			Untested: whether clicking Run on an excluded test in Visual Studio's Test Explorer runs
+			it or silently skips it, since VSTest may combine this filter with the IDE's selection.
+			We no longer develop in Visual Studio, so nobody has checked.
+
+			The builds do not read this file at all: build/Bloom.proj's RunNUnit target, which is
+			what TeamCity and the GitHub Actions workflows invoke, runs dotnet test against the
+			already-built BloomTests.dll rather than against this project (deliberately; see the
+			comment above that target), so no MSBuild property of ours is ever evaluated there.
+			Those builds keep controlling their own categories through /p:excludedCategories.
+		-->
+		<TestCaseFilter>TestCategory!=Integration&amp;TestCategory!=Nightly</TestCaseFilter>
+	</RunConfiguration>
+</RunSettings>

--- a/src/BloomTests/WebLibraryIntegration/S3RetryBudgetTests.cs
+++ b/src/BloomTests/WebLibraryIntegration/S3RetryBudgetTests.cs
@@ -34,11 +34,13 @@ namespace BloomTests.WebLibraryIntegration
     /// changes only when someone upgrades the AWS SDK - rare, deliberate, and caught by the next
     /// nightly well before it could ship.
     ///
-    /// Note that nothing in this repository acts on the Nightly category - do not go looking for
-    /// it in Bloom.proj and conclude the attribute is dead. The PR build excludes it by passing
-    /// the category name in excludedCategories, which is configured on the build server, so that
-    /// it keeps working if we ever move the PR build off TeamCity. The nightly does not pass it,
-    /// which is what makes these run there.
+    /// Who acts on the Nightly category, since it is deliberately not keyed off anything in
+    /// Bloom.proj: a developer's plain `dotnet test` leaves it out via
+    /// src/BloomTests/BloomTests.runsettings, and the harvester-artifacts workflow leaves it out by
+    /// passing the name in excludedCategories. The PR build does the same, but configured on the
+    /// build server rather than here, so that it keeps working if we ever move that build off
+    /// TeamCity. The nightly is the one runner that does not exclude it, which is what makes these
+    /// run daily.
     /// </summary>
     [TestFixture]
     [Category("Nightly")]


### PR DESCRIPTION
## Why

A developer or agent running `dotnet test src/BloomTests/BloomTests.csproj` got the whole suite — including the `WebLibraryIntegration` tests that upload to and download from the live unit-test S3 bucket, and (since BL-16575) the `Nightly` tests that spend real seconds waiting on socket timeouts. Only the build servers excluded those, by passing `excludedCategories`, so the exclusion existed nowhere a developer would benefit from it.

## What changed

**Developers** now get a default from a new `src/BloomTests/BloomTests.runsettings`, wired in by the project's `RunSettingsFilePath`, leaving out `Integration` and `Nightly`.

The condition on that property is load-bearing. VSTest **ANDs** a runsettings `TestCaseFilter` with a command-line filter rather than replacing it, so setting it unconditionally would make `--filter TestCategory=Integration` resolve to `(TestCategory!=Integration)&(TestCategory=Integration)` — matching nothing, leaving those tests unrunnable. Keying it off `VSTestTestCaseFilter` (the property `dotnet test`'s filter argument arrives as) hands VSTest no runsettings when the caller brought a filter of their own, so asking for a category by name works.

**harvester-artifacts** wants a fast gate rather than full coverage, so it now excludes `Integration` and `Nightly` too.

**nightly** is unchanged, deliberately: it is the only runner that pays for both, and a comment there now says not to "align" its list with the others.

**Bloom.proj** needed a fix to accept more than one category, because MSBuild reads a raw semicolon in a `/p:` switch as a separator between property assignments:

- Quoting the value (`/p:"excludedCategories=A;B"`) works where the quotes reach `MSBuild.exe` — which is why TeamCity's build configuration can use that form — but PowerShell strips them, so it would hard-fail in a workflow.
- The workflows therefore pass `%3B`-escaped separators, which no shell touches, and `CategoriesToExclude` is now unescaped before being split into items.

Without that unescaping the whole list arrived as a **single** category and produced `--filter "TestCategory!=A;B"`, which matches nothing and so excludes nothing: a green build that skipped none of what it was told to skip — the same silent failure the neighbouring comment warns about for commas. Single-category callers are unaffected.

## Verification

Against the real `RunNUnit` target with real `MSBuild.exe`, each caller in its own invocation style:

| Caller | Emitted filter |
| --- | --- |
| TeamCity (quoted form, direct spawn) | `TestCategory!=SkipOnTeamCity&TestCategory!=Integration&TestCategory!=Nightly` |
| harvester (`%3B` form, from PowerShell) | `TestCategory!=Integration&TestCategory!=Nightly&TestCategory!=SkipOnTeamCity` |
| nightly (single category) | `TestCategory!=SkipOnTeamCity` |

On the developer side: the default run leaves out all 9 `Integration` tests and both `Nightly` tests while still running the non-excluded tests in the same fixtures, and `--filter TestCategory=Nightly` / `--filter TestCategory=Integration` each still select and run theirs.

## Note

Also corrects the note on `S3RetryBudgetTests`, which said nothing in this repository acts on the `Nightly` category. Two things now do.

No tracker card — this is tooling work done without one.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5, 1M context)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8166)
<!-- Reviewable:end -->

---
[Devin review](https://app.devin.ai/review/BloomBooks/BloomDesktop/pull/8166)
