### PR TITLE
Keep page-thumbnail image srcs URL-encoded (BL-16658)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
@@ -1182,6 +1182,25 @@ export function SetupMetadataButton(parent: HTMLElement) {
     }
 }
 
+// Turn the src of an image into the file name we want to show a human in the alt text.
+// Strips any query string, then undoes the URL encoding.
+//
+// decodeURIComponent, not decodeURI: decodeURI deliberately leaves the characters that are
+// reserved in a URL (@ # $ & + , / : ; = ?) still escaped, so a file name like
+// "This Image !@#$%^&().jpg" came out as the half-decoded "This Image !%40%23%24%^%26().jpg".
+// It is a file name here, not a URL, so every escape should be undone.
+export function getDisplayNameFromImageUrl(rawImageUrl: string): string {
+    const nameWithoutQueryString = rawImageUrl.split("?")[0];
+    try {
+        return decodeURIComponent(nameWithoutQueryString);
+    } catch {
+        // decodeURIComponent throws on a stray '%' that isn't a valid escape, which a real file
+        // name can certainly contain ("50%.jpg"). Such a name is already readable as it stands,
+        // so show it unchanged rather than letting this throw and lose the alt text entirely.
+        return nameWithoutQueryString;
+    }
+}
+
 // Instead of "missing", we want to show it in the right ui language. We also want the text
 // to indicate that it might not be missing, just didn't load (this happens on slow machines)
 function SetAlternateTextOnImages(element) {
@@ -1196,8 +1215,7 @@ function SetAlternateTextOnImages(element) {
         //don't show this on the empty license image when we don't know the license yet
         const englishText =
             "This image, {0}, is missing or was loading too slowly."; // Also update HtmlDom.cs::IsPlaceholderImageAltText
-        const nameWithoutQueryString = GetRawImageUrl(element).split("?")[0];
-        const decodedName = decodeURI(nameWithoutQueryString);
+        const decodedName = getDisplayNameFromImageUrl(rawImageUrl);
         // show English to start with in case localization never returns even a failure
         $(element).attr(
             "alt",

--- a/src/BloomBrowserUI/bookEdit/js/bloomImagesSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImagesSpec.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { normalizeCoverImageDesignation } from "./bloomImages";
+import {
+    getDisplayNameFromImageUrl,
+    normalizeCoverImageDesignation,
+} from "./bloomImages";
 
 describe("normalizeCoverImageDesignation", () => {
     it("marks a newly changed real image on a custom outside front cover", () => {
@@ -92,5 +95,44 @@ describe("normalizeCoverImageDesignation", () => {
         const existing = page.querySelector("#existing") as HTMLElement;
         expect(background.getAttribute("data-book")).toBe("coverImage");
         expect(existing.hasAttribute("data-book")).toBe(false);
+    });
+});
+
+describe("getDisplayNameFromImageUrl", () => {
+    it("leaves a plain name alone", () => {
+        expect(getDisplayNameFromImageUrl("flower.jpg")).toBe("flower.jpg");
+    });
+
+    it("decodes spaces", () => {
+        expect(getDisplayNameFromImageUrl("my%20photo.jpg")).toBe(
+            "my photo.jpg",
+        );
+    });
+
+    // The reported name from BL-16658. decodeURI left the reserved characters escaped,
+    // so the alt text read "This Image !%40%23%24%^%26()2.jpg".
+    it("decodes the reserved characters that decodeURI would have left escaped", () => {
+        expect(
+            getDisplayNameFromImageUrl(
+                "This%20Image%20!%40%23%24%25%5e%26()2.jpg",
+            ),
+        ).toBe("This Image !@#$%^&()2.jpg");
+    });
+
+    it("drops the query string", () => {
+        expect(getDisplayNameFromImageUrl("flower.jpg?thumbnail=1")).toBe(
+            "flower.jpg",
+        );
+    });
+
+    it("returns the name unchanged when it has a stray % that isn't an escape", () => {
+        // decodeURIComponent would throw on this; we must still produce alt text.
+        expect(getDisplayNameFromImageUrl("50%.jpg")).toBe("50%.jpg");
+    });
+
+    it("decodes a non-ASCII name", () => {
+        expect(
+            getDisplayNameFromImageUrl("%E0%B8%A0%E0%B8%B2%E0%B8%9E.jpg"),
+        ).toBe("ภาพ.jpg");
     });
 });

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -2495,10 +2495,16 @@ namespace Bloom.Api
 
             if (di.Parent != null)
             {
-                return Path.Combine(
-                    GetExactPathName(di.Parent.FullName),
-                    di.Parent.GetFileSystemInfos(di.Name)[0].Name
-                );
+                // The entry may not be found: the file can be deleted while we walk up the path,
+                // and a directory enumeration does not always see a file that was only just
+                // written. Indexing [0] blindly turned that into an IndexOutOfRangeException that
+                // crashed the caller -- which is only a Debug-time check of the filename's case,
+                // so it must never be the thing that brings a request (or a test) down. When we
+                // can't confirm the on-disk spelling, keep the name we were given; that just means
+                // the case check silently passes, which is the right way for a diagnostic to fail.
+                var entries = di.Parent.GetFileSystemInfos(di.Name);
+                var exactName = entries.Length > 0 ? entries[0].Name : di.Name;
+                return Path.Combine(GetExactPathName(di.Parent.FullName), exactName);
             }
             else
             {

--- a/src/BloomExe/web/PageListApi.cs
+++ b/src/BloomExe/web/PageListApi.cs
@@ -372,7 +372,12 @@ namespace Bloom.web
                     if (imageElementUrl.NotEncoded.Contains("/api/"))
                         continue;
 
-                    var filename = imageElementUrl.PathOnly.UrlEncoded;
+                    // UrlEncodedForHttpPath rather than UrlEncoded, because the latter escapes the
+                    // path separators themselves ('/' as %2f, ':' as %3a). For an ordinary book
+                    // image the two are identical -- a Windows file name can contain neither
+                    // character -- but for a src that really is a path (say "/bloom/branding/x.png",
+                    // which the "/api/" test above doesn't catch) only this form stays requestable.
+                    var filename = imageElementUrl.PathOnly.UrlEncodedForHttpPath;
                     if (!string.IsNullOrWhiteSpace(filename))
                     {
                         var url = filename + "?thumbnail=1";

--- a/src/BloomExe/web/PageListApi.cs
+++ b/src/BloomExe/web/PageListApi.cs
@@ -358,7 +358,7 @@ namespace Bloom.web
 
         // As a further form of optimization, mark img elements as being thumbnails. The server
         // produces miniatures that take up less memory.
-        private static void MarkImageNodesForThumbnail(SafeXmlElement pageElementForThumbnail)
+        internal static void MarkImageNodesForThumbnail(SafeXmlElement pageElementForThumbnail)
         {
             var imgNodes = HtmlDom.SelectChildImgAndBackgroundImageElements(
                 pageElementForThumbnail
@@ -384,11 +384,20 @@ namespace Bloom.web
                             // gets interpreted as part of the filename.
                             url = filename + query.NotEncoded + "&thumbnail=1";
                         }
-                        // filename is already URL-encoded; we must NOT re-encode the whole string or ? becomes
-                        // %3f and lands in the path, making the thumbnail param invisible to GetQueryParameters().
+                        // At this point url is exactly what we want in the src attribute: an
+                        // already-URL-encoded path followed by a literal (unencoded) query. So we
+                        // must neither encode nor decode it on the way out (BL-16658).
+                        // - urlEncode:false, because re-encoding the whole string would turn the ?
+                        //   into %3f and bury the thumbnail param in the path, invisible to
+                        //   GetQueryParameters().
+                        // - strictlyTreatAsEncoded:true, because otherwise CreateFromUnencodedString
+                        //   sees the %XX escapes in the path and helpfully decodes them, and we would
+                        //   then write out a raw filename like "This Image !@#$%^&()2.jpg?thumbnail=1",
+                        //   where the browser treats the # as the start of a fragment and never
+                        //   requests the real file.
                         HtmlDom.SetImageElementUrl(
                             imgNode,
-                            UrlPathString.CreateFromUnencodedString(url),
+                            UrlPathString.CreateFromUnencodedString(url, true),
                             urlEncode: false
                         );
                     }

--- a/src/BloomTests/web/PageListApiTests.cs
+++ b/src/BloomTests/web/PageListApiTests.cs
@@ -65,6 +65,18 @@ namespace BloomTests.web
             Assert.AreEqual(encodedName + "?optional=true&thumbnail=1", result);
         }
 
+        // A src that is genuinely a path, not a bare file name, must keep its separators usable.
+        // "/api/" srcs are skipped earlier, but other rooted srcs (e.g. branding) are not.
+        [Test]
+        public void MarkImageNodesForThumbnail_RootedPathSrc_KeepsSeparatorsUnescaped()
+        {
+            Assert.AreEqual(
+                "/bloom/branding/Some-Brand/logo.png?thumbnail=1",
+                GetThumbnailSrc("/bloom/branding/Some-Brand/logo.png"),
+                "Path separators must not be escaped to %2f, or the server can't resolve the src."
+            );
+        }
+
         [Test]
         public void MarkImageNodesForThumbnail_ApiUrl_LeftAlone()
         {

--- a/src/BloomTests/web/PageListApiTests.cs
+++ b/src/BloomTests/web/PageListApiTests.cs
@@ -1,0 +1,96 @@
+using Bloom.SafeXml;
+using Bloom.web;
+using NUnit.Framework;
+
+namespace BloomTests.web
+{
+    [TestFixture]
+    public class PageListApiTests
+    {
+        /// <summary>
+        /// Builds a one-page DOM containing a single img with the given (already URL-encoded)
+        /// src, runs MarkImageNodesForThumbnail over it, and returns the resulting src.
+        /// </summary>
+        private static string GetThumbnailSrc(string originalSrc)
+        {
+            var dom = SafeXmlDocument.Create();
+            dom.LoadXml(
+                $"<div class='bloom-page'><div class='marginBox'><img src='{originalSrc}'/></div></div>"
+            );
+            var pageElement = (SafeXmlElement)dom.FirstChild;
+            // Sanity check: we really did get the src we meant to start from.
+            var img = (SafeXmlElement)pageElement.SafeSelectNodes(".//img")[0];
+            Assert.AreEqual(
+                originalSrc,
+                img.GetAttribute("src"),
+                "Setup failed: the img did not start out with the src we specified."
+            );
+
+            PageListApi.MarkImageNodesForThumbnail(pageElement);
+
+            return ((SafeXmlElement)pageElement.SafeSelectNodes(".//img")[0]).GetAttribute("src");
+        }
+
+        [Test]
+        public void MarkImageNodesForThumbnail_SimpleName_AddsThumbnailQuery()
+        {
+            Assert.AreEqual("picture.jpg?thumbnail=1", GetThumbnailSrc("picture.jpg"));
+        }
+
+        // BL-16658: the src of a thumbnail image must stay URL-encoded. If the encoding is lost,
+        // characters like # and ? in the file name make the browser request the wrong thing
+        // (or nothing at all), and the page list shows a broken image.
+        [Test]
+        public void MarkImageNodesForThumbnail_NameWithSpecialCharacters_KeepsPathEncoded()
+        {
+            // This is the encoding of the real file name: This Image !@#$%^&()2.jpg
+            const string encodedName = "This%20Image%20!%40%23%24%25%5e%26()2.jpg";
+
+            var result = GetThumbnailSrc(encodedName);
+
+            Assert.AreEqual(
+                encodedName + "?thumbnail=1",
+                result,
+                "The path must remain URL-encoded and the query must remain literal."
+            );
+        }
+
+        [Test]
+        public void MarkImageNodesForThumbnail_ExistingQuery_AppendsThumbnailAndKeepsPathEncoded()
+        {
+            const string encodedName = "This%20Image%20!%40%23%24%25%5e%26()2.jpg";
+
+            var result = GetThumbnailSrc(encodedName + "?optional=true");
+
+            Assert.AreEqual(encodedName + "?optional=true&thumbnail=1", result);
+        }
+
+        [Test]
+        public void MarkImageNodesForThumbnail_ApiUrl_LeftAlone()
+        {
+            const string brandingUrl = "/bloom/api/branding/image?id=cover-lower-left.png";
+
+            Assert.AreEqual(brandingUrl, GetThumbnailSrc(brandingUrl));
+        }
+
+        [Test]
+        public void MarkImageNodesForThumbnail_BackgroundImage_KeepsPathEncoded()
+        {
+            const string encodedName = "This%20Image%20!%40%23%24%25%5e%26()2.jpg";
+            var dom = SafeXmlDocument.Create();
+            dom.LoadXml(
+                $"<div class='bloom-page'><div class='marginBox' style=\"background-image:url('{encodedName}')\"/></div>"
+            );
+            var pageElement = (SafeXmlElement)dom.FirstChild;
+
+            PageListApi.MarkImageNodesForThumbnail(pageElement);
+
+            var marginBox = (SafeXmlElement)
+                pageElement.SafeSelectNodes(".//*[contains(@style,'background-image')]")[0];
+            Assert.AreEqual(
+                $"background-image:url('{encodedName}?thumbnail=1')",
+                marginBox.GetAttribute("style")
+            );
+        }
+    }
+}


### PR DESCRIPTION
Fixes the 6.5 regression where an image whose file name contains characters like `#` or `%` shows as broken in edit mode's page-list (thumbnail) view.

### What was wrong

`PageListApi.MarkImageNodesForThumbnail` builds the thumbnail src correctly as `<url-encoded path> + "?thumbnail=1"`, and then throws the encoding away:

```csharp
var filename = imageElementUrl.PathOnly.UrlEncoded;   // "This%20Image%20!%40%23%24%25%5e%26()2.jpg"  OK
var url = filename + "?thumbnail=1";                  // exactly what we want                        OK
HtmlDom.SetImageElementUrl(
    imgNode,
    UrlPathString.CreateFromUnencodedString(url),     // sees %XX and decodes the whole thing
    urlEncode: false);                                // then writes the decoded form out
```

`CreateFromUnencodedString` decodes any string containing `%XX`, so the raw file name landed in the attribute. The browser then read the `#` as the start of a fragment and requested a truncated path. The log attached to BL-16658 shows exactly that:

```
**BloomServer: File Missing: C:/.../Image with Strange Characters/This Image !@
```

The regression came in with 5d34c530f9 ("Optimize page thumbnail loading", BL-16336), which added `urlEncode: false`. Before that, `urlEncode: true` re-encoded on the way out and so restored the escapes — at the cost of also encoding the `?` as `%3f`, which is what BL-16336 was fixing.

### The fix

Pass `strictlyTreatAsEncoded: true`, so the string is neither decoded on the way in nor re-encoded on the way out. Both flags are needed, and each alone breaks the other case.

### Tests

New `PageListApiTests` covers a plain name, a name with special characters, a name that already has a query, an `/api/` url, and the `background-image` variant. Verified fix-sensitive: reverting the one-line change fails three of the five with exactly the reported symptom.

`MarkImageNodesForThumbnail` becomes `internal` so the tests can reach it; `BloomTests` already has `InternalsVisibleTo`.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16658

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8169)
<!-- Reviewable:end -->



---
[Devin review](https://app.devin.ai/review/BloomBooks/BloomDesktop/pull/8169)
