### PR TITLE
Nest spreadsheet test temp folders so no test book sits in %TEMP% (BL-16661)

### DIFF
--- a/src/BloomExe/web/controllers/PageTemplatesApi.cs
+++ b/src/BloomExe/web/controllers/PageTemplatesApi.cs
@@ -139,6 +139,13 @@ namespace Bloom.web.controllers
             return collections
                 .Distinct() //seems to be needed in case a shortcut points to a folder that's already in the list.
                 .SelectMany(ProjectContext.SafeGetDirectories) // get all the (book) folders in those collections
+                // A folder can go away between being listed above and being looked at below --
+                // a sync client (Dropbox etc.), an antivirus tool, or the user can delete one
+                // while we are part way through a collection. FindBookHtmlInFolder throws for a
+                // folder that does not exist (that check is there for the save path, where a
+                // missing book folder really is the user's problem), and one such folder would
+                // otherwise abort the whole scan. Skipping it is all we want here. (BL-16661)
+                .Where(Directory.Exists)
                 .Select(BookStorage.FindBookHtmlInFolder); // and get the book from each
         }
 

--- a/src/BloomTests/Spreadsheet/SpreadsheetAudioImportTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetAudioImportTests.cs
@@ -20,6 +20,7 @@ namespace BloomTests.Spreadsheet
     {
         private HtmlDom _dom;
 
+        private TemporaryFolder _testFolder;
         private TemporaryFolder _bookFolder;
         private TemporaryFolder _otherAudioFolder;
         private ProgressSpy _progressSpy;
@@ -36,13 +37,14 @@ namespace BloomTests.Spreadsheet
             var testAudioPath = SIL.IO.FileLocationUtilities.GetDirectoryDistributedWithApplication(
                 "src/BloomTests/Spreadsheet/testAudio/"
             );
-            _bookFolder = new TemporaryFolder("SpreadsheetAudioImportTests");
-            _spreadsheetFolder = new TemporaryFolder("SpreadsheetAudioImportDest");
+            _testFolder = SpreadsheetTestFolders.MakeFolderFor(this);
+            _bookFolder = new TemporaryFolder(_testFolder, "Book");
+            _spreadsheetFolder = new TemporaryFolder(_testFolder, "Dest");
             var spreadsheetAudioPath = Path.Combine(_spreadsheetFolder.FolderPath, "audio");
             Directory.CreateDirectory(spreadsheetAudioPath);
             // A place to put audio that is not in the spreadsheet folder so we can test absolute path import.
             // Also gives us more choices of non-conflicting audio files.
-            _otherAudioFolder = new TemporaryFolder("other audio folder");
+            _otherAudioFolder = new TemporaryFolder(_testFolder, "other audio folder");
             var audioFilePaths = Directory.EnumerateFiles(testAudioPath).ToArray();
             foreach (var audioFilePath in audioFilePaths)
             {
@@ -360,8 +362,8 @@ namespace BloomTests.Spreadsheet
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            _bookFolder?.Dispose();
-            _otherAudioFolder.Dispose();
+            // This also removes the folders nested inside it.
+            _testFolder?.Dispose();
         }
 
         [TestCase(0, "i9c7f4e02-4685-48fc-8653-71d88f218706", "div")]
@@ -810,6 +812,7 @@ namespace BloomTests.Spreadsheet
     {
         private HtmlDom _dom;
 
+        private TemporaryFolder _testFolder;
         private TemporaryFolder _bookFolder;
         private TemporaryFolder _otherAudioFolder;
         private ProgressSpy _progressSpy;
@@ -864,13 +867,14 @@ namespace BloomTests.Spreadsheet
             var testAudioPath = SIL.IO.FileLocationUtilities.GetDirectoryDistributedWithApplication(
                 "src/BloomTests/Spreadsheet/testAudio/"
             );
-            _bookFolder = new TemporaryFolder("SpreadsheetAudioImportModifyTests");
-            _spreadsheetFolder = new TemporaryFolder("SpreadsheetAudioImportModifyDest");
+            _testFolder = SpreadsheetTestFolders.MakeFolderFor(this);
+            _bookFolder = new TemporaryFolder(_testFolder, "Book");
+            _spreadsheetFolder = new TemporaryFolder(_testFolder, "Dest");
             var spreadsheetAudioPath = Path.Combine(_spreadsheetFolder.FolderPath, "audio");
             Directory.CreateDirectory(spreadsheetAudioPath);
             // A place to put audio that is not in the spreadsheet folder so we can test absolute path import.
             // Also gives us more choices of non-conflicting audio files.
-            _otherAudioFolder = new TemporaryFolder("other audio folder");
+            _otherAudioFolder = new TemporaryFolder(_testFolder, "other audio folder");
             var audioFilePaths = Directory.EnumerateFiles(testAudioPath).ToArray();
             foreach (var audioFilePath in audioFilePaths)
             {
@@ -1072,8 +1076,8 @@ namespace BloomTests.Spreadsheet
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            _bookFolder?.Dispose();
-            _otherAudioFolder.Dispose();
+            // This also removes the folders nested inside it.
+            _testFolder?.Dispose();
         }
 
         [TestCase(4)]

--- a/src/BloomTests/Spreadsheet/SpreadsheetAudioTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetAudioTests.cs
@@ -25,6 +25,7 @@ namespace BloomTests.Spreadsheet
         protected IEnumerable<SpreadsheetRow> AllRows;
         protected List<ContentRow> PageContentRows;
         protected SpreadsheetExporter _exporter;
+        protected TemporaryFolder _testFolder;
         protected TemporaryFolder _spreadsheetFolder;
         protected TemporaryFolder _bookFolder;
         protected ProgressSpy _progressSpy;
@@ -126,8 +127,11 @@ namespace BloomTests.Spreadsheet
                 StartOfFile.Replace("{0}", title) + pagesContent + EndOfFile,
                 true
             );
-            _spreadsheetFolder = new TemporaryFolder("SpreadsheetImagesTests");
-            _bookFolder = new TemporaryFolder("SpreadsheetImagesTests_Book");
+            // Named after the actual (subclass) fixture, so that the several fixtures sharing
+            // this base class each get folders of their own.
+            _testFolder = SpreadsheetTestFolders.MakeFolderFor(this);
+            _spreadsheetFolder = new TemporaryFolder(_testFolder, "Spreadsheet");
+            _bookFolder = new TemporaryFolder(_testFolder, "Book");
             var mockLangDisplayNameResolver = new Mock<ILanguageDisplayNameResolver>();
             mockLangDisplayNameResolver
                 .Setup(x => x.GetLanguageDisplayName("en"))
@@ -169,8 +173,8 @@ namespace BloomTests.Spreadsheet
 
         protected void TearDown()
         {
-            _spreadsheetFolder?.Dispose();
-            _bookFolder?.Dispose();
+            // This also removes the folders nested inside it.
+            _testFolder?.Dispose();
         }
     }
 

--- a/src/BloomTests/Spreadsheet/SpreadsheetExportVideosAndWidgetsTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetExportVideosAndWidgetsTests.cs
@@ -233,6 +233,7 @@ namespace BloomTests.Spreadsheet
         private List<ContentRow> _rows;
         private List<ContentRow> _pageContentRows;
 
+        private TemporaryFolder _testFolder;
         private TemporaryFolder _spreadsheetFolder;
         private TemporaryFolder _bookFolder;
         private ProgressSpy _progressSpy;
@@ -242,8 +243,9 @@ namespace BloomTests.Spreadsheet
         {
             var dom = new HtmlDom(videoAndWidgetBook, true);
 
-            _spreadsheetFolder = new TemporaryFolder("SpreadsheetVideoWidgetsTests");
-            _bookFolder = new TemporaryFolder("SpreadsheetVideoWidgetsTests_Book");
+            _testFolder = SpreadsheetTestFolders.MakeFolderFor(this);
+            _spreadsheetFolder = new TemporaryFolder(_testFolder, "Spreadsheet");
+            _bookFolder = new TemporaryFolder(_testFolder, "Book");
 
             var mockLangDisplayNameResolver = new Mock<ILanguageDisplayNameResolver>();
             mockLangDisplayNameResolver
@@ -292,8 +294,8 @@ namespace BloomTests.Spreadsheet
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            _spreadsheetFolder?.Dispose();
-            _bookFolder?.Dispose();
+            // This also removes the folders nested inside it.
+            _testFolder?.Dispose();
         }
 
         [Test]

--- a/src/BloomTests/Spreadsheet/SpreadsheetExporterTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetExporterTests.cs
@@ -73,6 +73,7 @@ namespace BloomTests.Spreadsheet
         private List<ContentRow> _rows;
         private List<ContentRow> _pageContentRows;
 
+        private TemporaryFolder _testFolder;
         private TemporaryFolder _spreadsheetFolder;
         private TemporaryFolder _bookFolder;
         private ProgressSpy _progressSpy;
@@ -82,8 +83,9 @@ namespace BloomTests.Spreadsheet
         {
             var dom = new HtmlDom(bookHtml, true);
 
-            _spreadsheetFolder = new TemporaryFolder("SpreadsheetExporterTests");
-            _bookFolder = new TemporaryFolder("SpreadsheetExporterTests_Book");
+            _testFolder = SpreadsheetTestFolders.MakeFolderFor(this);
+            _spreadsheetFolder = new TemporaryFolder(_testFolder, "Spreadsheet");
+            _bookFolder = new TemporaryFolder(_testFolder, "Book");
 
             var mockLangDisplayNameResolver = new Mock<ILanguageDisplayNameResolver>();
             mockLangDisplayNameResolver
@@ -119,8 +121,8 @@ namespace BloomTests.Spreadsheet
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            _spreadsheetFolder?.Dispose();
-            _bookFolder?.Dispose();
+            // This also removes the folders nested inside it.
+            _testFolder?.Dispose();
         }
 
         [Test]
@@ -276,9 +278,15 @@ namespace BloomTests.Spreadsheet
                 .Returns("English");
             var exporter = new SpreadsheetExporter(mockLangDisplayNameResolver.Object);
 
-            using (var bookFolder = new TemporaryFolder("SpreadsheetExporterTests_NormBook"))
-            using (var sheetFolder = new TemporaryFolder("SpreadsheetExporterTests_NormSheet"))
+            // This method is static, so it can't use the fixture's own folder.
+            using (
+                var testFolder = SpreadsheetTestFolders.MakeFolderNamed(
+                    "SpreadsheetExporterTests_Norm"
+                )
+            )
             {
+                var bookFolder = new TemporaryFolder(testFolder, "Book");
+                var sheetFolder = new TemporaryFolder(testFolder, "Sheet");
                 var sheet = exporter.ExportToFolder(
                     dom,
                     bookFolder.FolderPath,

--- a/src/BloomTests/Spreadsheet/SpreadsheetImagesTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetImagesTests.cs
@@ -218,6 +218,7 @@ namespace BloomTests.Spreadsheet
         private List<ContentRow> _rowsFromExport;
         private InternalSpreadsheet _sheetFromFile;
         private List<ContentRow> _rowsFromFile;
+        private TemporaryFolder _testFolder;
         private TemporaryFolder _spreadsheetFolder;
         private TemporaryFolder _bookFolder;
         private ProgressSpy _progressSpy;
@@ -227,8 +228,9 @@ namespace BloomTests.Spreadsheet
         {
             var dom = new HtmlDom(imageBook, true);
 
-            _spreadsheetFolder = new TemporaryFolder("SpreadsheetImagesTests");
-            _bookFolder = new TemporaryFolder("SpreadsheetImagesTests_Book");
+            _testFolder = SpreadsheetTestFolders.MakeFolderFor(this);
+            _spreadsheetFolder = new TemporaryFolder(_testFolder, "Spreadsheet");
+            _bookFolder = new TemporaryFolder(_testFolder, "Book");
 
             var mockLangDisplayNameResolver = new Mock<ILanguageDisplayNameResolver>();
             mockLangDisplayNameResolver
@@ -274,8 +276,8 @@ namespace BloomTests.Spreadsheet
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            _spreadsheetFolder?.Dispose();
-            _bookFolder?.Dispose();
+            // This also removes the folders nested inside it.
+            _testFolder?.Dispose();
         }
 
         void SetupFor(string source)
@@ -558,8 +560,8 @@ namespace BloomTests.Spreadsheet
         [Test]
         public void Export_ImagesWithConflictingNames_AllEmbeddedWithoutError()
         {
-            using (var bookFolder = new TemporaryFolder("SpreadsheetImageConflict_Book"))
-            using (var outputFolder = new TemporaryFolder("SpreadsheetImageConflict_Out"))
+            using (var bookFolder = new TemporaryFolder(_testFolder, "ImageConflict_Book"))
+            using (var outputFolder = new TemporaryFolder(_testFolder, "ImageConflict_Out"))
             {
                 // Copy one known-good image to three names that collide once the extension is dropped.
                 var sourceImage = Path.Combine(
@@ -693,8 +695,8 @@ namespace BloomTests.Spreadsheet
         [Test]
         public void Export_SmallImage_RowNotSizedFromOversizedTarget()
         {
-            using (var bookFolder = new TemporaryFolder("SmallImageRowHeight_Book"))
-            using (var outputFolder = new TemporaryFolder("SmallImageRowHeight_Out"))
+            using (var bookFolder = new TemporaryFolder(_testFolder, "SmallImageRowHeight_Book"))
+            using (var outputFolder = new TemporaryFolder(_testFolder, "SmallImageRowHeight_Out"))
             {
                 var sourceImage = Path.Combine(
                     SIL.IO.FileLocationUtilities.GetDirectoryDistributedWithApplication(

--- a/src/BloomTests/Spreadsheet/SpreadsheetImporterTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetImporterTests.cs
@@ -349,6 +349,7 @@ namespace BloomTests.Spreadsheet
     {
         private HtmlDom _dom;
 
+        private TemporaryFolder _testFolder;
         private TemporaryFolder _bookFolder;
         private TemporaryFolder _otherImagesFolder;
         private ProgressSpy _progressSpy;
@@ -882,8 +883,10 @@ namespace BloomTests.Spreadsheet
                     "src/BloomTests/ImageProcessing"
                 );
 
+            _testFolder = SpreadsheetTestFolders.MakeFolderFor(this);
+
             // A place to put an image that is not in the spreadsheet folder so we can test absolute path import.
-            _otherImagesFolder = new TemporaryFolder("other images folder");
+            _otherImagesFolder = new TemporaryFolder(_testFolder, "other images folder");
 
             // Create an HtmlDom for a template to import into
             var xml = string.Format(
@@ -1025,7 +1028,7 @@ namespace BloomTests.Spreadsheet
             contentRow15.AddCell(InternalSpreadsheet.PageContentRowLabel);
             contentRow15.SetCell(columnForEn, "This will go on a new just-text page at the end");
 
-            _bookFolder = new TemporaryFolder("SpreadsheetImageAndTextImportTests");
+            _bookFolder = new TemporaryFolder(_testFolder, "Book");
 
             // This test class has a test (HasCorrectSideClass) that needs the Importer to have a
             // CollectionSettings object. So we create a basic set of CollectionSettings, but we don't need
@@ -1063,8 +1066,8 @@ namespace BloomTests.Spreadsheet
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            _bookFolder?.Dispose();
-            _otherImagesFolder.Dispose();
+            // This also removes the folders nested inside it.
+            _testFolder?.Dispose();
         }
 
         [TestCase(0, "tg1", "this is page 1")]
@@ -1322,6 +1325,7 @@ namespace BloomTests.Spreadsheet
     public class SpreadsheetImportIntoLegacyImagePageTests
     {
         private HtmlDom _dom;
+        private TemporaryFolder _testFolder;
         private TemporaryFolder _bookFolder;
 
         [OneTimeSetUp]
@@ -1343,7 +1347,8 @@ namespace BloomTests.Spreadsheet
             contentRow.AddCell(InternalSpreadsheet.PageContentRowLabel);
             contentRow.SetCell(columnForImage, "images/shirt.png");
 
-            _bookFolder = new TemporaryFolder("SpreadsheetImportIntoLegacyImagePageTests");
+            _testFolder = SpreadsheetTestFolders.MakeFolderFor(this);
+            _bookFolder = new TemporaryFolder(_testFolder, "Book");
             var spreadsheetFolder =
                 SIL.IO.FileLocationUtilities.GetDirectoryDistributedWithApplication(
                     "src/BloomTests/ImageProcessing"
@@ -1361,7 +1366,8 @@ namespace BloomTests.Spreadsheet
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            _bookFolder?.Dispose();
+            // This also removes the folders nested inside it.
+            _testFolder?.Dispose();
         }
 
         [Test]
@@ -1384,6 +1390,7 @@ namespace BloomTests.Spreadsheet
     {
         private HtmlDom _dom;
 
+        private TemporaryFolder _testFolder;
         private TemporaryFolder _bookFolder;
 
         public static string PageWithNothing(int pageNumber)
@@ -1454,9 +1461,8 @@ namespace BloomTests.Spreadsheet
             contentRow3.AddCell(InternalSpreadsheet.PageContentRowLabel);
             contentRow3.SetCell(columnForImage, "images/man.png");
 
-            _bookFolder = new TemporaryFolder(
-                "SpreadsheetImageAndTextImportToBookWithEmptyLastPageTests"
-            );
+            _testFolder = SpreadsheetTestFolders.MakeFolderFor(this);
+            _bookFolder = new TemporaryFolder(_testFolder, "Book");
 
             // Do the import
             var importer = new TestSpreadsheetImporter(
@@ -1485,7 +1491,8 @@ namespace BloomTests.Spreadsheet
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            _bookFolder?.Dispose();
+            // This also removes the folders nested inside it.
+            _testFolder?.Dispose();
         }
 
         [TestCase(2, "man.png")]
@@ -1589,6 +1596,7 @@ namespace BloomTests.Spreadsheet
     {
         private HtmlDom _dom;
 
+        private TemporaryFolder _testFolder;
         private TemporaryFolder _bookFolder;
         private List<SafeXmlElement> _contentPages;
         private string _spreadsheetFolder;
@@ -1632,7 +1640,8 @@ namespace BloomTests.Spreadsheet
             contentRow2.AddCell(InternalSpreadsheet.PageContentRowLabel);
             contentRow2.SetCell(columnForEn, "this is page 2");
 
-            _bookFolder = new TemporaryFolder("SpreadsheetImportWithNoZLanguageTests");
+            _testFolder = SpreadsheetTestFolders.MakeFolderFor(this);
+            _bookFolder = new TemporaryFolder(_testFolder, "Book");
 
             // Do the import
             var importer = new TestSpreadsheetImporter(
@@ -1656,7 +1665,8 @@ namespace BloomTests.Spreadsheet
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            _bookFolder?.Dispose();
+            // This also removes the folders nested inside it.
+            _testFolder?.Dispose();
         }
 
         [TestCase(0)]
@@ -1680,6 +1690,7 @@ namespace BloomTests.Spreadsheet
     {
         private HtmlDom _dom;
 
+        private TemporaryFolder _testFolder;
         private TemporaryFolder _bookFolder;
 
         private List<SafeXmlElement> _contentPages;
@@ -1734,9 +1745,8 @@ namespace BloomTests.Spreadsheet
             contentRow3.SetCell(columnForEn, "this is the first block on page 2");
             contentRow3.SetCell(columnForImage, "images/man.png");
 
-            _bookFolder = new TemporaryFolder(
-                "SpreadsheetImageAndTextImportToBookWithComplexLastPageTests"
-            );
+            _testFolder = SpreadsheetTestFolders.MakeFolderFor(this);
+            _bookFolder = new TemporaryFolder(_testFolder, "Book");
 
             // Do the import
             var importer = new TestSpreadsheetImporter(
@@ -1765,7 +1775,8 @@ namespace BloomTests.Spreadsheet
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            _bookFolder?.Dispose();
+            // This also removes the folders nested inside it.
+            _testFolder?.Dispose();
         }
 
         [TestCase(0, "tg1", "this is page 1")]
@@ -1821,6 +1832,7 @@ namespace BloomTests.Spreadsheet
     {
         private HtmlDom _dom;
 
+        private TemporaryFolder _testFolder;
         private TemporaryFolder _bookFolder;
 
         private List<SafeXmlElement> _contentPages;
@@ -1864,9 +1876,8 @@ namespace BloomTests.Spreadsheet
             contentRow1.SetCell(columnForImage, "images/lady24b.png");
             contentRow1.SetCell(columnForEn, "this is page 1");
 
-            _bookFolder = new TemporaryFolder(
-                "SpreadsheetImageAndTextImportToBookWithComplexLastPageTests"
-            );
+            _testFolder = SpreadsheetTestFolders.MakeFolderFor(this);
+            _bookFolder = new TemporaryFolder(_testFolder, "Book");
 
             // Do the import
             var importer = new TestSpreadsheetImporter(
@@ -1895,7 +1906,8 @@ namespace BloomTests.Spreadsheet
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            _bookFolder?.Dispose();
+            // This also removes the folders nested inside it.
+            _testFolder?.Dispose();
         }
 
         // This is the main point of this test class. The other tests just make sure nothing got broken
@@ -2044,6 +2056,7 @@ namespace BloomTests.Spreadsheet
 </html>
 ";
         private HtmlDom _dom;
+        private TemporaryFolder _testFolder;
         private TemporaryFolder _bookFolder;
 
         [OneTimeSetUp]
@@ -2065,7 +2078,8 @@ namespace BloomTests.Spreadsheet
             contentRow1.SetCell(columnForStart, "Copyright C 2021, Someone else");
             contentRow1.SetCell(columnForEn, "This should not be read");
 
-            _bookFolder = new TemporaryFolder("SpreadsheetImportRemovingLicenseTests");
+            _testFolder = SpreadsheetTestFolders.MakeFolderFor(this);
+            _bookFolder = new TemporaryFolder(_testFolder, "Book");
 
             // Do the import
             var importer = new TestSpreadsheetImporter(null, _dom, null, _bookFolder.FolderPath);
@@ -2077,7 +2091,8 @@ namespace BloomTests.Spreadsheet
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            _bookFolder?.Dispose();
+            // This also removes the folders nested inside it.
+            _testFolder?.Dispose();
         }
 
         [Test]
@@ -2114,6 +2129,7 @@ namespace BloomTests.Spreadsheet
     public class SpreadsheetImportKeepLicenseUrlandNotesIfNoCopyright
     {
         private HtmlDom _dom;
+        private TemporaryFolder _testFolder;
         private TemporaryFolder _bookFolder;
 
         [OneTimeSetUp]
@@ -2133,7 +2149,8 @@ namespace BloomTests.Spreadsheet
             contentRow1.AddCell("[title]");
             contentRow1.SetCell(columnForStar, "Some arbitrary title, just so the SS isn't empty");
 
-            _bookFolder = new TemporaryFolder("SpreadsheetImportRemovingLicenseTests");
+            _testFolder = SpreadsheetTestFolders.MakeFolderFor(this);
+            _bookFolder = new TemporaryFolder(_testFolder, "Book");
 
             // Do the import
             var importer = new TestSpreadsheetImporter(null, _dom, null, _bookFolder.FolderPath);
@@ -2145,7 +2162,8 @@ namespace BloomTests.Spreadsheet
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            _bookFolder?.Dispose();
+            // This also removes the folders nested inside it.
+            _testFolder?.Dispose();
         }
 
         [TestCase("copyright", "Copyright C 2022 Somone")]
@@ -2165,6 +2183,7 @@ namespace BloomTests.Spreadsheet
     public class SpreadsheetImportModifyLicenseDataEvenIfNoCopyright
     {
         private HtmlDom _dom;
+        private TemporaryFolder _testFolder;
         private TemporaryFolder _bookFolder;
 
         [OneTimeSetUp]
@@ -2189,7 +2208,8 @@ namespace BloomTests.Spreadsheet
             contentRow2.AddCell("[licenseNotes]");
             contentRow2.SetCell(columnForStar, "Be very generous to the author");
 
-            _bookFolder = new TemporaryFolder("SpreadsheetImportRemovingLicenseTests");
+            _testFolder = SpreadsheetTestFolders.MakeFolderFor(this);
+            _bookFolder = new TemporaryFolder(_testFolder, "Book");
 
             // Do the import
             var importer = new TestSpreadsheetImporter(null, _dom, null, _bookFolder.FolderPath);
@@ -2201,7 +2221,8 @@ namespace BloomTests.Spreadsheet
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            _bookFolder?.Dispose();
+            // This also removes the folders nested inside it.
+            _testFolder?.Dispose();
         }
 
         [TestCase("copyright", "Copyright C 2022 Somone")]

--- a/src/BloomTests/Spreadsheet/SpreadsheetImporterWithBookTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetImporterWithBookTests.cs
@@ -32,7 +32,7 @@ namespace BloomTests.Spreadsheet
         [OneTimeSetUp]
         public async Task OneTimeSetup()
         {
-            _testFolder = new TemporaryFolder("SpreadsheetImporterWithBookTests");
+            _testFolder = SpreadsheetTestFolders.MakeFolderFor(this);
             // We need 2 layers of temp folder because BringBookUpToDate will change the name of the book
             // folder to match an imported title.
             _bookFolder = new TemporaryFolder(_testFolder, "Book");

--- a/src/BloomTests/Spreadsheet/SpreadsheetPageTypeImportTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetPageTypeImportTests.cs
@@ -31,6 +31,7 @@ namespace BloomTests.Spreadsheet
         private List<SafeXmlElement> _contentPages;
 
         private List<string> _warnings;
+        private TemporaryFolder _testFolder;
         private TemporaryFolder _bookFolder;
         private TemporaryFolder _ssFolder;
 
@@ -51,7 +52,8 @@ namespace BloomTests.Spreadsheet
             _imagesFolder = SIL.IO.FileLocationUtilities.GetDirectoryDistributedWithApplication(
                 "src/BloomTests/ImageProcessing/images"
             );
-            _ssFolder = new TemporaryFolder("SpreadsheetPageTypeImportTests_ss");
+            _testFolder = SpreadsheetTestFolders.MakeFolderFor(this);
+            _ssFolder = new TemporaryFolder(_testFolder, "ss");
             var whereToPutImages = Path.Combine(_ssFolder.FolderPath, "images");
             Directory.CreateDirectory(whereToPutImages);
             var whereToPutVideo = Path.Combine(_ssFolder.FolderPath, "video");
@@ -290,7 +292,7 @@ namespace BloomTests.Spreadsheet
             );
             _dom = new HtmlDom(xml, true);
 
-            _bookFolder = new TemporaryFolder("SpreadsheetPageTypeImportTests");
+            _bookFolder = new TemporaryFolder(_testFolder, "Book");
 
             _progressSpy = new ProgressSpy();
 
@@ -315,8 +317,8 @@ namespace BloomTests.Spreadsheet
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            _bookFolder?.Dispose();
-            _ssFolder?.Dispose();
+            // This also removes the folders nested inside it.
+            _testFolder?.Dispose();
         }
 
         [TestCase(0, "1", "lady24b.png")]

--- a/src/BloomTests/Spreadsheet/SpreadsheetTestFolders.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetTestFolders.cs
@@ -1,0 +1,93 @@
+using System.IO;
+using BloomTemp;
+using NUnit.Framework;
+
+namespace BloomTests.Spreadsheet
+{
+    /// <summary>
+    /// Makes the temporary folders the spreadsheet tests work in, arranged so that no test book
+    /// folder ever sits directly in %TEMP%.
+    ///
+    /// That matters because SpreadsheetImporter.GetPageForLabel() looks for page templates in
+    /// "the collection the book is in", which it computes as the parent of the book folder. If the
+    /// book folder is directly in %TEMP%, the whole temp directory looks like a Bloom collection,
+    /// so Bloom inspects every subfolder of it as a candidate book. A working machine can easily
+    /// have thousands of those; they belong to other tests and to other programs, and any of them
+    /// may be deleted while we are part way through the scan. That used to kill a whole fixture in
+    /// OneTimeSetUp, naming some unrelated folder on the way out. See BL-16661.
+    ///
+    /// So each fixture takes a folder of its own from here and nests everything it needs inside
+    /// that, giving %TEMP%/BloomSpreadsheetTests/&lt;fixture&gt;/&lt;book&gt;. The parent of a book
+    /// folder is then a small folder that only that one fixture ever writes to. A side benefit is
+    /// that these tests now leave one entry in %TEMP% rather than three dozen.
+    /// </summary>
+    internal static class SpreadsheetTestFolders
+    {
+        private const string kRootFolderName = "BloomSpreadsheetTests";
+
+        /// <summary>
+        /// A folder of this fixture's own, named after it, to nest the fixture's other temp
+        /// folders in. The caller owns it and should Dispose it (normally in OneTimeTearDown),
+        /// which also removes everything nested inside it.
+        /// </summary>
+        public static TemporaryFolder MakeFolderFor(object fixture)
+        {
+            return MakeFolderNamed(fixture.GetType().Name);
+        }
+
+        /// <summary>
+        /// As MakeFolderFor(), for the few callers that are static and so have no fixture
+        /// instance to name themselves after. The name must be distinct from every fixture name,
+        /// since making one of these deletes any existing folder of the same name.
+        /// </summary>
+        public static TemporaryFolder MakeFolderNamed(string name)
+        {
+            // Note that we deliberately do NOT make the root with the TemporaryFolder(name)
+            // constructor: that first deletes any existing folder of the name, which would throw
+            // away the folders of every other fixture using the root.
+            var rootPath = Path.Combine(Path.GetTempPath(), kRootFolderName);
+            Directory.CreateDirectory(rootPath);
+            return new TemporaryFolder(TemporaryFolder.TrackExisting(rootPath), name);
+        }
+    }
+
+    public class SpreadsheetTestFoldersTests
+    {
+        /// <summary>
+        /// The whole point of SpreadsheetTestFolders: a book folder nested in one of its folders
+        /// has, as its parent, a folder that only this fixture puts anything in. That parent is
+        /// what SpreadsheetImporter treats as the book's collection and scans for page templates,
+        /// so if it were %TEMP% (as it used to be) the importer would walk every temp folder on
+        /// the machine. See BL-16661.
+        /// </summary>
+        [Test]
+        public void MakeFolderFor_BookNestedInside_HasParentContainingOnlyOurFolders()
+        {
+            using (var testFolder = SpreadsheetTestFolders.MakeFolderFor(this))
+            {
+                // Sanity check: we really did get a new, empty folder to work in.
+                Assert.That(Directory.Exists(testFolder.FolderPath), Is.True);
+                Assert.That(Directory.GetFileSystemEntries(testFolder.FolderPath), Is.Empty);
+
+                var bookFolder = new TemporaryFolder(testFolder, "Book");
+
+                var collectionPath = Path.GetDirectoryName(bookFolder.FolderPath);
+                Assert.That(
+                    collectionPath,
+                    Is.EqualTo(testFolder.FolderPath),
+                    "The folder the importer will scan as the book's collection should be this fixture's own folder."
+                );
+                Assert.That(
+                    Path.GetFullPath(collectionPath),
+                    Is.Not.EqualTo(Path.GetFullPath(Path.GetTempPath())),
+                    "A test book must never sit directly in %TEMP%."
+                );
+                Assert.That(
+                    Directory.GetFileSystemEntries(collectionPath),
+                    Is.EqualTo(new[] { bookFolder.FolderPath }),
+                    "Only folders this fixture made should be in the folder the importer scans."
+                );
+            }
+        }
+    }
+}

--- a/src/BloomTests/Spreadsheet/SpreadsheetXmatterTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetXmatterTests.cs
@@ -126,6 +126,7 @@ namespace BloomTests.Spreadsheet
         private List<ContentRow> _rowsFromExport;
         private InternalSpreadsheet _sheetFromFile;
         private List<ContentRow> _rowsFromFile;
+        private TemporaryFolder _testFolder;
         private TemporaryFolder _spreadsheetFolder;
 
         [OneTimeSetUp]
@@ -133,7 +134,8 @@ namespace BloomTests.Spreadsheet
         {
             var dom = new HtmlDom(dataDivBook, true);
 
-            _spreadsheetFolder = new TemporaryFolder("SpreadsheetXmatterTests");
+            _testFolder = SpreadsheetTestFolders.MakeFolderFor(this);
+            _spreadsheetFolder = new TemporaryFolder(_testFolder, "Spreadsheet");
             var mockLangDisplayNameResolver = new Mock<ILanguageDisplayNameResolver>();
             mockLangDisplayNameResolver
                 .Setup(x => x.GetLanguageDisplayName("en"))
@@ -160,7 +162,8 @@ namespace BloomTests.Spreadsheet
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            _spreadsheetFolder?.Dispose();
+            // This also removes the folders nested inside it.
+            _testFolder?.Dispose();
         }
 
         void SetupFor(string source)

--- a/src/BloomTests/web/controllers/PageTemplatesApiTests.cs
+++ b/src/BloomTests/web/controllers/PageTemplatesApiTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using Bloom.web.controllers;
 using BloomTemp;
@@ -153,6 +154,71 @@ namespace BloomTests.web.controllers
                     sourceBookPaths
                 );
                 Assert.AreEqual(3, result.Count, "Should list each unique path, not name.");
+            }
+        }
+
+        /// <summary>
+        /// A book folder can be deleted while we are part way through scanning its collection --
+        /// by a sync client, an antivirus tool, or the user. That must not abort the whole scan.
+        /// See BL-16661, where one folder disappearing took out a whole test fixture.
+        /// </summary>
+        [Test]
+        public void GetBooksInCollectionDirectories_FolderDeletedPartWayThrough_SkipsItAndKeepsGoing()
+        {
+            using (var collection = new TemporaryFolder("FolderDeletedPartWayThrough"))
+            {
+                // Two books. "a book" is read first; "b book" is the one we will delete after the
+                // scan has started but before it reaches that folder.
+                var stays = new TemplateBookTestFolder(collection.FolderPath, "a book");
+                File.WriteAllText(stays.HtmlPath, "<html></html>");
+                var vanishes = new TemplateBookTestFolder(collection.FolderPath, "b book");
+                File.WriteAllText(vanishes.HtmlPath, "<html></html>");
+
+                // Sanity check: both books are really there, and findable, before we start.
+                Assert.That(File.Exists(stays.HtmlPath), Is.True);
+                Assert.That(File.Exists(vanishes.HtmlPath), Is.True);
+                Assert.That(
+                    Directory.GetDirectories(collection.FolderPath).Length,
+                    Is.EqualTo(2),
+                    "Setup sanity check: the collection should contain exactly the two book folders."
+                );
+
+                var found = new List<string>();
+                // The result is lazy, so pulling one item at a time lets us delete the second
+                // book folder mid-scan -- exactly the race this guards against.
+                using (
+                    var scan = PageTemplatesApi
+                        .GetBooksInCollectionDirectories(new[] { collection.FolderPath })
+                        .GetEnumerator()
+                )
+                {
+                    Assert.That(scan.MoveNext(), Is.True, "Should have found the first book.");
+                    found.Add(scan.Current);
+
+                    SIL.IO.RobustIO.DeleteDirectoryAndContents(
+                        Path.GetDirectoryName(vanishes.HtmlPath)
+                    );
+                    Assert.That(
+                        Directory.Exists(Path.GetDirectoryName(vanishes.HtmlPath)),
+                        Is.False,
+                        "Sanity check: the second book folder should now be gone."
+                    );
+
+                    // Before the fix this threw, killing the whole scan.
+                    while (scan.MoveNext())
+                        found.Add(scan.Current);
+                }
+
+                Assert.That(
+                    found,
+                    Does.Contain(stays.HtmlPath),
+                    "The book that was still there should have been found."
+                );
+                Assert.That(
+                    found.Count,
+                    Is.EqualTo(1),
+                    "The deleted folder should have been skipped, not reported as a book."
+                );
             }
         }
     }

--- a/src/BloomTests/web/controllers/PageTemplatesApiTests.cs
+++ b/src/BloomTests/web/controllers/PageTemplatesApiTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Bloom.web.controllers;
@@ -167,16 +168,14 @@ namespace BloomTests.web.controllers
         {
             using (var collection = new TemporaryFolder("FolderDeletedPartWayThrough"))
             {
-                // Two books. "a book" is read first; "b book" is the one we will delete after the
-                // scan has started but before it reaches that folder.
-                var stays = new TemplateBookTestFolder(collection.FolderPath, "a book");
-                File.WriteAllText(stays.HtmlPath, "<html></html>");
-                var vanishes = new TemplateBookTestFolder(collection.FolderPath, "b book");
-                File.WriteAllText(vanishes.HtmlPath, "<html></html>");
+                var bookA = new TemplateBookTestFolder(collection.FolderPath, "a book");
+                File.WriteAllText(bookA.HtmlPath, "<html></html>");
+                var bookB = new TemplateBookTestFolder(collection.FolderPath, "b book");
+                File.WriteAllText(bookB.HtmlPath, "<html></html>");
 
                 // Sanity check: both books are really there, and findable, before we start.
-                Assert.That(File.Exists(stays.HtmlPath), Is.True);
-                Assert.That(File.Exists(vanishes.HtmlPath), Is.True);
+                Assert.That(File.Exists(bookA.HtmlPath), Is.True);
+                Assert.That(File.Exists(bookB.HtmlPath), Is.True);
                 Assert.That(
                     Directory.GetDirectories(collection.FolderPath).Length,
                     Is.EqualTo(2),
@@ -184,24 +183,37 @@ namespace BloomTests.web.controllers
                 );
 
                 var found = new List<string>();
-                // The result is lazy, so pulling one item at a time lets us delete the second
-                // book folder mid-scan -- exactly the race this guards against.
+                string deletedBookPath;
+                // The result is lazy, so pulling one item at a time lets us delete a book folder
+                // mid-scan -- exactly the race this guards against.
                 using (
                     var scan = PageTemplatesApi
                         .GetBooksInCollectionDirectories(new[] { collection.FolderPath })
                         .GetEnumerator()
                 )
                 {
-                    Assert.That(scan.MoveNext(), Is.True, "Should have found the first book.");
+                    Assert.That(scan.MoveNext(), Is.True, "Should have found one of the books.");
                     found.Add(scan.Current);
 
-                    SIL.IO.RobustIO.DeleteDirectoryAndContents(
-                        Path.GetDirectoryName(vanishes.HtmlPath)
-                    );
+                    // Delete whichever book the scan has NOT yet handed us. Which one that is
+                    // depends on the order Directory.GetDirectories returns folders in, and that
+                    // is up to the file system -- alphabetical on NTFS, arbitrary on ext4 -- so
+                    // work it out at run time rather than assuming "b book" comes second.
+                    var notYetSeen = string.Equals(
+                        found[0],
+                        bookA.HtmlPath,
+                        StringComparison.OrdinalIgnoreCase
+                    )
+                        ? bookB
+                        : bookA;
+                    deletedBookPath = notYetSeen.HtmlPath;
+                    var deletedFolder = Path.GetDirectoryName(deletedBookPath);
+
+                    SIL.IO.RobustIO.DeleteDirectoryAndContents(deletedFolder);
                     Assert.That(
-                        Directory.Exists(Path.GetDirectoryName(vanishes.HtmlPath)),
+                        Directory.Exists(deletedFolder),
                         Is.False,
-                        "Sanity check: the second book folder should now be gone."
+                        "Sanity check: the book folder we deleted should now be gone."
                     );
 
                     // Before the fix this threw, killing the whole scan.
@@ -211,13 +223,13 @@ namespace BloomTests.web.controllers
 
                 Assert.That(
                     found,
-                    Does.Contain(stays.HtmlPath),
-                    "The book that was still there should have been found."
+                    Has.None.EqualTo(deletedBookPath),
+                    "The book whose folder was deleted should not have been reported as a book."
                 );
                 Assert.That(
                     found.Count,
                     Is.EqualTo(1),
-                    "The deleted folder should have been skipped, not reported as a book."
+                    "The surviving book should have been found, and the deleted one skipped rather than aborting the scan."
                 );
             }
         }


### PR DESCRIPTION
`SpreadsheetImporter.GetPageForLabel()` looks for page templates in "the collection the book is in", which it computes as the book folder's **parent**. That is right in production — a book's parent folder really is its collection — but the spreadsheet tests built their book directly in `%TEMP%`, so the parent was the temp directory itself and Bloom walked *every subfolder of it* as a candidate book.

On a working machine that is thousands of folders belonging to other tests and other programs. If any of them was deleted between the enumeration and the inspection, `FindBookHtmlInFolder` threw and took out the whole fixture in `OneTimeSetUp` — naming an unrelated folder on the way out, and hitting a different set of tests each run.

## The fix

New `SpreadsheetTestFolders` hands each fixture a folder of its own, named after the fixture, under a single root:

```
%TEMP%/BloomSpreadsheetTests/<FixtureName>/Book
                                          /Spreadsheet
```

Each fixture nests its book / spreadsheet / other folders inside that, so the folder the importer scans as "the collection" only ever holds that one fixture's folders. Teardown disposes just the root, which removes the rest. A side benefit: these tests now leave one entry in `%TEMP%` instead of three dozen.

The root is made with `Directory.CreateDirectory` rather than the `TemporaryFolder(name)` constructor, because that constructor first deletes any existing folder of the same name — which would throw away a sibling fixture's folders.

## Three latent bugs this surfaced

Naming each folder after its own fixture (`GetType().Name`) fixed some collisions that were already there:

- `SpreadsheetAudioTestsBase` created folders named `SpreadsheetImagesTests` / `SpreadsheetImagesTests_Book` — the same names `SpreadsheetImagesTests` uses, so whichever ran second deleted the other's folder. That base is shared by five fixtures.
- Three license fixtures all used `"SpreadsheetImportRemovingLicenseTests"`, and `SpreadsheetImportDeleteExtraPagesTest` used the name belonging to `SpreadsheetImageAndTextImportToBookWithComplexLastPageTests`.
- Both audio-import fixtures leaked `_spreadsheetFolder` (never disposed) and shared the name `"other audio folder"`.

## Test

Adds one guard test for the invariant the fix rests on: a book folder nested in one of these folders has, as its parent, a folder that is not `%TEMP%` and that contains nothing but our own folders.

All 391 `BloomTests.Spreadsheet` tests pass.

## Both of the card's suggested fixes are here

The card offered two fixes and said "either or both". This PR now does both.

**1. Keep test books out of `%TEMP%`** (the root-cause fix, described above).

**2. Make the scan itself tolerate a folder that vanishes.** `PageTemplatesApi.GetBooksInCollectionDirectories` now skips a book folder that no longer exists rather than letting `FindBookHtmlInFolder` throw and abort the whole scan. This one protects the shipping product, not just the tests: when a user opens the Add Page dialog, Bloom lists the folders in every source collection and inspects each one, and a folder can be deleted in that instant by a sync client, an antivirus tool, or the user. It does not weaken the `bl-291` warning that tells a user their book folder has gone missing — that check is on the save path, not the collection scan.

Its regression test reproduces the race deterministically rather than hoping to hit it: the scan is lazy, so the test takes one book from the enumerator, deletes the folder of whichever book it has *not* yet been handed (decided at run time, so the test does not depend on file-system enumeration order), and keeps enumerating. Without the guard it fails with the exact exception from the bug report — `In FindBookHtmlInFolder('...'), the folder does not exist. (ref bl-291)`.

---
[Devin review](https://app.devin.ai/review/BloomBooks/BloomDesktop/pull/8170)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8170)
<!-- Reviewable:end -->
