### PR TITLE
Add diagnostics for missing files requested by bare name (BL-16577)

### DIFF
--- a/src/BloomExe/BloomFileLocator.cs
+++ b/src/BloomExe/BloomFileLocator.cs
@@ -30,6 +30,12 @@ namespace Bloom
         private readonly IEnumerable<string> _userInstalledSearchPaths;
         private readonly IEnumerable<string> _afterXMatterSearchPaths;
 
+        /// <summary>
+        /// Where our built web assets live, *relative* to the application (or solution) folder.
+        /// Only pass this to something that resolves it against that folder, such as
+        /// FileLocationUtilities.GetFileDistributedWithApplication() or GetBrowserFile(). If you
+        /// want to test for a file yourself, use <see cref="AbsoluteBrowserRoot"/> instead.
+        /// </summary>
         public static string BrowserRoot
         {
             get
@@ -41,6 +47,21 @@ namespace Bloom
                     : "browser";
             }
         }
+
+        /// <summary>
+        /// The full path of the folder that <see cref="BrowserRoot"/> names. Use this anywhere we
+        /// test for, or hand around, the location of a file that ships with Bloom.
+        ///
+        /// BrowserRoot on its own is a relative path, so asking whether something exists at it
+        /// silently resolves against the process's current working directory. Bloom does not
+        /// control that directory: Windows File Explorer sets it to the folder of a file you
+        /// double-click (see the comment on Program.NormalizeWorkingDirectory), a shortcut's
+        /// "Start in" value can override it (BL-16230), and any Open/Save dialog that does not set
+        /// RestoreDirectory moves it mid-session. Files that ship with Bloom must not be findable
+        /// only when that directory happens to be right. See BL-16577.
+        /// </summary>
+        public static string AbsoluteBrowserRoot =>
+            Path.Combine(FileLocationUtilities.DirectoryOfApplicationOrSolution, BrowserRoot);
 
         public static BloomFileLocator sTheMostRecentBloomFileLocator;
 
@@ -126,7 +147,11 @@ namespace Bloom
         /// <returns></returns>
         protected IEnumerable<string> GetSearchPaths(string fileName = null)
         {
-            yield return BloomFileLocator.BrowserRoot;
+            // Absolute, not BrowserRoot itself: LocateFile() combines each of these with the file
+            // name and asks whether it exists, so a relative root here would make files that ship
+            // with Bloom findable only when the current working directory happens to be the
+            // application folder. See BL-16577 and AbsoluteBrowserRoot.
+            yield return BloomFileLocator.AbsoluteBrowserRoot;
 
             //The versions of the files that come with the program should always win out.
             //NB: This should not include any sample books.

--- a/src/BloomExe/MiscUI/BloomOpenFileDialog.cs
+++ b/src/BloomExe/MiscUI/BloomOpenFileDialog.cs
@@ -15,6 +15,13 @@ namespace Bloom.MiscUI
             Multiselect = false;
             CheckFileExists = true;
             CheckPathExists = true;
+            // The Windows file dialog otherwise leaves the process's current working directory
+            // wherever the user last browsed, for the rest of the session. Bloom looks for some of
+            // the files it ships with relative to that directory, so letting a dialog move it can
+            // break those lookups long after the dialog is closed. See BL-16577 and BL-16230.
+            // (This only restores the process directory; the dialog still opens where the shell or
+            // our InitialDirectory says it should.)
+            RestoreDirectory = true;
             _dialog.FileOk += (sender, args) =>
             {
                 // Truly enforce the filter. See BL-12929 and BL-13552.

--- a/src/BloomExe/Utils/MiscUtils.cs
+++ b/src/BloomExe/Utils/MiscUtils.cs
@@ -442,7 +442,11 @@ namespace Bloom.Utils
                     dlg.DefaultExt = defaultExtension;
                     dlg.FileName = initialFilename;
                     dlg.Filter = filter;
-                    dlg.RestoreDirectory = false;
+                    // True so the dialog does not leave the process's current working directory
+                    // wherever the user browsed; see the comment in BloomOpenFileDialog's
+                    // constructor (BL-16577). Where the dialog opens is controlled by
+                    // InitialDirectory below, not by this.
+                    dlg.RestoreDirectory = true;
                     dlg.OverwritePrompt = true;
                     dlg.InitialDirectory = initialFolder;
                     dlg.FileOk += (sender, args) =>

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -1214,9 +1214,12 @@ namespace Bloom.Api
                 && Path.GetExtension(modPath).Equals(".js", StringComparison.OrdinalIgnoreCase)
             )
             {
-                var browserRelativePath = Path.Combine(BloomFileLocator.BrowserRoot, modPath);
-                if (RobustFileExistsWithCaseCheck(browserRelativePath))
-                    return browserRelativePath;
+                // AbsoluteBrowserRoot, not BrowserRoot: the latter is relative, so this test would
+                // resolve against the process's current working directory, which Bloom does not
+                // control and which is often not the application folder (BL-16577, BL-16230).
+                var browserFilePath = Path.Combine(BloomFileLocator.AbsoluteBrowserRoot, modPath);
+                if (RobustFileExistsWithCaseCheck(browserFilePath))
+                    return browserFilePath;
             }
 
             // Is this request the full path to an image file? For most images, we just have the filename. However, in at
@@ -1487,12 +1490,48 @@ namespace Bloom.Api
                     "Cannot Find File"
                 );
                 var detailMsg = String.Format(
-                    "Server could not find the file {0}. LocalPath was {1}{2}",
+                    "Server could not find the file {0}. LocalPath was {1}{2}{3}",
                     path,
                     localPath,
+                    GetBareNameDiagnostics(localPath),
                     Environment.NewLine
                 );
                 NonFatalProblem.Report(ModalIf.Beta, PassiveIf.All, userMsg, detailMsg);
+            }
+        }
+
+        /// <summary>
+        /// Extra detail for the report when the request had no directory at all, e.g. "Checkbox.js".
+        /// Those are almost always files we ship: a bundle we inject into a page at the server root
+        /// (see Book.AddJavascriptFile) imports its sibling chunks by bare name, so they arrive here
+        /// as a bare name too. Such a file should always be found under BrowserRoot, so if it isn't
+        /// we want to know what the process's working directory was (some of our lookups used to
+        /// resolve BrowserRoot against it) and whether the file is really absent from the install.
+        /// See BL-16577. Returns the empty string for ordinary requests, which carry a directory.
+        /// </summary>
+        private static string GetBareNameDiagnostics(string localPath)
+        {
+            try
+            {
+                if (!String.IsNullOrEmpty(Path.GetDirectoryName(localPath)))
+                    return "";
+                var browserRoot = BloomFileLocator.AbsoluteBrowserRoot;
+                var expectedPath = Path.Combine(browserRoot, localPath);
+                return String.Format(
+                    "{0}The request had no directory. BrowserRoot is {1} (exists: {2}); {3} exists: {4}; current directory is {5}",
+                    Environment.NewLine,
+                    browserRoot,
+                    Directory.Exists(browserRoot),
+                    expectedPath,
+                    RobustFile.Exists(expectedPath),
+                    Directory.GetCurrentDirectory()
+                );
+            }
+            catch (Exception e)
+            {
+                // This is only diagnostics for a problem we are already reporting; never let it
+                // become the thing that fails.
+                return Environment.NewLine + "Could not gather diagnostics: " + e.Message;
             }
         }
 

--- a/src/BloomTests/BloomFileLocatorTests.cs
+++ b/src/BloomTests/BloomFileLocatorTests.cs
@@ -121,6 +121,34 @@ namespace BloomTests
         }
 
         /// <summary>
+        /// BrowserRoot is relative to the application (or solution) folder, so testing for a file
+        /// with it resolves against the process's current working directory - which Bloom does not
+        /// control and which is often not the application folder. AbsoluteBrowserRoot exists so that
+        /// nothing locating a file that ships with Bloom has to care. See BL-16577.
+        /// </summary>
+        [Test]
+        public void AbsoluteBrowserRoot_IsAFullPathToAnExistingFolder()
+        {
+            // Sanity check: the thing we are about to say is *not* usable on its own really is
+            // relative, so this test is testing what it claims to.
+            Assert.That(
+                Path.IsPathRooted(BloomFileLocator.BrowserRoot),
+                Is.False,
+                "BrowserRoot has become absolute; AbsoluteBrowserRoot and this test may no longer be needed."
+            );
+
+            var absoluteBrowserRoot = BloomFileLocator.AbsoluteBrowserRoot;
+
+            Assert.That(Path.IsPathRooted(absoluteBrowserRoot), Is.True);
+            Assert.That(
+                Directory.Exists(absoluteBrowserRoot),
+                Is.True,
+                $"{absoluteBrowserRoot} should be the folder holding the files we ship."
+            );
+            Assert.That(absoluteBrowserRoot, Does.EndWith(BloomFileLocator.BrowserRoot));
+        }
+
+        /// <summary>
         /// Make sure we DO search the remaining xmatter paths.
         /// </summary>
         [Test]

--- a/src/BloomTests/PretendRequestInfo.cs
+++ b/src/BloomTests/PretendRequestInfo.cs
@@ -43,7 +43,15 @@ namespace Bloom.Api
             // Use the same decoding logic as in the "real" RequestInfo.
             var pathWithoutLiteralPlusSigns = urlToDecode.Replace("+", "%2B");
             LocalPathWithoutQuery = System.Web.HttpUtility.UrlDecode(pathWithoutLiteralPlusSigns);
+
+            var startOfQuery = RawUrl.IndexOf('?');
+            _queryParameters =
+                startOfQuery < 0
+                    ? new NameValueCollection()
+                    : System.Web.HttpUtility.ParseQueryString(RawUrl.Substring(startOfQuery + 1));
         }
+
+        private readonly NameValueCollection _queryParameters;
 
         public string LocalPathWithoutQuery { get; set; }
 
@@ -105,9 +113,14 @@ namespace Bloom.Api
             StatusCode = errorCode;
         }
 
+        /// <summary>
+        /// The query parameters of the url this was constructed with. This used to always be empty,
+        /// which made any request the server routes on a query parameter (such as the assetv one it
+        /// adds to every JS request) impossible to test.
+        /// </summary>
         public NameValueCollection GetQueryParameters()
         {
-            return new NameValueCollection();
+            return _queryParameters;
         }
 
         public NameValueCollection GetPostDataWhenFormEncoded()

--- a/src/BloomTests/web/BloomServerTests.cs
+++ b/src/BloomTests/web/BloomServerTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2014-2018 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
+using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Imaging;
@@ -166,6 +167,64 @@ namespace BloomTests.web
 
                 Assert.That(BloomServer.CanOpenConsecutivePorts(startingPort, 2), Is.False);
             }
+        }
+
+        /// <summary>
+        /// A bundle we inject into a page at the server root imports its sibling chunks by bare
+        /// name, so the server is regularly asked for files that sit directly in the browser folder
+        /// with no directory in the request at all (BL-16577).
+        ///
+        /// It must resolve those to a full path. Finding a file that ships with Bloom may not depend
+        /// on the process's current working directory: Windows File Explorer sets that to the folder
+        /// of a file the user double-clicked, and any Open/Save dialog can move it mid-session.
+        /// We deliberately do NOT move the current directory here to prove that - it is
+        /// process-wide state, and doing so makes other tests in this assembly fail
+        /// unpredictably - so instead we assert the property that a current-directory-relative
+        /// lookup would violate: the path we resolved to and served is rooted.
+        /// </summary>
+        [Test]
+        public void CanGetJavascriptDirectlyInBrowserRoot_AndResolvesItToAFullPath()
+        {
+            // Named like a Vite chunk (which is what the real requests are), but unique so we
+            // neither collide with nor depend on any particular chunk of the current build.
+            var chunkName = "BloomServerTestsChunk" + Guid.NewGuid().ToString("N") + ".js";
+            var chunkPath = Path.Combine(BloomFileLocator.AbsoluteBrowserRoot, chunkName);
+            using (var server = CreateBloomServer())
+            {
+                try
+                {
+                    RobustFile.WriteAllText(chunkPath, "// pretend chunk");
+
+                    var transaction = MakeJavascriptRequest(server, chunkName);
+
+                    Assert.That(transaction.StatusCode, Is.Not.EqualTo(404));
+                    Assert.That(transaction.ReplyContents, Is.EqualTo("// pretend chunk"));
+                    Assert.That(
+                        Path.IsPathRooted(transaction.ReplyImagePath),
+                        Is.True,
+                        $"Served {transaction.ReplyImagePath}, which is not a full path, so finding it depended on the current working directory."
+                    );
+                    Assert.That(transaction.ReplyImagePath, Is.EqualTo(chunkPath));
+                }
+                finally
+                {
+                    RobustFile.Delete(chunkPath);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Requests a JS file by bare name. The assetv query parameter is what the server itself
+        /// redirects JS requests to (see ProcessRequestAsync); supplying it up front keeps this
+        /// test on the file-serving path instead of getting the redirect.
+        /// </summary>
+        private PretendRequestInfo MakeJavascriptRequest(BloomServer server, string fileName)
+        {
+            var transaction = new PretendRequestInfo(
+                BloomServer.ServerUrlWithBloomPrefixEndingInSlash + fileName + "?assetv=test"
+            );
+            server.MakeReply(transaction);
+            return transaction;
         }
 
         [Test]


### PR DESCRIPTION
## What this is

Sentry issue [2699459502](https://bloom-app.sentry.io/issues/2699459502/) ("Cannot Find File") is
dominated by requests for the bare name `Checkbox.js`. The card supposed no such file exists in
Bloom. It does: it's a Vite chunk in `output/browser`. A bundle we inject into a page at the server
root (`Book.AddJavascriptFile`) imports its sibling chunks by bare name, so they arrive at the
server with no directory — and they should always be found under `BrowserRoot`.

**This PR does not fix that bug.** I could not establish why the lookup fails on the affected
machines: the third lookup, `GetFileDistributedWithApplication`, is anchored to the application
folder, and the absolute browser root is already a factory search path, so on a valid install the
file is found regardless of anything here. What this adds is the instrumentation needed to find
out, plus a real weakness the investigation turned up.

## Changes

**Diagnostics.** When a request that carries *no directory* misses, the Sentry detail message now
also reports `BrowserRoot`, whether the expected file is actually present, and the process's
current working directory. That distinguishes "the file is genuinely absent from that install"
from "we looked in the wrong place". Requests that carry a directory are unaffected.

**The current-directory weakness.** `BloomFileLocator.BrowserRoot` is a *relative* path, so testing
for a file with it resolves against the process's current working directory. Bloom doesn't control
that directory:

- Windows File Explorer sets it to the folder of a double-clicked file — Bloom's own comment in
  `Program.cs` says so (BL-11004);
- a shortcut's "Start in" value overrides it — this already bit us as BL-16230, which is why
  `Program.NormalizeWorkingDirectory()` exists;
- any Open/Save dialog that doesn't set `RestoreDirectory` moves it **mid-session**, permanently —
  and `BloomOpenFileDialog` never set it.

Two lookups depended on it: `BloomServer.LookForAFullPathToFile`'s browser-root preference (added
in `57893d0f1f` for BL-15894) and `BloomFileLocator.GetSearchPaths`. Both now use a new
`AbsoluteBrowserRoot`, and the file dialogs no longer move the working directory.

**Test double.** `PretendRequestInfo.GetQueryParameters()` always returned an empty collection,
which made any request the server routes on a query parameter — such as the `assetv` one it adds to
every JS request — impossible to test at all. It now parses the query.

## Risk to look at

The `GetSearchPaths` change is the one with teeth: that entry previously resolved to nothing
whenever the working directory wasn't the application folder, so making it work **changes lookup
precedence** — the browser root now genuinely wins over the factory paths, which is what the
comment there always intended. The precedence tests in `BloomFileLocatorTests` cover this and pass.

## Testing

`BloomServerTests` + `BloomFileLocatorTests` + `BookStarterTests`: **125 passed, 0 failed**, stable
across repeated runs, before and after merging `master`.

Full-suite counts are not usable as a signal at the moment — four runs of one unchanged tree gave
135, 1, 32 and 62 failures. That is other worktrees sharing `%TEMP%` plus tests that mutate
process-wide state, not this branch. (My first attempt at a regression test here changed the
process's current directory and took out a different unrelated test on each run; it was rewritten
to assert the resolved path is rooted instead.)

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16577


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8171)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8171)
<!-- Reviewable:end -->
