### PR TITLE
Remove a deleted canvas element's hint bubbles with it (BL-16648)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/CanvasElementDelete.test.ts
+++ b/src/BloomBrowserUI/bookEdit/js/CanvasElementDelete.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test, vi } from "vitest";
+import $ from "jquery";
+import "../../lib/jquery.qtip.js"; // puts qtip into $.fn
+
+// Comical wants paper.js and a real <canvas>, which jsdom doesn't give us. deleteCanvasElement
+// only needs it to take the element out of the DOM, which is what the real
+// deleteBubbleFromFamily does at the end of its work.
+vi.mock("comicaljs", () => ({
+    Bubble: class {},
+    Comical: {
+        setSelectorForBubblesWhichTailMidpointMayOverlap: () => {},
+        activateElement: () => {},
+        update: () => {},
+        deleteBubbleFromFamily: (
+            element: HTMLElement,
+            container: HTMLElement,
+        ) => container.removeChild(element),
+    },
+}));
+
+// This import deliberately comes after the vi.mock call above, so that the module graph
+// it pulls in gets the stubbed comicaljs.
+import { CanvasElementManager } from "./CanvasElementManager";
+
+// Attach a qtip the way BloomHintBubbles.makeHintBubbleCore does for a
+// data-derived="topic" field: always showing, and rendered into the page scaling
+// container rather than inside the element it annotates.
+function makeTopicHintBubble(topicField: HTMLElement): void {
+    $(topicField).qtip({
+        content: "Choose topic",
+        position: { container: $("div#page-scaling-container") },
+        show: { ready: true },
+        hide: { event: false },
+        style: { classes: "topic-chooser-hint-bubble" },
+    });
+}
+
+function setUpTwoTopicCanvasElements(): HTMLElement[] {
+    document.body.innerHTML = `
+        <div id="page-scaling-container">
+            <div class="bloom-page">
+                <div class="bloom-canvas">
+                    <div class="bloom-canvas-element" id="ce1">
+                        <div class="coverBottomBookTopic" data-derived="topic"
+                             data-hint="Choose topic">Fiction</div>
+                    </div>
+                    <div class="bloom-canvas-element" id="ce2">
+                        <div class="coverBottomBookTopic" data-derived="topic"
+                             data-hint="Choose topic">Fiction</div>
+                    </div>
+                </div>
+            </div>
+        </div>`;
+    const canvasElements = Array.from(
+        document.querySelectorAll<HTMLElement>(".bloom-canvas-element"),
+    );
+    canvasElements.forEach((canvasElement) =>
+        makeTopicHintBubble(
+            canvasElement.querySelector("[data-derived]") as HTMLElement,
+        ),
+    );
+    return canvasElements;
+}
+
+describe("CanvasElementManager.deleteCanvasElement", () => {
+    test("removes the deleted element's topic chooser bubble but not another one's", async () => {
+        const [canvasElement1, canvasElement2] = setUpTwoTopicCanvasElements();
+        // qtip renders after its default show delay, so let that happen.
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        const manager = new CanvasElementManager();
+        // Rebuilding the editing UI needs the whole editor; it isn't what we're testing.
+        manager.refreshCanvasElementEditing = () => {};
+
+        const bubbleOf = (canvasElement: HTMLElement) =>
+            document.getElementById(
+                canvasElement
+                    .querySelector("[data-derived]")!
+                    .getAttribute("aria-describedby")!,
+            );
+        // Sanity check: each topic field starts out with its own bubble in the document.
+        const bubble1 = bubbleOf(canvasElement1);
+        const bubble2 = bubbleOf(canvasElement2);
+        if (!bubble1 || !bubble2 || bubble1 === bubble2) {
+            throw new Error(
+                "Test setup failed to give each topic field its own qtip bubble",
+            );
+        }
+        expect(document.querySelectorAll("div.qtip").length).toBe(2);
+
+        manager.deleteCanvasElement(canvasElement1);
+
+        expect(canvasElement1.isConnected).toBe(false);
+        expect(bubble1.isConnected).toBe(false);
+        expect(bubble2.isConnected).toBe(true);
+        expect(document.querySelectorAll("div.qtip").length).toBe(1);
+    });
+});

--- a/src/BloomBrowserUI/bookEdit/js/CanvasElementDelete.test.ts
+++ b/src/BloomBrowserUI/bookEdit/js/CanvasElementDelete.test.ts
@@ -62,11 +62,26 @@ function setUpTwoTopicCanvasElements(): HTMLElement[] {
     return canvasElements;
 }
 
+// qtip renders its bubble after a show delay rather than synchronously, so wait for the
+// bubbles to appear. Polling rather than sleeping a fixed time keeps this from becoming a
+// race on a loaded machine.
+async function waitForRenderedBubbles(expectedCount: number): Promise<void> {
+    const deadline = Date.now() + 5000;
+    const rendered = () => document.querySelectorAll("div.qtip").length;
+    while (rendered() < expectedCount) {
+        if (Date.now() > deadline) {
+            throw new Error(
+                `Test setup: only ${rendered()} of ${expectedCount} qtip bubbles rendered`,
+            );
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+}
+
 describe("CanvasElementManager.deleteCanvasElement", () => {
     test("removes the deleted element's topic chooser bubble but not another one's", async () => {
         const [canvasElement1, canvasElement2] = setUpTwoTopicCanvasElements();
-        // qtip renders after its default show delay, so let that happen.
-        await new Promise((resolve) => setTimeout(resolve, 200));
+        await waitForRenderedBubbles(2);
         const manager = new CanvasElementManager();
         // Rebuilding the editing UI needs the whole editor; it isn't what we're testing.
         manager.refreshCanvasElementEditing = () => {};

--- a/src/BloomBrowserUI/bookEdit/js/CanvasElementManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/CanvasElementManager.ts
@@ -6054,6 +6054,14 @@ export class CanvasElementManager {
             Comical.update(containerElement);
         }
 
+        // The qtip bubbles belonging to things inside this canvas element (source bubbles, hint
+        // bubbles, and in particular the "Choose topic" link on a data-derived="topic" field)
+        // are not children of it; they live in the page scaling container. So removing the
+        // canvas element would leave them behind until the page is reloaded. Destroy them now,
+        // while the divs they are attached to still exist. This is scoped to this canvas
+        // element, so other canvas elements (e.g., a second topic field) keep their bubbles.
+        BloomSourceBubbles.removeSourceBubbles(textOverPicDiv);
+
         Comical.deleteBubbleFromFamily(textOverPicDiv, containerElement);
 
         // Update UI and make sure things get redrawn correctly.


### PR DESCRIPTION
Fixes one of the 6.4 findings reported on BL-16648 — **not** the whole card:

> Deleting a "topic" caption box leaves the "choose topic" link showing on the page. (Probably common to custom pages, not just new one.)

The other two findings in that comment (spreadsheet export/import of custom-layout pages; the right-click menu losing items when a text box is set to Topic/Languages) are untouched here.

## What was wrong

The "Choose topic" control is a jQuery **qtip** hint bubble. `BloomHintBubbles` gives one to every `[data-hint]` element, and the topic field's hint carries `data-functiononhintclick="showTopicChooser"`, which turns the bubble's text into the link that opens the topic chooser.

qtip renders that bubble into `#page-scaling-container`, *not* inside the element it annotates, and it only tears itself down when the target is removed **through jQuery** (it binds `remove.qtip-<id>` and relies on the `$.cleanData` patch). Comical removes a canvas element with a native `container.removeChild(...)`, so neither hook fires and the bubble is orphaned — still visible, still clickable — until the page is reloaded.

## The fix

`deleteCanvasElement` now calls `BloomSourceBubbles.removeSourceBubbles(textOverPicDiv)` immediately before `Comical.deleteBubbleFromFamily` takes the element out, i.e. while the divs the bubbles are attached to still exist (which is how that helper finds them).

Notes on the placement:

- It is **scoped to the element being deleted**, so a page with more than one topic block loses only the corresponding control.
- It sits **after** the background-image early return, which does *not* remove anything from the DOM (it swaps in `placeHolder.png`), so those bubbles are correctly left alone.
- `deleteCanvasElement` is the single funnel for every delete path — context menu, keyboard Delete, and the background-image conversion in `canvasControlRegistry` — so all of them are covered.
- It also cleans up source/hint bubbles on ordinary text canvas elements, which had the same leak (just less visible, because those bubbles are focus-only rather than always-shown).

## Testing

New vitest test `CanvasElementDelete.test.ts`: two canvas elements each holding a topic field with a real qtip; delete one and assert its bubble is gone and the other's survives. Confirmed it fails without the fix.

Also verified interactively in a running Bloom on a real custom cover page: duplicated the topic canvas element to get two "Choose topic" bubbles, deleted one, and watched only that one disappear — immediately, with no page reload. With the fix reverted, the orphan bubble was still there a second later.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16648


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8176)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8176)
<!-- Reviewable:end -->
