### PR TITLE
Take OffScreenBrowser's thread out of WinForms' application lifetime (BL-16668)

### DIFF
--- a/src/BloomExe/FatalExceptionHandler.cs
+++ b/src/BloomExe/FatalExceptionHandler.cs
@@ -84,8 +84,15 @@ namespace Bloom
 
             if (DisplayError(e.Exception))
             {
-                //Are we inside a Application.Run() statement?
-                if (Application.MessageLoop)
+                // Is there a running GUI application to shut down?
+                //
+                // Deliberately NOT Application.MessageLoop, which used to be asked here. That is a
+                // per-THREAD flag, so it answers "does the thread this exception arrived on have a
+                // WinForms loop" — and for anything surfacing on a worker thread the answer is no even
+                // while Bloom is running perfectly normally. We then took Environment.Exit(1), which
+                // does not run `finally` blocks and so skips the one in Main that releases Bloom's
+                // single-instance token, potentially leaving Bloom unable to start again (BL-16668).
+                if (Program.MainMessageLoopIsRunning)
                     ProgramExit.Exit();
                 else
                     Environment.Exit(1); //the 1 here is just non-zero

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -1408,6 +1408,7 @@ namespace Bloom
             // Crashes if initialized twice, and there's at least once case when joining a TC
             // where we can come here twice.
             WritingSystem.EnsureSldrInitialized();
+            MainMessageLoopIsRunning = true;
             try
             {
                 Application.Run();
@@ -1450,6 +1451,7 @@ namespace Bloom
             }
             finally
             {
+                MainMessageLoopIsRunning = false;
                 if (FileMeddlerManager.IsMeddling)
                     FileMeddlerManager.Stop();
                 WebView2Browser.CleanupWebView2UserFolders();
@@ -2623,6 +2625,21 @@ Anyone looking specifically at our issue tracking system can read what you sent 
 
         // Should be set to true if this is being called by Harvester, false otherwise.
         public static bool RunningHarvesterMode { get; set; }
+
+        /// <summary>
+        /// True only while Bloom's MAIN message loop — the Application.Run() in RunBloom — is pumping.
+        /// In other words, "there is a running GUI application to shut down".
+        /// </summary>
+        /// <remarks>
+        /// Use this, not Application.MessageLoop, to ask that question. Application.MessageLoop is
+        /// per-THREAD: it answers "does the calling thread have a WinForms loop", which is a different
+        /// question and gives the wrong answer for anything raised on a worker thread. That mattered in
+        /// BL-16668: FatalExceptionHandler used it to choose between a graceful ProgramExit.Exit() and a
+        /// bare Environment.Exit(1), so a fatal error surfacing on a worker's thread took the hard-kill
+        /// path — which skips the `finally` in Main that releases Bloom's single-instance token, and so
+        /// could leave Bloom unable to start again.
+        /// </remarks>
+        public static bool MainMessageLoopIsRunning { get; private set; }
 
         private static bool _runningE2eTests;
 

--- a/src/BloomExe/Publish/OffScreenBrowser.cs
+++ b/src/BloomExe/Publish/OffScreenBrowser.cs
@@ -112,10 +112,13 @@ namespace Bloom.Publish
                 }
                 finally
                 {
-                    // Application.Run disposed this thread's windows as its loop ended; since we no longer
-                    // use it, dispose the synchronization context (and so its hidden marshaling control)
-                    // ourselves. We are on the owning thread, the only one allowed to do that, and WM_QUIT
-                    // is only retrieved once the queue is otherwise empty, so all posted work has run.
+                    // As its loop ended, Application.Run's teardown destroyed this thread's window
+                    // HANDLES — it did not Dispose the controls themselves; the browser has always been
+                    // disposed explicitly, from Dispose() below. Since we no longer call it, dispose the
+                    // synchronization context — and with it the hidden marshaling control — ourselves,
+                    // so we don't leave a Control to be finalized on a dead thread. We are on the owning
+                    // thread, the only one allowed to do that, and WM_QUIT is only retrieved once the
+                    // queue is otherwise empty, so everything posted has already run.
                     ctx.Dispose();
                 }
             }
@@ -144,6 +147,11 @@ namespace Bloom.Publish
         /// windows and their async completions — while remaining invisible to WinForms' application-lifetime
         /// bookkeeping. So no non-GUI entry point (the harvester, bulk upload, any future CLI verb) can be
         /// told the application is exiting just because we finished with a browser.
+        ///
+        /// Leaving that bookkeeping cuts both ways, deliberately: WinForms no longer knows about this loop,
+        /// so Application.Exit() no longer ends it either. If the GUI shuts down while a browser is still
+        /// alive, this thread keeps pumping until the process goes away — harmless, because the thread is
+        /// IsBackground (it cannot hold the process open) and the CoreWebView2 process dies with its host.
         /// </remarks>
         private static void RunPrivateMessageLoop()
         {

--- a/src/BloomExe/Publish/OffScreenBrowser.cs
+++ b/src/BloomExe/Publish/OffScreenBrowser.cs
@@ -1,5 +1,7 @@
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -27,8 +29,8 @@ namespace Bloom.Publish
     /// deliberately not static/shared between instances, so instances on different threads never contend).
     /// A caller that only needs one browser simply never calls StartFreshBrowser.
     ///
-    /// How it stays safe: the browser is owned by a private, dedicated STA thread with its own Windows Forms
-    /// message loop, and THAT thread — not the caller — services the browser's callbacks. So a caller can
+    /// How it stays safe: the browser is owned by a private, dedicated STA thread with its own message
+    /// loop, and THAT thread — not the caller — services the browser's callbacks. So a caller can
     /// simply block for a result. It never has to pump the MAIN UI message loop the way
     /// Browser.RunJavascriptWithStringResult_Sync_Dangerous does (Application.DoEvents), which lets unrelated
     /// user commands run in the middle of the call stack — the reentrancy blamed for BL-12614 / BL-13120. And
@@ -48,9 +50,6 @@ namespace Bloom.Publish
         // every inner browser this instance creates. Captured from the first browser and reused for each
         // fresh browser (see StartFreshBrowser), so we don't pay environment creation each time.
         private CoreWebView2Environment _environment;
-
-        // The message loop we run on the dedicated thread; ExitThread() on it ends the loop at Dispose.
-        private ApplicationContext _appContext;
 
         // The dedicated thread's Windows Forms synchronization context. Posting to it marshals work onto that
         // thread; awaits inside that work resume there too.
@@ -90,14 +89,15 @@ namespace Bloom.Publish
         /// </summary>
         public int BrowserThreadId => _thread.ManagedThreadId;
 
-        // Runs on the dedicated thread: establishes a message loop, creates the browser, then pumps messages
-        // until Dispose() ends the loop via the ApplicationContext.
+        // Runs on the dedicated thread: establishes a synchronization context, creates the browser, then
+        // pumps messages until Dispose() posts WM_QUIT.
         private void ThreadMain()
         {
             try
             {
-                // Give this thread a Windows Forms message loop + synchronization context, so the browser's
-                // async continuations (and cross-thread Posts from callers) run here.
+                // Give this thread a Windows Forms synchronization context, so the browser's async
+                // continuations (and cross-thread Posts from callers) run here. Posting through it works by
+                // sending window messages to a hidden marshaling control, which our pump below dispatches.
                 var ctx = new WindowsFormsSynchronizationContext();
                 SynchronizationContext.SetSynchronizationContext(ctx);
                 _ctx = ctx;
@@ -106,8 +106,18 @@ namespace Bloom.Publish
                 // CoreWebView2 initialization completes via that loop), then signal the constructor.
                 ctx.Post(_ => InitializeAsync(), null);
 
-                _appContext = new ApplicationContext();
-                Application.Run(_appContext); // pump until the context's loop is ended in Dispose
+                try
+                {
+                    RunPrivateMessageLoop();
+                }
+                finally
+                {
+                    // Application.Run disposed this thread's windows as its loop ended; since we no longer
+                    // use it, dispose the synchronization context (and so its hidden marshaling control)
+                    // ourselves. We are on the owning thread, the only one allowed to do that, and WM_QUIT
+                    // is only retrieved once the queue is otherwise empty, so all posted work has run.
+                    ctx.Dispose();
+                }
             }
             catch (Exception e)
             {
@@ -115,6 +125,75 @@ namespace Bloom.Publish
                 _ready.Set();
             }
         }
+
+        /// <summary>
+        /// Pumps this thread's messages until WM_QUIT, using the raw Win32 loop rather than
+        /// <see cref="Application.Run(ApplicationContext)"/>.
+        /// </summary>
+        /// <remarks>
+        /// Why not Application.Run: it registers this loop with WinForms as an *application* message loop.
+        /// Ending it therefore makes WinForms conclude that the application is exiting (when, as in a CLI
+        /// process, it is the process's only such loop) and raise Application.ApplicationExit. That is a lie
+        /// — a worker's private browser thread finishing is not the application quitting — and things
+        /// listening for a real shutdown act on it: ApplicationContainer disposed itself, killing the DI
+        /// scope the harvester's still-running createArtifacts depended on (BL-16668). We create and tear
+        /// down one of these browsers per batch of page checks, so that fired mid-run.
+        ///
+        /// A bare GetMessage/TranslateMessage/DispatchMessage loop dispatches everything this thread
+        /// actually needs — the WindowsFormsSynchronizationContext's marshaling control, the WebView2's
+        /// windows and their async completions — while remaining invisible to WinForms' application-lifetime
+        /// bookkeeping. So no non-GUI entry point (the harvester, bulk upload, any future CLI verb) can be
+        /// told the application is exiting just because we finished with a browser.
+        /// </remarks>
+        private static void RunPrivateMessageLoop()
+        {
+            // GetMessage returns 0 for WM_QUIT and -1 on error; anything else means we have a message.
+            int result;
+            while ((result = GetMessage(out var msg, IntPtr.Zero, 0, 0)) != 0)
+            {
+                if (result == -1)
+                    throw new Win32Exception(
+                        Marshal.GetLastWin32Error(),
+                        "GetMessage failed in the OffScreenBrowser message loop"
+                    );
+                TranslateMessage(ref msg);
+                DispatchMessage(ref msg);
+            }
+        }
+
+        #region Win32 message pump
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct NativeMessage
+        {
+            public IntPtr HWnd;
+            public uint Message;
+            public IntPtr WParam;
+            public IntPtr LParam;
+            public uint Time;
+            public int PointX;
+            public int PointY;
+        }
+
+        [DllImport("user32.dll", EntryPoint = "GetMessageW", SetLastError = true)]
+        private static extern int GetMessage(
+            out NativeMessage message,
+            IntPtr hWnd,
+            uint filterMin,
+            uint filterMax
+        );
+
+        [DllImport("user32.dll")]
+        private static extern bool TranslateMessage(ref NativeMessage message);
+
+        [DllImport("user32.dll", EntryPoint = "DispatchMessageW")]
+        private static extern IntPtr DispatchMessage(ref NativeMessage message);
+
+        // Queues WM_QUIT for the CALLING thread, which is why Dispose posts the call onto our thread.
+        [DllImport("user32.dll")]
+        private static extern void PostQuitMessage(int exitCode);
+
+        #endregion
 
         private async void InitializeAsync()
         {
@@ -308,7 +387,9 @@ namespace Bloom.Publish
                         }
                         finally
                         {
-                            _appContext?.ExitThread();
+                            // We are on the browser's own thread here, so this queues WM_QUIT for the loop
+                            // in RunPrivateMessageLoop.
+                            PostQuitMessage(0);
                         }
                     },
                     null

--- a/src/BloomExe/Publish/OffScreenBrowser.cs
+++ b/src/BloomExe/Publish/OffScreenBrowser.cs
@@ -119,6 +119,16 @@ namespace Bloom.Publish
                     // so we don't leave a Control to be finalized on a dead thread. We are on the owning
                     // thread, the only one allowed to do that, and WM_QUIT is only retrieved once the
                     // queue is otherwise empty, so everything posted has already run.
+                    //
+                    // What this does NOT clean up, deliberately: WinForms' per-thread ThreadContext.
+                    // Installing the synchronization context creates one, Application.Run's teardown
+                    // used to remove it, and disposing the context here does not. So each browser leaves
+                    // one behind, held by a static table. We decided (BL-16668) to accept that rather
+                    // than chase it: the table is keyed by native thread id, so entries are overwritten
+                    // as ids are reused instead of accumulating without bound, and the per-instance cost
+                    // is a small object plus a thread handle. The only way to really remove it would be
+                    // to keep one browser thread for the process lifetime, which would undo
+                    // ReleaseBrowser's deliberate "don't leave an idle WebView2 running" intent.
                     ctx.Dispose();
                 }
             }

--- a/src/BloomTests/CLI/CreateArtifactsCommandTests.cs
+++ b/src/BloomTests/CLI/CreateArtifactsCommandTests.cs
@@ -238,6 +238,99 @@ namespace BloomTests.CLI
             }
         }
 
+        // The harvester never asks for just one artifact: it passes --bloomdOutputPath,
+        // --bloomDigitalOutputPath AND --epubOutputPath in a single createArtifacts run. That
+        // combination is what BL-16668 broke, and why every other test here missed it. Making the
+        // bloomdigital spins up (and then tears down) PublishHelper's off-screen browser, whose
+        // dedicated thread runs the only WinForms message loop a CLI process has. Ending that loop
+        // made WinForms raise Application.ApplicationExit, which disposed the ApplicationContainer --
+        // the parent scope of our still-in-use ProjectContext -- so the epub step, which runs
+        // afterwards, died with ObjectDisposedException resolving ProjectContext.BookServer and
+        // createArtifacts returned EpubException. A test that requests a single artifact cannot
+        // catch that, because nothing runs after the premature disposal.
+        [Test]
+        public void CreateArtifacts_BloomDigitalAndEpubRequestedTogether_BothCreated()
+        {
+            using (
+                var testFolder = new TemporaryFolder(
+                    "CreateArtifacts_BloomDigitalAndEpubRequestedTogether_BothCreated"
+                )
+            )
+            {
+                var collectionFolderPath = testFolder.Combine("collection");
+
+                var bookFolderPath = Path.Combine(collectionFolderPath, "book");
+                System.IO.Directory.CreateDirectory(bookFolderPath);
+                var collectionFilePath = Path.Combine(
+                    collectionFolderPath,
+                    "collection.bloomCollection"
+                );
+                var settings = new CollectionSettings(collectionFilePath);
+                settings.Save();
+                var metaData = new BookMetaData();
+                metaData.WriteToFolder(bookFolderPath);
+                var bookPath = System.IO.Path.Combine(bookFolderPath, "book.htm");
+                System.IO.File.WriteAllText(
+                    bookPath,
+                    @"<html>
+                    <body>
+						<div class='bloom-page'>
+							<div class='marginBox'>
+								<div class='bloom-translationGroup normal-style'>
+									<div class='bloom-editable normal-style bloom-content1 bloom-contentNational1 bloom-visibility-code-on' lang='en'>
+                                        Hello
+									</div>
+								</div>
+							</div>
+						</div>
+					</body>
+				</html>"
+                );
+
+                var bloomDigitalOutputPath = Path.Combine(testFolder.FolderPath, "bloomdigital");
+                var epubOutputPath = Path.Combine(testFolder.FolderPath, "epub", "book.epub");
+                // Sanity check: neither artifact exists yet, so finding them later really does mean
+                // this run made them.
+                Assert.That(
+                    Directory.Exists(bloomDigitalOutputPath),
+                    Is.False,
+                    "test setup: bloomdigital output should not exist before the run"
+                );
+                Assert.That(
+                    File.Exists(epubOutputPath),
+                    Is.False,
+                    "test setup: epub output should not exist before the run"
+                );
+
+                var result = CreateArtifactsCommand.HandleInternal(
+                    new CreateArtifactsParameters()
+                    {
+                        BookPath = bookFolderPath,
+                        CollectionPath = collectionFilePath,
+                        BloomDigitalOutputPath = bloomDigitalOutputPath,
+                        EpubOutputPath = epubOutputPath,
+                        NoAnalytics = true,
+                    }
+                );
+
+                Assert.That(
+                    result,
+                    Is.EqualTo(CreateArtifactsExitCode.Success),
+                    "createArtifacts should succeed when both a bloomdigital and an epub are requested"
+                );
+                Assert.That(
+                    File.Exists(Path.Combine(bloomDigitalOutputPath, "index.htm")),
+                    Is.True,
+                    "the bloomdigital artifact should have been created"
+                );
+                Assert.That(
+                    File.Exists(epubOutputPath),
+                    Is.True,
+                    "the epub artifact should have been created"
+                );
+            }
+        }
+
         [Test]
         public void CreateArtifacts_WithJsonOutput_CreatesJsonFile()
         {


### PR DESCRIPTION
`Bloom.exe createArtifacts` was dying with `ObjectDisposedException` on the epub step, so the
harvester failed **every** book with epubs enabled and uploaded no artifacts at all — not even
the .bloompub it had already built successfully. Reported downstream as BH-7836.

### What was happening

`Application.Run` registers the loop it starts as an **application** message loop. `OffScreenBrowser`
(introduced in `48d8e2588c` for BL-12614 / BL-13120) runs one on its own dedicated STA thread. The
CLI path never calls `Application.Run` itself — it waits with `Thread.Sleep` + `Application.DoEvents`
— so that browser thread's loop is the *only* application message loop in the process. Therefore:

1. `createArtifacts` builds the .bloompub first; `BloomPubMaker` does `using (var helper = new PublishHelper())`.
2. Disposing it calls `PublishHelper.ReleaseBrowser()` → `OffScreenBrowser.Dispose()` → `ApplicationContext.ExitThread()`.
3. The process's only application message loop ends, so WinForms raises `Application.ApplicationExit`.
4. `ApplicationContainer.OnApplicationExit` disposes the container — the **parent** of `ProjectContext._scope`.
5. The epub step, which runs next, evaluates `s_projectContext.BookServer` → `ObjectDisposedException`.

In the GUI this never fired, because the main thread's loop is still running. It only bites a
non-GUI entry point.

### The fix

Rather than teach one more listener to distrust the event, stop telling the lie: pump the browser
thread with a bare `GetMessage`/`TranslateMessage`/`DispatchMessage` loop and end it with
`PostQuitMessage` from the teardown we already post onto that thread. That dispatches everything
the thread actually needs — the `WindowsFormsSynchronizationContext`'s marshaling control and the
WebView2's windows and async completions — while staying invisible to WinForms'
application-lifetime bookkeeping.

This removes the whole bug class: no non-GUI entry point (harvester, bulk upload, a future CLI
verb) can now be told the application is exiting merely because a worker finished with a browser.
`ReleaseBrowser`'s resource-saving intent is untouched — the browser and its thread are still torn
down per batch of page checks. Since `Application.Run` also disposed the thread's windows as its
loop ended, the pump now disposes the synchronization context itself, so we don't leave a `Control`
to be finalized on a dead thread.

### Regression test

Every existing `CreateArtifactsCommandTests` case requested a single artifact, which is exactly why
CI stayed green through this. The harvester always passes `--bloomdOutputPath`/
`--bloomDigitalOutputPath` **and** `--epubOutputPath` in one run, and only that combination exposes
the bug — with one artifact, nothing runs after the premature disposal. The new test asks for both
and fails on unmodified `master` with the production stack trace, frame for frame:

```
Expected: Success   But was: EpubException
System.ObjectDisposedException: Instances cannot be resolved and nested lifetimes cannot be created
from this LifetimeScope as it (or one of its parent scopes) has already been disposed.
   at Bloom.ProjectContext.get_BookServer() ... ProjectContext.cs:840
   at Bloom.CLI.CreateArtifactsCommand.CreateEpubArtifact ... CreateArtifactsCommand.cs:401
```

The test commit is deliberately byte-identical to the one on `BL-16668-harvester-exit-guard`, which
carries the minimal alternative fix (guarding `OnApplicationExit` on `Program.RunningHarvesterMode`)
for comparison.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16668


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8177)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8177)
<!-- Reviewable:end -->
