### PR TITLE
Don't listen for ApplicationExit when there is no GUI application (BL-16668)

### DIFF
--- a/src/BloomExe/ApplicationContainer.cs
+++ b/src/BloomExe/ApplicationContainer.cs
@@ -81,7 +81,25 @@ namespace Bloom
 
             _container = builder.Build();
 
-            Application.ApplicationExit += OnApplicationExit;
+            // Only listen for the application exiting when there IS an application in the GUI sense.
+            // A command-line verb never calls Application.Run, so the only WinForms message loop in the
+            // process belongs to some worker -- currently the dedicated thread of the off-screen browser
+            // PublishHelper uses for page checks, created and disposed once per batch. When that loop
+            // ends, WinForms decides the application is exiting and raises ApplicationExit, mid-run. Acting
+            // on that disposed this container, the parent scope of the still-in-use ProjectContext, so the
+            // next artifact step died with ObjectDisposedException (BL-16668). Not subscribing is safe
+            // because in that flow the container's lifetime is already bounded by the `using` blocks in the
+            // CLI command handlers, and the process exits as soon as those unwind.
+            //
+            // One knock-on worth knowing: OnApplicationExit is the only caller of
+            // Program.FinishLocalizationHarvesting(), so a command-line verb no longer runs it. That is
+            // #if DEBUG code which does nothing unless LocalizationManager.IgnoreExistingEnglishTranslationFiles
+            // is set, so release CLI runs are unaffected -- but a DEBUG localization-harvesting run driven
+            // through a CLI verb would no longer merge the English translation files. If we ever want that,
+            // call it from the CLI path explicitly rather than by leaning on a shutdown event that is not
+            // really telling us the application is shutting down.
+            if (!Program.RunningInConsoleMode)
+                Application.ApplicationExit += OnApplicationExit;
 
             // Register the API Handlers that are global to the application (not dependent on knowing a particular project).
             // Note: it is is a work in progress to transfer more API handlers from ProjectContext to here.
@@ -98,6 +116,10 @@ namespace Bloom
             server.ApiHandler.RecordApplicationLevelHandlers();
         }
 
+        /// <summary>
+        /// The application is really shutting down, so tear the container down. Only ever subscribed
+        /// when Bloom is running as a GUI application -- see the constructor for why.
+        /// </summary>
         private void OnApplicationExit(object sender, EventArgs e)
         {
             Application.ApplicationExit -= OnApplicationExit;

--- a/src/BloomExe/CLI/CreateArtifactsCommand.cs
+++ b/src/BloomExe/CLI/CreateArtifactsCommand.cs
@@ -195,7 +195,15 @@ namespace Bloom.CLI
                     catch (Exception ex)
                     {
                         Console.WriteLine(ex.ToString());
-                        exitCode = CreateArtifactsExitCode.EpubException;
+                        // |=, not =: these are [Flags] values and every other step here accumulates.
+                        // A plain assignment discarded whatever had already been recorded -- most
+                        // notably BookHtmlNotFound from the bloomdigital step just above -- so the
+                        // harvester was told only "EpubException" and lost the fact that the book's
+                        // HTML was also wrong. That is the combination the harvester actually hits,
+                        // since it always asks for both artifacts. Safe to accumulate from this
+                        // worker: the main thread is blocked on countdownEvent below and does not
+                        // touch exitCode until after we signal.
+                        exitCode |= CreateArtifactsExitCode.EpubException;
                     }
                     countdownEvent.Signal(); // Decrement by one
                 });

--- a/src/BloomTests/CLI/CreateArtifactsCommandTests.cs
+++ b/src/BloomTests/CLI/CreateArtifactsCommandTests.cs
@@ -11,11 +11,23 @@ namespace BloomTests.CLI
     [TestFixture]
     public class CreateArtifactsCommandTests
     {
+        [SetUp]
+        public void SetUp()
+        {
+            // Program.Main sets this for a real command-line run, before it dispatches to the verb. These
+            // tests call HandleInternal directly and so bypass Main, which means they have to stand in for
+            // it — exactly as TearDown below already does for RunningHarvesterMode. ApplicationContainer
+            // reads this flag to know there is no GUI application whose exit it should listen for; without
+            // it set, the container tears itself down mid-run and the epub step fails (BL-16668).
+            Program.RunningInConsoleMode = true;
+        }
+
         [TearDown]
         public void TearDown()
         {
             // Without this, subsequent tests will fail because they think the harvester is still running.
             Program.RunningHarvesterMode = false;
+            Program.RunningInConsoleMode = false;
         }
 
         [Test]
@@ -235,6 +247,99 @@ namespace BloomTests.CLI
                 );
 
                 Assert.That(result, Is.EqualTo(CreateArtifactsExitCode.LegacyBookCannotHarvest));
+            }
+        }
+
+        // The harvester never asks for just one artifact: it passes --bloomdOutputPath,
+        // --bloomDigitalOutputPath AND --epubOutputPath in a single createArtifacts run. That
+        // combination is what BL-16668 broke, and why every other test here missed it. Making the
+        // bloomdigital spins up (and then tears down) PublishHelper's off-screen browser, whose
+        // dedicated thread runs the only WinForms message loop a CLI process has. Ending that loop
+        // made WinForms raise Application.ApplicationExit, which disposed the ApplicationContainer --
+        // the parent scope of our still-in-use ProjectContext -- so the epub step, which runs
+        // afterwards, died with ObjectDisposedException resolving ProjectContext.BookServer and
+        // createArtifacts returned EpubException. A test that requests a single artifact cannot
+        // catch that, because nothing runs after the premature disposal.
+        [Test]
+        public void CreateArtifacts_BloomDigitalAndEpubRequestedTogether_BothCreated()
+        {
+            using (
+                var testFolder = new TemporaryFolder(
+                    "CreateArtifacts_BloomDigitalAndEpubRequestedTogether_BothCreated"
+                )
+            )
+            {
+                var collectionFolderPath = testFolder.Combine("collection");
+
+                var bookFolderPath = Path.Combine(collectionFolderPath, "book");
+                System.IO.Directory.CreateDirectory(bookFolderPath);
+                var collectionFilePath = Path.Combine(
+                    collectionFolderPath,
+                    "collection.bloomCollection"
+                );
+                var settings = new CollectionSettings(collectionFilePath);
+                settings.Save();
+                var metaData = new BookMetaData();
+                metaData.WriteToFolder(bookFolderPath);
+                var bookPath = System.IO.Path.Combine(bookFolderPath, "book.htm");
+                System.IO.File.WriteAllText(
+                    bookPath,
+                    @"<html>
+                    <body>
+						<div class='bloom-page'>
+							<div class='marginBox'>
+								<div class='bloom-translationGroup normal-style'>
+									<div class='bloom-editable normal-style bloom-content1 bloom-contentNational1 bloom-visibility-code-on' lang='en'>
+                                        Hello
+									</div>
+								</div>
+							</div>
+						</div>
+					</body>
+				</html>"
+                );
+
+                var bloomDigitalOutputPath = Path.Combine(testFolder.FolderPath, "bloomdigital");
+                var epubOutputPath = Path.Combine(testFolder.FolderPath, "epub", "book.epub");
+                // Sanity check: neither artifact exists yet, so finding them later really does mean
+                // this run made them.
+                Assert.That(
+                    Directory.Exists(bloomDigitalOutputPath),
+                    Is.False,
+                    "test setup: bloomdigital output should not exist before the run"
+                );
+                Assert.That(
+                    File.Exists(epubOutputPath),
+                    Is.False,
+                    "test setup: epub output should not exist before the run"
+                );
+
+                var result = CreateArtifactsCommand.HandleInternal(
+                    new CreateArtifactsParameters()
+                    {
+                        BookPath = bookFolderPath,
+                        CollectionPath = collectionFilePath,
+                        BloomDigitalOutputPath = bloomDigitalOutputPath,
+                        EpubOutputPath = epubOutputPath,
+                        NoAnalytics = true,
+                    }
+                );
+
+                Assert.That(
+                    result,
+                    Is.EqualTo(CreateArtifactsExitCode.Success),
+                    "createArtifacts should succeed when both a bloomdigital and an epub are requested"
+                );
+                Assert.That(
+                    File.Exists(Path.Combine(bloomDigitalOutputPath, "index.htm")),
+                    Is.True,
+                    "the bloomdigital artifact should have been created"
+                );
+                Assert.That(
+                    File.Exists(epubOutputPath),
+                    Is.True,
+                    "the epub artifact should have been created"
+                );
             }
         }
 


### PR DESCRIPTION
`Bloom.exe createArtifacts` was dying with `ObjectDisposedException` on the epub step, so the
harvester failed **every** book with epubs enabled and uploaded no artifacts at all — not even
the .bloompub it had already built successfully. Reported downstream as BH-7836.

### What was happening

A command-line verb never calls `Application.Run`, so the only WinForms message loop in the process
belongs to a worker: the dedicated thread of the off-screen browser `PublishHelper` uses for its
page checks, created and disposed once per batch. So:

1. `createArtifacts` builds the .bloompub first; `BloomPubMaker` does `using (var helper = new PublishHelper())`.
2. Disposing it calls `PublishHelper.ReleaseBrowser()` → `OffScreenBrowser.Dispose()`, ending that loop.
3. It was the process's only message loop, so WinForms raises `Application.ApplicationExit`.
4. `ApplicationContainer.OnApplicationExit` disposes the container — the **parent** of `ProjectContext._scope`.
5. The epub step, which runs next, evaluates `s_projectContext.BookServer` → `ObjectDisposedException`.

In the GUI this never fires, because the main thread's loop is still running. It only ever bit a
non-GUI entry point.

`d41fa15f9e` had already met this mechanism and made `ProjectContext.Dispose` tolerate the container
being disposed first — but the premature disposal itself remained. It was harmless there only
because it happened after all the requested work.

### The fix

Rather than act on a signal we know to be wrong, don't subscribe to it. `Program.RunningInConsoleMode`
is set by `Program.Main` for **every** command-line verb (`hydrate`, `upload`, `download`, `getfonts`,
`changeLayout`, `createArtifacts`, `spreadsheetExport`/`Import`, `sendFontAnalytics`) before it
dispatches to any of them, so gating the subscription on it means the container never hears a claim
of application exit that no GUI is behind.

Two notes on why it is this flag and this location:

- **`RunningInConsoleMode`, not `RunningHarvesterMode`.** An earlier draft used the harvester flag.
  This one covers every verb — the others never set the harvester flag and would have stayed
  exposed — and it has no ordering hazard: it is true before any container exists, whereas
  `CreateArtifactsCommand` sets `RunningHarvesterMode` *after* constructing the container, so a
  guard on that flag works only because the event happens to fire later.
- **Gating the subscription, not the handler.** The question is settled before we would subscribe,
  so there is no reason to sign up and then ignore the answer.

Verified that the console-mode branch of `Main` is self-contained — it parses, dispatches, pumps
with `Application.DoEvents()` and returns, never reaching `RunBloom`'s `Application.Run` — so
`RunningInConsoleMode` being true really does mean there is no GUI application to listen for, and no
GUI path is affected.

### Regression test

Every pre-existing `CreateArtifactsCommandTests` case requested a single artifact, which is exactly
why CI stayed green through this. The harvester always passes `--bloomdOutputPath`/
`--bloomDigitalOutputPath` **and** `--epubOutputPath` in one run, and only that combination exposes
the bug — with one artifact, nothing runs after the premature disposal. The new test asks for both
and fails on unmodified `master` with the production stack trace, frame for frame:

```
Expected: Success   But was: EpubException
System.ObjectDisposedException: Instances cannot be resolved and nested lifetimes cannot be created
from this LifetimeScope as it (or one of its parent scopes) has already been disposed.
   at Bloom.ProjectContext.get_BookServer() ... ProjectContext.cs:840
   at Bloom.CLI.CreateArtifactsCommand.CreateEpubArtifact ... CreateArtifactsCommand.cs:401
```

The tests call `HandleInternal` directly and so bypass `Main`, which sets that flag for real runs, so
they have to stand in for it — hence the new `SetUp`, mirroring what the fixture already did for
`RunningHarvesterMode` in `TearDown`. The repro was re-verified with `ApplicationContainer.cs` at
exact `master` state and that `SetUp` in place, confirming it is the fix passing the test rather than
the harness.

### Relationship to #8177

#8177 is the more thorough alternative: it stops `OffScreenBrowser` using `Application.Run` at all,
so the false `ApplicationExit` is never raised and no listener has to know to distrust it. That is
the better end state, but it is a bigger change (a private Win32 message pump) and it turned out to
have a consequence of its own — with no WinForms loop on that thread, `Application.MessageLoop` goes
false, which sent Bloom's fatal-error handler down a hard-kill path that skips releasing the
single-instance token. Fixable, and fixed there, but it widened the change.

This PR is the deliberate small-scope choice for now. **The two should not both land**: with the
pump change in place this guard is dead code.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16668


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8178)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8178)
<!-- Reviewable:end -->
