### PR TITLE
Keep the cursor in place when showing hidden characters (BL-16616)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/showInvisibles.ts
+++ b/src/BloomBrowserUI/bookEdit/js/showInvisibles.ts
@@ -1,4 +1,5 @@
 import bloomQtipUtils from "./bloomQtipUtils";
+import { EditableDivUtils } from "./editableDivUtils";
 import $ from "jquery";
 
 // For testing and debugging, functionality to replace invisible characters with symbols.
@@ -94,6 +95,13 @@ export function showInvisibles(e) {
         return;
     }
     inShowInvisiblesMode = true;
+    // Rewriting the editable's HTML below destroys the selection, which made the
+    // cursor jump to the start of the box (BL-16616). Save the caret position as a
+    // character offset and restore it afterwards; offsets stay valid because each
+    // invisible character is replaced by a single visible symbol character.
+    const selectionIndex = EditableDivUtils.getElementSelectionIndex(
+        editable.get(0),
+    );
     editable.html((i, html) => {
         // for each replacement, replace all instances of the invisible char/entity with the symbol
         invisibles.forEach(function (invisibleType) {
@@ -111,6 +119,14 @@ export function showInvisibles(e) {
         });
         return html;
     });
+    if (selectionIndex >= 0) {
+        EditableDivUtils.makeSelectionIn(
+            editable.get(0),
+            selectionIndex,
+            -1,
+            true,
+        );
+    }
     // Make one qtip per type of invisible character to explain the symbol to the user without cluttering the page too much
     const invisibleCharTypesWithQtips = new Set();
 
@@ -157,6 +173,12 @@ export function hideInvisibles(e) {
 
         // restore all the original characters
         const editable = $(e.target).closest(".bloom-editable");
+        // As in showInvisibles, preserve the caret across the HTML rewrite.
+        // On blur the selection has already left the editable, so this returns -1
+        // and we correctly don't yank the selection back.
+        const selectionIndex = EditableDivUtils.getElementSelectionIndex(
+            editable.get(0),
+        );
         editable.html((i, html) => {
             return html.replace(
                 /<span class="invisibles"[^<>]*data-original="(?:\\u(....)|(&[a-z,0-9]*;))"[^<>]*>.<\/span>/g,
@@ -166,5 +188,13 @@ export function hideInvisibles(e) {
                 },
             );
         });
+        if (selectionIndex >= 0) {
+            EditableDivUtils.makeSelectionIn(
+                editable.get(0),
+                selectionIndex,
+                -1,
+                true,
+            );
+        }
     }
 }


### PR DESCRIPTION
Ctrl+Shift+Space (show hidden characters) made the cursor jump to the start of the text box, because `showInvisibles`/`hideInvisibles` rewrite the whole bloom-editable's innerHTML (wrapping each invisible character in a symbol span on keydown, unwrapping on keyup), and replacing innerHTML destroys the selection.

Save the caret as a character offset before each rewrite and restore it afterwards, using the existing `EditableDivUtils.getElementSelectionIndex` / `makeSelectionIn` pair — the same pattern `readerToolsModel` uses around its own innerHTML rewrites. Offsets stay valid because each invisible character is swapped one-for-one with a single symbol character. On blur, the selection has already left the editable, so the index is -1 and we don't steal the selection back.

Verified live in Bloom over CDP: with the fix the caret stays put through show/hide (both with and without invisible characters present); reverting to the pre-fix code reproduces the reported jump-to-start exactly.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16616

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8180)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8180)
<!-- Reviewable:end -->
