### PR TITLE
Don't trigger long-press from shortcut keystrokes (BL-16616)

### DIFF
--- a/src/BloomBrowserUI/lib/long-press/jquery.longpress.js
+++ b/src/BloomBrowserUI/lib/long-press/jquery.longpress.js
@@ -196,6 +196,19 @@ import "./jquery.mousewheel.js";
     }
 
     function onKeyDown(e) {
+        // A keystroke with Ctrl or the Windows/Cmd key held down is a shortcut, not
+        // typing, so it never enters a character for us to offer alternates for.
+        // Without this check, holding a shortcut like Ctrl+Shift+Space (show hidden
+        // characters) popped up alternates for whatever character happened to precede
+        // the caret (BL-16616). Ctrl+Alt is exempt because Windows reports AltGr that
+        // way, and AltGr keystrokes do type characters.
+        // The exemption does mean a real Ctrl+Alt shortcut held down (e.g. Ctrl+Alt+2,
+        // heading 2) can still open the panel, as it always could. We decided to accept
+        // that rather than try to distinguish true AltGr via
+        // e.getModifierState("AltGraph"), which risks breaking long-press for genuine
+        // AltGr typists if some keyboard layout or IME path fails to report it.
+        if ((e.ctrlKey && !e.altKey) || e.metaKey) return;
+
         // See comment for BL-5215 in toolbox.ts
         window.top[isLongPressEvaluating] = true;
 


### PR DESCRIPTION
Follow-up to #8180 (keep the cursor in place when showing hidden characters). QA reported that Ctrl+Shift+Space now pops up the long-press special-characters panel.

The long-press keydown handler never checked modifier keys: holding Ctrl+Shift+Space repeats the Space keydown, which armed the long-press timer, and the timer offers alternates for whatever character precedes the caret. Before the caret fix, the destroyed selection made that lookup fail — the cursor-jump bug was the only thing keeping the panel hidden (the hole was already reachable by holding Ctrl+Space, for example).

Fix: bail out of the long-press keydown handler when Ctrl or the Windows/Cmd key is down, since such a keystroke is a shortcut and never types a character. Ctrl+Alt is exempt because Windows reports AltGr as Ctrl+Alt, and AltGr keystrokes genuinely type characters users may long-press.

Verified in a running Bloom over CDP: holding Ctrl+Shift+Space in a text box no longer shows the long-press panel and the caret stays put; holding a plain letter key still shows the panel.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16616

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8181)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8181)
<!-- Reviewable:end -->
