### PR TITLE
Fix gear icon displaced in Picture on Right page with ebook theme (BL-14901)

### DIFF
--- a/src/content/appearanceThemes/appearance-theme-rounded-border-ebook.css
+++ b/src/content/appearanceThemes/appearance-theme-rounded-border-ebook.css
@@ -122,3 +122,12 @@
     --pageNumber-left-margin: deliberately-invalid; /* prevents left being set at all. unset does not work. Prevent centering for this layout */
     --pageNumber-always-left-margin: deliberately-invalid; /* prevents left being set at all. unset does not work. Prevent centering for this layout */
 }
+
+:is(
+        .Ebook7x5Landscape,
+        .Device16x9Landscape
+    ).numberedPage.pictureOnRight.pictureOnRight {
+    /* On these pages the page number moves to the right side (rule above),
+       so the format button has nothing to dodge (BL-14901) */
+    --formatButton-pageNumber-dodge: 0px;
+}

--- a/src/content/appearanceThemes/appearance-theme-zero-margin-ebook.css
+++ b/src/content/appearanceThemes/appearance-theme-zero-margin-ebook.css
@@ -82,3 +82,9 @@ Note that hiding the page numbers is done by a setting in appearance.json, not h
     /* move so that page number doesn't it hide it if the text box is in the lower left */
     --formatButton-pageNumber-dodge: 20px;
 }
+.Ebook7x5Landscape.numberedPage.pictureOnRight.pictureOnRight,
+.Device16x9Landscape.numberedPage.pictureOnRight.pictureOnRight {
+    /* On these pages the page number moves to the right side (rule above),
+       so the format button has nothing to dodge (BL-14901) */
+    --formatButton-pageNumber-dodge: 0px;
+}


### PR DESCRIPTION
Fixes the 6.0 regression where the format cog (gear icon) on a "Picture on Right" page was displaced away from the book margin when the book uses an ebook page theme.

The two ebook appearance themes (Zero Margin Ebook, Rounded Border Ebook) set `--formatButton-pageNumber-dodge: 20px` so the edit-mode cog dodges the page number, which those themes normally place at the bottom left. But on landscape `pictureOnRight` pages the same themes move the page number to the right side, so the dodge just pushed the cog 20px away from the margin for nothing. Each theme now zeroes the dodge using the same `pictureOnRight` selectors it already uses to move the page number.

The fix is deliberately in the theme files rather than the shared `editMode.less` dodge rule: the EFL migration stylesheets also set a dodge but keep their page number bottom-left on `pictureOnRight` pages, so a blanket rule would have regressed BL-13206 for those books.

Verified live in Bloom (Device16x9Landscape book, Image on Right page + Basic Text & Image control page, both ebook themes): the cog's computed `margin-left` is now 3px (was 23px) on the pictureOnRight page, and remains 23px (dodge intact) on the control page.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-14901

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8182)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8182)
<!-- Reviewable:end -->
