### PR TITLE
Fix Cancel Upload sometimes doing nothing (BL-16340)

### DIFF
--- a/src/BloomBrowserUI/publish/LibraryPublish/LibraryPublishSteps.tsx
+++ b/src/BloomBrowserUI/publish/LibraryPublish/LibraryPublishSteps.tsx
@@ -294,9 +294,14 @@ export const LibraryPublishSteps: React.FunctionComponent<{
         );
     };
 
+    // True from the moment the user clicks Cancel until C# reports what became of the upload.
+    // While it is true, UPLOAD BOOK is greyed out, so every path that ends an upload has to
+    // clear it. Missing one leaves the user with no working button at all and no way back
+    // short of leaving the screen, which is how BL-16340 presented.
     const [isCanceling, setIsCanceling] = useState<boolean>(false);
     const handleUploadError = React.useCallback(() => {
         setIsUploading(false);
+        setIsCanceling(false);
     }, []);
 
     useSubscribeToWebSocketForEvent(
@@ -339,6 +344,10 @@ export const LibraryPublishSteps: React.FunctionComponent<{
         kWebSocketEventId_uploadSuccessful,
         (results) => {
             setIsUploading(false);
+            // The user may have asked to cancel and C# finished anyway -- either the cancel
+            // arrived after the upload was committed, or it was delayed getting to C# at all.
+            // Whatever the reason, the upload is over, so the Cancel state has to end with it.
+            setIsCanceling(false);
             setBookUrl(results.url);
             setIsUploadComplete(true);
         },

--- a/src/BloomBrowserUI/publish/LibraryPublish/LibraryPublishSteps.tsx
+++ b/src/BloomBrowserUI/publish/LibraryPublish/LibraryPublishSteps.tsx
@@ -248,6 +248,8 @@ export const LibraryPublishSteps: React.FunctionComponent<{
     function uploadOneBook() {
         setIsUploadComplete(false);
         setIsUploading(true);
+        cancelRequestedRef.current = false;
+        setHasAttemptBegun(false);
         // If either pre-upload request dies at the transport level we get no reply and no progress
         // message, so nothing else would ever clear isUploading. That used to leave only a stale
         // Cancel button, but now it would also keep the other publish tools disabled, so clear it
@@ -260,6 +262,10 @@ export const LibraryPublishSteps: React.FunctionComponent<{
                     // The API already sent an error message
                     return;
                 }
+                // C# has now marked the attempt as started, so a Cancel from here on cannot be
+                // wiped out by that same request arriving late. Only now do we let the user
+                // press Cancel. See the note on hasAttemptBegun.
+                setHasAttemptBegun(true);
                 get(
                     "libraryPublish/getUploadCollisionInfo?index=" +
                         conflictIndex,
@@ -268,6 +274,12 @@ export const LibraryPublishSteps: React.FunctionComponent<{
                             // The API already sent an error message
                             return;
                         }
+                        // The user cancelled while we were asking the server about an existing
+                        // copy. That reply is no longer wanted: showing the collision dialog now
+                        // would pop a dialog up over an attempt the user has abandoned, and
+                        // posting the upload would only be declined. Either way we say nothing
+                        // more -- C# has already reported the cancellation. (BL-16340)
+                        if (cancelRequestedRef.current) return;
                         if (result.data.shouldShow) {
                             setUploadCollisionInfo(result.data);
                             showUploadCollisionDialog();
@@ -306,8 +318,22 @@ export const LibraryPublishSteps: React.FunctionComponent<{
     // a cancel-pending upload was still running -- and pressing it would then clear the pending
     // cancel server-side and start a second upload alongside the first.
     const [isCanceling, setIsCanceling] = useState<boolean>(false);
+
+    // True once C# has acknowledged the start of this attempt (the subscription check has come
+    // back). Until then Cancel is shown but disabled, because a cancel sent before C# knows an
+    // attempt exists races with the request that begins it -- and if the cancel loses that race
+    // it is wiped out and the book uploads anyway. Waiting for the acknowledgement removes the
+    // race by construction rather than narrowing it. (BL-16340)
+    const [hasAttemptBegun, setHasAttemptBegun] = useState<boolean>(false);
+
+    // Whether the user has cancelled the attempt that is currently starting up. This is a ref,
+    // not state, because the pre-upload callbacks below close over their render's values and
+    // would not see a state update made after they were created.
+    const cancelRequestedRef = useRef(false);
+
     const handleUploadError = React.useCallback(() => {
         setIsUploading(false);
+        setHasAttemptBegun(false);
     }, []);
 
     useSubscribeToWebSocketForEvent(
@@ -315,6 +341,7 @@ export const LibraryPublishSteps: React.FunctionComponent<{
         kWebSocketEventId_uploadCanceled,
         () => {
             setIsCanceling(false);
+            setHasAttemptBegun(false);
         },
     );
 
@@ -354,6 +381,7 @@ export const LibraryPublishSteps: React.FunctionComponent<{
             // arrived after the upload was committed, or it was delayed getting to C# at all.
             // Whatever the reason, the upload is over, so the Cancel state has to end with it.
             setIsCanceling(false);
+            setHasAttemptBegun(false);
             setBookUrl(results.url);
             setIsUploadComplete(true);
         },
@@ -644,9 +672,10 @@ export const LibraryPublishSteps: React.FunctionComponent<{
                             )}
                             {isUploading ? (
                                 <BloomButton
-                                    enabled={!isCanceling}
+                                    enabled={!isCanceling && hasAttemptBegun}
                                     l10nKey={"Common.Cancel"}
                                     onClick={() => {
+                                        cancelRequestedRef.current = true;
                                         setIsCanceling(true);
                                         setIsUploading(false);
                                         post("libraryPublish/cancel");
@@ -762,6 +791,7 @@ export const LibraryPublishSteps: React.FunctionComponent<{
                 {...uploadCollisionInfo}
                 onCancel={() => {
                     setIsUploading(false);
+                    setHasAttemptBegun(false);
                 }}
                 conflictIndex={conflictIndex}
                 setConflictIndex={changeConflictIndex}

--- a/src/BloomBrowserUI/publish/LibraryPublish/LibraryPublishSteps.tsx
+++ b/src/BloomBrowserUI/publish/LibraryPublish/LibraryPublishSteps.tsx
@@ -297,11 +297,17 @@ export const LibraryPublishSteps: React.FunctionComponent<{
     // True from the moment the user clicks Cancel until C# reports what became of the upload.
     // While it is true, UPLOAD BOOK is greyed out, so every path that ends an upload has to
     // clear it. Missing one leaves the user with no working button at all and no way back
-    // short of leaving the screen, which is how BL-16340 presented.
+    // short of leaving the screen, which is how BL-16340 presented. The two things that clear
+    // it are the uploadCanceled event and uploadSuccessful, and C# now guarantees one of them
+    // on every ending of a cancelled upload.
+    //
+    // Deliberately NOT cleared here on an error line: this fires for ANY Error-kind progress
+    // message, not just a terminal one, so clearing it here would re-enable UPLOAD BOOK while
+    // a cancel-pending upload was still running -- and pressing it would then clear the pending
+    // cancel server-side and start a second upload alongside the first.
     const [isCanceling, setIsCanceling] = useState<boolean>(false);
     const handleUploadError = React.useCallback(() => {
         setIsUploading(false);
-        setIsCanceling(false);
     }, []);
 
     useSubscribeToWebSocketForEvent(

--- a/src/BloomExe/web/WebProgressAdapter.cs
+++ b/src/BloomExe/web/WebProgressAdapter.cs
@@ -45,7 +45,17 @@ namespace Bloom.web
             set { _showVerbose = value; }
         }
 
-        public bool CancelRequested { get; set; }
+        // Volatile because a cancel is set by an api handler on a server worker thread while the
+        // work being cancelled polls this from a background thread, with no lock between the two
+        // (BL-16340). An auto-property gives no such guarantee.
+        private volatile bool _cancelRequested;
+
+        public bool CancelRequested
+        {
+            get { return _cancelRequested; }
+            set { _cancelRequested = value; }
+        }
+
         public bool ErrorEncountered
         {
             get { return false; }

--- a/src/BloomExe/web/controllers/LibraryPublishApi.cs
+++ b/src/BloomExe/web/controllers/LibraryPublishApi.cs
@@ -289,12 +289,14 @@ namespace Bloom.web.controllers
             }
             if (alreadyCancelled)
             {
-                // The user cancelled during the pre-upload round trips, yet the client has still
-                // asked us to upload. That is a real path, not a stray request: the "this book is
-                // already on BloomLibrary" dialog can still be on screen after a cancel, and each
-                // of its buttons posts here. Say so rather than declining in silence, which would
-                // leave the user pressing a button that does nothing at all. (BL-16340)
-                ReportUploadCanceled();
+                // The user cancelled and this upload request is what is left of the attempt --
+                // most often one the client had already posted, which then queued behind the UI
+                // thread while the lock-free cancel overtook it. HandleCancel has therefore
+                // already said "Upload was cancelled"; saying it again would put two identical
+                // red lines in the log for a single click. Send the event only: it costs nothing
+                // (the client just clears the same state again) and guarantees the screen is
+                // released even if this request is the last thing to happen. (BL-16340)
+                ReportUploadCanceled(withMessage: false);
                 request.PostSucceeded();
                 return;
             }
@@ -611,10 +613,11 @@ namespace Bloom.web.controllers
             // "already on BloomLibrary" dialog, which can still be on screen after the user
             // cancelled; without this check we would give the book a brand-new instance id on
             // disk and then decline to upload it, leaving its identity permanently changed for
-            // an upload that never happened. (BL-16340)
+            // an upload that never happened. Event only, for the same reason as in HandleUpload:
+            // the cancellation has already been announced. (BL-16340)
             if (_progress.CancelRequested)
             {
-                ReportUploadCanceled();
+                ReportUploadCanceled(withMessage: false);
                 request.PostSucceeded();
                 return;
             }

--- a/src/BloomExe/web/controllers/LibraryPublishApi.cs
+++ b/src/BloomExe/web/controllers/LibraryPublishApi.cs
@@ -178,23 +178,27 @@ namespace Bloom.web.controllers
         /// </summary>
         private void HandleCancel(ApiRequest request)
         {
-            // If the user clicked Cancel before the upload itself got under way, no upload is
-            // running to notice the flag and report on it. That window is real and not small:
-            // the client shows Cancel from the moment the user commits, but two API round trips
-            // (the subscription check and the "existing copy on server" query) happen before
-            // libraryPublish/upload even arrives. Nothing else would ever tell the client the
-            // cancel took effect -- and the client only ever leaves its Cancel state on that
-            // report -- so make the report here. HandleUpload takes the same lock and declines
-            // to start. (BL-16340)
+            // Whether we announce the cancellation ourselves depends on how far the attempt has
+            // got. Only in StartingUp is there nobody else to do it: the client shows Cancel from
+            // the moment the user commits, but two API round trips (the subscription check and
+            // the "existing copy on server" query) happen before libraryPublish/upload arrives,
+            // so during those there is no upload running to notice the flag -- and the screen
+            // only ever leaves its Cancel state on such a report. While Uploading, UploadBookAsync
+            // reports whatever becomes of it. When Idle we must stay SILENT: the attempt is
+            // already over, and announcing a cancellation then would contradict the outcome the
+            // user was just given -- telling someone their upload was cancelled seconds after
+            // being told it succeeded is worse than saying nothing. (BL-16340)
             bool nobodyElseWillReportIt;
             lock (_uploadStateLock)
             {
                 _progress.CancelRequested = true;
-                nobodyElseWillReportIt = !_uploadInProgress;
+                nobodyElseWillReportIt = _attemptState == UploadAttemptState.StartingUp;
+                if (nobodyElseWillReportIt)
+                    _attemptState = UploadAttemptState.Idle; // we are about to report it
             }
 
             // Outside the lock: this sends a websocket message, and the lock exists only to make
-            // the flag pair above indivisible.
+            // the state read/write above indivisible.
             if (nobodyElseWillReportIt)
                 ReportUploadCanceled();
 
@@ -227,15 +231,31 @@ namespace Bloom.web.controllers
 
         private bool _changeUploader = false;
 
-        // True from the moment we take charge of an upload until we have reported its outcome.
-        // HandleCancel uses it to work out whether anyone else is going to report the cancel.
-        private bool _uploadInProgress;
+        /// <summary>
+        /// How far the current upload attempt has got, as C# sees it. It exists so HandleCancel
+        /// can tell whether anyone else is going to report a cancellation -- and, just as
+        /// importantly, whether the attempt is already over and it should say nothing at all.
+        /// </summary>
+        private enum UploadAttemptState
+        {
+            /// No attempt is under way, or the last one's outcome has already been reported.
+            Idle,
 
-        // Makes "is a cancel already pending?" and "an upload is now running" one indivisible
-        // step, shared with HandleCancel. Without it the two could interleave such that
-        // HandleCancel reported the cancel AND the upload started anyway, so the cancel got
-        // reported twice. Only ever held across these two field reads/writes -- never across
-        // the upload, or a websocket send.
+            /// The client has committed to an upload and is making the pre-upload round trips,
+            /// but libraryPublish/upload has not arrived yet.
+            StartingUp,
+
+            /// An upload is running; UploadBookAsync will report whatever becomes of it.
+            Uploading,
+        }
+
+        private UploadAttemptState _attemptState = UploadAttemptState.Idle;
+
+        // Guards _attemptState together with _progress.CancelRequested, so that reading one and
+        // writing the other is a single indivisible step. Without it the two could interleave
+        // such that HandleCancel reported the cancel AND the upload started anyway, so the
+        // cancel got reported twice. Only ever held across those field reads/writes -- never
+        // across the upload, the HTTP response, or a websocket send.
         private readonly object _uploadStateLock = new object();
 
         private async Task HandleUpload(ApiRequest request, bool changeUploader)
@@ -253,12 +273,16 @@ namespace Bloom.web.controllers
             {
                 alreadyCancelled = _progress.CancelRequested;
                 if (!alreadyCancelled)
-                    _uploadInProgress = true;
+                    _attemptState = UploadAttemptState.Uploading;
             }
             if (alreadyCancelled)
             {
-                // A cancel arrived during the pre-upload handshake. HandleCancel has already
-                // told the user, so all that is left to do is not upload.
+                // The user cancelled during the pre-upload round trips, yet the client has still
+                // asked us to upload. That is a real path, not a stray request: the "this book is
+                // already on BloomLibrary" dialog can still be on screen after a cancel, and each
+                // of its buttons posts here. Say so rather than declining in silence, which would
+                // leave the user pressing a button that does nothing at all. (BL-16340)
+                ReportUploadCanceled();
                 request.PostSucceeded();
                 return;
             }
@@ -272,8 +296,10 @@ namespace Bloom.web.controllers
             }
             finally
             {
+                // The attempt is over and its outcome has been reported, so a cancel arriving
+                // from here on is too late to mean anything -- see HandleCancel.
                 lock (_uploadStateLock)
-                    _uploadInProgress = false;
+                    _attemptState = UploadAttemptState.Idle;
             }
             request.PostSucceeded();
         }
@@ -431,8 +457,9 @@ namespace Bloom.web.controllers
 
             // Bulk upload shares _progress with single-book upload but has no Cancel of its own,
             // so a cancellation left over from an earlier single-book upload would silently stop
-            // it before it started.
-            _progress.CancelRequested = false;
+            // it before it started. Taken under the same lock as every other write to this flag.
+            lock (_uploadStateLock)
+                _progress.CancelRequested = false;
 
             Model.BulkUpload(Model.Book.CollectionSettings.FolderPath, _progress);
             request.PostSucceeded();
@@ -447,7 +474,8 @@ namespace Bloom.web.controllers
             }
 
             // See the note in HandleUploadCollection about why this is cleared here.
-            _progress.CancelRequested = false;
+            lock (_uploadStateLock)
+                _progress.CancelRequested = false;
 
             var folderPath = request.RequiredPostString();
             if (!string.IsNullOrEmpty(folderPath) && Directory.Exists(folderPath))
@@ -516,7 +544,11 @@ namespace Bloom.web.controllers
             // as far as C# is concerned it is where a new attempt begins -- and therefore where
             // any cancellation left over from an earlier attempt is cleared. Deliberately not in
             // HandleUpload, which arrives too late to clear it safely; see the note there.
-            _progress.CancelRequested = false;
+            lock (_uploadStateLock)
+            {
+                _progress.CancelRequested = false;
+                _attemptState = UploadAttemptState.StartingUp;
+            }
 
             var subscriptionMatch = Model.CheckSubscriptionMatchBeforeUpload();
             if (subscriptionMatch != null)
@@ -539,6 +571,18 @@ namespace Bloom.web.controllers
 
         private async Task HandleUploadAfterChangingBookId(ApiRequest request)
         {
+            // Check for a pending cancel BEFORE changing anything. This is reached from the
+            // "already on BloomLibrary" dialog, which can still be on screen after the user
+            // cancelled; without this check we would give the book a brand-new instance id on
+            // disk and then decline to upload it, leaving its identity permanently changed for
+            // an upload that never happened. (BL-16340)
+            if (_progress.CancelRequested)
+            {
+                ReportUploadCanceled();
+                request.PostSucceeded();
+                return;
+            }
+
             if (!Model.ChangeBookInstanceId(_progress))
             {
                 request.Failed("Can't fix ID because in TC");

--- a/src/BloomExe/web/controllers/LibraryPublishApi.cs
+++ b/src/BloomExe/web/controllers/LibraryPublishApi.cs
@@ -286,9 +286,10 @@ namespace Bloom.web.controllers
                 request.PostSucceeded();
                 return;
             }
+            var toldClientTheOutcome = false;
             try
             {
-                await UploadBookAsync();
+                toldClientTheOutcome = await UploadBookAsync();
             }
             catch (Exception)
             {
@@ -296,15 +297,35 @@ namespace Bloom.web.controllers
             }
             finally
             {
-                // The attempt is over and its outcome has been reported, so a cancel arriving
-                // from here on is too late to mean anything -- see HandleCancel.
+                // The attempt is over, so a cancel arriving from here on is too late to mean
+                // anything -- see HandleCancel.
+                bool mustStillReleaseTheScreen;
                 lock (_uploadStateLock)
+                {
                     _attemptState = UploadAttemptState.Idle;
+
+                    // A cancel can land after UploadBookAsync has already decided how this
+                    // ended. If the upload then finished in a way that emits only an error line
+                    // -- a failure or an exception -- nothing would ever release the screen from
+                    // its Cancel state, and UPLOAD BOOK would stay greyed out for good: the
+                    // original BL-16340 symptom, just through a narrower window. So make the end
+                    // of every attempt reconcile. Sending the event twice is harmless (the
+                    // client just clears the same state again); not sending it is not.
+                    mustStillReleaseTheScreen = _progress.CancelRequested && !toldClientTheOutcome;
+                }
+                if (mustStillReleaseTheScreen)
+                    ReportUploadCanceled(withMessage: false); // the failure was already reported
             }
             request.PostSucceeded();
         }
 
-        private async Task UploadBookAsync()
+        /// <summary>
+        /// Runs the upload and tells the user how it went.
+        /// </summary>
+        /// <returns>True if we sent the client an outcome EVENT (uploadSuccessful or
+        /// uploadCanceled) rather than only a progress message. The caller needs to know,
+        /// because the screen leaves its Cancel state only on such an event.</returns>
+        private async Task<bool> UploadBookAsync()
         {
             _webSocketProgress.Message("Common.Starting", "Starting...");
             SetParentControlsState(false); // Disable UI
@@ -370,24 +391,26 @@ namespace Bloom.web.controllers
                 // left permanently greyed out -- the whole of BL-16340. For "quiet" a message
                 // has already been given, so send the event without adding a second one.
                 ReportUploadCanceled(withMessage: uploadResult != "quiet");
-                return;
+                return true;
             }
 
             if (caughtException != null)
             {
                 ReportBasicErrorDuringUpload();
                 _webSocketProgress.Exception(caughtException);
-                return;
+                return false;
             }
 
             if (uploadResult == "quiet")
             {
                 // no more reporting, sufficient message already given.
+                return false;
             }
             else if (string.IsNullOrEmpty(uploadResult))
             {
                 // Something went wrong, possibly already reported.
                 ReportTryAgainDuringUpload();
+                return false;
             }
             else
             {
@@ -404,6 +427,7 @@ namespace Bloom.web.controllers
                     kWebSocketEventId_uploadSuccessful,
                     result
                 );
+                return true;
             }
         }
 

--- a/src/BloomExe/web/controllers/LibraryPublishApi.cs
+++ b/src/BloomExe/web/controllers/LibraryPublishApi.cs
@@ -103,7 +103,15 @@ namespace Bloom.web.controllers
             );
             apiHandler.RegisterEndpointHandler("libraryPublish/setSummary", HandleSetSummary, true);
             apiHandler.RegisterEndpointHandler("libraryPublish/useSandbox", HandleUseSandbox, true);
-            apiHandler.RegisterEndpointHandler("libraryPublish/cancel", HandleCancel, true);
+            // Deliberately handled off the UI thread and without the api sync lock. All this
+            // handler does is set a flag, but its whole purpose is to interrupt an upload which
+            // may be monopolizing both the UI thread (offscreen-browser thumbnailing) and the
+            // lock for minutes at a time. If the cancel had to queue behind the very work it is
+            // trying to stop, the flag could get set only after the upload had passed its last
+            // cancellation check: the upload would run to completion and the user would be left
+            // with a Cancel that did nothing (BL-16340). Compare progress/cancel and
+            // signLanguage/cancelImportVideo, which are registered this way for the same reason.
+            apiHandler.RegisterEndpointHandler("libraryPublish/cancel", HandleCancel, false, false);
             apiHandler.RegisterEndpointHandler(
                 "libraryPublish/getUploadCollisionInfo",
                 HandleGetUploadCollisionInfo,
@@ -163,10 +171,38 @@ namespace Bloom.web.controllers
             request.ReplyWithBoolean(BookUpload.UseSandbox);
         }
 
+        /// <summary>
+        /// Ask the upload to stop. All we do is set the flag that the upload polls between its
+        /// stages; it can take a while to notice, since we don't interrupt a stage (notably PDF
+        /// creation) that is already under way.
+        /// </summary>
         private void HandleCancel(ApiRequest request)
         {
             _progress.CancelRequested = true;
+
+            // If the user clicked Cancel before the upload itself got under way, no upload is
+            // running to notice the flag and report on it. That window is real and not small:
+            // the client shows Cancel from the moment the user commits, but two API round trips
+            // (the subscription check and the "existing copy on server" query) happen before
+            // libraryPublish/upload even arrives. Nothing else would ever tell the client the
+            // cancel took effect -- and the client only ever leaves its Cancel state on that
+            // report -- so make the report here. HandleUpload checks the same flag and declines
+            // to start. (BL-16340)
+            if (!_uploadInProgress)
+                ReportUploadCanceled();
+
             request.PostSucceeded();
+        }
+
+        /// <summary>
+        /// Tell the user, and the publish screen, that the upload was cancelled. Sending the
+        /// event matters as much as showing the message: the screen greys out UPLOAD BOOK as
+        /// soon as the user clicks Cancel, and this event is the only thing that brings it back.
+        /// </summary>
+        private void ReportUploadCanceled()
+        {
+            _webSocketProgress.Message("Cancelled", "Upload was cancelled", ProgressKind.Error);
+            _webSocketServer.SendEvent(kWebSocketContext, kWebSocketEventId_uploadCanceled);
         }
 
         private async Task HandleUpload(ApiRequest request)
@@ -181,14 +217,30 @@ namespace Bloom.web.controllers
 
         private bool _changeUploader = false;
 
+        // True from the moment we take charge of an upload until we have reported its outcome.
+        // HandleCancel uses it to work out whether anyone else is going to report the cancel.
+        // Volatile because it is written here on one thread and read by HandleCancel on another.
+        private volatile bool _uploadInProgress;
+
         private async Task HandleUpload(ApiRequest request, bool changeUploader)
         {
             if (request.HttpMethod == HttpMethods.Get)
                 return;
             _changeUploader = changeUploader;
 
-            _progress.CancelRequested = false;
+            // Note that we deliberately do NOT clear CancelRequested here. The user can click
+            // Cancel before this request arrives (see HandleCancel), and clearing it here would
+            // throw that cancel away and upload the book anyway (BL-16340). It is cleared in
+            // HandleCheckSubscriptionMatch, which the client calls at the start of every attempt.
+            if (_progress.CancelRequested)
+            {
+                // A cancel arrived during the pre-upload handshake. HandleCancel has already
+                // told the user, so all that is left to do is not upload.
+                request.PostSucceeded();
+                return;
+            }
 
+            _uploadInProgress = true;
             try
             {
                 await UploadBookAsync();
@@ -196,6 +248,10 @@ namespace Bloom.web.controllers
             catch (Exception)
             {
                 ReportTryAgainDuringUpload();
+            }
+            finally
+            {
+                _uploadInProgress = false;
             }
             request.PostSucceeded();
         }
@@ -251,10 +307,14 @@ namespace Bloom.web.controllers
                 SetParentControlsState(true); // Re-enable UI
             }
 
-            if (_progress.CancelRequested)
+            // A cancel that arrived too late to stop anything must not be reported as though it
+            // had worked: if we got a book id back, the book really is on BloomLibrary now, and
+            // telling the user it was cancelled is a falsehood they might act on. uploadResult is
+            // empty when the upload was abandoned (including by the cancellation checks inside
+            // BookUpload) or failed, and "quiet" when a message has already been given.
+            if (_progress.CancelRequested && string.IsNullOrEmpty(uploadResult))
             {
-                _webSocketProgress.Message("Cancelled", "Upload was cancelled", ProgressKind.Error);
-                _webSocketServer.SendEvent(kWebSocketContext, kWebSocketEventId_uploadCanceled);
+                ReportUploadCanceled();
                 return;
             }
 
@@ -340,6 +400,11 @@ namespace Bloom.web.controllers
                 return;
             }
 
+            // Bulk upload shares _progress with single-book upload but has no Cancel of its own,
+            // so a cancellation left over from an earlier single-book upload would silently stop
+            // it before it started.
+            _progress.CancelRequested = false;
+
             Model.BulkUpload(Model.Book.CollectionSettings.FolderPath, _progress);
             request.PostSucceeded();
         }
@@ -351,6 +416,9 @@ namespace Bloom.web.controllers
                 request.PostSucceeded();
                 return;
             }
+
+            // See the note in HandleUploadCollection about why this is cleared here.
+            _progress.CancelRequested = false;
 
             var folderPath = request.RequiredPostString();
             if (!string.IsNullOrEmpty(folderPath) && Directory.Exists(folderPath))
@@ -415,6 +483,12 @@ namespace Bloom.web.controllers
 
         private void HandleCheckSubscriptionMatch(ApiRequest request)
         {
+            // This is the first thing the client asks for once the user commits to an upload, so
+            // as far as C# is concerned it is where a new attempt begins -- and therefore where
+            // any cancellation left over from an earlier attempt is cleared. Deliberately not in
+            // HandleUpload, which arrives too late to clear it safely; see the note there.
+            _progress.CancelRequested = false;
+
             var subscriptionMatch = Model.CheckSubscriptionMatchBeforeUpload();
             if (subscriptionMatch != null)
             {

--- a/src/BloomExe/web/controllers/LibraryPublishApi.cs
+++ b/src/BloomExe/web/controllers/LibraryPublishApi.cs
@@ -178,17 +178,24 @@ namespace Bloom.web.controllers
         /// </summary>
         private void HandleCancel(ApiRequest request)
         {
-            _progress.CancelRequested = true;
-
             // If the user clicked Cancel before the upload itself got under way, no upload is
             // running to notice the flag and report on it. That window is real and not small:
             // the client shows Cancel from the moment the user commits, but two API round trips
             // (the subscription check and the "existing copy on server" query) happen before
             // libraryPublish/upload even arrives. Nothing else would ever tell the client the
             // cancel took effect -- and the client only ever leaves its Cancel state on that
-            // report -- so make the report here. HandleUpload checks the same flag and declines
+            // report -- so make the report here. HandleUpload takes the same lock and declines
             // to start. (BL-16340)
-            if (!_uploadInProgress)
+            bool nobodyElseWillReportIt;
+            lock (_uploadStateLock)
+            {
+                _progress.CancelRequested = true;
+                nobodyElseWillReportIt = !_uploadInProgress;
+            }
+
+            // Outside the lock: this sends a websocket message, and the lock exists only to make
+            // the flag pair above indivisible.
+            if (nobodyElseWillReportIt)
                 ReportUploadCanceled();
 
             request.PostSucceeded();
@@ -198,10 +205,13 @@ namespace Bloom.web.controllers
         /// Tell the user, and the publish screen, that the upload was cancelled. Sending the
         /// event matters as much as showing the message: the screen greys out UPLOAD BOOK as
         /// soon as the user clicks Cancel, and this event is the only thing that brings it back.
+        /// Pass false for withMessage when a message has already been given, to avoid a second
+        /// one -- the event still has to go out.
         /// </summary>
-        private void ReportUploadCanceled()
+        private void ReportUploadCanceled(bool withMessage = true)
         {
-            _webSocketProgress.Message("Cancelled", "Upload was cancelled", ProgressKind.Error);
+            if (withMessage)
+                _webSocketProgress.Message("Cancelled", "Upload was cancelled", ProgressKind.Error);
             _webSocketServer.SendEvent(kWebSocketContext, kWebSocketEventId_uploadCanceled);
         }
 
@@ -219,8 +229,14 @@ namespace Bloom.web.controllers
 
         // True from the moment we take charge of an upload until we have reported its outcome.
         // HandleCancel uses it to work out whether anyone else is going to report the cancel.
-        // Volatile because it is written here on one thread and read by HandleCancel on another.
-        private volatile bool _uploadInProgress;
+        private bool _uploadInProgress;
+
+        // Makes "is a cancel already pending?" and "an upload is now running" one indivisible
+        // step, shared with HandleCancel. Without it the two could interleave such that
+        // HandleCancel reported the cancel AND the upload started anyway, so the cancel got
+        // reported twice. Only ever held across these two field reads/writes -- never across
+        // the upload, or a websocket send.
+        private readonly object _uploadStateLock = new object();
 
         private async Task HandleUpload(ApiRequest request, bool changeUploader)
         {
@@ -232,15 +248,20 @@ namespace Bloom.web.controllers
             // Cancel before this request arrives (see HandleCancel), and clearing it here would
             // throw that cancel away and upload the book anyway (BL-16340). It is cleared in
             // HandleCheckSubscriptionMatch, which the client calls at the start of every attempt.
-            if (_progress.CancelRequested)
+            bool alreadyCancelled;
+            lock (_uploadStateLock)
+            {
+                alreadyCancelled = _progress.CancelRequested;
+                if (!alreadyCancelled)
+                    _uploadInProgress = true;
+            }
+            if (alreadyCancelled)
             {
                 // A cancel arrived during the pre-upload handshake. HandleCancel has already
                 // told the user, so all that is left to do is not upload.
                 request.PostSucceeded();
                 return;
             }
-
-            _uploadInProgress = true;
             try
             {
                 await UploadBookAsync();
@@ -251,7 +272,8 @@ namespace Bloom.web.controllers
             }
             finally
             {
-                _uploadInProgress = false;
+                lock (_uploadStateLock)
+                    _uploadInProgress = false;
             }
             request.PostSucceeded();
         }
@@ -312,9 +334,16 @@ namespace Bloom.web.controllers
             // telling the user it was cancelled is a falsehood they might act on. uploadResult is
             // empty when the upload was abandoned (including by the cancellation checks inside
             // BookUpload) or failed, and "quiet" when a message has already been given.
-            if (_progress.CancelRequested && string.IsNullOrEmpty(uploadResult))
+            var uploadActuallyCompleted =
+                !string.IsNullOrEmpty(uploadResult) && uploadResult != "quiet";
+            if (_progress.CancelRequested && !uploadActuallyCompleted)
             {
-                ReportUploadCanceled();
+                // Send the event on EVERY cancelled ending, including the "quiet" one. The
+                // screen's Cancel state is cleared only by this event, and making it depend
+                // instead on some other path happening to emit an error line is how it gets
+                // left permanently greyed out -- the whole of BL-16340. For "quiet" a message
+                // has already been given, so send the event without adding a second one.
+                ReportUploadCanceled(withMessage: uploadResult != "quiet");
                 return;
             }
 

--- a/src/BloomExe/web/controllers/LibraryPublishApi.cs
+++ b/src/BloomExe/web/controllers/LibraryPublishApi.cs
@@ -188,19 +188,31 @@ namespace Bloom.web.controllers
             // already over, and announcing a cancellation then would contradict the outcome the
             // user was just given -- telling someone their upload was cancelled seconds after
             // being told it succeeded is worse than saying nothing. (BL-16340)
-            bool nobodyElseWillReportIt;
+            UploadAttemptState stateWhenCancelled;
             lock (_uploadStateLock)
             {
                 _progress.CancelRequested = true;
-                nobodyElseWillReportIt = _attemptState == UploadAttemptState.StartingUp;
-                if (nobodyElseWillReportIt)
+                stateWhenCancelled = _attemptState;
+                if (stateWhenCancelled == UploadAttemptState.StartingUp)
                     _attemptState = UploadAttemptState.Idle; // we are about to report it
             }
 
-            // Outside the lock: this sends a websocket message, and the lock exists only to make
+            // Outside the lock: these send websocket messages, and the lock exists only to make
             // the state read/write above indivisible.
-            if (nobodyElseWillReportIt)
+            if (stateWhenCancelled == UploadAttemptState.StartingUp)
+            {
                 ReportUploadCanceled();
+            }
+            else if (stateWhenCancelled == UploadAttemptState.Idle)
+            {
+                // Nothing was running, so we have nothing to say about how it went -- but the
+                // screen may still be sitting in its Cancel state (an upload can finish in the
+                // moment between the user's click and this request arriving). Send the event
+                // alone: it releases the screen without claiming an upload was cancelled when
+                // it may in fact have just succeeded.
+                ReportUploadCanceled(withMessage: false);
+            }
+            // Uploading: UploadBookAsync reports whatever becomes of it.
 
             request.PostSucceeded();
         }

--- a/src/BloomTests/web/controllers/EndpointHandlerTests.cs
+++ b/src/BloomTests/web/controllers/EndpointHandlerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading;
+using System.Threading.Tasks;
 using Bloom.Api;
 using Bloom.Book;
 using NUnit.Framework;
@@ -83,6 +84,77 @@ namespace BloomTests.web
                 handler: request => request.PostSucceeded()
             );
             Assert.That(result, Is.EqualTo("OK"));
+        }
+
+        /// <summary>
+        /// An endpoint whose job is to interrupt long-running work must be registered with
+        /// requiresSync false, or it queues behind the very request it exists to interrupt and
+        /// the flag it sets arrives too late to stop anything. libraryPublish/cancel is the case
+        /// this was written for (BL-16340); progress/cancel relies on the same property.
+        /// </summary>
+        [Test]
+        public void RequestNotRequiringSync_IsServedWhileAnotherRequestHoldsTheSyncLock()
+        {
+            using (var slowRequestStarted = new ManualResetEventSlim())
+            using (var letSlowRequestFinish = new ManualResetEventSlim())
+            {
+                var slowRequestWasReleased = false;
+                _server.ApiHandler.RegisterEndpointHandler(
+                    "test/slow",
+                    request =>
+                    {
+                        slowRequestStarted.Set();
+                        slowRequestWasReleased = letSlowRequestFinish.Wait(20000);
+                        request.PostSucceeded();
+                    },
+                    handleOnUiThread: false,
+                    requiresSync: true
+                );
+                _server.ApiHandler.RegisterEndpointHandler(
+                    "test/interrupt",
+                    request => request.PostSucceeded(),
+                    handleOnUiThread: false,
+                    requiresSync: false
+                );
+
+                var slowRequest = Task.Run(() =>
+                    ApiTest.GetString(_server, "test/slow", timeoutInMilliseconds: 30000)
+                );
+                // Sanity check: unless the slow request is actually running, it isn't holding the
+                // lock and the rest of the test would prove nothing.
+                Assert.That(
+                    slowRequestStarted.Wait(10000),
+                    Is.True,
+                    "the slow request never started, so it never held the lock"
+                );
+                Assert.That(
+                    slowRequest.IsCompleted,
+                    Is.False,
+                    "the slow request should still have been in flight"
+                );
+
+                var interruptResult = ApiTest.GetString(
+                    _server,
+                    "test/interrupt",
+                    timeoutInMilliseconds: 5000
+                );
+
+                Assert.That(interruptResult, Is.EqualTo("OK"));
+                Assert.That(
+                    slowRequest.IsCompleted,
+                    Is.False,
+                    "the interrupting request should have been served while the slow one still held the lock"
+                );
+
+                letSlowRequestFinish.Set();
+                Assert.That(
+                    slowRequest.Wait(20000),
+                    Is.True,
+                    "the slow request never finished once released"
+                );
+                Assert.That(slowRequestWasReleased, Is.True);
+                Assert.That(slowRequest.Result, Is.EqualTo("OK"));
+            }
         }
 
         [Test]

--- a/src/BloomTests/web/controllers/EndpointHandlerTests.cs
+++ b/src/BloomTests/web/controllers/EndpointHandlerTests.cs
@@ -91,6 +91,11 @@ namespace BloomTests.web
         /// requiresSync false, or it queues behind the very request it exists to interrupt and
         /// the flag it sets arrives too late to stop anything. libraryPublish/cancel is the case
         /// this was written for (BL-16340); progress/cancel relies on the same property.
+        ///
+        /// Parking one request inside the lock needs a second worker to be free to serve the
+        /// interrupting one. BloomServer starts Math.Max(ProcessorCount, 2) of them, so there is
+        /// always at least one spare; were that ever reduced to a single worker this would fail
+        /// for a reason that has nothing to do with the lock.
         /// </summary>
         [Test]
         public void RequestNotRequiringSync_IsServedWhileAnotherRequestHoldsTheSyncLock()


### PR DESCRIPTION
Cancel's whole job is to set one boolean, `_progress.CancelRequested`, which the upload polls between stages. The publish screen greys out UPLOAD BOOK the instant the user clicks Cancel, and the only thing that ever brings it back is the `uploadCanceled` websocket event — which C# sends only if that flag is still true when the upload finishes. So anything that stops the flag being set in time leaves the upload running to completion **and** the button dead for good, which is exactly what was reported.

Three ways that could happen, all fixed here:

1. **The cancel request had to queue behind the very work it was trying to interrupt.** `libraryPublish/cancel` was registered to run on the UI thread and (by default) to take the global api sync lock — both of which a long upload can occupy for minutes (offscreen-browser thumbnailing on the UI thread, then `BloomPdfMaker.exe` pulling the book and its resources back through Bloom's own server). If the POST was stuck until after the upload's last cancellation check, the flag arrived too late to stop anything. It is now registered `(handleOnUiThread: false, requiresSync: false)`, like the other cancel endpoints (`progress/cancel`, `signLanguage/cancelImportVideo`), which exist to set a flag and nothing more.

2. **A cancel during the pre-upload handshake was thrown away.** The client shows Cancel from the moment the user commits, but two api round trips happen before `libraryPublish/upload` is posted, and `HandleUpload` opened by clearing `CancelRequested`. The flag is now cleared in `HandleCheckSubscriptionMatch` — the first call of every upload attempt — and `HandleUpload` declines to start if it is already set. `HandleCancel` reports the cancellation itself when no upload is running, so the user gets the same feedback in that window.

3. **The UI had no way back regardless of what C# decided.** `isCanceling` is now also cleared on `uploadSuccessful` and on an error in the progress box, so the user can never be left with no working button.

Also:

- A cancel that arrives after the server has committed the upload no longer reports "Upload was cancelled". If a book id came back, the book really is on BloomLibrary, and saying otherwise is a falsehood the user might act on.
- `WebProgressAdapter.CancelRequested` is backed by a `volatile` field; it is written and read from different threads with no lock between them.
- Bulk upload shares `_progress` but has no Cancel of its own, so it now clears the flag too; otherwise a leftover cancel could silently stop it before it started.

### Tests

Added `EndpointHandlerTests.RequestNotRequiringSync_IsServedWhileAnotherRequestHoldsTheSyncLock`, which proves the property fix 1 depends on. Verified it is not falsely passing: flipping the interrupting endpoint to `requiresSync: true` makes it fail.

### Note on verification

The bug itself is a race — the reporter could not reproduce it either — so it was **not** reproduced deterministically here. The fixes are reasoned from the code paths rather than confirmed against a failing repro. Fix 3 is the one that categorically rules out the reported symptom; fixes 1 and 2 address the causes that the code paths support.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16340


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8184)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8184)
<!-- Reviewable:end -->
