### PR TITLE
Lock workspace tabs while a newly selected book loads (BL-15971)

### DIFF
--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -19,6 +19,15 @@ House rules:
 
 ---
 
+## 2026-08-10 — NoErrorForEmptyAudio fails when the temp path contains "17"
+- **Cut:** `SpreadsheetAudioImportTests.NoErrorForEmptyAudio` asserts no progress message matches
+  `.*17.*` (checking page 17 imported cleanly), but progress messages include full temp paths, and
+  `TestTempDirectory`'s session-scoped dir (`%TEMP%\BloomTests\<sessionkey>-p<pid>`) can contain
+  "17" in the session key (e.g. `a7817563`), so an unrelated "file not found" message matches and
+  fails the test.
+- **Idea:** tighten the assertion to `page 17` (or strip paths from messages before matching).
+- **Context:** hit 2026-08-10 during BL-15971 preflight on Andrew's machine.
+
 ## 2026-07-30 — Visual regression suite reports only the first stale image per case
 - **Cut:** Each case in `src/BloomVisualRegressionTests/index.spec.ts` compares the book preview
   and then every bloom-player page in sequence, and every comparison throws on failure — so the

--- a/src/BloomBrowserUI/app/App.tsx
+++ b/src/BloomBrowserUI/app/App.tsx
@@ -4,13 +4,13 @@ import "App.less";
 import "../bookEdit/workspaceRoot";
 import { CollectionsTabPane } from "../collectionsTab/CollectionsTabPane";
 import { WireUpForWinforms } from "../utils/WireUpWinform";
+import { TopBar } from "../react_components/TopBar/TopBar";
 import {
     defaultWorkspaceTabState,
     getActiveWorkspaceTab,
-    TopBar,
     useWorkspaceTabInfo,
     WorkspaceTabId,
-} from "../react_components/TopBar/TopBar";
+} from "../react_components/TopBar/workspaceTabInfo";
 import { PublishTabPane } from "../publish/PublishTab/PublishTabPane";
 import { kPanelBackground } from "../bloomMaterialUITheme";
 import { EditTabPane } from "./EditTabPane";

--- a/src/BloomBrowserUI/collectionsTab/collectionsTabBookPane/CollectionsTabBookPane.tsx
+++ b/src/BloomBrowserUI/collectionsTab/collectionsTabBookPane/CollectionsTabBookPane.tsx
@@ -24,6 +24,7 @@ import {
 } from "../../react_components/BloomDialog/BloomDialogPlumbing";
 import { BookInfoIndicator } from "../../react_components/BookInfoIndicator";
 import { useGetFeatureStatus } from "../../react_components/featureStatus";
+import { useWorkspaceTabInfo } from "../../react_components/TopBar/TopBar";
 
 export const CollectionsTabBookPane: React.FunctionComponent<{
     // If false, as it usually is, the overlay above the preview iframe
@@ -133,9 +134,13 @@ export const CollectionsTabBookPane: React.FunctionComponent<{
         collectionKind,
     ]);
 
+    // While C# has locked workspace navigation (e.g. it is still loading a newly selected
+    // book), this button must be disabled in step with the main tabs (BL-15971).
+    const navigationLocked = useWorkspaceTabInfo().navigationLocked;
+
     // Note: If canMakeBook is true, then saveable is probably false (the source book is likely not in the editable collection),
     // but you still want the button to be enabled
-    const isButtonEnabled = canMakeBook || saveable;
+    const isButtonEnabled = (canMakeBook || saveable) && !navigationLocked;
 
     const editOrMakeButton: JSX.Element | boolean = collectionKind !==
         "error" && (

--- a/src/BloomBrowserUI/collectionsTab/collectionsTabBookPane/CollectionsTabBookPane.tsx
+++ b/src/BloomBrowserUI/collectionsTab/collectionsTabBookPane/CollectionsTabBookPane.tsx
@@ -24,7 +24,7 @@ import {
 } from "../../react_components/BloomDialog/BloomDialogPlumbing";
 import { BookInfoIndicator } from "../../react_components/BookInfoIndicator";
 import { useGetFeatureStatus } from "../../react_components/featureStatus";
-import { useWorkspaceTabInfo } from "../../react_components/TopBar/TopBar";
+import { useWorkspaceTabInfo } from "../../react_components/TopBar/workspaceTabInfo";
 
 export const CollectionsTabBookPane: React.FunctionComponent<{
     // If false, as it usually is, the overlay above the preview iframe

--- a/src/BloomBrowserUI/publish/PublishTab/PublishTabPane.tsx
+++ b/src/BloomBrowserUI/publish/PublishTab/PublishTabPane.tsx
@@ -30,7 +30,7 @@ import {
 import { AboutDialogLauncher } from "../../react_components/aboutDialog";
 import { RegistrationDialogEventLauncher } from "../../react_components/registration/registrationDialogLauncher";
 import { RequiresSubscriptionOverlayWrapper } from "../../react_components/requiresSubscription";
-import { useWorkspaceTabInfo } from "../../react_components/TopBar/TopBar";
+import { useWorkspaceTabInfo } from "../../react_components/TopBar/workspaceTabInfo";
 
 export const CheckoutNeededScreen: React.FunctionComponent<{
     titleForDisplay: string;

--- a/src/BloomBrowserUI/react_components/TopBar/TopBar.tsx
+++ b/src/BloomBrowserUI/react_components/TopBar/TopBar.tsx
@@ -4,7 +4,14 @@ import { CollectionsTabIcon } from "./CollectionsTabIcon";
 import { EditTabIcon } from "./EditTabIcon";
 import { PublishTabIcon } from "./PublishTabIcon";
 import { WireUpForWinforms } from "../../utils/WireUpWinform";
-import { postJson, useWatchApiObject } from "../../utils/bloomApi";
+import { postJson } from "../../utils/bloomApi";
+import {
+    defaultWorkspaceTabState,
+    getActiveWorkspaceTab,
+    TabStates,
+    useWorkspaceTabInfo,
+    WorkspaceTabId,
+} from "./workspaceTabInfo";
 import { TopBarControls } from "./TopBarControls";
 import { Span } from "../l10nComponents";
 import {
@@ -15,22 +22,6 @@ import {
 } from "../../bloomMaterialUITheme";
 import { ScopedCssBaseline } from "@mui/material";
 import { TopBarContextMenu } from "./TopBarContextMenu";
-
-export type WorkspaceTabId = "collection" | "edit" | "publish";
-
-export type WorkspaceTabState = "active" | "enabled" | "disabled" | "hidden";
-
-export type TabStates = Record<WorkspaceTabId, WorkspaceTabState>;
-
-// What C# (WorkspaceView.GetTabInfo) tells us about workspace navigation.
-export interface IWorkspaceTabInfo {
-    tabStates: TabStates;
-    // True while some operation has made itself modal by locking navigation: a BloomLibrary
-    // upload, a Reading App Builder action, or an Edit-tab modal dialog. Screens with their own
-    // navigation (notably the Publish tab's switcher between publish tools) use this to lock in
-    // step with the main tabs.
-    navigationLocked: boolean;
-}
 
 interface ITabDefinition {
     id: WorkspaceTabId;
@@ -59,33 +50,6 @@ const tabDefinitions: Array<ITabDefinition> = [
         color: kBloomRed,
     },
 ];
-
-export function getActiveWorkspaceTab(tabStates: TabStates): WorkspaceTabId {
-    return (
-        tabDefinitions.find((t) => tabStates[t.id] === "active")?.id ??
-        "collection"
-    );
-}
-
-export const defaultWorkspaceTabState: IWorkspaceTabInfo = {
-    tabStates: {
-        collection: "active",
-        edit: "hidden",
-        publish: "hidden",
-    },
-    navigationLocked: false,
-};
-
-// Subscribes to what C# says about workspace navigation, kept in one place because several
-// screens in different browser controls need the same answer.
-export function useWorkspaceTabInfo(): IWorkspaceTabInfo {
-    return useWatchApiObject<IWorkspaceTabInfo>(
-        "workspace/tabs",
-        defaultWorkspaceTabState,
-        "workspace",
-        "tabs",
-    );
-}
 
 export const TopBar: React.FunctionComponent = () => {
     const state = useWorkspaceTabInfo();

--- a/src/BloomBrowserUI/react_components/TopBar/TopBarControls.tsx
+++ b/src/BloomBrowserUI/react_components/TopBar/TopBarControls.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { CollectionTopBarControls } from "./CollectionTopBarControls/CollectionTopBarControls";
 import { WorkspaceTopRightControls } from "./workspaceTopRightControls/WorkspaceTopRightControls";
 import { EditTopBarControls } from "../../bookEdit/topbar/editTopBarControls";
-import { WorkspaceTabId } from "./TopBar";
+import { WorkspaceTabId } from "./workspaceTabInfo";
 
 export const TopBarControls: React.FunctionComponent<{
     activeTab: WorkspaceTabId;

--- a/src/BloomBrowserUI/react_components/TopBar/workspaceTabInfo.ts
+++ b/src/BloomBrowserUI/react_components/TopBar/workspaceTabInfo.ts
@@ -1,0 +1,51 @@
+import { useWatchApiObject } from "../../utils/bloomApi";
+
+// The workspace-navigation state shared between TopBar and other screens.
+// This module deliberately has no side effects, so screens that only need the
+// hook (e.g. PublishTabPane, CollectionsTabBookPane) can import it without
+// pulling in TopBar.tsx's module-scope WireUpForWinforms registration.
+
+export type WorkspaceTabId = "collection" | "edit" | "publish";
+
+export type WorkspaceTabState = "active" | "enabled" | "disabled" | "hidden";
+
+export type TabStates = Record<WorkspaceTabId, WorkspaceTabState>;
+
+// What C# (WorkspaceView.GetTabInfo) tells us about workspace navigation.
+export interface IWorkspaceTabInfo {
+    tabStates: TabStates;
+    // True while some operation has made itself modal by locking navigation: a BloomLibrary
+    // upload, a Reading App Builder action, or an Edit-tab modal dialog. Screens with their own
+    // navigation (notably the Publish tab's switcher between publish tools) use this to lock in
+    // step with the main tabs.
+    navigationLocked: boolean;
+}
+
+const kWorkspaceTabIds: WorkspaceTabId[] = ["collection", "edit", "publish"];
+
+export function getActiveWorkspaceTab(tabStates: TabStates): WorkspaceTabId {
+    return (
+        kWorkspaceTabIds.find((id) => tabStates[id] === "active") ??
+        "collection"
+    );
+}
+
+export const defaultWorkspaceTabState: IWorkspaceTabInfo = {
+    tabStates: {
+        collection: "active",
+        edit: "hidden",
+        publish: "hidden",
+    },
+    navigationLocked: false,
+};
+
+// Subscribes to what C# says about workspace navigation, kept in one place because several
+// parts of the workspace UI need the same answer.
+export function useWorkspaceTabInfo(): IWorkspaceTabInfo {
+    return useWatchApiObject<IWorkspaceTabInfo>(
+        "workspace/tabs",
+        defaultWorkspaceTabState,
+        "workspace",
+        "tabs",
+    );
+}

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -336,8 +336,11 @@ namespace Bloom.Edit
                 Cursor = Cursors.WaitCursor;
                 if (_model.GetBookHasChanged())
                 {
-                    //even before showing, we need to clear some things so the user doesn't see the old stuff
-                    _pageListView.Clear();
+                    // Even before showing, we need to clear things out so the user doesn't see the
+                    // old stuff. As well as the page list, this blanks the main content browser,
+                    // which otherwise keeps showing a page of the previously edited book until the
+                    // new book finishes navigating (BL-15971).
+                    ClearOutDisplay();
                 }
                 _model.OnBecomeVisible();
                 Logger.WriteEvent("Entered Edit Tab");

--- a/src/BloomExe/web/controllers/CollectionApi.cs
+++ b/src/BloomExe/web/controllers/CollectionApi.cs
@@ -171,6 +171,11 @@ namespace Bloom.web.controllers
                             // without actually loading all the files. We need the title for the Performance Measurement and later
                             // we'll use the BookInfo object to get the fully updated book.
                             BookInfo newBookInfo = null;
+                            // Like other long-running operations (Edit-tab saves, uploads), lock the
+                            // workspace tabs while we load the newly selected book. Bringing a heavy
+                            // book up to date can take several seconds, and clicking Edit during that
+                            // window could show the previous book (BL-15971).
+                            _collectionTabView.WorkspaceView?.SetTabsEnabled(false);
                             try
                             {
                                 newBookInfo = GetBookInfoFromPost(request);
@@ -231,6 +236,10 @@ namespace Bloom.web.controllers
                                 }
                                 throw;
                             }
+                            finally
+                            {
+                                _collectionTabView.WorkspaceView?.SetTabsEnabled(true);
+                            }
 
                             request.PostSucceeded();
                             break;
@@ -243,18 +252,28 @@ namespace Bloom.web.controllers
                 kApiUrlPart + "selectAndEditBook",
                 request =>
                 {
-                    var book = GetBookObjectFromPost(request);
-                    if (book.FolderPath != _bookSelection?.CurrentSelection?.FolderPath)
+                    // Lock the workspace tabs while we load the book, as in "selected-book"
+                    // above (BL-15971).
+                    _collectionTabView.WorkspaceView?.SetTabsEnabled(false);
+                    try
                     {
-                        _collectionModel.SelectBook(book);
+                        var book = GetBookObjectFromPost(request);
+                        if (book.FolderPath != _bookSelection?.CurrentSelection?.FolderPath)
+                        {
+                            _collectionModel.SelectBook(book);
+                        }
+                        if (
+                            book.IsSaveable
+                            && GetCollectionOfRequest(request).Type
+                                == BookCollection.CollectionType.TheOneEditableCollection
+                        )
+                        {
+                            _editBookCommand.Raise(_bookSelection.CurrentSelection);
+                        }
                     }
-                    if (
-                        book.IsSaveable
-                        && GetCollectionOfRequest(request).Type
-                            == BookCollection.CollectionType.TheOneEditableCollection
-                    )
+                    finally
                     {
-                        _editBookCommand.Raise(_bookSelection.CurrentSelection);
+                        _collectionTabView.WorkspaceView?.SetTabsEnabled(true);
                     }
 
                     request.PostSucceeded();


### PR DESCRIPTION
Selecting a different book in the Collections tab did not lock the workspace UI while the new book was loaded (which can take several seconds for a heavy book, mostly in `BringBookUpToDate`). During that window the Edit tab and the "Edit this book" button stayed clickable, and entering the Edit tab could briefly show the previously edited book.

Three changes:

- **CollectionApi**: the `selected-book` and `selectAndEditBook` handlers now call `WorkspaceView.SetTabsEnabled(false)` while loading/selecting the book (re-enabled in `finally`) — the same mechanism used by Edit-tab saves, BloomLibrary uploads, and RAB builds (BL-16654).
- **CollectionsTabBookPane**: the "Edit this book"/"Make a book" button now honors the existing `navigationLocked` flag, so it greys out in step with the main tabs.
- **EditingView.OnVisibleChanged**: when entering the Edit tab after the book changed, call `ClearOutDisplay()` (which also blanks the main content browser) instead of only clearing the page list, so the old book's page is no longer visible while the new book navigates.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-15971

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8185)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8185)
<!-- Reviewable:end -->
