### PR TITLE
Fix BL-16209 Bloom won't open a collection with illegal chars in language display name

### DIFF
--- a/src/BloomExe/web/ReadersApi.cs
+++ b/src/BloomExe/web/ReadersApi.cs
@@ -415,6 +415,12 @@ namespace Bloom.Api
                     e
                 );
                 request.Failed("Saving synphonyLanguageData failed to get Json");
+                // The return matters (BL-16209 review). Without it we fell through with langdata
+                // still "", wrote that empty string over the collection's ReaderToolsWords-<lang>.json
+                // — discarding the user's word list and grapheme data — and then reported the same
+                // request as succeeded on top of having failed it. Doing nothing here is exactly what
+                // the note above intends by "just not update the file".
+                return;
             }
 
             SaveSynphonyLanguageData(langdata);
@@ -487,6 +493,20 @@ namespace Bloom.Api
             return $"contains(concat(' ', @class, ' '), ' {className} ')";
         }
 
+        /// <remarks>
+        /// Reviewed during BL-16209 (which was caused by a display name with a double quote in it
+        /// breaking hand-built JSON elsewhere). This escaper handles the backslash and the double
+        /// quote — and note it must escape the backslash FIRST, or it would re-escape the
+        /// backslash the quote rule just added — plus carriage return and newline. It does not
+        /// escape the other JSON control characters, e.g. a literal tab or anything else below
+        /// U+0020, which RFC 8259 also requires to be escaped.
+        ///
+        /// We decided deliberately to leave that as it is rather than switch to JsonConvert: the
+        /// text through here is book page content, so a stray tab is far less likely than the
+        /// quote mark that caused BL-16209, and changing it would alter the exact bytes of other
+        /// reader-tool JSON for no known symptom. Revisit if page text ever turns out to carry
+        /// control characters through this path.
+        /// </remarks>
         private static string EscapeJsonValue(string value)
         {
             // As http://stackoverflow.com/questions/42068/how-do-i-handle-newlines-in-json attempts to explain,
@@ -741,17 +761,23 @@ namespace Bloom.Api
         /// records of "when things changed" and so forth.</Note>
         private void SaveSynphonyLanguageData(string jsonString)
         {
-            // insert LangName and LangID if missing
+            // insert LangName and LangID if missing.
+            // JsonConvert.ToString() supplies the enclosing quotes and escapes anything in the
+            // value that JSON would otherwise choke on; a display name is arbitrary user text and
+            // may contain a double quote or backslash (BL-16209). A language tag is far more
+            // constrained (it also has to survive being put in a file name just below), but it
+            // goes through the same escaping so this method has no hand-quoted values left.
             if (jsonString.Contains("\"LangName\":\"\""))
                 jsonString = jsonString.Replace(
                     "\"LangName\":\"\"",
-                    "\"LangName\":\"" + CurrentBook.BookData.Language1.Name + "\""
+                    "\"LangName\":"
+                        + JsonConvert.ToString(CurrentBook.BookData.Language1.Name ?? "")
                 );
 
             if (jsonString.Contains("\"LangID\":\"\""))
                 jsonString = jsonString.Replace(
                     "\"LangID\":\"\"",
-                    "\"LangID\":\"" + CurrentBook.BookData.Language1.Tag + "\""
+                    "\"LangID\":" + JsonConvert.ToString(CurrentBook.BookData.Language1.Tag ?? "")
                 );
 
             var fileName = String.Format(
@@ -768,26 +794,28 @@ namespace Bloom.Api
         }
 
         /// <summary>
-        /// Efficiently determines if we should write the language data file by comparing
-        /// file size and content bytes to avoid unnecessary writes.
+        /// Determines whether the language data file actually needs writing, by comparing what
+        /// is already on disk with what we are about to write. See the Note on
+        /// SaveSynphonyLanguageData for why avoiding a pointless write matters.
         /// </summary>
-        private bool ShouldWriteLanguageDataFile(string fileName, string newContent)
+        /// <remarks>
+        /// This compares the decoded text, not raw bytes. It used to compare
+        /// Encoding.UTF8.GetBytes(newContent) against the file, but the file is written with
+        /// Encoding.UTF8, which emits a byte-order mark that GetBytes() does not. The lengths
+        /// therefore always differed by those 3 bytes, so this always returned true and the
+        /// optimization never once skipped a write (found by Devin's review of BL-16209).
+        /// Comparing text also means a file saved without a BOM by some older version still
+        /// compares equal, so we don't rewrite it just to add one.
+        /// </remarks>
+        internal static bool ShouldWriteLanguageDataFile(string fileName, string newContent)
         {
             try
             {
                 if (!RobustFile.Exists(fileName))
                     return true;
 
-                var newContentBytes = Encoding.UTF8.GetBytes(newContent);
-                var fileInfo = new FileInfo(fileName);
-
-                // Quick check: if file size is different, content must be different
-                if (fileInfo.Length != newContentBytes.Length)
-                    return true;
-
-                // File sizes match, so compare the actual byte content
-                var existingContentBytes = RobustFile.ReadAllBytes(fileName);
-                return !newContentBytes.SequenceEqual(existingContentBytes);
+                // ReadAllText detects and strips a byte-order mark, so this is BOM-insensitive.
+                return RobustFile.ReadAllText(fileName, Encoding.UTF8) != newContent;
             }
             catch
             {

--- a/src/BloomExe/web/controllers/CollectionSettingsApi.cs
+++ b/src/BloomExe/web/controllers/CollectionSettingsApi.cs
@@ -509,9 +509,23 @@ namespace Bloom.web.controllers
                     _collectionSettings.Language1Tag
                 );
             }
-            var jsonString =
-                $"{{\"languageName\":\"{languageName}\",\"languageCode\":\"{langTag}\"}}";
-            request.ReplyWithJson(jsonString);
+            request.ReplyWithJson(MakeLanguageDataJson(languageName, langTag));
+        }
+
+        /// <summary>
+        /// Builds the JSON that the languageData endpoint returns. A display name is arbitrary
+        /// user text: it can perfectly well contain a double quote or a backslash (BL-16209), so
+        /// it has to be serialized rather than pasted into a hand-built JSON string. Getting that
+        /// wrong produced invalid JSON, which made the whole collection tab fail to render.
+        /// The callers of this endpoint treat languageName as a string (one of them asks it for
+        /// its .length), so keep coercing a null name to empty the way the old hand-built string
+        /// did rather than sending a JSON null.
+        /// </summary>
+        internal static string MakeLanguageDataJson(string languageName, string languageTag)
+        {
+            return JsonConvert.SerializeObject(
+                new { languageName = languageName ?? "", languageCode = languageTag ?? "" }
+            );
         }
 
         // Used by BookSettingsDialog and others

--- a/src/BloomTests/web/controllers/CollectionSettingsApiTests.cs
+++ b/src/BloomTests/web/controllers/CollectionSettingsApiTests.cs
@@ -1,0 +1,67 @@
+using Bloom.web.controllers;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace BloomTests.web.controllers
+{
+    [TestFixture]
+    public class CollectionSettingsApiTests
+    {
+        // A language display name is arbitrary user text. Apostrophes are common in real language
+        // names, and BL-16209 showed that a user can put anything at all in there, including the
+        // characters that break a hand-built JSON string.
+        private const string kNastyDisplayName = "Unsafe ~!@#$%^&*()_-+={}[]\\|:;\"'<>.?/";
+
+        /// <summary>
+        /// BL-16209: the languageData reply used to be assembled by string interpolation, so a
+        /// display name containing a double quote or a backslash produced invalid JSON. The
+        /// collection tab then read undefined for languageName, threw, and left the user with a
+        /// blank screen they could not get past.
+        /// </summary>
+        [Test]
+        public void MakeLanguageDataJson_NameHasJsonBreakingCharacters_ProducesValidParseableJson()
+        {
+            // Sanity check the test data: this only proves anything if the name really does
+            // contain the characters that JSON has to escape.
+            Assert.That(
+                kNastyDisplayName,
+                Does.Contain("\"").And.Contain("\\"),
+                "Test data should contain a double quote and a backslash"
+            );
+
+            var json = CollectionSettingsApi.MakeLanguageDataJson(
+                kNastyDisplayName,
+                "qaa-BA-x-Unsafeam"
+            );
+
+            dynamic result = JsonConvert.DeserializeObject(json);
+            Assert.That((string)result.languageName, Is.EqualTo(kNastyDisplayName));
+            Assert.That((string)result.languageCode, Is.EqualTo("qaa-BA-x-Unsafeam"));
+        }
+
+        /// <summary>
+        /// The clients treat languageName as a string (BooksOnBlorgProgressBar asks it for its
+        /// .length), and the hand-built string this replaced turned a null name into "". Keep
+        /// doing that, so a null can't reintroduce the BL-16209 crash by another route.
+        /// </summary>
+        [Test]
+        public void MakeLanguageDataJson_NullName_ProducesEmptyStringNotNull()
+        {
+            var json = CollectionSettingsApi.MakeLanguageDataJson(null, null);
+
+            dynamic result = JsonConvert.DeserializeObject(json);
+            Assert.That((string)result.languageName, Is.EqualTo(""));
+            Assert.That((string)result.languageCode, Is.EqualTo(""));
+        }
+
+        [Test]
+        public void MakeLanguageDataJson_OrdinaryName_ProducesExpectedFields()
+        {
+            var json = CollectionSettingsApi.MakeLanguageDataJson("Kaqchikel", "cak");
+
+            dynamic result = JsonConvert.DeserializeObject(json);
+            Assert.That((string)result.languageName, Is.EqualTo("Kaqchikel"));
+            Assert.That((string)result.languageCode, Is.EqualTo("cak"));
+        }
+    }
+}

--- a/src/BloomTests/web/controllers/ReadersApiTests.cs
+++ b/src/BloomTests/web/controllers/ReadersApiTests.cs
@@ -1,8 +1,11 @@
 ﻿using System.IO;
+using System.Linq;
+using System.Text;
 using Bloom.Api;
 using Bloom.Book;
 using Bloom.Collection;
 using Bloom.SafeXml;
+using Bloom.web;
 using Moq;
 using NUnit.Framework;
 using SIL.IO;
@@ -283,6 +286,104 @@ namespace BloomTests.web
                     }
                 );
             return storage;
+        }
+    }
+
+    /// <summary>
+    /// Tests for ReadersApi.ShouldWriteLanguageDataFile. Deliberately a separate fixture
+    /// from ReadersApiTests: these exercise a pure static method and need no BloomServer,
+    /// and standing up (and tearing down) a real HttpListener per test for no reason is
+    /// both wasteful and a source of teardown races in the shared test host.
+    /// </summary>
+    [TestFixture]
+    public class ReadersApiLanguageDataFileTests
+    {
+        /// <summary>
+        /// BL-16209 (found by Devin reviewing that fix): the file is written with Encoding.UTF8,
+        /// which emits a byte-order mark, but this check used to compare against
+        /// Encoding.UTF8.GetBytes(newContent), which has none. The lengths always differed by
+        /// those 3 bytes, so it always said "write", and the whole point of the check — not
+        /// touching the file, and so not setting off a Team Collection sync — never worked.
+        /// </summary>
+        [Test]
+        public void ShouldWriteLanguageDataFile_ContentUnchangedAndFileHasBom_ReturnsFalse()
+        {
+            using (var tempFile = new TempFile())
+            {
+                var content = "{\"LangName\":\"Kaqchikel\",\"LangID\":\"cak\"}";
+                // Exactly how SaveSynphonyLanguageData writes it: UTF8 *with* a BOM.
+                RobustFile.WriteAllText(tempFile.Path, content, Encoding.UTF8);
+
+                // Sanity check the test data: the file really does start with a BOM, which is
+                // the whole reason the old byte comparison could never match.
+                var bytes = RobustFile.ReadAllBytes(tempFile.Path);
+                Assert.That(
+                    bytes.Take(3),
+                    Is.EqualTo(Encoding.UTF8.GetPreamble()),
+                    "Test setup should have written a byte-order mark"
+                );
+                Assert.That(
+                    bytes.Length,
+                    Is.EqualTo(Encoding.UTF8.GetBytes(content).Length + 3),
+                    "The on-disk length should differ from GetBytes() by exactly the BOM"
+                );
+
+                Assert.That(
+                    ReadersApi.ShouldWriteLanguageDataFile(tempFile.Path, content),
+                    Is.False,
+                    "Identical content should not need rewriting"
+                );
+            }
+        }
+
+        [Test]
+        public void ShouldWriteLanguageDataFile_ContentUnchangedButFileHasNoBom_ReturnsFalse()
+        {
+            using (var tempFile = new TempFile())
+            {
+                var content = "{\"LangName\":\"Kaqchikel\",\"LangID\":\"cak\"}";
+                // A file an older Bloom could have left behind, with no BOM.
+                RobustFile.WriteAllText(tempFile.Path, content, new UTF8Encoding(false));
+                Assert.That(
+                    RobustFile.ReadAllBytes(tempFile.Path).Take(3),
+                    Is.Not.EqualTo(Encoding.UTF8.GetPreamble()),
+                    "Test setup should have written no byte-order mark"
+                );
+
+                Assert.That(
+                    ReadersApi.ShouldWriteLanguageDataFile(tempFile.Path, content),
+                    Is.False,
+                    "We should not rewrite an unchanged file just to add a BOM"
+                );
+            }
+        }
+
+        [Test]
+        public void ShouldWriteLanguageDataFile_ContentDiffers_ReturnsTrue()
+        {
+            using (var tempFile = new TempFile())
+            {
+                RobustFile.WriteAllText(
+                    tempFile.Path,
+                    "{\"LangName\":\"Kaqchikel\"}",
+                    Encoding.UTF8
+                );
+                Assert.That(
+                    ReadersApi.ShouldWriteLanguageDataFile(
+                        tempFile.Path,
+                        "{\"LangName\":\"Q'eqchi'\"}"
+                    ),
+                    Is.True
+                );
+            }
+        }
+
+        [Test]
+        public void ShouldWriteLanguageDataFile_FileDoesNotExist_ReturnsTrue()
+        {
+            var missing = Path.Combine(Path.GetTempPath(), "BL16209-no-such-file.json");
+            Assert.That(RobustFile.Exists(missing), Is.False, "Test precondition");
+            Assert.That(ReadersApi.ShouldWriteLanguageDataFile(missing, "{}"), Is.True);
         }
     }
 }


### PR DESCRIPTION
A collection whose language display name contained a `"` or a `\` could not be opened at all: Bloom showed a blank window with no message, permanently, because the name is saved in the `.bloomCollection` file.

`settings/languageData` built its JSON reply by string interpolation:

```csharp
$"{{\"languageName\":\"{languageName}\",\"languageCode\":\"{langTag}\"}}"
```

so the reporter's name produced invalid JSON:

```
{"languageName":"Unsafe \~!@#$%^&amp;\*()_-+={}\|\\:;"'\<\>.?/","languageCode":"qaa-BA-x-Unsafeam"}
```

axios can't parse that, leaves the body as a raw string, `langData.data.languageName` is `undefined`, and `BooksOnBlorgProgressBar.tsx:36` throws on `languageName.length`. With no error boundary above it, React unmounts the whole tree — hence the blank screen and the total silence (the JS error *is* reported to `common/error`, but that only raises a toast, and the toast host lives in the tree that just died).

Not an exotic input: apostrophes are common in real language names, and one double quote is enough.

## Changes

- `CollectionSettingsApi`: serialize the reply with `JsonConvert` via a new testable `MakeLanguageDataJson`. Also fixes the second consumer of that endpoint, the "Make Reader Template Bloom Pack" dialog, which was rendering `undefined` for the collection language.
- `ReadersApi.SaveSynphonyLanguageData`: same bug class — it spliced the raw display name into the `LangName` field of the Synphony language-data JSON. Now uses `JsonConvert.ToString` for quoting/escaping.
- Both keep coercing a null name to `""`, as the old hand-built strings did, so a null can't reintroduce the same crash by another route.
- New `CollectionSettingsApiTests` (3 tests): the JSON-breaking name, a null name, an ordinary name. The first fails against the old code.

## Verification

Reproduced in the real app with the reporter's "Please Delete ME" collection from the card: confirmed the blank screen and captured the `Cannot read properties of undefined (reading 'length')` throw at `BooksOnBlorgProgressBar.tsx:36` over CDP, then after the fix confirmed the collection tab renders fully, with the progress-bar label reading `0 Unsafe \~!@... books on BloomLibrary.org`.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16209


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8186)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8186)
<!-- Reviewable:end -->
