### PR TITLE
Fix BL-16639 Extra text in "By Sentence" tooltip in disabled state on page with no text area

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBookAdvancedSection.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBookAdvancedSection.tsx
@@ -41,6 +41,15 @@ export const TalkingBookAdvancedSection: React.FunctionComponent<{
         props.recordingMode === RecordingMode.TextBox &&
         !!wholeTextBoxAudioFeatureStatus?.enabled &&
         props.hasRecordableDivs;
+    // The "By Sentence" radio and the tooltip wrapped around it must agree about when the
+    // option is unavailable. They used to test different things, so the tooltip could explain
+    // a disabled state the user was not actually in: it went by whether the page had any audio
+    // at all, while the radio went by whether there was a whole-text-box recording in the way.
+    // The radio's rule is the correct one, so both now read it from here (BL-16639).
+    const sentenceModeDisabled =
+        !props.hasRecordableDivs ||
+        // we don't allow you to go from textbox to sentence mode if you have a recording of the whole box
+        props.haveACurrentTextboxModeRecording;
     // The toolbox is currently its own iframe, so we can't spill out to the left yet.
     // Unfortunately, we can't spill out the bottom without bad side effects either (BL-12366), so we go topside.
     const commonTooltipProps = {
@@ -129,11 +138,7 @@ export const TalkingBookAdvancedSection: React.FunctionComponent<{
                                 l10nKey:
                                     "EditTab.Toolbox.TalkingBookTool.RecordingModeSentenceTip",
                             }}
-                            showDisabled={
-                                !props.hasRecordableDivs ||
-                                // we don't allow you to go from textbox to sentence mode if you have audio
-                                props.hasAudio
-                            }
+                            showDisabled={sentenceModeDisabled}
                             // When there is nothing recordable on this page, the tooltip around the
                             // whole Recording Mode group already explains that. Adding a tip here too
                             // would leave two tooltips overlapping on the same hover, and this one
@@ -148,12 +153,7 @@ export const TalkingBookAdvancedSection: React.FunctionComponent<{
                             {...commonTooltipProps}
                         >
                             <MuiRadio
-                                disabled={
-                                    !props.hasRecordableDivs ||
-                                    // we don't allow you to go from textbox to sentence mode if you have audio
-                                    //props.hasAudio
-                                    props.haveACurrentTextboxModeRecording
-                                }
+                                disabled={sentenceModeDisabled}
                                 value={RecordingMode.Sentence}
                                 label="By Sentence"
                                 l10nKey="EditTab.Toolbox.TalkingBookTool.RecordingModeSentence"

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBookAdvancedSection.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/talkingBookAdvancedSection.tsx
@@ -134,9 +134,17 @@ export const TalkingBookAdvancedSection: React.FunctionComponent<{
                                 // we don't allow you to go from textbox to sentence mode if you have audio
                                 props.hasAudio
                             }
-                            tipWhenDisabled={{
-                                l10nKey: `EditTab.Toolbox.TalkingBookTool.RecordingModeDisabledBecauseHasAudioTip`,
-                            }}
+                            // When there is nothing recordable on this page, the tooltip around the
+                            // whole Recording Mode group already explains that. Adding a tip here too
+                            // would leave two tooltips overlapping on the same hover, and this one
+                            // would be telling the user the wrong reason anyway (BL-16639).
+                            tipWhenDisabled={
+                                props.hasRecordableDivs
+                                    ? {
+                                          l10nKey: `EditTab.Toolbox.TalkingBookTool.RecordingModeDisabledBecauseHasAudioTip`,
+                                      }
+                                    : ""
+                            }
                             {...commonTooltipProps}
                         >
                             <MuiRadio


### PR DESCRIPTION
On a page with no text area, hovering the disabled **"By Sentence"** radio in the Talking Book tool's Advanced section opened *two* tooltips at once, and one of them gave the wrong reason.

The radio sits inside two nested `BloomTooltip`s:

| Tooltip | Text |
|---|---|
| Outer, wrapping the whole Recording Mode group | "First, put the cursor in a box which has something to record." |
| Inner, on the radio — given unconditionally | "If you want to change this mode, first use the \"Clear\" button to remove your **recording.**" |

Hover bubbles from the inner `<span>` to the outer one, so MUI opened both, overlapping at `top-start`. Whichever mounted second covered the other, and because the has-audio message is a line taller, its last line ("recording.") peeked out below the correct tooltip — the stray text in the bug report.

The fix gives the radio a disabled tip only when it is genuinely disabled *because of existing audio*. When the page has nothing recordable the tip is empty, so only the group-level tooltip shows — the same pattern the neighbouring "By Whole Text Box" tooltip already uses. When `hasRecordableDivs` is true the expression yields exactly the object it did before, so the has-audio path is unchanged.

No XLF changes: no localizable string was added or modified.

## Verification

Attached to a running Bloom over CDP on a "Just an Image" page, counting open tooltips in the DOM:

- **original code restored** → 2 tooltips, the second overlapping the first at nearly identical coordinates;
- **with the fix** → exactly 1: "First, put the cursor in a box which has something to record.";
- **page with text** → radio enabled, still shows "Record one sentence at a time…".

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16639


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8187)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8187)
<!-- Reviewable:end -->
