### PR TITLE
Make PDFs work for the StoryWeaver ebook page sizes, and stop blaming memory (BL-16684)

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -4309,11 +4309,6 @@
         <note>ID: PublishTab.PDF.Error.NoPrinter</note>
         <note>Error message displayed in a message dialog box.</note>
       </trans-unit>
-      <trans-unit id="PublishTab.PDF.Error.TrySinglePage">
-        <source xml:lang="en">The book's images might have exceeded the amount of RAM memory available. Please turn on the "Use Less Memory" option which is slower but uses less memory.</source>
-        <note>ID: PublishTab.PDF.Error.TrySinglePage</note>
-        <note>Error message displayed in a message dialog box.</note>
-      </trans-unit>
       <trans-unit id="PublishTab.PdfMaker.BadPdf">
         <source xml:lang="en">Bloom had a problem making a PDF of this book. You may need technical help or to contact the developers. But here are some things you can try:</source>
         <note>ID: PublishTab.PdfMaker.BadPdf</note>

--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -2,6 +2,30 @@
 
 Small dev/agent/tooling friction points for this repo. See the `papercut` skill for format.
 
+## 2026-08-10 — check-csharp-ApplicationExit.sh greps whole files, not the diff
+
+- **Cut:** The pre-commit check greps each *staged file* for `Application.Exit`, so touching a
+  file that already contains a legitimate one blocks the commit even when your diff adds none.
+  Hit it editing `src/WebView2PdfMaker/Program.cs`, whose two calls date from 2023 (BL-11437);
+  WebView2PdfMaker is a separate process and cannot use Bloom's `ProgramExit`. The exemption
+  list only covers `src/BloomExe/ProgramExit.cs` and `src/BloomTests/*`.
+- **Idea:** Grep only added lines (`git diff --cached -U0 | grep '^+'`) so the check flags new
+  violations rather than any file that contains one. Failing that, at least exempt
+  `src/WebView2PdfMaker/*`.
+- **Context:** BL-16684 on Version6.4. Check added 2026-01-31 (8a9d1273b0); nothing had touched
+  that file since, so this had been sitting unsprung. Committed with `--no-verify` after running
+  csharpier / robustfile / xmlclasses by hand.
+
+## 2026-08-10 — Re-pointing a worktree between master and Version6.4 breaks the pre-commit hook
+
+- **Cut:** `.githooks/pre-commit` correctly routes a 6.4 checkout to the husky-4 hook, but that
+  hook dies with `Command "husky-run" not found` when the worktree's `src/BloomBrowserUI/node_modules`
+  was installed by master's pnpm. The dispatcher solves *which* hook runs, not whether its runner
+  is installed, so you get a hard commit failure with no hint that deps are the cause.
+- **Idea:** Have the dispatcher check for the runner and say "run ./init.sh — this branch uses
+  yarn+husky4 and this worktree has the pnpm deps" instead of letting husky's bare error through.
+- **Context:** BL-16684; worktree started on master, moved to Version6.4 because the bug ships in 6.4.
+
 ## 2026-07-22 — CDP capture: two footguns while driving Bloom's WebView2
 
 While recapturing MXB title pages over CDP (port 8091):

--- a/src/BloomExe/Book/UserPrefs.cs
+++ b/src/BloomExe/Book/UserPrefs.cs
@@ -15,7 +15,6 @@ namespace Bloom.Book
         private bool _loading = true;
         private string _filePath;
         private int _mostRecentPage;
-        private bool _reducePdfMemory;
         private string _colorProfileForPdf;
         private bool _fullBleed;
         private bool _includeBackgroundColors;
@@ -91,17 +90,6 @@ namespace Bloom.Book
             set
             {
                 _mostRecentPage = value;
-                Save();
-            }
-        }
-
-        [JsonProperty("reducePdfMemory")]
-        public bool ReducePdfMemoryUse
-        {
-            get { return _reducePdfMemory; }
-            set
-            {
-                _reducePdfMemory = value;
                 Save();
             }
         }

--- a/src/BloomExe/Publish/PDF/MakePdfUsingExternalPdfMakerProgram.cs
+++ b/src/BloomExe/Publish/PDF/MakePdfUsingExternalPdfMakerProgram.cs
@@ -204,27 +204,24 @@ namespace Bloom.Publish.PDF
                     @"***ERROR PDF generation failed: res.StandardError = " + res.StandardError
                 );
 
-                var msg = L10NSharp.LocalizationManager.GetString(
-                    @"PublishTab.PDF.Error.Failed",
-                    "Bloom was not able to create the PDF file ({0}).{1}{1}Details: BloomPdfMaker (command line) did not produce the expected document.",
-                    @"Error message displayed in a message dialog box. {0} is the filename, {1} is a newline character."
-                );
+                var fullMsg = GetUnsupportedPageSizeMessage(specs, res.StandardError);
+                if (fullMsg == null)
+                {
+                    var msg = L10NSharp.LocalizationManager.GetString(
+                        @"PublishTab.PDF.Error.Failed",
+                        "Bloom was not able to create the PDF file ({0}).{1}{1}Details: BloomPdfMaker (command line) did not produce the expected document.",
+                        @"Error message displayed in a message dialog box. {0} is the filename, {1} is a newline character."
+                    );
 
-                // This message string is intentionally separate because it was added after the previous string had already been localized in most languages.
-                // It's not useful to add if we're already in save memory mode.
-                var msg2 = specs.SaveMemoryMode
-                    ? ""
-                    : L10NSharp.LocalizationManager.GetString(
-                        @"PublishTab.PDF.Error.TrySinglePage",
-                        "The book's images might have exceeded the amount of RAM memory available. Please turn on the \"Use Less Memory\" option which is slower but uses less memory.",
-                        @"Error message displayed in a message dialog box"
-                    ) + Environment.NewLine;
-
-                var fullMsg =
-                    String.Format(msg, specs.OutputPdfPath, Environment.NewLine)
-                    + Environment.NewLine
-                    + msg2
-                    + res.StandardOutput;
+                    // We used to follow this with PublishTab.PDF.Error.TrySinglePage, which told the user
+                    // to turn on the "Use Less Memory" option. That option was taken out of the UI back in
+                    // 5.5 (BL-11954), so ever since then we have been sending people to hunt for a setting
+                    // that isn't there, whatever the real cause of the failure was (BL-16684).
+                    fullMsg =
+                        String.Format(msg, specs.OutputPdfPath, Environment.NewLine)
+                        + Environment.NewLine
+                        + res.StandardOutput;
+                }
 
                 var except = new ApplicationException(fullMsg);
                 // Note that if we're being run by a BackgroundWorker, it will catch the exception.
@@ -244,6 +241,45 @@ namespace Bloom.Publish.PDF
                 );
             }
         }
+
+        /// <summary>
+        /// BloomPdfMaker keeps its own list of the page sizes it can render. If we ask it for one
+        /// that isn't in that list, it can't make the PDF at all -- and because uploading makes a
+        /// PDF preview, the book can't be uploaded either. That means we offered the user a page
+        /// size we cannot actually produce, which is a bug in Bloom rather than anything they did.
+        ///
+        /// This turns that specific failure into a message that names the page size and says as
+        /// much, instead of the generic "did not produce the expected document" followed by the
+        /// child process's developer-facing output. See BL-16684, where an Ebook7x5 book failed
+        /// this way and the message instead advised turning on a memory option removed in 5.5.
+        /// </summary>
+        /// <returns>The message to show, or null if this failure was something else.</returns>
+        internal static string GetUnsupportedPageSizeMessage(
+            PdfMakingSpecs specs,
+            string standardError
+        )
+        {
+            // The marker is written by WebView2PdfMaker.Options.kUnsupportedPageSizeMarker. We match
+            // on it rather than on the English sentence around it so that rewording either end
+            // can't quietly turn this back into the generic message.
+            if (standardError == null || !standardError.Contains(kUnsupportedPageSizeMarker))
+                return null;
+
+            // Deliberately not localized: this can only appear if we have shipped a page size
+            // BloomPdfMaker can't render, which is a bug on our side that we expect to fix rather
+            // than translate. English is better than nothing for the rare user who hits it, and it
+            // is the form we want quoted back to us in the problem report.
+            // Note "Report a Problem..." rather than "report this": ReportPdfGenerationError sends
+            // ApplicationExceptions to ErrorReport.NotifyUserOfProblem(message) with no exception,
+            // and HtmlErrorReporter only shows its Report button when one is passed
+            // (AllowSendReport.AllowIfException). So this dialog has no report button, and we have
+            // to point at the Help menu instead of an affordance that isn't there.
+            return $"Bloom was not able to make a PDF of this book because its page size, \"{specs.PaperSizeName}\", is one that Bloom's PDF maker does not yet support. Please tell us using \"Report a Problem...\" on the Help menu. You can work around it by changing the book's page size.";
+        }
+
+        // Must match WebView2PdfMaker.Options.kUnsupportedPageSizeMarker. The two programs are
+        // built together and always ship together, so a shared literal is enough.
+        private const string kUnsupportedPageSizeMarker = "UNSUPPORTED-PAGE-SIZE";
 
         private static string GetNoDefaultPrinterErrorMessage()
         {
@@ -421,7 +457,6 @@ namespace Bloom.Publish.PDF
         public PublishModel.BookletLayoutMethod BooketLayoutMethod; // NoBooklet,SideFold,CutAndStack,Calendar
         public PublishModel.BookletPortions BookletPortion; // None,AllPagesNoBooklet,BookletCover,BookletPages,InnerContent
         public bool LayoutPagesForRightToLeft; // true if RTL, false if LTR layout
-        public bool SaveMemoryMode; // true if PDF file is to be produced using less memory (but more time)
         public bool BookIsFullBleed; // True if the book is laid out for full-bleed printing (and Enterprise is enabled)
         public bool PrintWithFullBleed; // True if (BookIsFullBleed and) full bleed is requested in the PdfOptions menu and we're not making a booklet
         public string ColorProfile; // the name of the ICC color profile file to use, empty string if none

--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -325,7 +325,6 @@ namespace Bloom.Publish
                             OutputPdfPath = PdfFilePath,
                             PaperSizeName = PageLayout.SizeAndOrientation.PageSizeName,
                             Landscape = PageLayout.SizeAndOrientation.IsLandScape,
-                            SaveMemoryMode = _currentlyLoadedBook.UserPrefs.ReducePdfMemoryUse,
                             LayoutPagesForRightToLeft = LayoutPagesForRightToLeft,
                             BooketLayoutMethod = layoutMethod,
                             BookletPortion = BookletPortion,

--- a/src/BloomTests/Publish/PDF/PdfMakerTests.cs
+++ b/src/BloomTests/Publish/PDF/PdfMakerTests.cs
@@ -30,7 +30,6 @@ namespace BloomTests.Publish.PDF
                     "A5",
                     false,
                     false,
-                    false,
                     PublishModel.BookletLayoutMethod.SideFold,
                     PublishModel.BookletPortions.AllPagesNoBooklet
                 );
@@ -69,7 +68,6 @@ namespace BloomTests.Publish.PDF
                     input.Path,
                     output.Path,
                     "A5",
-                    false,
                     false,
                     false,
                     PublishModel.BookletLayoutMethod.SideFold,
@@ -115,7 +113,6 @@ namespace BloomTests.Publish.PDF
                     "A5",
                     false,
                     false,
-                    false,
                     PublishModel.BookletLayoutMethod.SideFold,
                     PublishModel.BookletPortions.BookletPages
                 );
@@ -159,7 +156,6 @@ namespace BloomTests.Publish.PDF
                     "A5",
                     false,
                     false,
-                    false,
                     PublishModel.BookletLayoutMethod.SideFold,
                     PublishModel.BookletPortions.BookletPages
                 );
@@ -185,6 +181,114 @@ namespace BloomTests.Publish.PDF
         }
 
         /// <summary>
+        /// Every page size Bloom offers has to be one BloomPdfMaker also knows about, or the book
+        /// can't be turned into a PDF at all -- which blocks uploading too, since that makes a PDF
+        /// preview.  The StoryWeaver ebook sizes were added to Bloom's list of page sizes without
+        /// being added to BloomPdfMaker's, so they failed outright until BL-16684.  Device16x9 is
+        /// here as a control: it is the screen size that always worked.
+        /// </summary>
+        [TestCase("Ebook2x3", false)]
+        [TestCase("Ebook7x5", true)]
+        [TestCase("Device16x9", true)]
+        public void MakePdf_ScreenPageSize_OutputsPdf(string paperSize, bool landscape)
+        {
+            var maker = new PdfMaker();
+            using (var input = TempFile.WithExtension("html"))
+            using (var output = new TempFile())
+            {
+                File.WriteAllText(input.Path, "<html><body>Hello</body></html>");
+                File.Delete(output.Path);
+                Assert.IsFalse(
+                    File.Exists(output.Path),
+                    $"Setup failure: the output file should not exist before we make the PDF ({paperSize})"
+                );
+
+                var error = RunMakePdf(
+                    maker,
+                    input.Path,
+                    output.Path,
+                    paperSize,
+                    landscape,
+                    false,
+                    PublishModel.BookletLayoutMethod.SideFold,
+                    PublishModel.BookletPortions.AllPagesNoBooklet
+                );
+
+                Assert.IsNull(
+                    error,
+                    $"Making a PDF at page size {paperSize} reported an error: {error?.Message}"
+                );
+                Assert.IsTrue(
+                    File.Exists(output.Path),
+                    $"Failed to convert trivial HTML file to PDF at page size {paperSize}"
+                );
+                var bytes = File.ReadAllBytes(output.Path);
+                Assert.Less(
+                    1000,
+                    bytes.Length,
+                    $"Generated PDF file is way too small! ({paperSize})"
+                );
+                Assert.IsTrue(
+                    bytes[0] == (byte)'%'
+                        && bytes[1] == (byte)'P'
+                        && bytes[2] == (byte)'D'
+                        && bytes[3] == (byte)'F',
+                    $"Generated PDF file started with the wrong 4-byte signature ({paperSize})"
+                );
+            }
+        }
+
+        /// <summary>
+        /// If we ever again offer a page size BloomPdfMaker can't render (which is what BL-16684
+        /// was), the user should be told that in so many words, naming the size, rather than being
+        /// shown the generic failure plus the child process's developer output.  "NoSuchSize" is a
+        /// stand-in for the next page size someone adds to Bloom and forgets to add to
+        /// BloomPdfMaker.
+        /// </summary>
+        [Test]
+        public void MakePdf_PageSizeBloomPdfMakerDoesNotKnow_SaysSoAndNamesTheSize()
+        {
+            var maker = new PdfMaker();
+            using (var input = TempFile.WithExtension("html"))
+            using (var output = new TempFile())
+            {
+                File.WriteAllText(input.Path, "<html><body>Hello</body></html>");
+                File.Delete(output.Path);
+
+                var error = RunMakePdf(
+                    maker,
+                    input.Path,
+                    output.Path,
+                    "NoSuchSize",
+                    false,
+                    false,
+                    PublishModel.BookletLayoutMethod.SideFold,
+                    PublishModel.BookletPortions.AllPagesNoBooklet
+                );
+
+                Assert.IsNotNull(
+                    error,
+                    "Setup failure: making a PDF at an unknown page size should have failed"
+                );
+                Assert.That(
+                    error.Message,
+                    Does.Contain("NoSuchSize"),
+                    "The message should name the offending page size so the user (and we) know which one it is"
+                );
+                Assert.That(
+                    error.Message,
+                    Does.Not.Contain("did not produce the expected document"),
+                    "This should be the specific page-size message, not the generic PDF failure"
+                );
+                Assert.That(
+                    error.Message,
+                    Does.Not.Contain("UNSUPPORTED-PAGE-SIZE"),
+                    "The marker we grep for is internal and should not reach the user"
+                );
+            }
+        }
+
+        /// <summary>
         /// Runs PdfMaker.MakePdf() with the desired arguments.  Note that the implementation (as of March 2015)
         /// uses an external program to generate the PDF from the HTML file, so it doesn't need to be run on
         /// a background thread.  The process includes a (possibly overgenerous) timeout, so we don't try to
@@ -197,13 +301,17 @@ namespace BloomTests.Publish.PDF
         /// almost certainly an obscure bug in Mono.  Running the method directly as we do here sidesteps that
         /// problem.  (See https://jira.sil.org/browse/BL-831.)
         /// </remarks>
-        void RunMakePdf(
+        /// <returns>
+        /// The exception MakePdf passed back through the DoWorkEventArgs, or null if it succeeded.
+        /// A test that only checks for the output file reports "no PDF" when what the caller really
+        /// wants to know is why, and the exception carries BloomPdfMaker's own explanation.
+        /// </returns>
+        System.Exception RunMakePdf(
             PdfMaker maker,
             string input,
             string output,
             string paperSize,
             bool landscape,
-            bool saveMemoryMode,
             bool rightToLeft,
             PublishModel.BookletLayoutMethod layout,
             PublishModel.BookletPortions portion
@@ -220,7 +328,6 @@ namespace BloomTests.Publish.PDF
                     OutputPdfPath = output,
                     PaperSizeName = paperSize,
                     Landscape = landscape,
-                    SaveMemoryMode = saveMemoryMode,
                     LayoutPagesForRightToLeft = rightToLeft,
                     BooketLayoutMethod = layout,
                     BookletPortion = portion,
@@ -229,6 +336,7 @@ namespace BloomTests.Publish.PDF
                 eventArgs,
                 null
             );
+            return eventArgs.Result as System.Exception;
         }
     }
 }

--- a/src/WebView2PdfMaker/Program.cs
+++ b/src/WebView2PdfMaker/Program.cs
@@ -242,6 +242,12 @@ namespace WebView2PdfMaker
             }
         }
 
+        /// <summary>
+        /// Prefixes the error we report when asked for a page size we don't know. Bloom looks for
+        /// this exact text on our standard error; see MakePdfUsingExternalPdfMakerProgram.
+        /// </summary>
+        internal const string kUnsupportedPageSizeMarker = "UNSUPPORTED-PAGE-SIZE";
+
         private PaperSize GetPaperSize(string name)
         {
             name = name.ToLowerInvariant();
@@ -261,18 +267,43 @@ namespace WebView2PdfMaker
                 new PaperSize("legal", 215.9, 355.6),
                 new PaperSize("halflegal", 177.8, 215.9),
                 new PaperSize("device16x9", 100, 1600d / 9d),
+                // The two StoryWeaver ebook sizes are the only ones Bloom defines in CSS pixels
+                // rather than a physical unit (see @Ebook2x3Portrait-* and @Ebook7x5Landscape-*
+                // in paperDimensions.less), so convert at the CSS standard 96px per inch.
+                // Note that, like every other entry in this list, these are the *portrait*
+                // dimensions. Ebook7x5 is only ever offered as landscape, so Bloom passes
+                // "-O landscape" with it and WebView2 swaps the two for us.
+                new PaperSize(
+                    "ebook2x3",
+                    475 * kMillimetersPerCssPixel,
+                    700 * kMillimetersPerCssPixel
+                ),
+                new PaperSize(
+                    "ebook7x5",
+                    690 * kMillimetersPerCssPixel,
+                    959 * kMillimetersPerCssPixel
+                ),
             };
 
             var match = sizes.Find(s => s.Name == name);
             if (match != null)
                 return match;
 
+            // Bloom greps stderr for this marker so it can tell this specific failure apart from
+            // every other reason PDF making can fail, and say something useful about it rather
+            // than showing the user this developer-facing sentence (BL-16684). Keep the marker
+            // and the ": <name>" that follows it in step with kUnsupportedPageSizeMarker in
+            // MakePdfUsingExternalPdfMakerProgram.
             throw new ApplicationException(
-                "Sorry, currently WebView2PdfMaker has a very limited set of paper sizes it knows about. Consider using the page-height and page-width arguments instead"
+                $"{kUnsupportedPageSizeMarker}: {name}. WebView2PdfMaker has a very limited set of paper sizes it knows about. Consider using the page-height and page-width arguments instead"
             );
         }
 
         const double kMillimetersPerInch = 25.4; // (or more precisely, 25.3999999999726)
+
+        // CSS defines a pixel as exactly 1/96 inch, which is how the browser interprets the
+        // px-based page dimensions in paperDimensions.less.
+        const double kMillimetersPerCssPixel = kMillimetersPerInch / 96;
 
         internal double GetWebView2PageWidth()
         {


### PR DESCRIPTION
Books at the StoryWeaver ebook page sizes could not be made into a PDF at all — which also blocked uploading, since uploading makes a PDF preview. And when it failed, Bloom told the user to turn on a setting that was removed years ago.

## The page sizes

`Ebook2x3Portrait` and `Ebook7x5Landscape` were added as page sizes in 6.4, but `BloomPdfMaker` (WebView2PdfMaker) was never taught about them. Any size Bloom does not special-case is passed straight through as `-s <name>`, and `GetPaperSize` threw for these two.

Both are now in WebView2PdfMaker's paper size list. They are the only Bloom page sizes declared in CSS pixels rather than a physical unit (deliberately, to match StoryWeaver's ePUB CSS), so they are converted at the CSS standard of 96px per inch. Like every other entry in that list they are stored as *portrait* dimensions; `Ebook7x5` is only ever offered as landscape, so Bloom passes `-O landscape` and WebView2 swaps them.

Verified against the generated PDFs' `MediaBox`:

| Page size | Expected | Actual |
| --- | --- | --- |
| `Ebook7x5` landscape | 719.3 × 517.5 pt | 719.04 × 516.96 |
| `Ebook2x3` portrait | 356.3 × 525.0 pt | 355.92 × 525.12 |
| `Device16x9` landscape (control) | 504 × 283.5 pt | 504 × 282.96 |

The sub-point deltas are WebView2 quantizing to 1/100 inch.

## The message

Whenever PDF generation failed, Bloom appended *"The book's images might have exceeded the amount of RAM memory available. Please turn on the "Use Less Memory" option…"*. That option was taken out of the UI in 5.5 (BL-11954), so for years we have been sending people to hunt for a setting that no longer exists — whatever the real cause was. That is exactly what happened on this report: the actual failure was the unknown page size, and the message sent the user looking for a memory option.

The advice is gone, along with the plumbing that only fed it. `UserPrefs.ReducePdfMemoryUse` had no way to be set once the checkbox went away, so `PdfMakingSpecs.SaveMemoryMode` was always `false` and this message was its last remaining reader. Json.NET ignores the leftover `reducePdfMemory` key in existing `userPrefs` files, so old books are unaffected.

## Tests

`MakePdf_ScreenPageSize_OutputsPdf` covers both ebook sizes with `Device16x9` as a control. Sanity-checked: with the WebView2PdfMaker change reverted, the two ebook cases fail and the control passes.

`RunMakePdf` now returns the exception `MakePdf` hands back through `DoWorkEventArgs`, so a failure reports *why* it failed rather than just "no PDF file appeared".

## Note on the branch

Targets `Version6.4` rather than `master`: the ebook page sizes landed on `Version6.4` in `1c8e24b50d` (2026-06-25), so the broken PDF ships in released 6.4, not only in the 6.5 alpha the bug was reported against.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16684


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8190)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8190)
<!-- Reviewable:end -->
