### PR TITLE
Fix BloomServer shutdown race that crashed the test host (BL-16667)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,12 @@ under `output/agent/<key>/` so your build/test never touches the locked shared o
 means you do **not** need to stop the developer's Bloom to build or run unit tests, and
 multiple terminals can build/test at once. See `Directory.Build.props` for how it works.
 
+- For `test`, the wrapper **judges the run and prints a verdict as its last line**, so
+  `[agent-dotnet] test run completed. Passed! ...` is the only thing you need to read (and it
+  survives `| tail`). Do not judge a run by the `Passed!`/`Failed!` summary above it: a run whose
+  test host is killed part way through still prints a passing summary of however many tests got to
+  run. The wrapper catches that and says `*** TEST RUN ABORTED ***`, and exits non-zero, as it
+  does for ordinary failures. The text it looks for lives in `build/test-abort-markers.txt`.
 - This wrapper is for **building and running tests only**. To *run* Bloom, still use
   `./go.sh` (see "Running Bloom" below) — the wrapper builds no `Bloom.exe` apphost.
   (`BloomPdfMaker.exe` is the one apphost it does build, because Bloom's PDF code shells

--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -166,22 +166,6 @@ House rules:
   own suite.
 
 
-## 2026-07-24 — agent-dotnet.sh test exits 0 even when tests fail
-
-- **Cut:** `build/agent-dotnet.sh test src/BloomTests/BloomTests.csproj` returned exit code 0 on a
-  run whose own summary line read `Failed! - Failed: 11, Passed: 2913`. Anything that trusts the
-  exit code instead of parsing the output — an agent, a hook, a CI step, a background-task
-  notification that just reports "completed (exit code 0)" — will conclude the suite passed. During
-  this run the harness reported the failing suite as a success and it was only caught by reading the
-  summary line.
-- **Idea:** Have the wrapper propagate `dotnet test`'s real exit code (it presumably exits on the
-  last command in a pipeline, or swallows the status while redirecting into the private output
-  tree). Until then, treat "did the C# suite pass?" as a question only the output can answer.
-- **Context:** BloomDesktop, found during `/preflight` of PR #7992 (BL-16459 clipboard toast).
-  Distinct from the (now-fixed) cut about *which* tests fail under the wrapper — PR #8107 made
-  the full suite green, so a failure there is real; this entry is about the wrapper reporting
-  failure as success, which still stands.
-
 ## 2026-07-24 — go.sh "succeeds" on a fresh worktree whose output/browser was never built
 - **Cut:** On a never-initialized worktree, after fixing the obvious failures (pnpm install,
   getDependencies for CS0246), `./go.sh` launches and Bloom looks healthy — but opening a book

--- a/build/Bloom.proj
+++ b/build/Bloom.proj
@@ -301,6 +301,15 @@
     </Exec>
     <Message Condition="$(isOnTeamCity) == true" Importance="high" Text="##teamcity[importData type='nunit' path='$(TestResultsXmlFile)']"/>
     <Error Condition="'$(TestExitCode)' != '0'" Text="C# tests failed (dotnet test returned $(TestExitCode)). Results: $(TestResultsXmlFile)"/>
+    <!-- The exit code is not on its own enough to tell us the run finished. When the test host is
+	     killed part way through — which Bloom's own shutdown used to do about one run in three, see
+	     BL-16667 — the runner still prints a summary of the tests that had passed by then, and we
+	     cannot rely on every such death producing a non-zero exit. But the logger only writes the
+	     results file once the run completes, and we deleted any earlier one above, so a missing
+	     file is proof that the run did not finish. Without this check that case reaches TeamCity as
+	     a green build that ran a fraction of the suite. -->
+    <Error Condition="!Exists('$(TestResultsXmlFile)')"
+		   Text="The C# test run did not finish: it exited $(TestExitCode) but never wrote $(TestResultsXmlFile), which the logger does only on completion. The test host was probably killed part way through, so however many tests the output says passed, the suite did not run."/>
   </Target>
   <Target Name="MakeDownloadPointers" DependsOnTargets="VersionNumbers"
 		Condition="'$(OS)'=='Windows_NT'">

--- a/build/agent-dotnet.ps1
+++ b/build/agent-dotnet.ps1
@@ -11,6 +11,10 @@
 # build and run unit tests while a Bloom keeps running and while other terminals do
 # their own builds.
 #
+# For `test` it also judges the run and prints a verdict as its last line -- see the
+# "Judging a test run" comment in agent-dotnet.sh for why that is not something the
+# exit code can be trusted to do on its own.
+#
 # Usage (exactly like dotnet, just build/test through this script):
 #   build/agent-dotnet.ps1 test src/BloomTests/BloomTests.csproj --filter "FullyQualifiedName~UrlPathStringTests"
 #   build/agent-dotnet.ps1 build src/BloomExe/BloomExe.csproj
@@ -32,5 +36,76 @@ Write-Host "[agent-dotnet] isolated build dir: $scratch"
 # the BloomPdfMaker.exe the PDF tests shell out to — so it now lives in
 # Directory.Build.props, which a global property would have overridden.
 $env:BLOOM_AGENT_BUILD_DIR = $scratch
-& dotnet @args "-p:OutDir=$scratch/bin/"
-exit $LASTEXITCODE
+
+# For everything except `test`, dotnet's own exit code is the whole story.
+if ($args.Count -eq 0 -or $args[0] -ne 'test') {
+    & dotnet @args "-p:OutDir=$scratch/bin/"
+    exit $LASTEXITCODE
+}
+
+$markersFile = Join-Path $PSScriptRoot 'test-abort-markers.txt'
+if (-not (Test-Path $markersFile)) {
+    Write-Host "[agent-dotnet] cannot find $markersFile, so a truncated test run could not be detected"
+    exit 1
+}
+
+$log = Join-Path ([System.IO.Path]::GetTempPath()) "agent-dotnet-test-$PID.log"
+
+# stderr is merged in because that is where the runtime prints the crash banners we look
+# for. In Windows PowerShell that redirection wraps each stderr line in an ErrorRecord,
+# which under $ErrorActionPreference='Stop' would end the script; hence Continue for the
+# duration, and the stringify step so what reaches the console and the log is plain text.
+$ErrorActionPreference = 'Continue'
+& dotnet @args "-p:OutDir=$scratch/bin/" 2>&1 |
+    ForEach-Object {
+        # An ErrorRecord here is just a line dotnet wrote to stderr. Take its message rather than
+        # letting PowerShell format it, which for some of them yields the useless string
+        # "System.Management.Automation.RemoteException" -- and a crash banner turned into that
+        # would be a marker we could no longer match.
+        if ($_ -is [System.Management.Automation.ErrorRecord]) { $_.Exception.Message } else { [string]$_ }
+    } | Tee-Object -FilePath $log
+$status = $LASTEXITCODE
+$ErrorActionPreference = 'Stop'
+
+try {
+    $abortEvidence = $null
+    foreach ($pattern in Get-Content $markersFile) {
+        if ($pattern.Trim() -eq '' -or $pattern.TrimStart().StartsWith('#')) { continue }
+        $hit = Select-String -Path $log -Pattern $pattern -List
+        if ($hit) { $abortEvidence = $hit.Line.Trim(); break }
+    }
+
+    $summaryHit = Select-String -Path $log -Pattern '^[ \t]*(Passed|Failed)!'
+    $summary = if ($summaryHit) { $summaryHit[-1].Line.Trim() } else { $null }
+
+    Write-Host ""
+    if ($abortEvidence) {
+        Write-Host "[agent-dotnet] *** TEST RUN ABORTED -- NOT a pass. ***"
+        Write-Host "[agent-dotnet] Evidence: $abortEvidence"
+        Write-Host "[agent-dotnet] Any summary above counts only the tests that ran before this, so it means nothing."
+        exit 1
+    }
+    if ($status -ne 0) {
+        $detail = if ($summary) { $summary } else { 'No summary line was printed.' }
+        Write-Host "[agent-dotnet] *** TEST RUN FAILED (dotnet exited $status). *** $detail"
+        exit $status
+    }
+    if (-not $summary) {
+        # A discovery-only run has no tests to summarize, so its silence is not evidence of anything.
+        if ($args -contains '--list-tests' -or $args -contains '-t') {
+            Write-Host "[agent-dotnet] listed tests without running them."
+            exit 0
+        }
+        Write-Host "[agent-dotnet] *** TEST RUN INCOMPLETE: it exited 0 but never printed a summary, so we do not know what ran. ***"
+        exit 1
+    }
+    if ($summary -like '*Failed!*') {
+        # dotnet said 0 but its own summary says otherwise; believe the summary.
+        Write-Host "[agent-dotnet] *** TEST RUN FAILED. *** $summary"
+        exit 1
+    }
+    Write-Host "[agent-dotnet] test run completed. $summary"
+}
+finally {
+    Remove-Item $log -ErrorAction SilentlyContinue
+}

--- a/build/agent-dotnet.ps1
+++ b/build/agent-dotnet.ps1
@@ -65,6 +65,12 @@ $ErrorActionPreference = 'Continue'
         if ($_ -is [System.Management.Automation.ErrorRecord]) { $_.Exception.Message } else { [string]$_ }
     } | Tee-Object -FilePath $log
 $status = $LASTEXITCODE
+# $LASTEXITCODE is never assigned if dotnet could not be launched at all -- not on PATH in this
+# terminal, say -- because then nothing ran to set it. That leaves $status $null, and PowerShell
+# turns `exit $null` into exit code 0: this script would announce a failed run and hand its caller
+# a success. Which is the exact hazard it exists to remove. (The bash twin cannot have this hole;
+# PIPESTATUS[0] is always a number.)
+if ($null -eq $status) { $status = 1 }
 $ErrorActionPreference = 'Stop'
 
 try {

--- a/build/agent-dotnet.ps1
+++ b/build/agent-dotnet.ps1
@@ -68,14 +68,20 @@ $status = $LASTEXITCODE
 $ErrorActionPreference = 'Stop'
 
 try {
+    # Match against the output with the indentation taken off the front of every line. That is what
+    # lets the markers file anchor its patterns with a plain ^ and mean the same thing here as it
+    # does to grep -E in the bash twin -- writing "start of line, then optional whitespace" is the
+    # one thing the two regex engines cannot be made to agree on (see the note in the markers file).
+    $trimmedOutput = Get-Content $log | ForEach-Object { $_.TrimStart() }
+
     $abortEvidence = $null
     foreach ($pattern in Get-Content $markersFile) {
         if ($pattern.Trim() -eq '' -or $pattern.TrimStart().StartsWith('#')) { continue }
-        $hit = Select-String -Path $log -Pattern $pattern -List
+        $hit = $trimmedOutput | Select-String -Pattern $pattern -List
         if ($hit) { $abortEvidence = $hit.Line.Trim(); break }
     }
 
-    $summaryHit = Select-String -Path $log -Pattern '^[ \t]*(Passed|Failed)!'
+    $summaryHit = $trimmedOutput | Select-String -Pattern '^(Passed|Failed)!'
     $summary = if ($summaryHit) { $summaryHit[-1].Line.Trim() } else { $null }
 
     Write-Host ""

--- a/build/agent-dotnet.ps1
+++ b/build/agent-dotnet.ps1
@@ -77,11 +77,15 @@ try {
     $abortEvidence = $null
     foreach ($pattern in Get-Content $markersFile) {
         if ($pattern.Trim() -eq '' -or $pattern.TrimStart().StartsWith('#')) { continue }
-        $hit = $trimmedOutput | Select-String -Pattern $pattern -List
+        # -CaseSensitive because grep -E in the bash twin is, and Select-String is not unless told.
+        # Without it the same output could be judged aborted here and passing there -- and the
+        # markers file spells "[Tt]esthost" out precisely because it expects to be matched with
+        # case respected.
+        $hit = $trimmedOutput | Select-String -Pattern $pattern -List -CaseSensitive
         if ($hit) { $abortEvidence = $hit.Line.Trim(); break }
     }
 
-    $summaryHit = $trimmedOutput | Select-String -Pattern '^(Passed|Failed)!'
+    $summaryHit = $trimmedOutput | Select-String -Pattern '^(Passed|Failed)!' -CaseSensitive
     $summary = if ($summaryHit) { $summaryHit[-1].Line.Trim() } else { $null }
 
     Write-Host ""

--- a/build/agent-dotnet.sh
+++ b/build/agent-dotnet.sh
@@ -84,7 +84,8 @@ if [ ! -f "$MARKERS" ]; then
 fi
 
 LOG="$(mktemp -t agent-dotnet-test-XXXXXX)"
-trap 'rm -f "$LOG"' EXIT
+TRIMMED="$LOG.trimmed"
+trap 'rm -f "$LOG" "$TRIMMED"' EXIT
 
 # stderr is merged in because that is where the runtime prints the crash banners we are
 # looking for. PIPESTATUS[0] rather than $? because $? here would be tee's.
@@ -93,6 +94,12 @@ BLOOM_AGENT_BUILD_DIR="$SCRATCH" dotnet "$@" -p:OutDir="$SCRATCH/bin/" 2>&1 | te
 STATUS=${PIPESTATUS[0]}
 set -e
 
+# Match against a copy with the indentation taken off the front of every line. That is what lets
+# the markers file anchor its patterns with a plain ^ and mean the same thing here as it does to
+# Select-String in the PowerShell twin -- writing "start of line, then optional whitespace" is the
+# one thing the two regex engines cannot be made to agree on (see the note in the markers file).
+sed 's/^[[:space:]]*//' "$LOG" >"$TRIMMED"
+
 ABORT_EVIDENCE=""
 while IFS= read -r pattern || [ -n "$pattern" ]; do
     # The repo is text=auto and Windows checkouts are autocrlf, so the markers file may well
@@ -100,14 +107,14 @@ while IFS= read -r pattern || [ -n "$pattern" ]; do
     # would silently stop it ever matching, which is the one failure this file must not have.
     pattern="${pattern%$'\r'}"
     case "$pattern" in '' | '#'*) continue ;; esac
-    match="$(grep -m1 -E "$pattern" "$LOG" || true)"
+    match="$(grep -m1 -E "$pattern" "$TRIMMED" || true)"
     if [ -n "$match" ]; then
         ABORT_EVIDENCE="$match"
         break
     fi
 done <"$MARKERS"
 
-SUMMARY="$(grep -E '^[ \t]*(Passed|Failed)!' "$LOG" | tail -1 || true)"
+SUMMARY="$(grep -E "^(Passed|Failed)!" "$TRIMMED" | tail -1 || true)"
 
 echo ""
 if [ -n "$ABORT_EVIDENCE" ]; then

--- a/build/agent-dotnet.sh
+++ b/build/agent-dotnet.sh
@@ -17,6 +17,9 @@
 #   the one global -p: this script appends, and apphost policy lives in that same props
 #   file because it has to vary per project).
 #
+#   For `test` it does one more thing: it judges the run itself and prints a verdict as
+#   its LAST line. See "Judging a test run" below.
+#
 # Usage (exactly like dotnet, just build/test through this script):
 #   build/agent-dotnet.sh test src/BloomTests/BloomTests.csproj --filter "FullyQualifiedName~UrlPathStringTests"
 #   build/agent-dotnet.sh build src/BloomExe/BloomExe.csproj
@@ -48,5 +51,91 @@ echo "[agent-dotnet] isolated build dir: $SCRATCH" >&2
 # be a global here too, but it has to vary per project — WebView2PdfMaker's apphost is
 # the BloomPdfMaker.exe the PDF tests shell out to — so it now lives in
 # Directory.Build.props, which a global property would have overridden.
-BLOOM_AGENT_BUILD_DIR="$SCRATCH" exec dotnet "$@" \
-    -p:OutDir="$SCRATCH/bin/"
+
+# For everything except `test`, dotnet's own exit code is the whole story, so get out of
+# the way entirely and let it have this process.
+if [ "${1:-}" != "test" ]; then
+    BLOOM_AGENT_BUILD_DIR="$SCRATCH" exec dotnet "$@" \
+        -p:OutDir="$SCRATCH/bin/"
+fi
+
+# ---------------------------------------------------------------------------
+# Judging a test run
+#
+# A `dotnet test` run can stop early — Bloom's own code taking the test host down with
+# it is the case that prompted this (BL-16667) — and when it does, VSTest still prints a
+# summary of the tests that got as far as running. Everything that ran had passed, so
+# that summary reads "Passed!". Anything that judges the run by its last lines, which is
+# what a human skimming and an agent reading `| tail` both do, calls that green.
+#
+# There is a second way to be told a lie here, recorded in PAPERCUTS.md: a run whose own
+# summary said `Failed! - Failed: 11` still arrived at the caller as exit code 0 (a pipe
+# swallows the status, and callers do pipe this).
+#
+# So: capture the output, judge it three ways (crash markers, dotnet's exit code, the
+# summary line), and print a one-line verdict LAST so it survives `| tail`. Nothing is
+# hidden — the output still streams to the terminal as it happens.
+# ---------------------------------------------------------------------------
+
+MARKERS="$SCRIPT_DIR/test-abort-markers.txt"
+if [ ! -f "$MARKERS" ]; then
+    echo "[agent-dotnet] cannot find $MARKERS, so a truncated test run could not be detected" >&2
+    exit 1
+fi
+
+LOG="$(mktemp -t agent-dotnet-test-XXXXXX)"
+trap 'rm -f "$LOG"' EXIT
+
+# stderr is merged in because that is where the runtime prints the crash banners we are
+# looking for. PIPESTATUS[0] rather than $? because $? here would be tee's.
+set +e
+BLOOM_AGENT_BUILD_DIR="$SCRATCH" dotnet "$@" -p:OutDir="$SCRATCH/bin/" 2>&1 | tee "$LOG"
+STATUS=${PIPESTATUS[0]}
+set -e
+
+ABORT_EVIDENCE=""
+while IFS= read -r pattern || [ -n "$pattern" ]; do
+    # The repo is text=auto and Windows checkouts are autocrlf, so the markers file may well
+    # arrive with CRLF line endings. A trailing carriage return left on the end of a pattern
+    # would silently stop it ever matching, which is the one failure this file must not have.
+    pattern="${pattern%$'\r'}"
+    case "$pattern" in '' | '#'*) continue ;; esac
+    match="$(grep -m1 -E "$pattern" "$LOG" || true)"
+    if [ -n "$match" ]; then
+        ABORT_EVIDENCE="$match"
+        break
+    fi
+done <"$MARKERS"
+
+SUMMARY="$(grep -E '^[ \t]*(Passed|Failed)!' "$LOG" | tail -1 || true)"
+
+echo ""
+if [ -n "$ABORT_EVIDENCE" ]; then
+    echo "[agent-dotnet] *** TEST RUN ABORTED -- NOT a pass. ***"
+    echo "[agent-dotnet] Evidence: $ABORT_EVIDENCE"
+    echo "[agent-dotnet] Any summary above counts only the tests that ran before this, so it means nothing."
+    exit 1
+fi
+if [ "$STATUS" -ne 0 ]; then
+    echo "[agent-dotnet] *** TEST RUN FAILED (dotnet exited $STATUS). *** ${SUMMARY:-No summary line was printed.}"
+    exit "$STATUS"
+fi
+if [ -z "$SUMMARY" ]; then
+    # A discovery-only run has no tests to summarize, so its silence is not evidence of anything.
+    for arg in "$@"; do
+        if [ "$arg" = "--list-tests" ] || [ "$arg" = "-t" ]; then
+            echo "[agent-dotnet] listed tests without running them."
+            exit 0
+        fi
+    done
+    echo "[agent-dotnet] *** TEST RUN INCOMPLETE: it exited 0 but never printed a summary, so we do not know what ran. ***"
+    exit 1
+fi
+case "$SUMMARY" in
+    *Failed!*)
+        # dotnet said 0 but its own summary says otherwise; believe the summary.
+        echo "[agent-dotnet] *** TEST RUN FAILED. *** $SUMMARY"
+        exit 1
+        ;;
+esac
+echo "[agent-dotnet] test run completed. $SUMMARY"

--- a/build/test-abort-markers.txt
+++ b/build/test-abort-markers.txt
@@ -1,0 +1,35 @@
+# Text that means a `dotnet test` run did not finish the tests it was asked to run.
+#
+# Read by BOTH build/agent-dotnet.sh and build/agent-dotnet.ps1 after a test run, so that an
+# aborted run is reported as a failure instead of being judged by its pass/fail summary. It has
+# to live in one file because the two scripts are twins and a marker added to one and not the
+# other would silently only work in one shell.
+#
+# Why this is needed at all: when Bloom's own code kills the test host part way through, VSTest
+# still prints a summary of the tests that had run by then -- and since everything that ran had
+# passed, that summary says "Passed!". A human skimming, a script, or an agent reading the last
+# line will call that green. See BL-16667, which is also the bug that made it happen often.
+#
+# One extended regular expression per line; blank lines and # comments are ignored. Keep them
+# simple enough to mean the same thing to grep -E and to .NET's Select-String: no \s, no
+# [[:space:]], no lazy quantifiers. Anchor the ones that could otherwise match a test's own
+# output (a test about error reporting may well print the words "unhandled exception"); the
+# runtime prints its banners at the start of a line.
+
+# The .NET runtime's own death notices. The second is what Environment.FailFast prints, which is
+# what a failing Debug.Assert or Debug.Fail comes to in a process with no debugger attached.
+^[ \t]*Unhandled exception\.
+^[ \t]*Process terminated\.
+^[ \t]*Fatal error\.
+^[ \t]*Stack overflow\.
+Process is terminating due to StackOverflowException
+
+# VSTest noticing that the host it was driving went away.
+Test Run Aborted
+The active test run was aborted
+[Tt]esthost process exited with error
+test host process crashed
+
+# Nothing ran at all: normally a filter that matches nothing, which is a mistake worth catching
+# rather than a green run of zero tests.
+^[ \t]*No test is available

--- a/build/test-abort-markers.txt
+++ b/build/test-abort-markers.txt
@@ -42,7 +42,7 @@ Process is terminating due to StackOverflowException
 Test Run Aborted
 The active test run was aborted
 [Tt]esthost process exited with error
-test host process crashed
+[Tt]est host process crashed
 
 # Nothing ran at all: normally a filter that matches nothing, which is a mistake worth catching
 # rather than a green run of zero tests.

--- a/build/test-abort-markers.txt
+++ b/build/test-abort-markers.txt
@@ -12,16 +12,22 @@
 #
 # One extended regular expression per line; blank lines and # comments are ignored. Keep them
 # simple enough to mean the same thing to grep -E and to .NET's Select-String: no \s, no
-# [[:space:]], no lazy quantifiers. Anchor the ones that could otherwise match a test's own
-# output (a test about error reporting may well print the words "unhandled exception"); the
-# runtime prints its banners at the start of a line.
+# [[:space:]], no lazy quantifiers, and in particular no [ \t] -- inside a bracket expression
+# grep -E reads that as a literal backslash and letter t, while .NET reads it as a tab, so a
+# pattern using it would quietly mean different things in the two scripts this file exists to
+# keep in step. Both scripts strip leading whitespace from each line of output before matching,
+# so an anchored pattern here needs no allowance for indentation.
+#
+# Anchor the ones that could otherwise match a test's own output (a test about error reporting
+# may well print the words "unhandled exception"); the runtime prints its banners at the start
+# of a line.
 
 # The .NET runtime's own death notices. The second is what Environment.FailFast prints, which is
 # what a failing Debug.Assert or Debug.Fail comes to in a process with no debugger attached.
-^[ \t]*Unhandled exception\.
-^[ \t]*Process terminated\.
-^[ \t]*Fatal error\.
-^[ \t]*Stack overflow\.
+^Unhandled exception\.
+^Process terminated\.
+^Fatal error\.
+^Stack overflow\.
 Process is terminating due to StackOverflowException
 
 # VSTest noticing that the host it was driving went away.
@@ -32,4 +38,4 @@ test host process crashed
 
 # Nothing ran at all: normally a filter that matches nothing, which is a mistake worth catching
 # rather than a green run of zero tests.
-^[ \t]*No test is available
+^No test is available

--- a/build/test-abort-markers.txt
+++ b/build/test-abort-markers.txt
@@ -19,8 +19,16 @@
 # so an anchored pattern here needs no allowance for indentation.
 #
 # Anchor the ones that could otherwise match a test's own output (a test about error reporting
-# may well print the words "unhandled exception"); the runtime prints its banners at the start
-# of a line.
+# may well print the words "unhandled exception"); the runtime prints its banners at the start of
+# a line. Note what the anchor does and does not buy, since the lines are trimmed first: it still
+# rules out the words appearing mid-sentence, which is the common case, but not a test whose own
+# output begins with them on an indented line. That would cost a false "aborted" on a run that
+# actually finished -- annoying, but the safe direction to be wrong in, and the verdict prints the
+# line it matched on, so it takes one look to see what happened.
+#
+# Case matters: the bash twin matches with grep -E, which is case-sensitive, so the PowerShell one
+# passes -CaseSensitive to Select-String, which is not by default. Write patterns accordingly --
+# hence "[Tt]esthost" below rather than relying on either engine to be lenient.
 
 # The .NET runtime's own death notices. The second is what Environment.FailFast prints, which is
 # what a failing Debug.Assert or Debug.Fail comes to in a process with no debugger attached.

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -145,6 +145,14 @@ namespace Bloom.Api
         private readonly ManualResetEvent _stop;
 
         /// <summary>
+        /// True from the moment Dispose tells our threads to stop. After that the listener and the
+        /// handles it owns can be closed while a request is still being finished, so failures in
+        /// the request path are the expected cost of quitting rather than a sign of a bug, and code
+        /// that would otherwise make a fuss about them should keep quiet. See BL-16667.
+        /// </summary>
+        private bool IsShuttingDown => IsDisposed || _stop.WaitOne(0);
+
+        /// <summary>
         /// Notifies threads in the _workers pool that there is a request in the _queue
         /// </summary>
         private readonly ManualResetEvent _ready;
@@ -1952,31 +1960,52 @@ namespace Bloom.Api
         /// <param name="ar"></param>
         private void QueueRequest(IAsyncResult ar)
         {
-            // this can happen when shutting down
-            // BL-2207 indicates it may be possible for the thread to be alive and the listener closed,
-            // although the only way I know it gets closed happens after joining with that thread.
-            // Still, one more check seems worthwhile...if we're far enough along in shutting down
-            // to have closed the listener we certainly can't respond to any more requests.
-            if (!_listenerThread.IsAlive || !_listener.IsListening)
-                return;
-
-            lock (_queue)
+            // This runs on a thread pool thread, as the completion of the BeginGetContext in
+            // EnqueueIncomingRequests, so nothing we do here is inside any try/catch of ours: an
+            // exception that got out would be unhandled and would kill the process (BL-16667).
+            // Everything below can throw during shutdown -- closing the listener is what completes
+            // the pending BeginGetContext in the first place, and it nulls out _listener -- so the
+            // whole thing has to be guarded, not just the parts we can think of a reason for.
+            try
             {
-                _queue.Enqueue(_listener.EndGetContext(ar));
+                // this can happen when shutting down
+                // BL-2207 indicates it may be possible for the thread to be alive and the listener closed,
+                // although the only way I know it gets closed happens after joining with that thread.
+                // Still, one more check seems worthwhile...if we're far enough along in shutting down
+                // to have closed the listener we certainly can't respond to any more requests.
+                if (!_listenerThread.IsAlive || _listener?.IsListening != true)
+                    return;
 
-                // Deal with a situation where all the workers are blocked,
-                // but there is a request in the queue that would unblock the current workers
-                // but that request can't run because it's stuck in queue
-                // and none of the existing worker threads are able to make progress anymore
-                if (_countBlockedThreads >= _workers.Count)
+                lock (_queue)
                 {
-                    // The worker should be spun up such that it can receive _ready.Set()
-                    SpinUpAWorker();
+                    _queue.Enqueue(_listener.EndGetContext(ar));
 
-                    // Note: Currently these workers are never stopped, so as not to complicate the code any further
+                    // Deal with a situation where all the workers are blocked,
+                    // but there is a request in the queue that would unblock the current workers
+                    // but that request can't run because it's stuck in queue
+                    // and none of the existing worker threads are able to make progress anymore
+                    if (_countBlockedThreads >= _workers.Count)
+                    {
+                        // The worker should be spun up such that it can receive _ready.Set()
+                        SpinUpAWorker();
+
+                        // Note: Currently these workers are never stopped, so as not to complicate the code any further
+                    }
+
+                    _ready.Set();
                 }
-
-                _ready.Set();
+            }
+            catch (Exception error)
+            {
+                // Losing an incoming request while we are shutting down is the expected case and is
+                // no loss at all. Losing one at any other time is worth knowing about, but still not
+                // worth killing Bloom over: the client will time out and can ask again.
+                Logger.WriteEvent(
+                    "At BloomServer: QueueRequest() could not accept a request"
+                        + (IsShuttingDown ? " (shutting down)" : "")
+                        + ": "
+                        + error.Message
+                );
             }
         }
 
@@ -2104,7 +2133,16 @@ namespace Bloom.Api
                         Logger.WriteEvent(error.StackTrace);
 #if DEBUG
                         //NB: "throw" here makes it impossible for even the programmer to continue and try to see how it happens
-                        Debug.Fail("(Debug Only) " + error.Message);
+                        // Two cases where stopping here does harm and no good (BL-16667):
+                        // - While we are shutting down. The listener and its handles get closed out from under
+                        //   requests that are still finishing, so exceptions here are the expected consequence of
+                        //   quitting, not a bug to investigate.
+                        // - Under unit tests. There is no developer at a debugger to stop, so all Debug.Fail can do
+                        //   is terminate the test host, which truncates the run -- and, because everything that had
+                        //   already run had passed, the run then reports itself green. The error is logged either
+                        //   way, and the request still fails, so a real server bug still shows up as a failing test.
+                        if (!IsShuttingDown && !Program.RunningUnitTests)
+                            Debug.Fail("(Debug Only) " + error.Message);
 #endif
                     }
                 }
@@ -2628,6 +2666,24 @@ namespace Bloom.Api
                             }
                         }
 
+                        // A worker finishes with a request before the response body has actually gone
+                        // out; it hands the rest of the send off (see PendingResponseWrites) precisely
+                        // so that it can get back to work. So having joined all the workers we still
+                        // have to wait for those sends, because closing the listener underneath one
+                        // makes it fail -- which used to kill the process (BL-16667).
+                        if (
+                            !PendingResponseWrites.WaitUntilAllHaveFinished(
+                                TimeSpan.FromSeconds(secondsToWait)
+                            )
+                        )
+                        {
+                            Logger.WriteEvent(
+                                $"BloomServer.Dispose: gave up after {secondsToWait} seconds waiting for "
+                                    + $"{PendingResponseWrites.InFlightCount} response(s) still being sent; "
+                                    + "closing the listener will abandon them."
+                            );
+                        }
+
                         CloseListener();
                     }
                     if (_cache != null)
@@ -2660,8 +2716,10 @@ namespace Bloom.Api
         {
             if (_listener == null)
                 return; // probably called from shutdown timer, and normal shutdown got this far
-            // stop listening for incoming http requests
-            Debug.Assert(_listener.IsListening);
+            // stop listening for incoming http requests.
+            // (There used to be a Debug.Assert(_listener.IsListening) here. It told us nothing the
+            // next line does not handle, and a failing Debug.Assert terminates a test host, which
+            // is how a run gets truncated -- see BL-16667.)
             if (_listener.IsListening)
             {
                 //In BL-3290, a user quitely failed here each time he exited Bloom, with a Cannot access a disposed object.

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -2874,14 +2874,22 @@ namespace Bloom.Api
                         // so that it can get back to work. So having joined all the workers we still
                         // have to wait for those sends, because closing the listener underneath one
                         // makes it fail -- which used to kill the process (BL-16667).
+                        //
+                        // Deliberately NOT secondsToWait, which the loop above halves for every worker
+                        // that would not stop. Sends are most likely to still be in flight exactly when
+                        // workers are stuck, so inheriting the impatience would shorten this wait to a
+                        // fraction of a second in the one case it is most needed. A fixed budget it is;
+                        // the worst it costs is a couple of seconds added to a shutdown that is already
+                        // going badly, and ProgramExit's own timer is 20 seconds.
+                        const double secondsToWaitForSends = 2.0;
                         if (
                             !PendingResponseWrites.WaitUntilAllHaveFinished(
-                                TimeSpan.FromSeconds(secondsToWait)
+                                TimeSpan.FromSeconds(secondsToWaitForSends)
                             )
                         )
                         {
                             Logger.WriteEvent(
-                                $"BloomServer.Dispose: gave up after {secondsToWait} seconds waiting for "
+                                $"BloomServer.Dispose: gave up after {secondsToWaitForSends} seconds waiting for "
                                     + $"{PendingResponseWrites.InFlightCount} response(s) still being sent; "
                                     + "closing the listener will abandon them."
                             );

--- a/src/BloomExe/web/PendingResponseWrites.cs
+++ b/src/BloomExe/web/PendingResponseWrites.cs
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using SIL.Reporting;
+
+namespace Bloom.Api
+{
+    /// <summary>
+    /// Keeps track of response bodies the server is still sending after the worker thread that
+    /// produced them has gone back for another request, so that shutdown can wait for them.
+    ///
+    /// Why this exists (BL-16667). Sending a small file used to be one call:
+    /// <c>HttpListenerResponse.Close(buffer, willBlock: false)</c>. That returns as soon as the
+    /// write has been issued, which is exactly what we want — it frees the worker thread for the
+    /// next request — but the framework then finishes the send on an I/O completion callback of
+    /// its own, and that callback's only handler is <c>catch (Win32Exception)</c>. When the
+    /// listener is closed while such a send is in flight — precisely what BloomServer.Dispose
+    /// does — the completion fails with an ObjectDisposedException, which that handler does not
+    /// catch. It is on a thread we do not own, so none of our own try/catch blocks see it either:
+    /// it reaches the runtime as an unhandled exception and takes the process with it. In a test
+    /// run that shows up as a run that stops partway through while still printing a cheerful
+    /// summary of the tests that got to run.
+    ///
+    /// So we issue the same asynchronous write — same I/O completion port, same thread, no
+    /// difference in when the data goes out — but we supply the completion ourselves. Two things
+    /// follow from owning that last step: a failure at the end of a send is ours to log and
+    /// swallow, and we know when a send has finished, so Dispose can wait for the ones still in
+    /// flight instead of closing the listener and hoping.
+    /// </summary>
+    internal static class PendingResponseWrites
+    {
+        /// <summary>Guards both <see cref="_inFlight"/> and <see cref="_noneInFlight"/>.</summary>
+        private static readonly object _lock = new object();
+
+        /// <summary>How many sends have been started and not yet finished.</summary>
+        private static int _inFlight;
+
+        /// <summary>Set whenever <see cref="_inFlight"/> is zero, so a caller can wait on it.</summary>
+        private static readonly ManualResetEventSlim _noneInFlight = new ManualResetEventSlim(true);
+
+        /// <summary>
+        /// How many sends are in flight right now. For tests and diagnostics; a caller that wants
+        /// to wait for them should use <see cref="WaitUntilAllHaveFinished"/> rather than poll this.
+        /// </summary>
+        internal static int InFlightCount
+        {
+            get
+            {
+                lock (_lock)
+                    return _inFlight;
+            }
+        }
+
+        /// <summary>
+        /// Sends the whole of <paramref name="buffer"/> as the body of <paramref name="response"/>
+        /// and then closes the response, without waiting for any of that to finish. The caller is
+        /// responsible for having set ContentLength64 (which is the one thing
+        /// HttpListenerResponse.Close(buffer, ...) would have worked out for itself).
+        /// </summary>
+        internal static void SendAndClose(HttpListenerResponse response, byte[] buffer)
+        {
+            Track(
+                () => response.OutputStream.WriteAsync(buffer, 0, buffer.Length),
+                // Closes the output stream and releases the request context, which is what the
+                // "Close" in Response.Close(buffer, ...) did for us before.
+                () => response.Close()
+            );
+        }
+
+        /// <summary>
+        /// The heart of <see cref="SendAndClose"/>: counts a send as in flight from the moment
+        /// <paramref name="startSend"/> is called until <paramref name="finishSend"/> has run,
+        /// and makes sure that nothing either of them does can escape to the runtime.
+        /// </summary>
+        /// <remarks>
+        /// Split out from SendAndClose so that tests can drive the counting and the error handling
+        /// without needing a real HttpListener and a real client to send to.
+        /// </remarks>
+        internal static void Track(Func<Task> startSend, Action finishSend)
+        {
+            NoteSendStarted();
+            try
+            {
+                // TaskScheduler.Default so that this always runs on the thread pool. Left to
+                // itself ContinueWith uses whatever scheduler the caller happens to be on, and
+                // finishing a response is not something we want queued behind anyone's work.
+                startSend()
+                    .ContinueWith(
+                        sendTask => FinishSend(finishSend, sendTask.Exception),
+                        TaskScheduler.Default
+                    );
+            }
+            catch (Exception error)
+            {
+                // The send threw before it even got as far as returning a task to us. The likely
+                // reason is that the listener has already been closed, so the handle the write
+                // needs is gone.
+                FinishSend(finishSend, error);
+            }
+        }
+
+        /// <summary>
+        /// Waits for every send that has been started to finish, giving up after
+        /// <paramref name="timeout"/>. Returns false if we gave up, which tells the caller that
+        /// whatever it was waiting to do — closing the listener — is going to make those sends
+        /// fail.
+        /// </summary>
+        /// <remarks>
+        /// Every send in the process, not just one server's. Bloom runs one server, so that is the
+        /// same thing; in tests, where fixtures make a server each, the worst it costs is that one
+        /// server's Dispose briefly waits for another's send, and the wait is bounded anyway.
+        /// </remarks>
+        internal static bool WaitUntilAllHaveFinished(TimeSpan timeout)
+        {
+            return _noneInFlight.Wait(timeout);
+        }
+
+        /// <summary>
+        /// Runs the caller's tidying-up for a send that has ended, however it ended, and stops
+        /// counting it. Deliberately catches everything: this runs on an I/O completion thread, so
+        /// anything that got out of here would be an unhandled exception and would kill the
+        /// process, which is the whole thing this class exists to prevent.
+        /// </summary>
+        private static void FinishSend(Action finishSend, Exception sendError)
+        {
+            try
+            {
+                if (sendError != null)
+                    ReportProblem("could not finish sending a response", sendError);
+                finishSend();
+            }
+            catch (Exception error)
+            {
+                ReportProblem("could not close a response it had sent", error);
+            }
+            finally
+            {
+                NoteSendFinished();
+            }
+        }
+
+        /// <summary>
+        /// Notes a problem with a send. These are expected during shutdown and whenever the client
+        /// goes away mid-request (the user switched pages, paused a video, closed a preview), so
+        /// they are worth a log entry and nothing more.
+        /// </summary>
+        private static void ReportProblem(string whatHappened, Exception error)
+        {
+            // Unwrap the AggregateException a faulted Task hands us; the one inside is the one
+            // that means anything.
+            if (error is AggregateException aggregate && aggregate.InnerExceptions.Count == 1)
+                error = aggregate.InnerException;
+            Logger.WriteEvent($"BloomServer {whatHappened}: {error.Message}");
+            Debug.WriteLine($"BloomServer {whatHappened}: {error}");
+        }
+
+        private static void NoteSendStarted()
+        {
+            lock (_lock)
+            {
+                if (_inFlight++ == 0)
+                    _noneInFlight.Reset();
+            }
+        }
+
+        private static void NoteSendFinished()
+        {
+            lock (_lock)
+            {
+                if (--_inFlight == 0)
+                    _noneInFlight.Set();
+            }
+        }
+    }
+}

--- a/src/BloomExe/web/PendingResponseWrites.cs
+++ b/src/BloomExe/web/PendingResponseWrites.cs
@@ -57,15 +57,22 @@ namespace Bloom.Api
         }
 
         /// <summary>
-        /// Sends the whole of <paramref name="buffer"/> as the body of <paramref name="response"/>
-        /// and then closes the response, without waiting for any of that to finish. The caller is
-        /// responsible for having set ContentLength64 (which is the one thing
-        /// HttpListenerResponse.Close(buffer, ...) would have worked out for itself).
+        /// Sends the first <paramref name="count"/> bytes of <paramref name="buffer"/> as the body
+        /// of <paramref name="response"/> and then closes the response, without waiting for any of
+        /// that to finish.
         /// </summary>
-        internal static void SendAndClose(HttpListenerResponse response, byte[] buffer)
+        /// <remarks>
+        /// Sets ContentLength64 from <paramref name="count"/> rather than trusting the caller to
+        /// have got it right, because the two disagreeing is not a small mistake: http.sys refuses
+        /// a body longer than the declared length, so the client would get a dead connection and
+        /// the only trace would be a line in the log. A caller that set it already is setting it to
+        /// the same number.
+        /// </remarks>
+        internal static void SendAndClose(HttpListenerResponse response, byte[] buffer, int count)
         {
+            response.ContentLength64 = count;
             Track(
-                () => response.OutputStream.WriteAsync(buffer, 0, buffer.Length),
+                () => response.OutputStream.WriteAsync(buffer, 0, count),
                 // Closes the output stream and releases the request context, which is what the
                 // "Close" in Response.Close(buffer, ...) did for us before.
                 () => response.Close()

--- a/src/BloomExe/web/RequestInfo.cs
+++ b/src/BloomExe/web/RequestInfo.cs
@@ -264,9 +264,12 @@ namespace Bloom.Api
                     fs = null;
                     // This used to be Response.Close(buffer, willBlock: false), which does the same thing but finishes
                     // the send on a framework callback that no catch of ours can reach -- see PendingResponseWrites for
-                    // why that could kill the process (BL-16667). ContentLength64 is already set above, which is the one
-                    // thing that overload would have worked out for itself.
-                    PendingResponseWrites.SendAndClose(_actualContext.Response, buffer);
+                    // why that could kill the process (BL-16667).
+                    PendingResponseWrites.SendAndClose(
+                        _actualContext.Response,
+                        buffer,
+                        buffer.Length
+                    );
                 }
                 else
                 {
@@ -355,7 +358,12 @@ namespace Bloom.Api
                 // As in ReplyWithFileContent: we send the body without waiting for it to arrive, but we
                 // finish the send ourselves rather than letting Response.Close(buffer, willBlock: false)
                 // finish it on a callback we cannot guard. See PendingResponseWrites (BL-16667).
-                PendingResponseWrites.SendAndClose(_actualContext.Response, buffer);
+                // Note actualLength, not buffer.Length: a short read leaves the tail of the buffer
+                // unwritten, and sending it would exceed the Content-Length set just above, which
+                // http.sys rejects. Every caller in Bloom passes an exact length over a MemoryStream,
+                // so today the two are the same number; the overload that defaults the length to 2MB
+                // is what makes them able to differ.
+                PendingResponseWrites.SendAndClose(_actualContext.Response, buffer, actualLength);
             }
 
             HaveFullyProcessedRequest = true;
@@ -457,9 +465,19 @@ namespace Bloom.Api
             // http.sys throws ProtocolViolationException if we try, which would leave the
             // client hanging without a response.
             if (_actualContext.Request.HttpMethod == "HEAD")
+            {
                 _actualContext.Response.Close();
+            }
             else
-                _actualContext.Response.Close(Encoding.UTF8.GetBytes(errorDescription), false);
+            {
+                // Same treatment as the other two bodies we send without waiting: the framework
+                // would finish this one on a callback we cannot guard, and closing the listener
+                // underneath it killed the process (BL-16667). This path matters most of all,
+                // because it is the one that fires as Bloom closes -- the browser goes on asking
+                // for things the server is no longer there to give.
+                var body = Encoding.UTF8.GetBytes(errorDescription);
+                PendingResponseWrites.SendAndClose(_actualContext.Response, body, body.Length);
+            }
             HaveFullyProcessedRequest = true;
         }
 

--- a/src/BloomExe/web/RequestInfo.cs
+++ b/src/BloomExe/web/RequestInfo.cs
@@ -252,18 +252,21 @@ namespace Bloom.Api
                 else if (fs.Length < 2 * 1024 * 1024)
                 {
                     // This buffer size was picked to be big enough for any of the standard files we load in every page.
-                    // Profiling indicates it is MUCH faster to use Response.Close() rather than writing to the output stream,
-                    // though the gain may be illusory since the final 'false' argument allows our code to proceed without waiting
-                    // for the complete data transfer. At a minimum, it makes this thread available to work on another
-                    // request sooner.
+                    // Profiling indicates it is MUCH faster to send the whole body in one go rather than writing to the
+                    // output stream, though the gain may be illusory since we don't wait for the complete data transfer.
+                    // At a minimum, it makes this thread available to work on another request sooner.
                     var buffer = new byte[fs.Length];
                     fs.Read(buffer, 0, (int)fs.Length);
                     // The client may not read the whole stream (e.g. paused video). I don't know whether that could lead
-                    // to a delay in Close() returning; probably not. But just to be safe, make sure we aren't holding
+                    // to a delay in the send finishing; probably not. But just to be safe, make sure we aren't holding
                     // on to the file.
                     fs.Dispose();
                     fs = null;
-                    _actualContext.Response.Close(buffer, false);
+                    // This used to be Response.Close(buffer, willBlock: false), which does the same thing but finishes
+                    // the send on a framework callback that no catch of ours can reach -- see PendingResponseWrites for
+                    // why that could kill the process (BL-16667). ContentLength64 is already set above, which is the one
+                    // thing that overload would have worked out for itself.
+                    PendingResponseWrites.SendAndClose(_actualContext.Response, buffer);
                 }
                 else
                 {
@@ -349,7 +352,10 @@ namespace Bloom.Api
             }
             else
             {
-                _actualContext.Response.Close(buffer, false);
+                // As in ReplyWithFileContent: we send the body without waiting for it to arrive, but we
+                // finish the send ourselves rather than letting Response.Close(buffer, willBlock: false)
+                // finish it on a callback we cannot guard. See PendingResponseWrites (BL-16667).
+                PendingResponseWrites.SendAndClose(_actualContext.Response, buffer);
             }
 
             HaveFullyProcessedRequest = true;

--- a/src/BloomTests/Spreadsheet/SpreadsheetAudioImportTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetAudioImportTests.cs
@@ -631,7 +631,14 @@ namespace BloomTests.Spreadsheet
         [Test]
         public void NoErrorForEmptyAudio()
         {
-            Assert.That(_progressSpy.Errors, Has.None.Match(".*17.*"));
+            // "page 17", not just "17": the row for page 17 has no audio at all and must not be
+            // complained about, but the errors for the OTHER pages quote full file paths, and a
+            // bare "17" matches any digits that happen to appear in one of those. Since BL-16664
+            // put this process's id into every temp path, that made the test fail whenever the
+            // process id contained "17" -- which is roughly one run in ten, and looks exactly like
+            // a mysterious intermittent failure. Found by the tenth full-suite run while hunting
+            // one down for BL-16667 (process id 178640).
+            Assert.That(_progressSpy.Errors, Has.None.Match("page 17"));
         }
 
         [Test]

--- a/src/BloomTests/web/PendingResponseWritesTests.cs
+++ b/src/BloomTests/web/PendingResponseWritesTests.cs
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System;
+using System.Threading.Tasks;
+using Bloom.Api;
+using NUnit.Framework;
+
+namespace BloomTests.web
+{
+    /// <summary>
+    /// Tests for the bookkeeping that lets BloomServer.Dispose wait for response bodies that are
+    /// still going out, and that keeps a failure at the end of a send from reaching the runtime.
+    /// See PendingResponseWrites, and BL-16667 for what happens when it does reach the runtime.
+    ///
+    /// These drive Track() rather than SendAndClose(), so that they can decide exactly when a send
+    /// finishes and how it ends, which a real HttpListener and a real client would not let them do.
+    /// </summary>
+    [TestFixture]
+    public class PendingResponseWritesTests
+    {
+        /// <summary>
+        /// PendingResponseWrites is deliberately static — shutdown has to be able to ask about
+        /// every send in the process — so a send left over from an earlier test would make these
+        /// assertions meaningless. Check we are starting from nothing.
+        /// </summary>
+        [SetUp]
+        public void EnsureNothingIsInFlightBeforeWeStart()
+        {
+            if (!PendingResponseWrites.WaitUntilAllHaveFinished(TimeSpan.FromSeconds(10)))
+                Assert.Fail(
+                    "A response send from an earlier test was still in flight; this fixture's counts would be meaningless."
+                );
+            Assert.That(
+                PendingResponseWrites.InFlightCount,
+                Is.EqualTo(0),
+                "sanity check on the starting state"
+            );
+        }
+
+        [Test]
+        public void Track_WhileSendIsUnfinished_CountsItAndMakesWaitingCallersWait()
+        {
+            var send = new TaskCompletionSource<bool>();
+            var finished = false;
+
+            PendingResponseWrites.Track(() => send.Task, () => finished = true);
+
+            // Sanity checks on the state we are about to change.
+            Assert.That(
+                PendingResponseWrites.InFlightCount,
+                Is.EqualTo(1),
+                "the send should be counted from the moment it starts"
+            );
+            Assert.That(finished, Is.False, "nothing should have tidied up yet");
+            Assert.That(
+                PendingResponseWrites.WaitUntilAllHaveFinished(TimeSpan.FromMilliseconds(50)),
+                Is.False,
+                "a caller must not be told everything is done while a send is unfinished"
+            );
+
+            send.SetResult(true);
+
+            Assert.That(
+                PendingResponseWrites.WaitUntilAllHaveFinished(TimeSpan.FromSeconds(10)),
+                Is.True,
+                "the wait should end once the send finishes"
+            );
+            Assert.That(finished, Is.True, "the response should have been closed");
+            Assert.That(PendingResponseWrites.InFlightCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Track_SendFails_StillClosesTheResponseAndStopsCounting()
+        {
+            var send = new TaskCompletionSource<bool>();
+            var finished = false;
+
+            PendingResponseWrites.Track(() => send.Task, () => finished = true);
+            Assert.That(
+                PendingResponseWrites.InFlightCount,
+                Is.EqualTo(1),
+                "sanity check: the send should be counted while it is unfinished"
+            );
+
+            // This is the shape of the real failure: the listener was closed under a send that had
+            // already been handed to the operating system.
+            send.SetException(new ObjectDisposedException("System.Net.HttpRequestQueueV2Handle"));
+
+            Assert.That(
+                PendingResponseWrites.WaitUntilAllHaveFinished(TimeSpan.FromSeconds(10)),
+                Is.True,
+                "a failed send must stop being counted, or shutdown would wait for it forever"
+            );
+            Assert.That(finished, Is.True, "we should still try to close the response");
+        }
+
+        [Test]
+        public void Track_SendThrowsBeforeItStarts_StillClosesTheResponseAndStopsCounting()
+        {
+            var finished = false;
+
+            // The other half of the same race: the listener's handle was already gone, so the write
+            // could not even be issued.
+            PendingResponseWrites.Track(
+                () => throw new ObjectDisposedException("System.Threading.ThreadPoolBoundHandle"),
+                () => finished = true
+            );
+
+            Assert.That(
+                PendingResponseWrites.WaitUntilAllHaveFinished(TimeSpan.FromSeconds(10)),
+                Is.True
+            );
+            Assert.That(finished, Is.True, "we should still try to close the response");
+            Assert.That(PendingResponseWrites.InFlightCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Track_ClosingTheResponseThrows_DoesNotEscapeAndStopsCounting()
+        {
+            // Closing can fail for the same reason sending can, and this runs on an I/O completion
+            // thread, where anything that got out would be unhandled and would kill the process.
+            Assert.DoesNotThrow(() =>
+                PendingResponseWrites.Track(
+                    () => Task.CompletedTask,
+                    () => throw new ObjectDisposedException("some handle")
+                )
+            );
+
+            Assert.That(
+                PendingResponseWrites.WaitUntilAllHaveFinished(TimeSpan.FromSeconds(10)),
+                Is.True
+            );
+            Assert.That(PendingResponseWrites.InFlightCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Track_SeveralSends_WaitEndsOnlyWhenTheLastOneFinishes()
+        {
+            var first = new TaskCompletionSource<bool>();
+            var second = new TaskCompletionSource<bool>();
+            PendingResponseWrites.Track(() => first.Task, () => { });
+            PendingResponseWrites.Track(() => second.Task, () => { });
+            Assert.That(
+                PendingResponseWrites.InFlightCount,
+                Is.EqualTo(2),
+                "sanity check on the starting state"
+            );
+
+            first.SetResult(true);
+
+            // Deliberately not asserting InFlightCount here: the first send's tidying-up runs on
+            // another thread, so 2 and 1 are both legitimate readings at this instant. What must be
+            // true is that a caller is not yet told everything is done.
+            Assert.That(
+                PendingResponseWrites.WaitUntilAllHaveFinished(TimeSpan.FromMilliseconds(50)),
+                Is.False,
+                "one send finishing must not release a caller waiting for all of them"
+            );
+
+            second.SetResult(true);
+
+            Assert.That(
+                PendingResponseWrites.WaitUntilAllHaveFinished(TimeSpan.FromSeconds(10)),
+                Is.True
+            );
+            Assert.That(PendingResponseWrites.InFlightCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void WaitUntilAllHaveFinished_NothingInFlight_ReturnsAtOnce()
+        {
+            Assert.That(
+                PendingResponseWrites.WaitUntilAllHaveFinished(TimeSpan.Zero),
+                Is.True,
+                "with nothing in flight there is nothing to wait for"
+            );
+        }
+    }
+}

--- a/src/BloomTests/web/ServeFileAndShutDownTests.cs
+++ b/src/BloomTests/web/ServeFileAndShutDownTests.cs
@@ -4,7 +4,9 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using Bloom.Api;
 using Bloom.Book;
@@ -90,6 +92,44 @@ namespace BloomTests.web
             // PendingResponseWrites), so it is worth checking that the client got every byte and
             // the right ones.
             Assert.That(received, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void MissingFileRequest_OverRealHttp_Returns404WithTheMessageAsTheBody()
+        {
+            // The error path sends its body the same way the success paths do, and it is the one
+            // most likely to be in flight when Bloom shuts down, because the browser goes on asking
+            // for things while the server is going away. Worth its own test because it is also the
+            // one path where nothing else had set ContentLength64 first.
+            var missing = Path.Combine(_folder.Path, "notThere.txt");
+            Assert.That(
+                File.Exists(missing),
+                Is.False,
+                "sanity check: this test is about a file that is not there"
+            );
+
+            using (var server = new BloomServer(new BookSelection()))
+            {
+                server.EnsureListening();
+                using (var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) })
+                using (var response = client.GetAsync(UrlFor(missing)).Result)
+                {
+                    Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+                    // Reading the body to the end is the point: if the declared length and the bytes
+                    // sent disagreed, this would hang or come up short rather than fail loudly.
+                    var body = response.Content.ReadAsStringAsync().Result;
+                    Assert.That(
+                        body,
+                        Is.Not.Empty,
+                        "the 404 should carry its message as the body, which is what client code reads"
+                    );
+                    Assert.That(
+                        response.Content.Headers.ContentLength,
+                        Is.EqualTo(Encoding.UTF8.GetByteCount(body)),
+                        "the length the server declared and the body it actually sent must agree"
+                    );
+                }
+            }
         }
 
         [Test]

--- a/src/BloomTests/web/ServeFileAndShutDownTests.cs
+++ b/src/BloomTests/web/ServeFileAndShutDownTests.cs
@@ -1,0 +1,175 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using Bloom.Api;
+using Bloom.Book;
+using NUnit.Framework;
+using TemporaryFolder = SIL.TestUtilities.TemporaryFolder;
+
+namespace BloomTests.web
+{
+    /// <summary>
+    /// Fetches a file from a real, listening BloomServer over real HTTP, and then shuts that server
+    /// down. The rest of the server tests use PretendRequestInfo, which never touches an
+    /// HttpListener, so nothing else covers what happens between "the worker thread has finished
+    /// with this request" and "the bytes have reached the client" — which is exactly where BL-16667
+    /// lived: the response body was still going out when Dispose closed the listener, the framework
+    /// callback finishing the send blew up, and being on a thread nobody owned it took the whole
+    /// process with it.
+    /// </summary>
+    [TestFixture]
+    public class ServeFileAndShutDownTests
+    {
+        private TemporaryFolder _folder;
+
+        [SetUp]
+        public void Setup()
+        {
+            // These tests listen on the one fixed port, so they must not overlap with the other
+            // fixtures that do. (Same reasoning as EndpointHandlerTests, whose lock this is.)
+            Monitor.Enter(EndpointHandlerTests._portMonitor);
+            _folder = new TemporaryFolder("ServeFileAndShutDownTests");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _folder.Dispose();
+            Monitor.Exit(EndpointHandlerTests._portMonitor);
+        }
+
+        /// <summary>
+        /// A file small enough to go down the "send it all in one go" path, which is the one that
+        /// finishes after the worker thread has moved on.
+        /// </summary>
+        private string MakeFileToServe(string name, int size)
+        {
+            var path = Path.Combine(_folder.Path, name);
+            var content = new byte[size];
+            for (var i = 0; i < size; i++)
+                content[i] = (byte)(i % 251); // a pattern, so truncation or padding shows up
+            File.WriteAllBytes(path, content);
+            return path;
+        }
+
+        /// <summary>
+        /// The server serves a file named by its full path after the /bloom/ prefix.
+        /// </summary>
+        private static string UrlFor(string filePath)
+        {
+            return BloomServer.ServerUrlWithBloomPrefixEndingInSlash + filePath.Replace('\\', '/');
+        }
+
+        [Test]
+        public void FileRequest_OverRealHttp_ReturnsTheWholeFile()
+        {
+            var path = MakeFileToServe("served.txt", 40000);
+            var expected = File.ReadAllBytes(path);
+            Assert.That(
+                expected.Length,
+                Is.EqualTo(40000),
+                "sanity check on the file we are about to ask for"
+            );
+
+            byte[] received;
+            using (var server = new BloomServer(new BookSelection()))
+            {
+                server.EnsureListening();
+                using (var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) })
+                {
+                    received = client.GetByteArrayAsync(UrlFor(path)).Result;
+                }
+            }
+
+            // Not just the length: the body is finished off by our own code now (see
+            // PendingResponseWrites), so it is worth checking that the client got every byte and
+            // the right ones.
+            Assert.That(received, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void DisposingWhileAResponseIsStillGoingOut_DoesNotKillTheProcess()
+        {
+            // This reproduces BL-16667, so it needs the send to be genuinely unfinished when Dispose
+            // runs -- which an ordinary GET cannot arrange, because by the time the client has the
+            // bytes the send is over. So: ask for a file far bigger than the socket will buffer, take
+            // the headers, and then never read the body. The server's worker thread is finished and
+            // has handed the rest of the send on, but the data is stuck half way out. Disposing now
+            // is what used to fail: closing the listener made the stalled send blow up on a framework
+            // callback that catches only Win32Exception, on a thread none of our try/catch blocks
+            // cover, so it reached the runtime and killed the process. In a test run that looked like
+            // the run stopping part way through and calling itself passed.
+            var path = MakeFileToServe("stalled.txt", 1900000); // still under the 2MB one-go limit
+
+            // Kept alive past the server's Dispose: letting the client go would close the connection
+            // and unstick the very send we need stuck.
+            var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+            HttpResponseMessage response;
+            try
+            {
+                using (var server = new BloomServer(new BookSelection()))
+                {
+                    server.EnsureListening();
+                    response = client
+                        .GetAsync(UrlFor(path), HttpCompletionOption.ResponseHeadersRead)
+                        .Result;
+                    Assert.That(
+                        (int)response.StatusCode,
+                        Is.EqualTo(200),
+                        "sanity check: the server should have accepted the request and started replying"
+                    );
+                    // Deliberately no read of response.Content here.
+                }
+                // Reaching this line at all is most of the point of the test: with the old code the
+                // process was gone before it.
+                Assert.That(
+                    PendingResponseWrites.WaitUntilAllHaveFinished(TimeSpan.FromSeconds(10)),
+                    Is.True,
+                    "the abandoned send should have been accounted for, not left counted forever"
+                );
+            }
+            finally
+            {
+                client.Dispose();
+            }
+        }
+
+        [Test]
+        public void DisposingImmediatelyAfterServingFiles_LeavesNothingInFlight()
+        {
+            var paths = Enumerable
+                .Range(0, 5)
+                .Select(i => MakeFileToServe($"served{i}.txt", 200000))
+                .ToArray();
+
+            using (var server = new BloomServer(new BookSelection()))
+            {
+                server.EnsureListening();
+                using (var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) })
+                {
+                    foreach (var path in paths)
+                    {
+                        var received = client.GetByteArrayAsync(UrlFor(path)).Result;
+                        Assert.That(
+                            received.Length,
+                            Is.EqualTo(200000),
+                            "the server did not return the whole file"
+                        );
+                    }
+                }
+                // Dispose happens here, with the last response only just answered.
+            }
+
+            Assert.That(
+                PendingResponseWrites.WaitUntilAllHaveFinished(TimeSpan.FromSeconds(10)),
+                Is.True,
+                "every send should have been waited for by the Dispose that followed it"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Running the full C# suite, roughly **one run in three** ended early — not with a test failure, but with the **test host process crashing**. Because everything that had run so far had passed, the run then printed `Passed! - Failed: 0, Passed: 348 ...` and anything judging it by that line called it green.

## The bug

Both crash faces in the card are the same lifetime problem. `RequestInfo` sent response bodies with `HttpListenerResponse.Close(buffer, willBlock: false)`. That returns as soon as the write is *issued* — which is the point, it frees the server worker thread — but the framework then finishes the send on an I/O completion callback of its own whose only handler is `catch (Win32Exception)`. `BloomServer.Dispose` joined the workers, saw nobody busy, and closed the `HttpListener` while such a send was still in flight. The send then failed with `ObjectDisposedException`, which that handler does not catch, on a thread none of our `try`/`catch` blocks cover — so it reached the runtime and took the process with it.

## The fix

Issue the same asynchronous write — same I/O completion port, same thread, no difference in when the data goes out — but supply the completion ourselves, in the new `PendingResponseWrites`. Owning that last step gives two things: a failure at the end of a send is ours to log and swallow, and we know when sends finish, so `Dispose` can wait for the ones in flight instead of closing the listener and hoping.

Three other things in the same area could also kill the process, and are fixed too:

- `RequestProcessorLoop`'s `Debug.Fail` now stays quiet during shutdown and under unit tests. There is no debugger to stop in a test host, so all it can do there is terminate the run; the error is still logged and the request still fails, so a real server bug still shows up as a failing test.
- `QueueRequest` is likewise an I/O completion callback, and was unguarded.
- `CloseListener`'s `Debug.Assert` asserted a condition the next line already handles.

## Making an aborted run report itself as a failure

Asked for alongside the fix, because the silent-truncation half of this bug is not specific to it:

- `build/agent-dotnet.{sh,ps1}` now judge a `test` run and print a verdict as their **last** line (so it survives `| tail`), exiting non-zero on crash markers, a `Failed!` summary, or a non-zero `dotnet` exit. The markers live in one shared `build/test-abort-markers.txt` so the twin scripts cannot drift. This also fixes the `PAPERCUTS.md` entry about the wrapper reporting a failing suite as a success, so that entry is removed.
- `build/Bloom.proj`'s `RunNUnit` now fails if the results file — which the logger writes only on completion — is missing, so CI cannot go green on a run that stopped early.

## Testing

`ServeFileAndShutDownTests.DisposingWhileAResponseIsStillGoingOut_DoesNotKillTheProcess` reproduces the bug **deterministically**: with the old `Close(buffer, false)` restored it kills the test host with exactly the stack from the card (`NonBlockingCloseCallback` → `EndWriteCore` → `Abort` → `ObjectDisposedException` on `HttpRequestQueueV2Handle`), and the new wrapper reported that run as `*** TEST RUN ABORTED ***`. It passes with the fix.

Also new: `PendingResponseWritesTests` (6 tests) for the counting, the timeout, and that neither a failed send nor a failed close can escape; and tests that fetch a real file, and a real 404, from a real listening server over real HTTP — which nothing covered before.

Full C# suite run four times end to end: all four completed, 0 failed.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16667


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8192)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8192)
<!-- Reviewable:end -->
