### PR TITLE
Fix BL-16682 Save page before invoking Bloom AI Image Tools (approach A: minimal)

### DIFF
--- a/.github/skills/bloom-automation/ai-image-editor-driving.md
+++ b/.github/skills/bloom-automation/ai-image-editor-driving.md
@@ -61,6 +61,13 @@ Right-click the canvas element → **"Edit with AI…"**. Loading the iframe dir
 `bloom-exe-ai-editor-open.uitest.ts` smoke test does) does **not** register
 `aiEditorLauncher.ts`'s postMessage handler, so the commit + current-page save path wouldn't run.
 
+**The overlay does not appear on the same tick as the click.** The menu command posts
+`aiImageEditor/saveThenLaunch`, which makes C# save the current page — reloading the `page`
+frame — and only then call back into the reloaded page to open the overlay (BL-16682; the saved
+book DOM has to be current or the editor opens with an empty "Image to Edit" slot). So **wait for
+the overlay**, e.g. `await page.waitForSelector("#ai-editor-overlay iframe")`, and don't re-use
+any content-frame handle taken before the click — that frame is gone.
+
 **Gotcha:** a Comical `<canvas class="comical-generated">` overlay sits on top of the image and
 intercepts element-targeted clicks (Playwright reports `<canvas …> intercepts pointer events`).
 Drive with **raw mouse coordinates** from the image's bounding box instead:

--- a/src/BloomBrowserUI/bookEdit/editablePage.ts
+++ b/src/BloomBrowserUI/bookEdit/editablePage.ts
@@ -104,6 +104,7 @@ export interface IPageFrameExports {
         imageInfo: Omit<IImageInfo, "imageId">,
     ): void;
     removeImageId(imageId: string): void;
+    openAiImageEditor(target: IAiImageEditorTarget): void;
 }
 
 // This exports the functions that should be accessible from other IFrames or from C#.
@@ -130,6 +131,12 @@ import {
     removeRequestPageContentDelay,
 } from "./js/bloomEditing";
 import { showGamePromptDialog } from "./toolbox/games/GameTool";
+// Called from C# once it has saved and reloaded the page, to open the AI Image Editor
+// overlay; see AiImageEditorApi.HandleSaveThenLaunch and aiEditorLauncher.ts.
+import {
+    openAiImageEditor,
+    IAiImageEditorTarget,
+} from "./toolbox/canvas/aiEditorLauncher";
 export {
     getBodyContentForSavePage,
     requestPageContent,
@@ -153,6 +160,7 @@ export {
     renderDragActivityTabControl,
     getTheOneCanvasElementManager,
     showGamePromptDialog,
+    openAiImageEditor,
 };
 import { origamiCanUndo, origamiUndo } from "./js/origami";
 import { postString } from "../utils/bloomApi";
@@ -428,6 +436,7 @@ interface EditablePageBundleApi {
     SayHello: typeof SayHello;
     renderDragActivityTabControl: typeof renderDragActivityTabControl;
     showGamePromptDialog: typeof showGamePromptDialog;
+    openAiImageEditor: typeof openAiImageEditor;
 }
 
 declare global {
@@ -506,4 +515,5 @@ window.editablePageBundle = {
     SayHello,
     renderDragActivityTabControl,
     showGamePromptDialog,
+    openAiImageEditor,
 };

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/aiEditorLauncher.test.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/aiEditorLauncher.test.ts
@@ -1,9 +1,15 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-// Tests for WHEN the AI Image Editor launcher saves the live page after a commit.
+// Tests for the AI Image Editor launcher's two dealings with SAVING the live page: once
+// before the editor opens, and once after a commit.
 //
-// The launcher swaps current-page images in the LIVE DOM and then has to save, because
-// nothing else persists that (see aiEditorLauncher.ts). The save goes through
+// BEFORE: the menu command doesn't open the editor at all. Everything C# tells the editor
+// about the book is read from the saved book DOM, so an image the user just added — which
+// lives only in the live page — wouldn't be there (BL-16682). So the command asks C# to
+// save the page first, and C# calls openAiImageEditor() back in the reloaded page.
+//
+// AFTER: the launcher swaps current-page images in the LIVE DOM and then has to save,
+// because nothing else persists that (see aiEditorLauncher.ts). That save goes through
 // saveChangesAndRethinkPageEvent, which RELOADS the page frame — and everything that
 // operates the overlay (its message listener, its ✕ handler) is code belonging to that
 // frame, even though the overlay div itself lives in the top window. So saving while the
@@ -11,7 +17,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 // has to restart Bloom to escape. That matters specifically on a PARTIAL failure, where
 // the launcher deliberately keeps the overlay up so the user can read the error.
 //
-// Hence: the save is deferred until the overlay comes down. These tests pin both halves —
+// Hence: that save is deferred until the overlay comes down. These tests pin both halves —
 // that it does not fire while the overlay is up, and that it is not simply lost.
 
 const post = vi.fn();
@@ -38,28 +44,40 @@ vi.mock("../../js/bloomImages", () => ({
     GetRawImageUrl: (element: HTMLElement) => element.getAttribute("src") ?? "",
 }));
 
-import { launchAiImageEditor } from "./aiEditorLauncher";
+import { launchAiImageEditor, openAiImageEditor } from "./aiEditorLauncher";
 
 const kSaveEvent = "common/saveChangesAndRethinkPageEvent";
 const kEditorUrl = "http://localhost:8089/bloom/aiImageEditor/index.html";
 const kPageId = "page1";
+const kImageFile = "old.png";
 
-// Builds a page holding one image, launches the editor against it, and returns the
-// handles a test needs. Leaves the launcher at the point where the overlay is up and the
-// editor has been sent its `init`.
-const launchAgainstAPageWithOneImage = () => {
+// Builds a page holding one image and returns the img the user is to right-click.
+const makePageWithOneImage = () => {
     document.body.innerHTML = `
         <div class="bloom-page" id="${kPageId}">
             <div class="bloom-canvas-element">
-                <img src="old.png" />
+                <img src="${kImageFile}" />
             </div>
         </div>`;
-    const img = document.querySelector("img") as HTMLImageElement;
-    const canvasElement = document.querySelector(
-        ".bloom-canvas-element",
-    ) as HTMLElement;
+    return document.querySelector("img") as HTMLImageElement;
+};
 
-    launchAiImageEditor(img, undefined, canvasElement);
+// Runs the menu command and then stands in for C#, which saves the page (reloading it) and
+// calls openAiImageEditor in the reloaded page. Returns the handles a test needs, with the
+// overlay up and the editor about to be sent its `init`. Pass clickedFileName to stand for
+// a click on an image the saved page does not contain.
+const launchAgainstAPageWithOneImage = (clickedFileName = kImageFile) => {
+    const img = makePageWithOneImage();
+
+    launchAiImageEditor(img, undefined);
+
+    // The command itself only asks for the save; the editor is not opened yet.
+    expect(post).not.toHaveBeenCalled();
+    expect(postJson).toHaveBeenCalledTimes(1);
+    postJson.mockClear();
+
+    // C#, once the saved page has reloaded.
+    openAiImageEditor({ imageFileName: clickedFileName });
 
     // The launcher does everything inside the launch reply's callback.
     expect(post).toHaveBeenCalledTimes(1);
@@ -75,7 +93,7 @@ const launchAgainstAPageWithOneImage = () => {
             bookImages: [
                 {
                     id: `${kPageId}:0`,
-                    src: "http://localhost:8089/bloom/book/old.png",
+                    src: `http://localhost:8089/bloom/book/${kImageFile}`,
                 },
             ],
             history: [],
@@ -99,7 +117,7 @@ const launchAgainstAPageWithOneImage = () => {
         );
     };
 
-    return { closeButton, postFromEditor };
+    return { closeButton, iframe, postFromEditor };
 };
 
 // Sends a commit for the one current-page image and answers it with the host's reply.
@@ -142,16 +160,78 @@ const commitAndReplyFromHost = (
     });
 };
 
-describe("aiEditorLauncher: saving the live page after a commit", () => {
-    beforeEach(() => {
-        post.mockClear();
-        postJson.mockClear();
-        postThatMightNavigate.mockClear();
-        changeImageByElement.mockClear();
-        delete (window as Window & { __bloomAiImageEditorCleanup?: () => void })
-            .__bloomAiImageEditorCleanup;
-        document.body.innerHTML = "";
+// Answers the editor's `ready` and returns the `init` the launcher posts back into its
+// iframe — which is where the edit target ("Image to Edit") is named.
+const getInitPayloadSentToEditor = (
+    iframe: HTMLIFrameElement,
+    postFromEditor: (data: unknown) => void,
+) => {
+    const postMessageToEditor = vi.spyOn(iframe.contentWindow!, "postMessage");
+    postFromEditor({ channel: "bloom-ai-image-tools", type: "ready" });
+
+    expect(postMessageToEditor).toHaveBeenCalledTimes(1);
+    const message = postMessageToEditor.mock.calls[0][0] as {
+        type: string;
+        payload: { selectedBookImageId?: string };
+    };
+    postMessageToEditor.mockRestore();
+    expect(message.type).toBe("init");
+    return message.payload;
+};
+
+const clearMocks = () => {
+    post.mockClear();
+    postJson.mockClear();
+    postThatMightNavigate.mockClear();
+    changeImageByElement.mockClear();
+    delete (window as Window & { __bloomAiImageEditorCleanup?: () => void })
+        .__bloomAiImageEditorCleanup;
+    document.body.innerHTML = "";
+};
+
+describe("aiEditorLauncher: saving the live page before opening the editor", () => {
+    beforeEach(clearMocks);
+
+    test("the menu command asks C# to save the page instead of opening the editor", () => {
+        const img = makePageWithOneImage();
+
+        launchAiImageEditor(img, undefined);
+
+        // Nothing is opened here: C# has to save the page (which reloads it) first, or the
+        // editor would be told about the book as it was before the user's latest image
+        // change (BL-16682).
+        expect(post).not.toHaveBeenCalled();
+        expect(postJson).toHaveBeenCalledTimes(1);
+        expect(postJson).toHaveBeenCalledWith("aiImageEditor/saveThenLaunch", {
+            // Only the file name travels: the save reloads this frame, so a live element
+            // reference could not survive the round trip.
+            imageFileName: kImageFile,
+        });
     });
+
+    test("the reopened editor gets the clicked image as its edit target", () => {
+        const { iframe, postFromEditor } = launchAgainstAPageWithOneImage();
+
+        const payload = getInitPayloadSentToEditor(iframe, postFromEditor);
+
+        // The bug: this was undefined, so the "Image to Edit" slot opened empty.
+        expect(payload.selectedBookImageId).toBe(`${kPageId}:0`);
+    });
+
+    test("an image the saved page doesn't have leaves the edit target unset", () => {
+        // Sanity check on the matching itself: C#'s book image list names old.png, so a
+        // click on some other file must not silently select old.png.
+        const { iframe, postFromEditor } =
+            launchAgainstAPageWithOneImage("somethingElse.png");
+
+        const payload = getInitPayloadSentToEditor(iframe, postFromEditor);
+
+        expect(payload.selectedBookImageId).toBeUndefined();
+    });
+});
+
+describe("aiEditorLauncher: saving the live page after a commit", () => {
+    beforeEach(clearMocks);
 
     test("a partial failure keeps the overlay up and holds the save until it closes", () => {
         const { closeButton, postFromEditor } =

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/aiEditorLauncher.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/aiEditorLauncher.ts
@@ -7,6 +7,10 @@
 // (read that file's header for the full picture). The AI image editor is a SEPARATE web app
 // (the `bloom-ai-image-tools` package); we do not import it — we load it into an
 // <iframe> overlay. The flow:
+//   0. POST aiImageEditor/saveThenLaunch -> C# saves the current page (which RELOADS the
+//      page frame) and then calls openAiImageEditor() below in the reloaded page. See
+//      launchAiImageEditor for why the page has to be saved first, and why C# rather than
+//      this frame is what remembers to carry on afterwards.
 //   1. POST aiImageEditor/launch -> C# mints a session, makes the per-book
 //      .ai-image-editor folder, and returns the AI image editor URL + the whole-book image
 //      list + enumerated history + httpBase/sessionToken.
@@ -32,14 +36,62 @@ import {
 import { changeImageByElement } from "../../js/bloomEditing";
 import { matchReplacementsToElements } from "./aiEditorSlotMatching";
 
-// Opens the AI Image Editor overlay for the given image. `img` is the right-clicked
-// image, `imgContainer` its image container (if any), and `canvasElement` the canvas
-// element the command was invoked on.
+// Pull the file name off an image url. `encoded` says whether the url is percent-encoded:
+// live DOM srcs and host-served URLs are, but oldSrc in commit results arrives from C#
+// already decoded (PathOnly.NotEncoded) — decoding it again corrupts (or throws on)
+// filenames containing a literal '%'. On a failed decode fall back to the raw name rather
+// than "", so an oddly-encoded src degrades to a possible mismatch instead of matching
+// nothing ever.
+const fileNameOf = (url?: string | null, encoded: boolean = true) => {
+    const raw = (url ?? "").split("?")[0].split("/").pop() ?? "";
+    if (!encoded) return raw;
+    try {
+        return decodeURIComponent(raw);
+    } catch {
+        return raw;
+    }
+};
+
+// What openAiImageEditor needs to know about the image the user right-clicked. Just the
+// file name: a page save reloads this frame, so nothing that survives the trip to C# and
+// back can be a live element reference — and the page id is simply whatever page comes
+// back, which we read off the reloaded document.
+export interface IAiImageEditorTarget {
+    imageFileName: string;
+}
+
+// Starts "Edit with AI…" for the given image. `img` is the right-clicked image and
+// `imgContainer` its image container (if any).
+//
+// We do NOT open the editor here. C# enumerates the book's images (and, on commit, reads
+// each slot's current src) from the SAVED book DOM, while an image the user just added
+// lives only in this live page — changeImage/changeImageByElement deliberately do not save
+// (BL-16330). Launching against that stale saved DOM opened the editor with an empty
+// "Image to Edit" slot (BL-16682), and a later commit's oldSrc, read from the same stale
+// DOM, would no longer match the live page. So the page must be saved first.
+//
+// Saving is what makes this a round trip through C#: Bloom's save strips the live page and
+// therefore always ends by re-navigating to it, which tears down this frame — so the code
+// that carries on afterwards cannot live here. C# does the save with EditingModel.SaveThen
+// and calls openAiImageEditor() below once the reloaded page reports in. See
+// AiImageEditorApi.HandleSaveThenLaunch.
 export const launchAiImageEditor = (
     img: HTMLImageElement,
     imgContainer: HTMLElement | undefined,
-    canvasElement: HTMLElement,
 ): void => {
+    const clickedUrl = imgContainer
+        ? getImageUrlFromImageContainer(imgContainer)
+        : img?.getAttribute("src");
+    postJson("aiImageEditor/saveThenLaunch", {
+        imageFileName: fileNameOf(clickedUrl),
+    } as IAiImageEditorTarget);
+};
+
+// Opens the AI Image Editor overlay, with the image named by `target` (the one the user
+// right-clicked, back before the save reloaded this page) in its "Image to Edit" slot.
+// Called from C# — via workspaceBundle.getEditablePageBundleExports() — once the page has
+// been saved and reloaded; see launchAiImageEditor above, which is what asks for that.
+export const openAiImageEditor = (target: IAiImageEditorTarget): void => {
     post("aiImageEditor/launch", (r) => {
         const launchData = r.data as {
             editorUrl: string;
@@ -87,32 +139,14 @@ export const launchAiImageEditor = (
         // applies replacements book-wide in C#, so there is no per-image DOM
         // id wrangling here anymore.
 
-        // Identify the image the user actually right-clicked so the AI image editor can
+        // Identify the image the user right-clicked so the AI image editor can
         // open with it already in the "Image to Edit" slot. We match by page +
         // filename rather than DOM ordinal, because the live page has extra
         // injected UI images that would throw positional indices off.
-        // `encoded` says whether the url is percent-encoded: live DOM srcs and
-        // host-served URLs are, but oldSrc in commit results arrives from C#
-        // already decoded (PathOnly.NotEncoded) — decoding it again corrupts
-        // (or throws on) filenames containing a literal '%'. On a failed decode
-        // fall back to the raw name rather than "", so an oddly-encoded src
-        // degrades to a possible mismatch instead of matching nothing ever.
-        const fileNameOf = (url?: string | null, encoded: boolean = true) => {
-            const raw = (url ?? "").split("?")[0].split("/").pop() ?? "";
-            if (!encoded) return raw;
-            try {
-                return decodeURIComponent(raw);
-            } catch {
-                return raw;
-            }
-        };
-        const clickedUrl = imgContainer
-            ? getImageUrlFromImageContainer(imgContainer as HTMLElement)
-            : (img as HTMLImageElement)?.getAttribute("src");
-        const clickedPageId = canvasElement
-            .closest(".bloom-page")
+        const clickedPageId = document
+            .querySelector(".bloom-page")
             ?.getAttribute("id");
-        const clickedFile = fileNameOf(clickedUrl);
+        const clickedFile = target.imageFileName;
         const clickedMatch =
             clickedPageId && clickedFile
                 ? (launchData.bookImages ?? []).find(
@@ -226,10 +260,11 @@ export const launchAiImageEditor = (
                 (r) => r && r.ok && r.isCurrentPage && r.newSrc && r.oldSrc,
             );
             if (toApply.length === 0) return { applied: 0, expected: 0 };
-            const pageDoc = img.ownerDocument;
+            // This code always runs in the page frame (C# calls openAiImageEditor there),
+            // so the live page is simply this document.
             const pageRoot =
-                (pageDoc.querySelector(".bloom-page") as HTMLElement) ||
-                pageDoc;
+                (document.querySelector(".bloom-page") as HTMLElement) ||
+                document;
             // Look up the page's image-bearing elements once, not per replacement.
             const candidates = Array.from(
                 pageRoot.querySelectorAll('img, [style*="background-image"]'),

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlRegistry.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlRegistry.ts
@@ -524,7 +524,7 @@ export const controlRegistry: Record<TopLevelControlId, IControlDefinition> = {
             if (!img) {
                 return;
             }
-            launchAiImageEditor(img, getImageContainer(ctx), ctx.canvasElement);
+            launchAiImageEditor(img, getImageContainer(ctx));
             runtime.closeMenu(true);
         },
     },

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -384,6 +384,11 @@ namespace Bloom.Edit
         {
             if (details.FromTab == Workspace.WorkspaceTab.edit)
             {
+                // Leaving the tab means no page will load to run whatever was queued for the next
+                // page load (see RunAfterNextPageLoad) — and it was queued for the page we are
+                // leaving, so it must not spring to life if the user comes back to that page later.
+                _doAfterNextPageLoad = null;
+
                 // When an external tool has overwritten the current book on disk (see
                 // ReloadCurrentBookDiscardingEdits), we are leaving the Edit tab specifically to
                 // discard the unsaved page. In that case reload from disk instead of saving, so the
@@ -2128,11 +2133,47 @@ namespace Bloom.Edit
         public void HandlePageDomLoadedEvent(string pageId)
         {
             var nowEditing = _stateMachine.ToEditing(pageId);
+            if (nowEditing)
+            {
+                // Run whatever was queued for "the browser has a page again" (see
+                // RunAfterNextPageLoad). Taken and cleared before invoking, so it fires at most
+                // once even if it throws, and so an action that queues another one works.
+                // Before AdvanceUpdatingAllPages, which may navigate straight off this page.
+                var afterPageLoad = _doAfterNextPageLoad;
+                _doAfterNextPageLoad = null;
+                afterPageLoad?.Invoke(pageId);
+            }
             // If we are in the middle of the "Update Book" per-page pass, a page finishing loading
             // (which means the edit-tab page setup code has run on it) is our cue to save it and
             // move on to the next page. See StartUpdatingAllPages().
             if (nowEditing && _updatingAllPages)
                 AdvanceUpdatingAllPages(pageId);
+        }
+
+        // The one action queued by RunAfterNextPageLoad, or null.
+        private Action<string> _doAfterNextPageLoad;
+
+        /// <summary>
+        /// Arrange for <paramref name="action"/> to run the next time a page finishes loading in
+        /// the browser, passing it that page's id.
+        ///
+        /// This exists for callers that must save the current page before doing something in the
+        /// browser that needs the saved book DOM to be up to date. Saving strips the live page, so
+        /// it always ends by re-navigating to it (see EditingStateMachine) — which means
+        /// SaveThen's own doAfterSaveToDisk is too early for such a caller: it runs before that
+        /// navigation, so the browser code it started would be torn down. Waiting for the page to
+        /// come back is the only safe point. AiImageEditorApi.HandleSaveThenLaunch is the caller
+        /// this was written for (BL-16682).
+        ///
+        /// Only one action is held; queueing a second replaces the first, and passing null cancels.
+        /// The page that loads next is not necessarily the one the caller was on (the user may have
+        /// navigated, or the save may have failed), so callers that care must check the id they are
+        /// given. Leaving the Edit tab drops it (see OnTabAboutToChange), since no page would load
+        /// to run it and the caller's page is no longer on screen.
+        /// </summary>
+        public void RunAfterNextPageLoad(Action<string> action)
+        {
+            _doAfterNextPageLoad = action;
         }
 
         // Fields supporting the "Update Book" per-page pass (see StartUpdatingAllPages()).

--- a/src/BloomExe/web/controllers/AiImageEditorApi.cs
+++ b/src/BloomExe/web/controllers/AiImageEditorApi.cs
@@ -47,6 +47,10 @@ namespace Bloom.web.controllers
     ///
     /// TWO COMMUNICATION PLANES
     ///   1. HTTP, AI image editor / front-end JS -> this controller, over Bloom's server:
+    ///        aiImageEditor/saveThenLaunch  what the menu command posts: save the page being
+    ///                                    edited (which reloads it), then call the launcher's
+    ///                                    openAiImageEditor() in the reloaded page. The one
+    ///                                    C#->browser call in this feature; see the method.
     ///        aiImageEditor/launch        mint session, make folders, enumerate book
     ///                                    images + history, return the launch payload.
     ///        aiImageEditor/file          GET/POST/DELETE files under .ai-image-editor/.
@@ -161,6 +165,12 @@ namespace Bloom.web.controllers
         public void RegisterWithApiHandler(BloomApiHandler apiHandler)
         {
             apiHandler.RegisterEndpointHandler(
+                "aiImageEditor/saveThenLaunch",
+                HandleSaveThenLaunch,
+                handleOnUiThread: true,
+                requiresSync: false
+            );
+            apiHandler.RegisterEndpointHandler(
                 "aiImageEditor/launch",
                 HandleLaunch,
                 handleOnUiThread: true,
@@ -213,6 +223,94 @@ namespace Bloom.web.controllers
             if (!string.IsNullOrWhiteSpace(overrideUrl))
                 return overrideUrl;
             return $"{BloomServer.ServerUrl}/bloom/aiImageEditor/index.html";
+        }
+
+        /// <summary>The image the user right-clicked, as the front-end sends it to
+        /// <see cref="HandleSaveThenLaunch"/> and as we hand it back to the browser once the page
+        /// has been saved. Just a file name — see IAiImageEditorTarget in aiEditorLauncher.ts.
+        /// </summary>
+        private class SaveThenLaunchRequest
+        {
+            public string imageFileName { get; set; }
+        }
+
+        /// <summary>
+        /// Saves the page the user is editing, then opens the AI image editor on it.
+        ///
+        /// The save is the point of this endpoint. Everything we tell the AI image editor about
+        /// the book — the image list from <see cref="EnumerateBookImages"/>, and on commit each
+        /// slot's current src — is read from the SAVED book DOM, but an image the user has just
+        /// added exists only in the live page (Bloom deliberately doesn't save on an image change;
+        /// see EditingModel.UpdateImageInBrowser and BL-16330). Launching against the unsaved DOM
+        /// opened the editor with an empty "Image to Edit" slot (BL-16682); it would also have
+        /// made the current page's commit results describe an image the live page no longer shows,
+        /// and left <see cref="DeleteSupersededAiImageFiles"/> blind to a file the live page uses.
+        ///
+        /// Saving reloads the page (it strips the live one), so we cannot simply open the editor
+        /// afterwards from here, nor from SaveThen's doAfterSaveToDisk, which runs before that
+        /// navigation: either way the page frame that hosts the editor would be torn down. Hence
+        /// EditingModel.RunAfterNextPageLoad — we open the editor once the reloaded page reports
+        /// in.
+        /// </summary>
+        private void HandleSaveThenLaunch(ApiRequest request)
+        {
+            // Must be read before SaveThen: by the time our callbacks run the request is complete.
+            SaveThenLaunchRequest payload;
+            try
+            {
+                payload = request.RequiredPostObject<SaveThenLaunchRequest>();
+            }
+            catch (Exception)
+            {
+                request.Failed(HttpStatusCode.BadRequest, "Invalid saveThenLaunch payload");
+                return;
+            }
+
+            var model = View?.Model;
+            var pageIdToSave = model?.CurrentPage?.Id;
+            if (model == null || string.IsNullOrEmpty(pageIdToSave))
+            {
+                request.Failed("No page is open for editing");
+                return;
+            }
+
+            // Queue this BEFORE the save: with no page loaded, SaveThen completes synchronously.
+            model.RunAfterNextPageLoad(loadedPageId =>
+            {
+                // A different page means the user navigated (or the save failed and we went
+                // somewhere else); the image we were asked to edit isn't there to edit.
+                if (loadedPageId == pageIdToSave)
+                    OpenEditorInBrowser(payload);
+            });
+            model.SaveThen(
+                () => pageIdToSave,
+                doIfNotInRightStateToSave: () => {
+                    // Leave the queued launch in place. Every state that refuses a save — a save
+                    // already in flight, mid-navigation, saved-and-stripped — is on its way to a
+                    // page load, and that load will open the editor with a book DOM the other
+                    // save has just brought up to date, which is all we wanted. Opening the
+                    // editor here instead would be actively worse: the in-flight save's reload
+                    // would then arrive with the overlay up and kill the page-frame code that
+                    // runs it, leaving a full-screen overlay the user cannot close.
+                }
+            );
+
+            request.PostSucceeded();
+        }
+
+        /// <summary>
+        /// Tells the page frame to open the AI image editor overlay on <paramref name="target"/>.
+        /// The browser owns the overlay (only it can postMessage to the editor's iframe), so all
+        /// this side does is call the launcher's entry point; see openAiImageEditor in
+        /// aiEditorLauncher.ts. Fire-and-forget, like EditingModel.UpdateImageInBrowser's call to
+        /// changeImage: there is nothing here to wait for.
+        /// </summary>
+        private void OpenEditorInBrowser(SaveThenLaunchRequest target)
+        {
+            var arg = JsonConvert.SerializeObject(target);
+            View?.Browser?.RunJavascriptFireAndForget(
+                $"workspaceBundle.getEditablePageBundleExports().openAiImageEditor({arg})"
+            );
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes BL-16682: "Edit with AI…" opened the AI Image Tools with an empty "Image to Edit" slot when the user had just added the image.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16682

## ⚖️ One of two alternatives — please compare

This is **approach A: the minimal fix.** The alternative is **#8191**, which fixes the same bug by moving the AI editor overlay into the top window. Pick one; the other gets closed.

|  | This PR (A) | #8191 (B) |
| --- | --- | --- |
| Where the overlay lives | page iframe (unchanged) | top window |
| `EditingModel` | **+41 lines** — new `RunAfterNextPageLoad` hook | untouched |
| Post-save hook used | the new hook | `SaveThen`'s existing `doAfterSaveToDisk` |
| Save after a commit | deferred until the user closes the overlay | immediate |
| Repeat commit in one session | still broken | fixed |
| Files | 1 launcher module | 3 modules, split by frame |
| Live-verified | **yes** | not yet |
| Reviewed | **not yet** (no Devin, no preflight) | yes |

## Why the bug happened

Everything Bloom tells the AI editor about the book — the whole-book image list, and on commit each slot's current src — is read from the **saved** book DOM. But an image the user just added lives only in the live page, because `changeImage`/`changeImageByElement` deliberately don't save (BL-16330). So the clicked image matched nothing in the list and no edit target was sent.

Saving first also closes two latent hazards: a current-page commit result would describe an image the live page no longer showed, and `DeleteSupersededAiImageFiles`, which judges orphanhood from the saved DOM, could delete a file the live page still used.

## How this approach fixes it

The menu command posts `aiImageEditor/saveThenLaunch`; C# saves the page with `EditingModel.SaveThen`, and then calls the launcher back **in the reloaded page frame**.

Bloom's save strips the live page and therefore always ends by re-navigating to it, which tears the page frame down — and `SaveThen`'s own `doAfterSaveToDisk` runs *before* that navigation, so it is too early. Hence the one new piece: `EditingModel.RunAfterNextPageLoad(action)`, run and cleared in `HandlePageDomLoadedEvent` beside the existing "Update Book" per-page chain, and dropped when the Edit tab is left.

When Bloom isn't in a state to save, the queued launch is deliberately left queued: those states are heading for a page load anyway, and opening the overlay right then would let the in-flight save's reload kill the code that operates it.

## Verification

- Front-end: full `vitest run --no-file-parallelism` — 685 passed, 5 skipped, 62 files. Three new launcher tests.
- C#: `--filter "FullyQualifiedName~Editing|FullyQualifiedName~AiImageEditor"` — 71 passed.
- `pnpm typecheck`, eslint, and the isolated production bundle build all clean.
- **Confirmed working in a running Bloom by the developer.**

⚠️ This branch has **not** been through preflight — no Devin review, and the full C# suite hasn't been run against it. If it's the one we keep, it needs that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8193)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8193)
<!-- Reviewable:end -->
