### PR TITLE
Alternative to #8192: fix BL-16667 with a synchronous send

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,12 @@ under `output/agent/<key>/` so your build/test never touches the locked shared o
 means you do **not** need to stop the developer's Bloom to build or run unit tests, and
 multiple terminals can build/test at once. See `Directory.Build.props` for how it works.
 
+- For `test`, the wrapper **judges the run and prints a verdict as its last line**, so
+  `[agent-dotnet] test run completed. Passed! ...` is the only thing you need to read (and it
+  survives `| tail`). Do not judge a run by the `Passed!`/`Failed!` summary above it: a run whose
+  test host is killed part way through still prints a passing summary of however many tests got to
+  run. The wrapper catches that and says `*** TEST RUN ABORTED ***`, and exits non-zero, as it
+  does for ordinary failures. The text it looks for lives in `build/test-abort-markers.txt`.
 - This wrapper is for **building and running tests only**. To *run* Bloom, still use
   `./go.sh` (see "Running Bloom" below) — the wrapper builds no `Bloom.exe` apphost.
   (`BloomPdfMaker.exe` is the one apphost it does build, because Bloom's PDF code shells

--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -166,22 +166,6 @@ House rules:
   own suite.
 
 
-## 2026-07-24 — agent-dotnet.sh test exits 0 even when tests fail
-
-- **Cut:** `build/agent-dotnet.sh test src/BloomTests/BloomTests.csproj` returned exit code 0 on a
-  run whose own summary line read `Failed! - Failed: 11, Passed: 2913`. Anything that trusts the
-  exit code instead of parsing the output — an agent, a hook, a CI step, a background-task
-  notification that just reports "completed (exit code 0)" — will conclude the suite passed. During
-  this run the harness reported the failing suite as a success and it was only caught by reading the
-  summary line.
-- **Idea:** Have the wrapper propagate `dotnet test`'s real exit code (it presumably exits on the
-  last command in a pipeline, or swallows the status while redirecting into the private output
-  tree). Until then, treat "did the C# suite pass?" as a question only the output can answer.
-- **Context:** BloomDesktop, found during `/preflight` of PR #7992 (BL-16459 clipboard toast).
-  Distinct from the (now-fixed) cut about *which* tests fail under the wrapper — PR #8107 made
-  the full suite green, so a failure there is real; this entry is about the wrapper reporting
-  failure as success, which still stands.
-
 ## 2026-07-24 — go.sh "succeeds" on a fresh worktree whose output/browser was never built
 - **Cut:** On a never-initialized worktree, after fixing the obvious failures (pnpm install,
   getDependencies for CS0246), `./go.sh` launches and Bloom looks healthy — but opening a book

--- a/build/Bloom.proj
+++ b/build/Bloom.proj
@@ -301,6 +301,15 @@
     </Exec>
     <Message Condition="$(isOnTeamCity) == true" Importance="high" Text="##teamcity[importData type='nunit' path='$(TestResultsXmlFile)']"/>
     <Error Condition="'$(TestExitCode)' != '0'" Text="C# tests failed (dotnet test returned $(TestExitCode)). Results: $(TestResultsXmlFile)"/>
+    <!-- The exit code is not on its own enough to tell us the run finished. When the test host is
+	     killed part way through — which Bloom's own shutdown used to do about one run in three, see
+	     BL-16667 — the runner still prints a summary of the tests that had passed by then, and we
+	     cannot rely on every such death producing a non-zero exit. But the logger only writes the
+	     results file once the run completes, and we deleted any earlier one above, so a missing
+	     file is proof that the run did not finish. Without this check that case reaches TeamCity as
+	     a green build that ran a fraction of the suite. -->
+    <Error Condition="!Exists('$(TestResultsXmlFile)')"
+		   Text="The C# test run did not finish: it exited $(TestExitCode) but never wrote $(TestResultsXmlFile), which the logger does only on completion. The test host was probably killed part way through, so however many tests the output says passed, the suite did not run."/>
   </Target>
   <Target Name="MakeDownloadPointers" DependsOnTargets="VersionNumbers"
 		Condition="'$(OS)'=='Windows_NT'">

--- a/build/agent-dotnet.ps1
+++ b/build/agent-dotnet.ps1
@@ -11,6 +11,10 @@
 # build and run unit tests while a Bloom keeps running and while other terminals do
 # their own builds.
 #
+# For `test` it also judges the run and prints a verdict as its last line -- see the
+# "Judging a test run" comment in agent-dotnet.sh for why that is not something the
+# exit code can be trusted to do on its own.
+#
 # Usage (exactly like dotnet, just build/test through this script):
 #   build/agent-dotnet.ps1 test src/BloomTests/BloomTests.csproj --filter "FullyQualifiedName~UrlPathStringTests"
 #   build/agent-dotnet.ps1 build src/BloomExe/BloomExe.csproj
@@ -32,5 +36,92 @@ Write-Host "[agent-dotnet] isolated build dir: $scratch"
 # the BloomPdfMaker.exe the PDF tests shell out to — so it now lives in
 # Directory.Build.props, which a global property would have overridden.
 $env:BLOOM_AGENT_BUILD_DIR = $scratch
-& dotnet @args "-p:OutDir=$scratch/bin/"
-exit $LASTEXITCODE
+
+# For everything except `test`, dotnet's own exit code is the whole story.
+if ($args.Count -eq 0 -or $args[0] -ne 'test') {
+    & dotnet @args "-p:OutDir=$scratch/bin/"
+    exit $LASTEXITCODE
+}
+
+$markersFile = Join-Path $PSScriptRoot 'test-abort-markers.txt'
+if (-not (Test-Path $markersFile)) {
+    Write-Host "[agent-dotnet] cannot find $markersFile, so a truncated test run could not be detected"
+    exit 1
+}
+
+$log = Join-Path ([System.IO.Path]::GetTempPath()) "agent-dotnet-test-$PID.log"
+
+# stderr is merged in because that is where the runtime prints the crash banners we look
+# for. In Windows PowerShell that redirection wraps each stderr line in an ErrorRecord,
+# which under $ErrorActionPreference='Stop' would end the script; hence Continue for the
+# duration, and the stringify step so what reaches the console and the log is plain text.
+$ErrorActionPreference = 'Continue'
+& dotnet @args "-p:OutDir=$scratch/bin/" 2>&1 |
+    ForEach-Object {
+        # An ErrorRecord here is just a line dotnet wrote to stderr. Take its message rather than
+        # letting PowerShell format it, which for some of them yields the useless string
+        # "System.Management.Automation.RemoteException" -- and a crash banner turned into that
+        # would be a marker we could no longer match.
+        if ($_ -is [System.Management.Automation.ErrorRecord]) { $_.Exception.Message } else { [string]$_ }
+    } | Tee-Object -FilePath $log
+$status = $LASTEXITCODE
+# $LASTEXITCODE is never assigned if dotnet could not be launched at all -- not on PATH in this
+# terminal, say -- because then nothing ran to set it. That leaves $status $null, and PowerShell
+# turns `exit $null` into exit code 0: this script would announce a failed run and hand its caller
+# a success. Which is the exact hazard it exists to remove. (The bash twin cannot have this hole;
+# PIPESTATUS[0] is always a number.)
+if ($null -eq $status) { $status = 1 }
+$ErrorActionPreference = 'Stop'
+
+try {
+    # Match against the output with the indentation taken off the front of every line. That is what
+    # lets the markers file anchor its patterns with a plain ^ and mean the same thing here as it
+    # does to grep -E in the bash twin -- writing "start of line, then optional whitespace" is the
+    # one thing the two regex engines cannot be made to agree on (see the note in the markers file).
+    $trimmedOutput = Get-Content $log | ForEach-Object { $_.TrimStart() }
+
+    $abortEvidence = $null
+    foreach ($pattern in Get-Content $markersFile) {
+        if ($pattern.Trim() -eq '' -or $pattern.TrimStart().StartsWith('#')) { continue }
+        # -CaseSensitive because grep -E in the bash twin is, and Select-String is not unless told.
+        # Without it the same output could be judged aborted here and passing there -- and the
+        # markers file spells "[Tt]esthost" out precisely because it expects to be matched with
+        # case respected.
+        $hit = $trimmedOutput | Select-String -Pattern $pattern -List -CaseSensitive
+        if ($hit) { $abortEvidence = $hit.Line.Trim(); break }
+    }
+
+    $summaryHit = $trimmedOutput | Select-String -Pattern '^(Passed|Failed)!' -CaseSensitive
+    $summary = if ($summaryHit) { $summaryHit[-1].Line.Trim() } else { $null }
+
+    Write-Host ""
+    if ($abortEvidence) {
+        Write-Host "[agent-dotnet] *** TEST RUN ABORTED -- NOT a pass. ***"
+        Write-Host "[agent-dotnet] Evidence: $abortEvidence"
+        Write-Host "[agent-dotnet] Any summary above counts only the tests that ran before this, so it means nothing."
+        exit 1
+    }
+    if ($status -ne 0) {
+        $detail = if ($summary) { $summary } else { 'No summary line was printed.' }
+        Write-Host "[agent-dotnet] *** TEST RUN FAILED (dotnet exited $status). *** $detail"
+        exit $status
+    }
+    if (-not $summary) {
+        # A discovery-only run has no tests to summarize, so its silence is not evidence of anything.
+        if ($args -contains '--list-tests' -or $args -contains '-t') {
+            Write-Host "[agent-dotnet] listed tests without running them."
+            exit 0
+        }
+        Write-Host "[agent-dotnet] *** TEST RUN INCOMPLETE: it exited 0 but never printed a summary, so we do not know what ran. ***"
+        exit 1
+    }
+    if ($summary -like '*Failed!*') {
+        # dotnet said 0 but its own summary says otherwise; believe the summary.
+        Write-Host "[agent-dotnet] *** TEST RUN FAILED. *** $summary"
+        exit 1
+    }
+    Write-Host "[agent-dotnet] test run completed. $summary"
+}
+finally {
+    Remove-Item $log -ErrorAction SilentlyContinue
+}

--- a/build/agent-dotnet.sh
+++ b/build/agent-dotnet.sh
@@ -17,6 +17,9 @@
 #   the one global -p: this script appends, and apphost policy lives in that same props
 #   file because it has to vary per project).
 #
+#   For `test` it does one more thing: it judges the run itself and prints a verdict as
+#   its LAST line. See "Judging a test run" below.
+#
 # Usage (exactly like dotnet, just build/test through this script):
 #   build/agent-dotnet.sh test src/BloomTests/BloomTests.csproj --filter "FullyQualifiedName~UrlPathStringTests"
 #   build/agent-dotnet.sh build src/BloomExe/BloomExe.csproj
@@ -48,5 +51,98 @@ echo "[agent-dotnet] isolated build dir: $SCRATCH" >&2
 # be a global here too, but it has to vary per project — WebView2PdfMaker's apphost is
 # the BloomPdfMaker.exe the PDF tests shell out to — so it now lives in
 # Directory.Build.props, which a global property would have overridden.
-BLOOM_AGENT_BUILD_DIR="$SCRATCH" exec dotnet "$@" \
-    -p:OutDir="$SCRATCH/bin/"
+
+# For everything except `test`, dotnet's own exit code is the whole story, so get out of
+# the way entirely and let it have this process.
+if [ "${1:-}" != "test" ]; then
+    BLOOM_AGENT_BUILD_DIR="$SCRATCH" exec dotnet "$@" \
+        -p:OutDir="$SCRATCH/bin/"
+fi
+
+# ---------------------------------------------------------------------------
+# Judging a test run
+#
+# A `dotnet test` run can stop early — Bloom's own code taking the test host down with
+# it is the case that prompted this (BL-16667) — and when it does, VSTest still prints a
+# summary of the tests that got as far as running. Everything that ran had passed, so
+# that summary reads "Passed!". Anything that judges the run by its last lines, which is
+# what a human skimming and an agent reading `| tail` both do, calls that green.
+#
+# There is a second way to be told a lie here, recorded in PAPERCUTS.md: a run whose own
+# summary said `Failed! - Failed: 11` still arrived at the caller as exit code 0 (a pipe
+# swallows the status, and callers do pipe this).
+#
+# So: capture the output, judge it three ways (crash markers, dotnet's exit code, the
+# summary line), and print a one-line verdict LAST so it survives `| tail`. Nothing is
+# hidden — the output still streams to the terminal as it happens.
+# ---------------------------------------------------------------------------
+
+MARKERS="$SCRIPT_DIR/test-abort-markers.txt"
+if [ ! -f "$MARKERS" ]; then
+    echo "[agent-dotnet] cannot find $MARKERS, so a truncated test run could not be detected" >&2
+    exit 1
+fi
+
+LOG="$(mktemp -t agent-dotnet-test-XXXXXX)"
+TRIMMED="$LOG.trimmed"
+trap 'rm -f "$LOG" "$TRIMMED"' EXIT
+
+# stderr is merged in because that is where the runtime prints the crash banners we are
+# looking for. PIPESTATUS[0] rather than $? because $? here would be tee's.
+set +e
+BLOOM_AGENT_BUILD_DIR="$SCRATCH" dotnet "$@" -p:OutDir="$SCRATCH/bin/" 2>&1 | tee "$LOG"
+STATUS=${PIPESTATUS[0]}
+set -e
+
+# Match against a copy with the indentation taken off the front of every line. That is what lets
+# the markers file anchor its patterns with a plain ^ and mean the same thing here as it does to
+# Select-String in the PowerShell twin -- writing "start of line, then optional whitespace" is the
+# one thing the two regex engines cannot be made to agree on (see the note in the markers file).
+sed 's/^[[:space:]]*//' "$LOG" >"$TRIMMED"
+
+ABORT_EVIDENCE=""
+while IFS= read -r pattern || [ -n "$pattern" ]; do
+    # The repo is text=auto and Windows checkouts are autocrlf, so the markers file may well
+    # arrive with CRLF line endings. A trailing carriage return left on the end of a pattern
+    # would silently stop it ever matching, which is the one failure this file must not have.
+    pattern="${pattern%$'\r'}"
+    case "$pattern" in '' | '#'*) continue ;; esac
+    match="$(grep -m1 -E "$pattern" "$TRIMMED" || true)"
+    if [ -n "$match" ]; then
+        ABORT_EVIDENCE="$match"
+        break
+    fi
+done <"$MARKERS"
+
+SUMMARY="$(grep -E "^(Passed|Failed)!" "$TRIMMED" | tail -1 || true)"
+
+echo ""
+if [ -n "$ABORT_EVIDENCE" ]; then
+    echo "[agent-dotnet] *** TEST RUN ABORTED -- NOT a pass. ***"
+    echo "[agent-dotnet] Evidence: $ABORT_EVIDENCE"
+    echo "[agent-dotnet] Any summary above counts only the tests that ran before this, so it means nothing."
+    exit 1
+fi
+if [ "$STATUS" -ne 0 ]; then
+    echo "[agent-dotnet] *** TEST RUN FAILED (dotnet exited $STATUS). *** ${SUMMARY:-No summary line was printed.}"
+    exit "$STATUS"
+fi
+if [ -z "$SUMMARY" ]; then
+    # A discovery-only run has no tests to summarize, so its silence is not evidence of anything.
+    for arg in "$@"; do
+        if [ "$arg" = "--list-tests" ] || [ "$arg" = "-t" ]; then
+            echo "[agent-dotnet] listed tests without running them."
+            exit 0
+        fi
+    done
+    echo "[agent-dotnet] *** TEST RUN INCOMPLETE: it exited 0 but never printed a summary, so we do not know what ran. ***"
+    exit 1
+fi
+case "$SUMMARY" in
+    *Failed!*)
+        # dotnet said 0 but its own summary says otherwise; believe the summary.
+        echo "[agent-dotnet] *** TEST RUN FAILED. *** $SUMMARY"
+        exit 1
+        ;;
+esac
+echo "[agent-dotnet] test run completed. $SUMMARY"

--- a/build/test-abort-markers.txt
+++ b/build/test-abort-markers.txt
@@ -1,0 +1,49 @@
+# Text that means a `dotnet test` run did not finish the tests it was asked to run.
+#
+# Read by BOTH build/agent-dotnet.sh and build/agent-dotnet.ps1 after a test run, so that an
+# aborted run is reported as a failure instead of being judged by its pass/fail summary. It has
+# to live in one file because the two scripts are twins and a marker added to one and not the
+# other would silently only work in one shell.
+#
+# Why this is needed at all: when Bloom's own code kills the test host part way through, VSTest
+# still prints a summary of the tests that had run by then -- and since everything that ran had
+# passed, that summary says "Passed!". A human skimming, a script, or an agent reading the last
+# line will call that green. See BL-16667, which is also the bug that made it happen often.
+#
+# One extended regular expression per line; blank lines and # comments are ignored. Keep them
+# simple enough to mean the same thing to grep -E and to .NET's Select-String: no \s, no
+# [[:space:]], no lazy quantifiers, and in particular no [ \t] -- inside a bracket expression
+# grep -E reads that as a literal backslash and letter t, while .NET reads it as a tab, so a
+# pattern using it would quietly mean different things in the two scripts this file exists to
+# keep in step. Both scripts strip leading whitespace from each line of output before matching,
+# so an anchored pattern here needs no allowance for indentation.
+#
+# Anchor the ones that could otherwise match a test's own output (a test about error reporting
+# may well print the words "unhandled exception"); the runtime prints its banners at the start of
+# a line. Note what the anchor does and does not buy, since the lines are trimmed first: it still
+# rules out the words appearing mid-sentence, which is the common case, but not a test whose own
+# output begins with them on an indented line. That would cost a false "aborted" on a run that
+# actually finished -- annoying, but the safe direction to be wrong in, and the verdict prints the
+# line it matched on, so it takes one look to see what happened.
+#
+# Case matters: the bash twin matches with grep -E, which is case-sensitive, so the PowerShell one
+# passes -CaseSensitive to Select-String, which is not by default. Write patterns accordingly --
+# hence "[Tt]esthost" below rather than relying on either engine to be lenient.
+
+# The .NET runtime's own death notices. The second is what Environment.FailFast prints, which is
+# what a failing Debug.Assert or Debug.Fail comes to in a process with no debugger attached.
+^Unhandled exception\.
+^Process terminated\.
+^Fatal error\.
+^Stack overflow\.
+Process is terminating due to StackOverflowException
+
+# VSTest noticing that the host it was driving went away.
+Test Run Aborted
+The active test run was aborted
+[Tt]esthost process exited with error
+[Tt]est host process crashed
+
+# Nothing ran at all: normally a filter that matches nothing, which is a mistake worth catching
+# rather than a green run of zero tests.
+^No test is available

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -157,6 +157,14 @@ namespace Bloom.Api
         private readonly ManualResetEvent _stop;
 
         /// <summary>
+        /// True from the moment Dispose tells our threads to stop. After that the listener and the
+        /// handles it owns can be closed while a request is still being finished, so failures in
+        /// the request path are the expected cost of quitting rather than a sign of a bug, and code
+        /// that would otherwise make a fuss about them should keep quiet. See BL-16667.
+        /// </summary>
+        private bool IsShuttingDown => IsDisposed || _stop.WaitOne(0);
+
+        /// <summary>
         /// Notifies threads in the _workers pool that there is a request in the _queue
         /// </summary>
         private readonly ManualResetEvent _ready;
@@ -1964,27 +1972,48 @@ namespace Bloom.Api
         /// <param name="ar"></param>
         private void QueueRequest(IAsyncResult ar)
         {
-            // this can happen when shutting down
-            // BL-2207 indicates it may be possible for the thread to be alive and the listener closed,
-            // although the only way I know it gets closed happens after joining with that thread.
-            // Still, one more check seems worthwhile...if we're far enough along in shutting down
-            // to have closed the listener we certainly can't respond to any more requests.
-            if (!_listenerThread.IsAlive || !_listener.IsListening)
-                return;
-
-            lock (_queue)
+            // This runs on a thread pool thread, as the completion of the BeginGetContext in
+            // EnqueueIncomingRequests, so nothing we do here is inside any try/catch of ours: an
+            // exception that got out would be unhandled and would kill the process (BL-16667).
+            // Everything below can throw during shutdown -- closing the listener is what completes
+            // the pending BeginGetContext in the first place, and it nulls out _listener -- so the
+            // whole thing has to be guarded, not just the parts we can think of a reason for.
+            try
             {
-                _queue.Enqueue(_listener.EndGetContext(ar));
+                // this can happen when shutting down
+                // BL-2207 indicates it may be possible for the thread to be alive and the listener closed,
+                // although the only way I know it gets closed happens after joining with that thread.
+                // Still, one more check seems worthwhile...if we're far enough along in shutting down
+                // to have closed the listener we certainly can't respond to any more requests.
+                if (!_listenerThread.IsAlive || _listener?.IsListening != true)
+                    return;
 
-                // Deal with a situation where all the workers are blocked,
-                // but there is a request in the queue that would unblock the current workers
-                // but that request can't run because it's stuck in queue
-                // and none of the existing worker threads are able to make progress anymore.
-                // Any worker added here is added before the _ready.Set() below, so it receives it.
-                // (Monitor is reentrant, so it is fine that we already hold this lock.)
-                EnsureAWorkerCanStillTakeWork();
+                lock (_queue)
+                {
+                    _queue.Enqueue(_listener.EndGetContext(ar));
 
-                _ready.Set();
+                    // Deal with a situation where all the workers are blocked,
+                    // but there is a request in the queue that would unblock the current workers
+                    // but that request can't run because it's stuck in queue
+                    // and none of the existing worker threads are able to make progress anymore.
+                    // Any worker added here is added before the _ready.Set() below, so it receives it.
+                    // (Monitor is reentrant, so it is fine that we already hold this lock.)
+                    EnsureAWorkerCanStillTakeWork();
+
+                    _ready.Set();
+                }
+            }
+            catch (Exception error)
+            {
+                // Losing an incoming request while we are shutting down is the expected case and is
+                // no loss at all. Losing one at any other time is worth knowing about, but still not
+                // worth killing Bloom over: the client will time out and can ask again.
+                Logger.WriteEvent(
+                    "At BloomServer: QueueRequest() could not accept a request"
+                        + (IsShuttingDown ? " (shutting down)" : "")
+                        + ": "
+                        + error.Message
+                );
             }
         }
 
@@ -2112,7 +2141,16 @@ namespace Bloom.Api
                         Logger.WriteEvent(error.StackTrace);
 #if DEBUG
                         //NB: "throw" here makes it impossible for even the programmer to continue and try to see how it happens
-                        Debug.Fail("(Debug Only) " + error.Message);
+                        // Two cases where stopping here does harm and no good (BL-16667):
+                        // - While we are shutting down. The listener and its handles get closed out from under
+                        //   requests that are still finishing, so exceptions here are the expected consequence of
+                        //   quitting, not a bug to investigate.
+                        // - Under unit tests. There is no developer at a debugger to stop, so all Debug.Fail can do
+                        //   is terminate the test host, which truncates the run -- and, because everything that had
+                        //   already run had passed, the run then reports itself green. The error is logged either
+                        //   way, and the request still fails, so a real server bug still shows up as a failing test.
+                        if (!IsShuttingDown && !Program.RunningUnitTests)
+                            Debug.Fail("(Debug Only) " + error.Message);
 #endif
                     }
                 }
@@ -2831,6 +2869,12 @@ namespace Bloom.Api
                             }
                         }
 
+                        // Joining the workers above is what makes closing the listener safe. A worker
+                        // does not finish with a request until the response body has actually gone out
+                        // (RequestInfo sends with willBlock: true for exactly this reason), so once
+                        // they have all stopped there is nothing left in flight for CloseListener to
+                        // pull the ground out from under. See BL-16667 for what happened when the
+                        // sends outlived the workers.
                         CloseListener();
                     }
                     if (_cache != null)
@@ -2863,8 +2907,10 @@ namespace Bloom.Api
         {
             if (_listener == null)
                 return; // probably called from shutdown timer, and normal shutdown got this far
-            // stop listening for incoming http requests
-            Debug.Assert(_listener.IsListening);
+            // stop listening for incoming http requests.
+            // (There used to be a Debug.Assert(_listener.IsListening) here. It told us nothing the
+            // next line does not handle, and a failing Debug.Assert terminates a test host, which
+            // is how a run gets truncated -- see BL-16667.)
             if (_listener.IsListening)
             {
                 //In BL-3290, a user quitely failed here each time he exited Bloom, with a Cannot access a disposed object.

--- a/src/BloomExe/web/RequestInfo.cs
+++ b/src/BloomExe/web/RequestInfo.cs
@@ -252,18 +252,31 @@ namespace Bloom.Api
                 else if (fs.Length < 2 * 1024 * 1024)
                 {
                     // This buffer size was picked to be big enough for any of the standard files we load in every page.
-                    // Profiling indicates it is MUCH faster to use Response.Close() rather than writing to the output stream,
-                    // though the gain may be illusory since the final 'false' argument allows our code to proceed without waiting
-                    // for the complete data transfer. At a minimum, it makes this thread available to work on another
-                    // request sooner.
+                    // Profiling indicates it is MUCH faster to send the whole body in one go rather than writing to the
+                    // output stream, though the gain may be illusory since we don't wait for the complete data transfer.
+                    // At a minimum, it makes this thread available to work on another request sooner.
                     var buffer = new byte[fs.Length];
                     fs.Read(buffer, 0, (int)fs.Length);
                     // The client may not read the whole stream (e.g. paused video). I don't know whether that could lead
-                    // to a delay in Close() returning; probably not. But just to be safe, make sure we aren't holding
+                    // to a delay in the send finishing; probably not. But just to be safe, make sure we aren't holding
                     // on to the file.
                     fs.Dispose();
                     fs = null;
-                    _actualContext.Response.Close(buffer, false);
+                    // willBlock: true. The `false` this replaces returned the moment the write was
+                    // issued and let the framework finish the send on a callback of its own, whose
+                    // only handler is `catch (Win32Exception)`. Closing the listener under such a
+                    // send -- which is exactly what quitting Bloom does -- made it fail with an
+                    // ObjectDisposedException that handler does not catch, on a thread none of ours
+                    // covers, so it reached the runtime and killed the process (BL-16667). Waiting
+                    // here means the send is over before this worker is counted as free, so by the
+                    // time Dispose has joined the workers there is nothing left in flight.
+                    //
+                    // It is also not slower. Measured over 300 60KB files on loopback: blocking took
+                    // ~4.6s against ~6.1s for the asynchronous form when all 300 were requested at
+                    // once, and the two were indistinguishable one at a time. The comment above
+                    // ("makes this thread available sooner") was a reasonable guess, but the
+                    // per-response task, continuation and completion hop cost more than they saved.
+                    _actualContext.Response.Close(buffer, true);
                 }
                 else
                 {
@@ -349,7 +362,17 @@ namespace Bloom.Api
             }
             else
             {
-                _actualContext.Response.Close(buffer, false);
+                // As in ReplyWithFileContent, willBlock: true so that nothing is still going out when
+                // the listener closes (BL-16667).
+                //
+                // Trimmed to actualLength first: a short read leaves the tail of the buffer
+                // unwritten, and sending it would exceed the Content-Length set just above, which
+                // http.sys rejects. Every caller in Bloom passes an exact length over a MemoryStream,
+                // so this resize does nothing today; the overload that defaults the length to 2MB is
+                // what makes the two able to differ.
+                if (actualLength != buffer.Length)
+                    Array.Resize(ref buffer, actualLength);
+                _actualContext.Response.Close(buffer, true);
             }
 
             HaveFullyProcessedRequest = true;
@@ -451,9 +474,17 @@ namespace Bloom.Api
             // http.sys throws ProtocolViolationException if we try, which would leave the
             // client hanging without a response.
             if (_actualContext.Request.HttpMethod == "HEAD")
+            {
                 _actualContext.Response.Close();
+            }
             else
-                _actualContext.Response.Close(Encoding.UTF8.GetBytes(errorDescription), false);
+            {
+                // Same treatment as the other two bodies (BL-16667), and this path matters most of
+                // all: it is the one that fires as Bloom closes, because the browser goes on asking
+                // for things the server is no longer there to give.
+                var body = Encoding.UTF8.GetBytes(errorDescription);
+                _actualContext.Response.Close(body, true);
+            }
             HaveFullyProcessedRequest = true;
         }
 

--- a/src/BloomTests/Spreadsheet/SpreadsheetAudioImportTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetAudioImportTests.cs
@@ -631,7 +631,14 @@ namespace BloomTests.Spreadsheet
         [Test]
         public void NoErrorForEmptyAudio()
         {
-            Assert.That(_progressSpy.Errors, Has.None.Match(".*17.*"));
+            // "page 17", not just "17": the row for page 17 has no audio at all and must not be
+            // complained about, but the errors for the OTHER pages quote full file paths, and a
+            // bare "17" matches any digits that happen to appear in one of those. Since BL-16664
+            // put this process's id into every temp path, that made the test fail whenever the
+            // process id contained "17" -- which is roughly one run in ten, and looks exactly like
+            // a mysterious intermittent failure. Found by the tenth full-suite run while hunting
+            // one down for BL-16667 (process id 178640).
+            Assert.That(_progressSpy.Errors, Has.None.Match("page 17"));
         }
 
         [Test]

--- a/src/BloomTests/web/ServeFileAndShutDownTests.cs
+++ b/src/BloomTests/web/ServeFileAndShutDownTests.cs
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using Bloom.Api;
+using Bloom.Book;
+using NUnit.Framework;
+using TemporaryFolder = SIL.TestUtilities.TemporaryFolder;
+
+namespace BloomTests.web
+{
+    /// <summary>
+    /// Fetches a file from a real, listening BloomServer over real HTTP, and then shuts that server
+    /// down. The rest of the server tests use PretendRequestInfo, which never touches an
+    /// HttpListener, so nothing else covers what happens between "the worker thread has finished
+    /// with this request" and "the bytes have reached the client" — which is exactly where BL-16667
+    /// lived: the response body was still going out when Dispose closed the listener, the framework
+    /// callback finishing the send blew up, and being on a thread nobody owned it took the whole
+    /// process with it.
+    /// </summary>
+    [TestFixture]
+    public class ServeFileAndShutDownTests
+    {
+        private TemporaryFolder _folder;
+
+        [SetUp]
+        public void Setup()
+        {
+            // These tests listen on the one fixed port, so they must not overlap with the other
+            // fixtures that do. (Same reasoning as EndpointHandlerTests, whose lock this is.)
+            Monitor.Enter(EndpointHandlerTests._portMonitor);
+            _folder = new TemporaryFolder("ServeFileAndShutDownTests");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _folder.Dispose();
+            Monitor.Exit(EndpointHandlerTests._portMonitor);
+        }
+
+        /// <summary>
+        /// A file small enough to go down the "send it all in one go" path, which is the one this
+        /// change alters.
+        /// </summary>
+        private string MakeFileToServe(string name, int size)
+        {
+            var path = Path.Combine(_folder.Path, name);
+            var content = new byte[size];
+            for (var i = 0; i < size; i++)
+                content[i] = (byte)(i % 251); // a pattern, so truncation or padding shows up
+            File.WriteAllBytes(path, content);
+            return path;
+        }
+
+        /// <summary>
+        /// The server serves a file named by its full path after the /bloom/ prefix.
+        /// </summary>
+        private static string UrlFor(string filePath)
+        {
+            return BloomServer.ServerUrlWithBloomPrefixEndingInSlash + filePath.Replace('\\', '/');
+        }
+
+        [Test]
+        public void FileRequest_OverRealHttp_ReturnsTheWholeFile()
+        {
+            var path = MakeFileToServe("served.txt", 40000);
+            var expected = File.ReadAllBytes(path);
+            Assert.That(
+                expected.Length,
+                Is.EqualTo(40000),
+                "sanity check on the file we are about to ask for"
+            );
+
+            byte[] received;
+            using (var server = new BloomServer(new BookSelection()))
+            {
+                server.EnsureListening();
+                using (var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) })
+                {
+                    received = client.GetByteArrayAsync(UrlFor(path)).Result;
+                }
+            }
+
+            // Not just the length: the way the body is sent changed, so it is worth checking that
+            // the client got every byte and the right ones.
+            Assert.That(received, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void MissingFileRequest_OverRealHttp_Returns404WithTheMessageAsTheBody()
+        {
+            // The error path sends its body the same way the success paths do, and it is the one
+            // most likely to be in flight when Bloom shuts down, because the browser goes on asking
+            // for things while the server is going away. Worth its own test because it is also the
+            // one path where nothing else had set ContentLength64 first.
+            var missing = Path.Combine(_folder.Path, "notThere.txt");
+            Assert.That(
+                File.Exists(missing),
+                Is.False,
+                "sanity check: this test is about a file that is not there"
+            );
+
+            using (var server = new BloomServer(new BookSelection()))
+            {
+                server.EnsureListening();
+                using (var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) })
+                using (var response = client.GetAsync(UrlFor(missing)).Result)
+                {
+                    Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+                    // Reading the body to the end is the point: if the declared length and the bytes
+                    // sent disagreed, this would hang or come up short rather than fail loudly.
+                    var body = response.Content.ReadAsStringAsync().Result;
+                    Assert.That(
+                        body,
+                        Is.Not.Empty,
+                        "the 404 should carry its message as the body, which is what client code reads"
+                    );
+                    Assert.That(
+                        response.Content.Headers.ContentLength,
+                        Is.EqualTo(Encoding.UTF8.GetByteCount(body)),
+                        "the length the server declared and the body it actually sent must agree"
+                    );
+                }
+            }
+        }
+
+        [Test]
+        public void DisposingWhileAResponseIsStillGoingOut_DoesNotKillTheProcess()
+        {
+            // This reproduces BL-16667, so it needs a send that is genuinely unfinished when Dispose
+            // runs -- which an ordinary GET cannot arrange, because by the time the client has the
+            // bytes the send is over. So: ask for a file far bigger than the socket will buffer, take
+            // the headers, and then never read the body. The send is stuck half way out.
+            //
+            // Under the old code the worker had already moved on and the framework was left to finish
+            // the send on a callback that catches only Win32Exception; closing the listener made that
+            // callback throw ObjectDisposedException on a thread none of our try/catch blocks cover,
+            // it reached the runtime, and the process died. In a test run that looked like the run
+            // stopping part way through while calling itself passed.
+            //
+            // Now the worker itself is inside the send, so Dispose's join waits on it, times out, and
+            // the failure surfaces on the worker thread where RequestProcessorLoop catches it. The
+            // test therefore takes a couple of seconds; that wait is the fix doing its job.
+            var path = MakeFileToServe("stalled.txt", 1900000); // still under the 2MB one-go limit
+
+            // Kept alive past the server's Dispose: letting the client go would close the connection
+            // and unstick the very send we need stuck.
+            var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+            HttpResponseMessage response;
+            try
+            {
+                using (var server = new BloomServer(new BookSelection()))
+                {
+                    server.EnsureListening();
+                    response = client
+                        .GetAsync(UrlFor(path), HttpCompletionOption.ResponseHeadersRead)
+                        .Result;
+                    Assert.That(
+                        (int)response.StatusCode,
+                        Is.EqualTo(200),
+                        "sanity check: the server should have accepted the request and started replying"
+                    );
+                    // Deliberately no read of response.Content here.
+                }
+                // Reaching this line at all is the point of the test: with the old code the process
+                // was gone before it.
+                Assert.That(
+                    (int)response.StatusCode,
+                    Is.EqualTo(200),
+                    "the server survived shutting down over an unfinished send"
+                );
+            }
+            finally
+            {
+                client.Dispose();
+            }
+        }
+
+        [Test]
+        public void DisposingImmediatelyAfterServingFiles_ShutsDownCleanly()
+        {
+            var paths = Enumerable
+                .Range(0, 5)
+                .Select(i => MakeFileToServe($"served{i}.txt", 200000))
+                .ToArray();
+
+            using (var server = new BloomServer(new BookSelection()))
+            {
+                server.EnsureListening();
+                using (var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) })
+                {
+                    foreach (var path in paths)
+                    {
+                        var received = client.GetByteArrayAsync(UrlFor(path)).Result;
+                        Assert.That(
+                            received.Length,
+                            Is.EqualTo(200000),
+                            "the server did not return the whole file"
+                        );
+                    }
+                }
+                // Dispose happens here, with the last response only just answered. Under the old
+                // code that was the moment the listener could close over a send still going out;
+                // getting past it is what this test is for.
+            }
+        }
+    }
+}


### PR DESCRIPTION
**An alternative to #8192, not an addition.** Same bug, same three guards, ~20 lines of production change instead of ~300. Opened so the two can be compared side by side; exactly one of them should be merged.

**Read the drawback first** — measurement below says #8192 is probably still the right one.

## The bug (identical in both)

`RequestInfo` sent response bodies with `Response.Close(buffer, willBlock: false)`. That returns as soon as the write is *issued* and lets the framework finish the send on a callback whose only handler is `catch (Win32Exception)`. Closing the `HttpListener` under such a send — which is what quitting Bloom does — made it fail with an `ObjectDisposedException` that handler does not catch, on a thread none of ours covers. It reached the runtime and killed the process.

In production this only happens at application exit: `BloomServer` is an application-level singleton, and `ProjectContext.Dispose` deliberately does not dispose it, so it survives collection switches.

## How this branch differs from #8192

| | #8192 | this branch |
|---|---|---|
| Approach | issue the same async write, but supply the completion ourselves so shutdown can wait for sends in flight | `willBlock: true` — the send finishes before the worker is free, so joining the workers is enough |
| Production lines changed | ~306 | ~20 |
| New types | `PendingResponseWrites` | none |

## Throughput is not the deciding factor

300 files of 60 KB over loopback, three rounds each:

| | #8192 (async) | this branch (blocking) |
|---|---|---|
| all 300 at once | 5962 / 6798 / 5690 ms | **4815 / 4585 / 4530 ms** |
| one at a time | 29978 / 30974 / 29664 ms | 29660 / 28453 / 29472 ms |

So the "makes this thread available sooner" comment this replaces was a reasonable guess that does not survive measurement.

## What *is* wrong with this branch

A client that stops reading holds its worker thread until the write drains, and enough of them starve the server. Measured with raw sockets that never read a byte, receive buffer squeezed to 512 bytes, 20 of them against 16 workers — then one ordinary small request:

| | ordinary request |
|---|---|
| **this branch** | **timed out after 15 s** (at 60 KB, 400 KB and 1.9 MB) |
| **#8192** | served in **94 / 106 / 115 ms** |

Bloom's existing worker top-up does not rescue it: a thread blocked in a socket write never calls `ReportThreadBlocking`, so `_countBlockedThreads` stays low and `EnsureAWorkerCanStillTakeWork` never fires.

Bloom's `>2MB` path already blocks this way today, so the exposure is not new — but this would extend it from large media to every asset Bloom serves.

## Shared with #8192

Independently justified, and not dependent on which send is used: the `Debug.Fail` that no longer fires during shutdown or under unit tests; the guard on `QueueRequest` (an I/O completion callback); the removed `Debug.Assert` in `CloseListener`; `ReplyWithStreamContent` now sending exactly `ContentLength64` bytes; the test-run abort reporting; and the `NoErrorForEmptyAudio` flake fix.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16667


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8194)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8194)
<!-- Reviewable:end -->
