### PR TITLE
Alternative to #8192/#8194: fix BL-16667 by retiring test servers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,17 @@ under `output/agent/<key>/` so your build/test never touches the locked shared o
 means you do **not** need to stop the developer's Bloom to build or run unit tests, and
 multiple terminals can build/test at once. See `Directory.Build.props` for how it works.
 
+- For `test`, the wrapper **judges the run and prints a verdict as its last line**, so
+  `[agent-dotnet] test run completed. Passed! ...` is the only thing you need to read (and it
+  survives `| tail`). Do not judge a run by the `Passed!`/`Failed!` summary above it: a run whose
+  test host is killed part way through still prints a passing summary of however many tests got to
+  run. The wrapper catches that and says `*** TEST RUN ABORTED ***`, and exits non-zero, as it
+  does for ordinary failures. The text it looks for lives in `build/test-abort-markers.txt`.
+- **Tests retire their BloomServers, they do not dispose them.** A fixture that made a server
+  listen calls `RetiredTestServers.Retire(server)`; the listener is closed a few fixtures later,
+  once whatever it was serving has certainly finished. Disposing on the spot is what used to kill
+  the test host (BL-16667). If you add a fixture that calls `EnsureListening`, retire it the same
+  way rather than calling `Dispose`.
 - This wrapper is for **building and running tests only**. To *run* Bloom, still use
   `./go.sh` (see "Running Bloom" below) — the wrapper builds no `Bloom.exe` apphost.
   (`BloomPdfMaker.exe` is the one apphost it does build, because Bloom's PDF code shells

--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -166,22 +166,6 @@ House rules:
   own suite.
 
 
-## 2026-07-24 — agent-dotnet.sh test exits 0 even when tests fail
-
-- **Cut:** `build/agent-dotnet.sh test src/BloomTests/BloomTests.csproj` returned exit code 0 on a
-  run whose own summary line read `Failed! - Failed: 11, Passed: 2913`. Anything that trusts the
-  exit code instead of parsing the output — an agent, a hook, a CI step, a background-task
-  notification that just reports "completed (exit code 0)" — will conclude the suite passed. During
-  this run the harness reported the failing suite as a success and it was only caught by reading the
-  summary line.
-- **Idea:** Have the wrapper propagate `dotnet test`'s real exit code (it presumably exits on the
-  last command in a pipeline, or swallows the status while redirecting into the private output
-  tree). Until then, treat "did the C# suite pass?" as a question only the output can answer.
-- **Context:** BloomDesktop, found during `/preflight` of PR #7992 (BL-16459 clipboard toast).
-  Distinct from the (now-fixed) cut about *which* tests fail under the wrapper — PR #8107 made
-  the full suite green, so a failure there is real; this entry is about the wrapper reporting
-  failure as success, which still stands.
-
 ## 2026-07-24 — go.sh "succeeds" on a fresh worktree whose output/browser was never built
 - **Cut:** On a never-initialized worktree, after fixing the obvious failures (pnpm install,
   getDependencies for CS0246), `./go.sh` launches and Bloom looks healthy — but opening a book

--- a/build/Bloom.proj
+++ b/build/Bloom.proj
@@ -301,6 +301,15 @@
     </Exec>
     <Message Condition="$(isOnTeamCity) == true" Importance="high" Text="##teamcity[importData type='nunit' path='$(TestResultsXmlFile)']"/>
     <Error Condition="'$(TestExitCode)' != '0'" Text="C# tests failed (dotnet test returned $(TestExitCode)). Results: $(TestResultsXmlFile)"/>
+    <!-- The exit code is not on its own enough to tell us the run finished. When the test host is
+	     killed part way through — which Bloom's own shutdown used to do about one run in three, see
+	     BL-16667 — the runner still prints a summary of the tests that had passed by then, and we
+	     cannot rely on every such death producing a non-zero exit. But the logger only writes the
+	     results file once the run completes, and we deleted any earlier one above, so a missing
+	     file is proof that the run did not finish. Without this check that case reaches TeamCity as
+	     a green build that ran a fraction of the suite. -->
+    <Error Condition="!Exists('$(TestResultsXmlFile)')"
+		   Text="The C# test run did not finish: it exited $(TestExitCode) but never wrote $(TestResultsXmlFile), which the logger does only on completion. The test host was probably killed part way through, so however many tests the output says passed, the suite did not run."/>
   </Target>
   <Target Name="MakeDownloadPointers" DependsOnTargets="VersionNumbers"
 		Condition="'$(OS)'=='Windows_NT'">

--- a/build/agent-dotnet.ps1
+++ b/build/agent-dotnet.ps1
@@ -11,6 +11,10 @@
 # build and run unit tests while a Bloom keeps running and while other terminals do
 # their own builds.
 #
+# For `test` it also judges the run and prints a verdict as its last line -- see the
+# "Judging a test run" comment in agent-dotnet.sh for why that is not something the
+# exit code can be trusted to do on its own.
+#
 # Usage (exactly like dotnet, just build/test through this script):
 #   build/agent-dotnet.ps1 test src/BloomTests/BloomTests.csproj --filter "FullyQualifiedName~UrlPathStringTests"
 #   build/agent-dotnet.ps1 build src/BloomExe/BloomExe.csproj
@@ -32,5 +36,92 @@ Write-Host "[agent-dotnet] isolated build dir: $scratch"
 # the BloomPdfMaker.exe the PDF tests shell out to — so it now lives in
 # Directory.Build.props, which a global property would have overridden.
 $env:BLOOM_AGENT_BUILD_DIR = $scratch
-& dotnet @args "-p:OutDir=$scratch/bin/"
-exit $LASTEXITCODE
+
+# For everything except `test`, dotnet's own exit code is the whole story.
+if ($args.Count -eq 0 -or $args[0] -ne 'test') {
+    & dotnet @args "-p:OutDir=$scratch/bin/"
+    exit $LASTEXITCODE
+}
+
+$markersFile = Join-Path $PSScriptRoot 'test-abort-markers.txt'
+if (-not (Test-Path $markersFile)) {
+    Write-Host "[agent-dotnet] cannot find $markersFile, so a truncated test run could not be detected"
+    exit 1
+}
+
+$log = Join-Path ([System.IO.Path]::GetTempPath()) "agent-dotnet-test-$PID.log"
+
+# stderr is merged in because that is where the runtime prints the crash banners we look
+# for. In Windows PowerShell that redirection wraps each stderr line in an ErrorRecord,
+# which under $ErrorActionPreference='Stop' would end the script; hence Continue for the
+# duration, and the stringify step so what reaches the console and the log is plain text.
+$ErrorActionPreference = 'Continue'
+& dotnet @args "-p:OutDir=$scratch/bin/" 2>&1 |
+    ForEach-Object {
+        # An ErrorRecord here is just a line dotnet wrote to stderr. Take its message rather than
+        # letting PowerShell format it, which for some of them yields the useless string
+        # "System.Management.Automation.RemoteException" -- and a crash banner turned into that
+        # would be a marker we could no longer match.
+        if ($_ -is [System.Management.Automation.ErrorRecord]) { $_.Exception.Message } else { [string]$_ }
+    } | Tee-Object -FilePath $log
+$status = $LASTEXITCODE
+# $LASTEXITCODE is never assigned if dotnet could not be launched at all -- not on PATH in this
+# terminal, say -- because then nothing ran to set it. That leaves $status $null, and PowerShell
+# turns `exit $null` into exit code 0: this script would announce a failed run and hand its caller
+# a success. Which is the exact hazard it exists to remove. (The bash twin cannot have this hole;
+# PIPESTATUS[0] is always a number.)
+if ($null -eq $status) { $status = 1 }
+$ErrorActionPreference = 'Stop'
+
+try {
+    # Match against the output with the indentation taken off the front of every line. That is what
+    # lets the markers file anchor its patterns with a plain ^ and mean the same thing here as it
+    # does to grep -E in the bash twin -- writing "start of line, then optional whitespace" is the
+    # one thing the two regex engines cannot be made to agree on (see the note in the markers file).
+    $trimmedOutput = Get-Content $log | ForEach-Object { $_.TrimStart() }
+
+    $abortEvidence = $null
+    foreach ($pattern in Get-Content $markersFile) {
+        if ($pattern.Trim() -eq '' -or $pattern.TrimStart().StartsWith('#')) { continue }
+        # -CaseSensitive because grep -E in the bash twin is, and Select-String is not unless told.
+        # Without it the same output could be judged aborted here and passing there -- and the
+        # markers file spells "[Tt]esthost" out precisely because it expects to be matched with
+        # case respected.
+        $hit = $trimmedOutput | Select-String -Pattern $pattern -List -CaseSensitive
+        if ($hit) { $abortEvidence = $hit.Line.Trim(); break }
+    }
+
+    $summaryHit = $trimmedOutput | Select-String -Pattern '^(Passed|Failed)!' -CaseSensitive
+    $summary = if ($summaryHit) { $summaryHit[-1].Line.Trim() } else { $null }
+
+    Write-Host ""
+    if ($abortEvidence) {
+        Write-Host "[agent-dotnet] *** TEST RUN ABORTED -- NOT a pass. ***"
+        Write-Host "[agent-dotnet] Evidence: $abortEvidence"
+        Write-Host "[agent-dotnet] Any summary above counts only the tests that ran before this, so it means nothing."
+        exit 1
+    }
+    if ($status -ne 0) {
+        $detail = if ($summary) { $summary } else { 'No summary line was printed.' }
+        Write-Host "[agent-dotnet] *** TEST RUN FAILED (dotnet exited $status). *** $detail"
+        exit $status
+    }
+    if (-not $summary) {
+        # A discovery-only run has no tests to summarize, so its silence is not evidence of anything.
+        if ($args -contains '--list-tests' -or $args -contains '-t') {
+            Write-Host "[agent-dotnet] listed tests without running them."
+            exit 0
+        }
+        Write-Host "[agent-dotnet] *** TEST RUN INCOMPLETE: it exited 0 but never printed a summary, so we do not know what ran. ***"
+        exit 1
+    }
+    if ($summary -like '*Failed!*') {
+        # dotnet said 0 but its own summary says otherwise; believe the summary.
+        Write-Host "[agent-dotnet] *** TEST RUN FAILED. *** $summary"
+        exit 1
+    }
+    Write-Host "[agent-dotnet] test run completed. $summary"
+}
+finally {
+    Remove-Item $log -ErrorAction SilentlyContinue
+}

--- a/build/agent-dotnet.ps1
+++ b/build/agent-dotnet.ps1
@@ -91,7 +91,7 @@ try {
         if ($hit) { $abortEvidence = $hit.Line.Trim(); break }
     }
 
-    $summaryHit = $trimmedOutput | Select-String -Pattern '^(Passed|Failed)!' -CaseSensitive
+    $summaryHit = $trimmedOutput | Select-String -Pattern '^(Passed|Failed|Skipped)!' -CaseSensitive
     $summary = if ($summaryHit) { $summaryHit[-1].Line.Trim() } else { $null }
 
     Write-Host ""
@@ -119,6 +119,13 @@ try {
         # dotnet said 0 but its own summary says otherwise; believe the summary.
         Write-Host "[agent-dotnet] *** TEST RUN FAILED. *** $summary"
         exit 1
+    }
+    if ($summary -like 'Skipped!*') {
+        # A healthy run in which every matched test was skipped -- e.g. the RAB test without
+        # BLOOM_RUN_RAB_MANUAL_TESTS. Not a failure, but say so plainly: "completed" on its own
+        # would read as "the tests passed", and nothing ran.
+        Write-Host "[agent-dotnet] test run completed, but every test was skipped. $summary"
+        exit 0
     }
     Write-Host "[agent-dotnet] test run completed. $summary"
 }

--- a/build/agent-dotnet.sh
+++ b/build/agent-dotnet.sh
@@ -17,6 +17,9 @@
 #   the one global -p: this script appends, and apphost policy lives in that same props
 #   file because it has to vary per project).
 #
+#   For `test` it does one more thing: it judges the run itself and prints a verdict as
+#   its LAST line. See "Judging a test run" below.
+#
 # Usage (exactly like dotnet, just build/test through this script):
 #   build/agent-dotnet.sh test src/BloomTests/BloomTests.csproj --filter "FullyQualifiedName~UrlPathStringTests"
 #   build/agent-dotnet.sh build src/BloomExe/BloomExe.csproj
@@ -48,5 +51,98 @@ echo "[agent-dotnet] isolated build dir: $SCRATCH" >&2
 # be a global here too, but it has to vary per project — WebView2PdfMaker's apphost is
 # the BloomPdfMaker.exe the PDF tests shell out to — so it now lives in
 # Directory.Build.props, which a global property would have overridden.
-BLOOM_AGENT_BUILD_DIR="$SCRATCH" exec dotnet "$@" \
-    -p:OutDir="$SCRATCH/bin/"
+
+# For everything except `test`, dotnet's own exit code is the whole story, so get out of
+# the way entirely and let it have this process.
+if [ "${1:-}" != "test" ]; then
+    BLOOM_AGENT_BUILD_DIR="$SCRATCH" exec dotnet "$@" \
+        -p:OutDir="$SCRATCH/bin/"
+fi
+
+# ---------------------------------------------------------------------------
+# Judging a test run
+#
+# A `dotnet test` run can stop early — Bloom's own code taking the test host down with
+# it is the case that prompted this (BL-16667) — and when it does, VSTest still prints a
+# summary of the tests that got as far as running. Everything that ran had passed, so
+# that summary reads "Passed!". Anything that judges the run by its last lines, which is
+# what a human skimming and an agent reading `| tail` both do, calls that green.
+#
+# There is a second way to be told a lie here, recorded in PAPERCUTS.md: a run whose own
+# summary said `Failed! - Failed: 11` still arrived at the caller as exit code 0 (a pipe
+# swallows the status, and callers do pipe this).
+#
+# So: capture the output, judge it three ways (crash markers, dotnet's exit code, the
+# summary line), and print a one-line verdict LAST so it survives `| tail`. Nothing is
+# hidden — the output still streams to the terminal as it happens.
+# ---------------------------------------------------------------------------
+
+MARKERS="$SCRIPT_DIR/test-abort-markers.txt"
+if [ ! -f "$MARKERS" ]; then
+    echo "[agent-dotnet] cannot find $MARKERS, so a truncated test run could not be detected" >&2
+    exit 1
+fi
+
+LOG="$(mktemp -t agent-dotnet-test-XXXXXX)"
+TRIMMED="$LOG.trimmed"
+trap 'rm -f "$LOG" "$TRIMMED"' EXIT
+
+# stderr is merged in because that is where the runtime prints the crash banners we are
+# looking for. PIPESTATUS[0] rather than $? because $? here would be tee's.
+set +e
+BLOOM_AGENT_BUILD_DIR="$SCRATCH" dotnet "$@" -p:OutDir="$SCRATCH/bin/" 2>&1 | tee "$LOG"
+STATUS=${PIPESTATUS[0]}
+set -e
+
+# Match against a copy with the indentation taken off the front of every line. That is what lets
+# the markers file anchor its patterns with a plain ^ and mean the same thing here as it does to
+# Select-String in the PowerShell twin -- writing "start of line, then optional whitespace" is the
+# one thing the two regex engines cannot be made to agree on (see the note in the markers file).
+sed 's/^[[:space:]]*//' "$LOG" >"$TRIMMED"
+
+ABORT_EVIDENCE=""
+while IFS= read -r pattern || [ -n "$pattern" ]; do
+    # The repo is text=auto and Windows checkouts are autocrlf, so the markers file may well
+    # arrive with CRLF line endings. A trailing carriage return left on the end of a pattern
+    # would silently stop it ever matching, which is the one failure this file must not have.
+    pattern="${pattern%$'\r'}"
+    case "$pattern" in '' | '#'*) continue ;; esac
+    match="$(grep -m1 -E "$pattern" "$TRIMMED" || true)"
+    if [ -n "$match" ]; then
+        ABORT_EVIDENCE="$match"
+        break
+    fi
+done <"$MARKERS"
+
+SUMMARY="$(grep -E "^(Passed|Failed)!" "$TRIMMED" | tail -1 || true)"
+
+echo ""
+if [ -n "$ABORT_EVIDENCE" ]; then
+    echo "[agent-dotnet] *** TEST RUN ABORTED -- NOT a pass. ***"
+    echo "[agent-dotnet] Evidence: $ABORT_EVIDENCE"
+    echo "[agent-dotnet] Any summary above counts only the tests that ran before this, so it means nothing."
+    exit 1
+fi
+if [ "$STATUS" -ne 0 ]; then
+    echo "[agent-dotnet] *** TEST RUN FAILED (dotnet exited $STATUS). *** ${SUMMARY:-No summary line was printed.}"
+    exit "$STATUS"
+fi
+if [ -z "$SUMMARY" ]; then
+    # A discovery-only run has no tests to summarize, so its silence is not evidence of anything.
+    for arg in "$@"; do
+        if [ "$arg" = "--list-tests" ] || [ "$arg" = "-t" ]; then
+            echo "[agent-dotnet] listed tests without running them."
+            exit 0
+        fi
+    done
+    echo "[agent-dotnet] *** TEST RUN INCOMPLETE: it exited 0 but never printed a summary, so we do not know what ran. ***"
+    exit 1
+fi
+case "$SUMMARY" in
+    *Failed!*)
+        # dotnet said 0 but its own summary says otherwise; believe the summary.
+        echo "[agent-dotnet] *** TEST RUN FAILED. *** $SUMMARY"
+        exit 1
+        ;;
+esac
+echo "[agent-dotnet] test run completed. $SUMMARY"

--- a/build/agent-dotnet.sh
+++ b/build/agent-dotnet.sh
@@ -114,7 +114,7 @@ while IFS= read -r pattern || [ -n "$pattern" ]; do
     fi
 done <"$MARKERS"
 
-SUMMARY="$(grep -E "^(Passed|Failed)!" "$TRIMMED" | tail -1 || true)"
+SUMMARY="$(grep -E "^(Passed|Failed|Skipped)!" "$TRIMMED" | tail -1 || true)"
 
 echo ""
 if [ -n "$ABORT_EVIDENCE" ]; then
@@ -143,6 +143,13 @@ case "$SUMMARY" in
         # dotnet said 0 but its own summary says otherwise; believe the summary.
         echo "[agent-dotnet] *** TEST RUN FAILED. *** $SUMMARY"
         exit 1
+        ;;
+    Skipped!*)
+        # A healthy run in which every matched test was skipped -- e.g. the RAB test without
+        # BLOOM_RUN_RAB_MANUAL_TESTS. Not a failure, but say so plainly: "completed" on its own
+        # would read as "the tests passed", and nothing ran.
+        echo "[agent-dotnet] test run completed, but every test was skipped. $SUMMARY"
+        exit 0
         ;;
 esac
 echo "[agent-dotnet] test run completed. $SUMMARY"

--- a/build/test-abort-markers.txt
+++ b/build/test-abort-markers.txt
@@ -1,0 +1,49 @@
+# Text that means a `dotnet test` run did not finish the tests it was asked to run.
+#
+# Read by BOTH build/agent-dotnet.sh and build/agent-dotnet.ps1 after a test run, so that an
+# aborted run is reported as a failure instead of being judged by its pass/fail summary. It has
+# to live in one file because the two scripts are twins and a marker added to one and not the
+# other would silently only work in one shell.
+#
+# Why this is needed at all: when Bloom's own code kills the test host part way through, VSTest
+# still prints a summary of the tests that had run by then -- and since everything that ran had
+# passed, that summary says "Passed!". A human skimming, a script, or an agent reading the last
+# line will call that green. See BL-16667, which is also the bug that made it happen often.
+#
+# One extended regular expression per line; blank lines and # comments are ignored. Keep them
+# simple enough to mean the same thing to grep -E and to .NET's Select-String: no \s, no
+# [[:space:]], no lazy quantifiers, and in particular no [ \t] -- inside a bracket expression
+# grep -E reads that as a literal backslash and letter t, while .NET reads it as a tab, so a
+# pattern using it would quietly mean different things in the two scripts this file exists to
+# keep in step. Both scripts strip leading whitespace from each line of output before matching,
+# so an anchored pattern here needs no allowance for indentation.
+#
+# Anchor the ones that could otherwise match a test's own output (a test about error reporting
+# may well print the words "unhandled exception"); the runtime prints its banners at the start of
+# a line. Note what the anchor does and does not buy, since the lines are trimmed first: it still
+# rules out the words appearing mid-sentence, which is the common case, but not a test whose own
+# output begins with them on an indented line. That would cost a false "aborted" on a run that
+# actually finished -- annoying, but the safe direction to be wrong in, and the verdict prints the
+# line it matched on, so it takes one look to see what happened.
+#
+# Case matters: the bash twin matches with grep -E, which is case-sensitive, so the PowerShell one
+# passes -CaseSensitive to Select-String, which is not by default. Write patterns accordingly --
+# hence "[Tt]esthost" below rather than relying on either engine to be lenient.
+
+# The .NET runtime's own death notices. The second is what Environment.FailFast prints, which is
+# what a failing Debug.Assert or Debug.Fail comes to in a process with no debugger attached.
+^Unhandled exception\.
+^Process terminated\.
+^Fatal error\.
+^Stack overflow\.
+Process is terminating due to StackOverflowException
+
+# VSTest noticing that the host it was driving went away.
+Test Run Aborted
+The active test run was aborted
+[Tt]esthost process exited with error
+[Tt]est host process crashed
+
+# Nothing ran at all: normally a filter that matches nothing, which is a mistake worth catching
+# rather than a green run of zero tests.
+^No test is available

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -2779,6 +2779,13 @@ namespace Bloom.Api
         /// the listener be closed later, once the requests it served are long finished --
         /// see BloomTests' RetiredTestServers.
         /// </summary>
+        /// <remarks>
+        /// Note the seam, since it is invisible: this goes straight to the private overload, so a
+        /// subclass that overrode the protected virtual Dispose(bool) would be called on the real
+        /// Dispose path but NOT on this one. Nothing derives from BloomServer today. If something
+        /// ever does, make the two-argument overload the virtual one rather than leaving a subclass
+        /// silently half-invoked.
+        /// </remarks>
         public void PreDispose()
         {
             Dispose(true, closeListener: false);

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -64,6 +64,15 @@ namespace Bloom.Api
         public static int portForHttp;
         public const int kNumberOfConsecutivePortsToReserve = 3;
 
+        /// <summary>
+        /// How many ports EnsureListening will try before giving up — and giving up means
+        /// ProgramExit.Exit, not an exception someone can catch. Class-level and internal rather
+        /// than a local, so that the tests can assert against the real number: they hold listeners
+        /// open deliberately (see BloomTests' RetiredTestServers) and their budget has to be
+        /// checked against this, not against a copy of it that could silently fall out of step.
+        /// </summary>
+        internal const int kNumberOfPortsToTry = 20;
+
         public static int WebSocketPort => portForHttp + 1;
 
         public static int RemoteDebuggingPort => portForHttp + 2;
@@ -1662,7 +1671,6 @@ namespace Bloom.Api
             if (_listener?.IsListening == true)
                 return;
             const int kStartingPort = 8089;
-            const int kNumberOfPortsToTry = 20;
             bool success = false;
 
             // Note: this now checks whether the following ports in the block are available,

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -2760,7 +2760,36 @@ namespace Bloom.Api
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        /// Frees everything this server can free WITHOUT closing its HttpListener: it stops
+        /// accepting requests, stops and joins its threads (which are foreground threads, so
+        /// releasing them is what lets a process exit), and releases the image cache. Afterwards
+        /// the only thing the server still holds is the listener, and therefore its port.
+        ///
+        /// Why this is separable from Dispose (BL-16667): closing the listener is the one step
+        /// that can crash. A response body can still be going out after the worker that produced
+        /// it has finished -- RequestInfo hands the tail of the send to the framework, which
+        /// completes it on a callback whose only handler is `catch (Win32Exception)` -- and
+        /// closing the listener underneath that makes it throw ObjectDisposedException on a thread
+        /// none of our try/catch blocks cover, which kills the process. Everything in this method
+        /// is safe to do at any time; only CloseListener has to wait until nothing is in flight.
+        ///
+        /// Production still calls Dispose, which is PreDispose followed immediately by
+        /// CloseListener, so nothing about Bloom's behaviour changes. The tests use this to let
+        /// the listener be closed later, once the requests it served are long finished --
+        /// see BloomTests' RetiredTestServers.
+        /// </summary>
+        public void PreDispose()
+        {
+            Dispose(true, closeListener: false);
+        }
+
         protected virtual void Dispose(bool fDisposing)
+        {
+            Dispose(fDisposing, closeListener: true);
+        }
+
+        private void Dispose(bool fDisposing, bool closeListener)
         {
             Debug.WriteLineIf(
                 !fDisposing,
@@ -2831,7 +2860,9 @@ namespace Bloom.Api
                             }
                         }
 
-                        CloseListener();
+                        // The one step PreDispose leaves undone; see its comment.
+                        if (closeListener)
+                            CloseListener();
                     }
                     if (_cache != null)
                     {
@@ -2852,7 +2883,12 @@ namespace Bloom.Api
 #endif
                 }
             }
-            IsDisposed = true;
+            // Deliberately NOT set by PreDispose: the server still owns its listener, so a later
+            // real Dispose has to be allowed to run and close it. Everything above is safe to
+            // repeat -- _stop is already set, the threads are already joined, the cache is already
+            // gone -- so the second pass does nothing but the CloseListener that was skipped.
+            if (closeListener)
+                IsDisposed = true;
         }
 
         /// <summary>

--- a/src/BloomTests/Book/BookProcessorTests.cs
+++ b/src/BloomTests/Book/BookProcessorTests.cs
@@ -56,7 +56,7 @@ namespace BloomTests.Book
         public void TearDown()
         {
             _browser?.Dispose();
-            _server?.Dispose();
+            RetiredTestServers.Retire(_server);
             _folder?.Dispose();
         }
 

--- a/src/BloomTests/Publish/BloomPub/BloomPubMakerTests.cs
+++ b/src/BloomTests/Publish/BloomPub/BloomPubMakerTests.cs
@@ -69,7 +69,7 @@ namespace BloomTests.Publish.BloomPub
             PublishHelper.ExternalPageChecksBrowserForTests = null;
             s_pageChecksBrowser.Dispose();
             s_pageChecksBrowser = null;
-            s_bloomServer.Dispose();
+            RetiredTestServers.Retire(s_bloomServer);
         }
 
         [SetUp]

--- a/src/BloomTests/Publish/Epub/ExportEpubTestsBaseClass.cs
+++ b/src/BloomTests/Publish/Epub/ExportEpubTestsBaseClass.cs
@@ -79,7 +79,7 @@ namespace BloomTests.Publish.Epub
             PublishHelper.ExternalPageChecksBrowserForTests = null;
             s_pageChecksBrowser.Dispose();
             s_pageChecksBrowser = null;
-            s_testServer.Dispose();
+            RetiredTestServers.Retire(s_testServer);
         }
 
         internal static BloomServer GetTestServer()

--- a/src/BloomTests/Publish/OffScreenBrowserTests.cs
+++ b/src/BloomTests/Publish/OffScreenBrowserTests.cs
@@ -38,7 +38,7 @@ namespace BloomTests.Publish
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            s_bloomServer.Dispose();
+            RetiredTestServers.Retire(s_bloomServer);
         }
 
         [Test]

--- a/src/BloomTests/RetiredTestServers.cs
+++ b/src/BloomTests/RetiredTestServers.cs
@@ -48,12 +48,21 @@ namespace BloomTests
         internal const int kPortsEnsureListeningTries = 20;
 
         /// <summary>
-        /// How many retired servers keep their listener open at once. Every one of these holds a
-        /// port, so this has to stay well under the number of ports EnsureListening will try;
-        /// bigger also means longer between a server's last request and its listener closing,
-        /// which is the safety this class is buying.
+        /// How many retired servers keep their listener open at once. Bigger means longer between
+        /// a server's last request and its listener closing, which is the safety this class buys.
+        ///
+        /// What limits it is not this run but the others: each held listener is a port, so a run
+        /// occupies this many plus the one it is actually using, out of the
+        /// <see cref="kPortsEnsureListeningTries"/> EnsureListening will try — machine-wide. We
+        /// habitually run suites in several worktrees at once, and the failure when a run cannot
+        /// find a port is not a failing test but ProgramExit.Exit, with nothing to say it was
+        /// about ports. At 3 a run holds 4, so four concurrent runs still fit; at 5 they would
+        /// not. TheRealCapLeavesRoomForSeveralConcurrentTestRuns holds us to that.
+        ///
+        /// The delay this buys is generous even so: retirements happen at fixture boundaries,
+        /// seconds apart, against a window of danger measured in milliseconds.
         /// </summary>
-        internal const int kMaxAwaitingClose = 5;
+        internal const int kMaxAwaitingClose = 3;
 
         private static readonly RetiredServerQueue _theQueue = new RetiredServerQueue(
             kMaxAwaitingClose

--- a/src/BloomTests/RetiredTestServers.cs
+++ b/src/BloomTests/RetiredTestServers.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using Bloom.Api;
-using NUnit.Framework;
 
 namespace BloomTests
 {
@@ -46,7 +45,7 @@ namespace BloomTests
     public static class RetiredTestServers
     {
         /// <summary>Matches kNumberOfPortsToTry in BloomServer.EnsureListening.</summary>
-        private const int kPortsEnsureListeningTries = 20;
+        internal const int kPortsEnsureListeningTries = 20;
 
         /// <summary>
         /// How many retired servers keep their listener open at once. Every one of these holds a
@@ -56,11 +55,46 @@ namespace BloomTests
         /// </summary>
         internal const int kMaxAwaitingClose = 5;
 
-        private static readonly object _lock = new object();
-        private static readonly Queue<BloomServer> _awaitingClose = new Queue<BloomServer>();
+        private static readonly RetiredServerQueue _theQueue = new RetiredServerQueue(
+            kMaxAwaitingClose
+        );
 
-        /// <summary>For the tests of this class, and for diagnosing a port shortage.</summary>
-        internal static int CountAwaitingClose
+        /// <summary>
+        /// Call this instead of server.Dispose() when a test or fixture has finished with a server
+        /// it made listen. Safe to call with null, and safe to call on a server that never
+        /// listened (there is simply nothing to wait for).
+        /// </summary>
+        public static void Retire(BloomServer server) => _theQueue.Retire(server);
+
+        /// <summary>
+        /// Closes every listener still waiting. Called once, after the whole run, by
+        /// <see cref="SetupFixture"/> -- and nowhere else. Calling it mid-run would close listeners
+        /// that only just finished serving, which is exactly the timing this class exists to avoid;
+        /// that is why the tests of this scheme drive their own <see cref="RetiredServerQueue"/>
+        /// rather than this one.
+        /// </summary>
+        internal static void CloseAllNow() => _theQueue.CloseAllNow();
+
+        /// <summary>For diagnosing a port shortage.</summary>
+        internal static int CountAwaitingClose => _theQueue.CountAwaitingClose;
+    }
+
+    /// <summary>
+    /// The bookkeeping behind <see cref="RetiredTestServers"/>, as an instance so that its own
+    /// tests can exercise it without touching the queue the run is using.
+    /// </summary>
+    internal sealed class RetiredServerQueue
+    {
+        private readonly int _maxAwaitingClose;
+        private readonly object _lock = new object();
+        private readonly Queue<BloomServer> _awaitingClose = new Queue<BloomServer>();
+
+        internal RetiredServerQueue(int maxAwaitingClose)
+        {
+            _maxAwaitingClose = maxAwaitingClose;
+        }
+
+        internal int CountAwaitingClose
         {
             get
             {
@@ -69,12 +103,7 @@ namespace BloomTests
             }
         }
 
-        /// <summary>
-        /// Call this instead of server.Dispose() when a test or fixture has finished with a server
-        /// it made listen. Safe to call with null, and safe to call on a server that never
-        /// listened (there is simply nothing to wait for).
-        /// </summary>
-        public static void Retire(BloomServer server)
+        internal void Retire(BloomServer server)
         {
             if (server == null)
                 return;
@@ -85,7 +114,7 @@ namespace BloomTests
             lock (_lock)
             {
                 _awaitingClose.Enqueue(server);
-                if (_awaitingClose.Count > kMaxAwaitingClose)
+                if (_awaitingClose.Count > _maxAwaitingClose)
                     readyToClose = _awaitingClose.Dequeue();
             }
 
@@ -93,11 +122,7 @@ namespace BloomTests
             CloseFully(readyToClose);
         }
 
-        /// <summary>
-        /// Closes every listener still waiting. Called once, after the whole run, by
-        /// <see cref="SetupFixture"/>.
-        /// </summary>
-        internal static void CloseAllNow()
+        internal void CloseAllNow()
         {
             while (true)
             {

--- a/src/BloomTests/RetiredTestServers.cs
+++ b/src/BloomTests/RetiredTestServers.cs
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System;
+using System.Collections.Generic;
+using Bloom.Api;
+using NUnit.Framework;
+
+namespace BloomTests
+{
+    /// <summary>
+    /// Where a test's BloomServer goes when the test is done with it, instead of being disposed
+    /// on the spot.
+    ///
+    /// The problem (BL-16667). A response body can still be going out after the worker thread that
+    /// produced it has finished: RequestInfo hands the tail of the send to the framework, which
+    /// finishes it on a callback whose only handler is `catch (Win32Exception)`. Closing the
+    /// HttpListener underneath such a send makes it fail with an ObjectDisposedException that the
+    /// handler does not catch, on a thread none of our own try/catch blocks cover. It reaches the
+    /// runtime and kills the process. In a full test run that showed up as the run stopping part
+    /// way through -- while still printing a cheerful summary of however many tests had passed
+    /// before it died -- roughly one run in three.
+    ///
+    /// Production meets this only when Bloom quits, once per session. The tests meet it 55 times a
+    /// run, which is why they are where it hurts.
+    ///
+    /// What this does. A retired server is PreDisposed at once -- that stops it accepting
+    /// requests, stops and joins its threads, and frees its image cache -- and then simply waits.
+    /// Its listener, the only thing that can crash on the way out, is closed later, once several
+    /// more servers have been retired behind it. By then the requests it was serving finished long
+    /// ago, so there is nothing left for the close to interrupt.
+    ///
+    /// Why a queue rather than keeping them all to the end of the run: a listener holds its port
+    /// until it is closed, and EnsureListening will only try <see cref="kPortsEnsureListeningTries"/>
+    /// ports before giving up and calling ProgramExit.Exit. A run binds about 55 servers, so
+    /// holding them all would run the suite out of ports; and squatting 55 ports for five minutes
+    /// would collide with the other test runs this team habitually has going in parallel
+    /// worktrees. Keeping a handful in the queue costs a handful of ports and still puts whole
+    /// fixtures between a server's last request and its listener closing.
+    ///
+    /// This is a mitigation, not a proof. It does not make closing a listener safe; it waits until
+    /// there is nothing to be unsafe about. If an aborted run ever shows up again -- and
+    /// build/agent-dotnet.* now says so loudly rather than printing a passing summary -- the thing
+    /// to look for is a test that leaves a response half-read.
+    /// </summary>
+    public static class RetiredTestServers
+    {
+        /// <summary>Matches kNumberOfPortsToTry in BloomServer.EnsureListening.</summary>
+        private const int kPortsEnsureListeningTries = 20;
+
+        /// <summary>
+        /// How many retired servers keep their listener open at once. Every one of these holds a
+        /// port, so this has to stay well under the number of ports EnsureListening will try;
+        /// bigger also means longer between a server's last request and its listener closing,
+        /// which is the safety this class is buying.
+        /// </summary>
+        internal const int kMaxAwaitingClose = 5;
+
+        private static readonly object _lock = new object();
+        private static readonly Queue<BloomServer> _awaitingClose = new Queue<BloomServer>();
+
+        /// <summary>For the tests of this class, and for diagnosing a port shortage.</summary>
+        internal static int CountAwaitingClose
+        {
+            get
+            {
+                lock (_lock)
+                    return _awaitingClose.Count;
+            }
+        }
+
+        /// <summary>
+        /// Call this instead of server.Dispose() when a test or fixture has finished with a server
+        /// it made listen. Safe to call with null, and safe to call on a server that never
+        /// listened (there is simply nothing to wait for).
+        /// </summary>
+        public static void Retire(BloomServer server)
+        {
+            if (server == null)
+                return;
+
+            server.PreDispose();
+
+            BloomServer readyToClose = null;
+            lock (_lock)
+            {
+                _awaitingClose.Enqueue(server);
+                if (_awaitingClose.Count > kMaxAwaitingClose)
+                    readyToClose = _awaitingClose.Dequeue();
+            }
+
+            // Outside the lock: closing can block for a moment, and nothing here needs the queue.
+            CloseFully(readyToClose);
+        }
+
+        /// <summary>
+        /// Closes every listener still waiting. Called once, after the whole run, by
+        /// <see cref="SetupFixture"/>.
+        /// </summary>
+        internal static void CloseAllNow()
+        {
+            while (true)
+            {
+                BloomServer next;
+                lock (_lock)
+                {
+                    if (_awaitingClose.Count == 0)
+                        return;
+                    next = _awaitingClose.Dequeue();
+                }
+                CloseFully(next);
+            }
+        }
+
+        private static void CloseFully(BloomServer server)
+        {
+            if (server == null)
+                return;
+            try
+            {
+                // The real Dispose this time. Everything PreDispose did is repeated harmlessly and
+                // the listener is closed -- see the note on BloomServer.PreDispose.
+                server.Dispose();
+            }
+            catch (Exception e)
+            {
+                // Deliberately swallowed, and deliberately noisy about it. A server we have already
+                // finished with must not be able to fail a test that has nothing to do with it, but
+                // if this ever happens it is worth someone seeing. Console.Error because that is the
+                // only channel `dotnet test` shows by default.
+                Console.Error.WriteLine(
+                    $"RetiredTestServers: closing a retired server threw, which is unexpected: {e}"
+                );
+            }
+        }
+    }
+}

--- a/src/BloomTests/RetiredTestServers.cs
+++ b/src/BloomTests/RetiredTestServers.cs
@@ -44,8 +44,12 @@ namespace BloomTests
     /// </summary>
     public static class RetiredTestServers
     {
-        /// <summary>Matches kNumberOfPortsToTry in BloomServer.EnsureListening.</summary>
-        internal const int kPortsEnsureListeningTries = 20;
+        /// <summary>
+        /// The real budget, referenced rather than copied. A hand-copied 20 would let someone lower
+        /// BloomServer's number while the test below went on passing — and what that test guards
+        /// against is ProgramExit.Exit, which says nothing about ports on its way out.
+        /// </summary>
+        internal const int kPortsEnsureListeningTries = BloomServer.kNumberOfPortsToTry;
 
         /// <summary>
         /// How many retired servers keep their listener open at once. Bigger means longer between
@@ -92,6 +96,16 @@ namespace BloomTests
     /// The bookkeeping behind <see cref="RetiredTestServers"/>, as an instance so that its own
     /// tests can exercise it without touching the queue the run is using.
     /// </summary>
+    /// <remarks>
+    /// Assumes the suite runs fixtures one at a time, which it does today: BloomTests.runsettings
+    /// sets no parallelism. The assumption matters because retiring a server also evicts an older
+    /// one, and both of those set BloomServer.ServerIsListening — a *static* — to false. Serially
+    /// that is harmless, since no other server is live to care. Turn assembly-level parallelism on
+    /// and an eviction during one fixture's teardown would clear that flag out from under another
+    /// fixture's live server. Devin raised it; recorded here rather than defended against, because
+    /// the defence would be pointless until the day parallelism is actually switched on, and on
+    /// that day this note is what says where to look.
+    /// </remarks>
     internal sealed class RetiredServerQueue
     {
         private readonly int _maxAwaitingClose;

--- a/src/BloomTests/SetUpFixture.cs
+++ b/src/BloomTests/SetUpFixture.cs
@@ -14,5 +14,15 @@ namespace BloomTests
         {
             L10NSharp.LocalizationManager.StrictInitializationMode = false;
         }
+
+        /// <summary>
+        /// Close the listeners of any servers still waiting to be closed. Everything they were
+        /// serving finished long ago, so this is the safe moment; see RetiredTestServers.
+        /// </summary>
+        [OneTimeTearDown]
+        public void CloseRetiredServers()
+        {
+            RetiredTestServers.CloseAllNow();
+        }
     }
 }

--- a/src/BloomTests/TeamCollection/TeamCollectionApiTests.cs
+++ b/src/BloomTests/TeamCollection/TeamCollectionApiTests.cs
@@ -251,7 +251,7 @@ namespace BloomTests.TeamCollection
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            _server?.Dispose();
+            RetiredTestServers.Retire(_server);
             _server = null;
         }
 

--- a/src/BloomTests/WebLibraryIntegration/BookUploadAndDownloadTests.cs
+++ b/src/BloomTests/WebLibraryIntegration/BookUploadAndDownloadTests.cs
@@ -135,7 +135,7 @@ namespace BloomTests.WebLibraryIntegration
         {
             _htmlThumbNailer.Dispose();
             _workFolder.Dispose();
-            s_bloomServer.Dispose();
+            RetiredTestServers.Retire(s_bloomServer);
         }
 
         private string MakeBook(

--- a/src/BloomTests/web/AvatarApiTests.cs
+++ b/src/BloomTests/web/AvatarApiTests.cs
@@ -73,7 +73,7 @@ namespace BloomTests.web
         [TearDown]
         public void TearDown()
         {
-            _server.Dispose();
+            RetiredTestServers.Retire(_server);
             _server = null;
             _folder.Dispose();
 

--- a/src/BloomTests/web/BloomServerWorkerPoolTests.cs
+++ b/src/BloomTests/web/BloomServerWorkerPoolTests.cs
@@ -29,7 +29,8 @@ namespace BloomTests.web
         [Test]
         public void ReportThreadBlocking_WhenTheLastFreeWorkerBlocks_AddsAWorker()
         {
-            using (var server = new BloomServer(new BookSelection()))
+            var server = new BloomServer(new BookSelection());
+            try
             {
                 server.EnsureListening();
                 var workersAtStart = server.WorkerCount;
@@ -70,6 +71,12 @@ namespace BloomTests.web
                     }
                 });
             }
+            finally
+            {
+                // Retired, not disposed: its listener is closed later, once whatever it was
+                // serving has certainly finished. See RetiredTestServers (BL-16667).
+                RetiredTestServers.Retire(server);
+            }
         }
 
         /// <summary>
@@ -80,7 +87,8 @@ namespace BloomTests.web
         [Test]
         public void ReportThreadBlocking_FromAThreadThatIsNotAWorker_DoesNotAddAWorker()
         {
-            using (var server = new BloomServer(new BookSelection()))
+            var server = new BloomServer(new BookSelection());
+            try
             {
                 server.EnsureListening();
                 var workersAtStart = server.WorkerCount;
@@ -100,6 +108,12 @@ namespace BloomTests.web
                     "blocks reported by a non-worker thread should not be counted at all"
                 );
             }
+            finally
+            {
+                // Retired, not disposed: its listener is closed later, once whatever it was
+                // serving has certainly finished. See RetiredTestServers (BL-16667).
+                RetiredTestServers.Retire(server);
+            }
         }
 
         /// <summary>
@@ -113,7 +127,8 @@ namespace BloomTests.web
         [Test]
         public void ReportThreadBlocking_WhenTheScopeIsDisposedOnAnotherThread_StillUndoesTheBlock()
         {
-            using (var server = new BloomServer(new BookSelection()))
+            var server = new BloomServer(new BookSelection());
+            try
             {
                 server.EnsureListening();
                 Assert.That(
@@ -143,6 +158,12 @@ namespace BloomTests.web
                     "disposing the scope on a different thread must still undo the block"
                 );
             }
+            finally
+            {
+                // Retired, not disposed: its listener is closed later, once whatever it was
+                // serving has certainly finished. See RetiredTestServers (BL-16667).
+                RetiredTestServers.Retire(server);
+            }
         }
 
         /// <summary>
@@ -153,7 +174,8 @@ namespace BloomTests.web
         [Test]
         public void ReportThreadBlocking_WhenTheScopeIsDisposedTwice_OnlyUndoesTheBlockOnce()
         {
-            using (var server = new BloomServer(new BookSelection()))
+            var server = new BloomServer(new BookSelection());
+            try
             {
                 server.EnsureListening();
                 IDisposable first = null,
@@ -179,6 +201,12 @@ namespace BloomTests.web
                 );
                 second.Dispose();
             }
+            finally
+            {
+                // Retired, not disposed: its listener is closed later, once whatever it was
+                // serving has certainly finished. See RetiredTestServers (BL-16667).
+                RetiredTestServers.Retire(server);
+            }
         }
 
         /// <summary>
@@ -194,7 +222,8 @@ namespace BloomTests.web
         [Test]
         public void ReportThreadBlocking_WhenAnEntryIsForADeadThread_StillAddsAWorker()
         {
-            using (var server = new BloomServer(new BookSelection()))
+            var server = new BloomServer(new BookSelection());
+            try
             {
                 server.EnsureListening();
                 var liveWorkers = server.WorkerCount;
@@ -252,6 +281,12 @@ namespace BloomTests.web
                             scope.Dispose();
                     }
                 });
+            }
+            finally
+            {
+                // Retired, not disposed: its listener is closed later, once whatever it was
+                // serving has certainly finished. See RetiredTestServers (BL-16667).
+                RetiredTestServers.Retire(server);
             }
         }
 

--- a/src/BloomTests/web/RetiredTestServersTests.cs
+++ b/src/BloomTests/web/RetiredTestServersTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System.Threading;
+using Bloom.Api;
+using Bloom.Book;
+using NUnit.Framework;
+
+namespace BloomTests.web
+{
+    /// <summary>
+    /// Guards the two properties the whole scheme rests on: that a retired server's listener is
+    /// closed eventually, and that only a handful are held open at a time. The second is the one
+    /// that would fail silently — EnsureListening only tries 20 ports before giving up and calling
+    /// ProgramExit.Exit, and a run retires about 55 servers, so letting the queue grow would take
+    /// the suite out somewhere unrelated and baffling.
+    /// </summary>
+    [TestFixture]
+    public class RetiredTestServersTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            // These servers listen, so they must not overlap with the other fixtures that do.
+            Monitor.Enter(EndpointHandlerTests._portMonitor);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Monitor.Exit(EndpointHandlerTests._portMonitor);
+        }
+
+        [Test]
+        public void Retire_HoldsNoMoreThanAHandfulOfListenersOpen()
+        {
+            // Deliberately more than the cap, and more than a run would ever have open at once.
+            const int howMany = RetiredTestServers.kMaxAwaitingClose + 4;
+
+            for (var i = 0; i < howMany; i++)
+            {
+                var server = new BloomServer(new BookSelection());
+                server.EnsureListening();
+                RetiredTestServers.Retire(server);
+
+                Assert.That(
+                    RetiredTestServers.CountAwaitingClose,
+                    Is.LessThanOrEqualTo(RetiredTestServers.kMaxAwaitingClose),
+                    $"after retiring {i + 1} servers, more than the cap were still holding a port; "
+                        + "a run retires about 55, so this would exhaust EnsureListening's ports"
+                );
+            }
+        }
+
+        [Test]
+        public void Retire_ThenCloseAllNow_LeavesNothingHoldingAPort()
+        {
+            var server = new BloomServer(new BookSelection());
+            server.EnsureListening();
+            RetiredTestServers.Retire(server);
+            Assert.That(
+                RetiredTestServers.CountAwaitingClose,
+                Is.GreaterThan(0),
+                "SANITY: the server we just retired should be waiting to be closed"
+            );
+
+            RetiredTestServers.CloseAllNow();
+
+            Assert.That(RetiredTestServers.CountAwaitingClose, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Retire_GivenNull_DoesNothing()
+        {
+            var before = RetiredTestServers.CountAwaitingClose;
+            Assert.DoesNotThrow(() => RetiredTestServers.Retire(null));
+            Assert.That(RetiredTestServers.CountAwaitingClose, Is.EqualTo(before));
+        }
+
+        [Test]
+        public void Retire_GivenAServerThatNeverListened_DoesNotThrow()
+        {
+            // Nothing to wait for, but callers should not have to know that.
+            Assert.DoesNotThrow(() =>
+                RetiredTestServers.Retire(new BloomServer(new BookSelection()))
+            );
+            RetiredTestServers.CloseAllNow();
+        }
+    }
+}

--- a/src/BloomTests/web/RetiredTestServersTests.cs
+++ b/src/BloomTests/web/RetiredTestServersTests.cs
@@ -101,19 +101,29 @@ namespace BloomTests.web
         }
 
         /// <summary>
-        /// The cap and the port budget are declared in different files — this one and
+        /// The cap and the port budget are declared in different files — RetiredTestServers and
         /// BloomServer.EnsureListening — so nothing but a test keeps them in a sensible relation.
-        /// Raising the cap towards the budget would leave no room for the server actually in use,
-        /// and the failure would arrive as EnsureListening giving up, which calls ProgramExit.Exit.
+        ///
+        /// And the relation that matters is not this run's, it is the machine's: ports are
+        /// machine-wide, we habitually run suites in several worktrees at once, and a run that
+        /// cannot find a port does not fail a test — EnsureListening gives up and calls
+        /// ProgramExit.Exit, with nothing in the output to say it was about ports. Devin raised
+        /// exactly this, and it is why the cap came down from 5 to 3.
         /// </summary>
         [Test]
-        public void TheRealCapLeavesPlentyOfPortsForTheServerInUse()
+        public void TheRealCapLeavesRoomForSeveralConcurrentTestRuns()
         {
+            const int concurrentRunsToAllowFor = 4;
+            // The ones waiting to be closed, plus the one the run is actually using.
+            var portsHeldPerRun = RetiredTestServers.kMaxAwaitingClose + 1;
+
             Assert.That(
-                RetiredTestServers.kMaxAwaitingClose,
-                Is.LessThan(RetiredTestServers.kPortsEnsureListeningTries / 2),
-                "the number of listeners we hold open must stay well under the number of ports "
-                    + "EnsureListening is willing to try"
+                portsHeldPerRun * concurrentRunsToAllowFor,
+                Is.LessThanOrEqualTo(RetiredTestServers.kPortsEnsureListeningTries),
+                $"holding {portsHeldPerRun} ports per run leaves room for fewer than "
+                    + $"{concurrentRunsToAllowFor} concurrent runs in EnsureListening's "
+                    + $"{RetiredTestServers.kPortsEnsureListeningTries} candidates; the run that "
+                    + "loses does not fail a test, it calls ProgramExit.Exit"
             );
         }
     }

--- a/src/BloomTests/web/RetiredTestServersTests.cs
+++ b/src/BloomTests/web/RetiredTestServersTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) 2026 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
-using System.Threading;
 using Bloom.Api;
 using Bloom.Book;
 using NUnit.Framework;
@@ -9,82 +8,113 @@ using NUnit.Framework;
 namespace BloomTests.web
 {
     /// <summary>
-    /// Guards the two properties the whole scheme rests on: that a retired server's listener is
+    /// Guards the bookkeeping behind RetiredTestServers: that a retired server's listener is
     /// closed eventually, and that only a handful are held open at a time. The second is the one
     /// that would fail silently — EnsureListening only tries 20 ports before giving up and calling
     /// ProgramExit.Exit, and a run retires about 55 servers, so letting the queue grow would take
     /// the suite out somewhere unrelated and baffling.
+    ///
+    /// Two things these tests deliberately do NOT do, because both would re-create the very race
+    /// the scheme exists to avoid (Devin caught the first version of this fixture doing both):
+    ///
+    /// - They drive their own <see cref="RetiredServerQueue"/> rather than the one the run is
+    ///   using, so nothing here can close a listener that some other fixture retired moments ago.
+    /// - They retire servers that never listened. A server that has served a response and is then
+    ///   closed microseconds later is exactly the unsafe timing; a server with no listener has
+    ///   nothing to close and nothing to interrupt, and the queue's behaviour is the same either
+    ///   way, since it counts servers rather than ports.
+    ///
+    /// That the real queue is wired to a cap the port budget can afford is checked separately,
+    /// below, and that ports genuinely last a whole run is what the full suite demonstrates.
     /// </summary>
     [TestFixture]
     public class RetiredTestServersTests
     {
-        [SetUp]
-        public void Setup()
-        {
-            // These servers listen, so they must not overlap with the other fixtures that do.
-            Monitor.Enter(EndpointHandlerTests._portMonitor);
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            Monitor.Exit(EndpointHandlerTests._portMonitor);
-        }
+        private static BloomServer AServerThatNeverListened() =>
+            new BloomServer(new BookSelection());
 
         [Test]
-        public void Retire_HoldsNoMoreThanAHandfulOfListenersOpen()
+        public void Retire_HoldsNoMoreThanTheCap()
         {
-            // Deliberately more than the cap, and more than a run would ever have open at once.
-            const int howMany = RetiredTestServers.kMaxAwaitingClose + 4;
+            const int cap = 3;
+            var queue = new RetiredServerQueue(cap);
 
-            for (var i = 0; i < howMany; i++)
+            for (var i = 0; i < cap + 4; i++)
             {
-                var server = new BloomServer(new BookSelection());
-                server.EnsureListening();
-                RetiredTestServers.Retire(server);
-
+                queue.Retire(AServerThatNeverListened());
                 Assert.That(
-                    RetiredTestServers.CountAwaitingClose,
-                    Is.LessThanOrEqualTo(RetiredTestServers.kMaxAwaitingClose),
-                    $"after retiring {i + 1} servers, more than the cap were still holding a port; "
-                        + "a run retires about 55, so this would exhaust EnsureListening's ports"
+                    queue.CountAwaitingClose,
+                    Is.LessThanOrEqualTo(cap),
+                    $"after retiring {i + 1} servers, more than the cap were still waiting; in the "
+                        + "real queue each of those holds a port, and a run retires about 55"
                 );
             }
         }
 
         [Test]
-        public void Retire_ThenCloseAllNow_LeavesNothingHoldingAPort()
+        public void Retire_BelowTheCap_ClosesNothingYet()
         {
-            var server = new BloomServer(new BookSelection());
-            server.EnsureListening();
-            RetiredTestServers.Retire(server);
+            var queue = new RetiredServerQueue(3);
+
+            queue.Retire(AServerThatNeverListened());
+            queue.Retire(AServerThatNeverListened());
+
             Assert.That(
-                RetiredTestServers.CountAwaitingClose,
-                Is.GreaterThan(0),
-                "SANITY: the server we just retired should be waiting to be closed"
+                queue.CountAwaitingClose,
+                Is.EqualTo(2),
+                "below the cap, retiring should hold on to servers rather than closing them — "
+                    + "the waiting is the whole point"
+            );
+        }
+
+        [Test]
+        public void CloseAllNow_LeavesNothingWaiting()
+        {
+            var queue = new RetiredServerQueue(3);
+            queue.Retire(AServerThatNeverListened());
+            queue.Retire(AServerThatNeverListened());
+            Assert.That(
+                queue.CountAwaitingClose,
+                Is.EqualTo(2),
+                "SANITY: the servers we just retired should be waiting"
             );
 
-            RetiredTestServers.CloseAllNow();
+            queue.CloseAllNow();
 
-            Assert.That(RetiredTestServers.CountAwaitingClose, Is.EqualTo(0));
+            Assert.That(queue.CountAwaitingClose, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void CloseAllNow_WhenNothingIsWaiting_DoesNothing()
+        {
+            var queue = new RetiredServerQueue(3);
+            Assert.DoesNotThrow(() => queue.CloseAllNow());
+            Assert.That(queue.CountAwaitingClose, Is.EqualTo(0));
         }
 
         [Test]
         public void Retire_GivenNull_DoesNothing()
         {
-            var before = RetiredTestServers.CountAwaitingClose;
-            Assert.DoesNotThrow(() => RetiredTestServers.Retire(null));
-            Assert.That(RetiredTestServers.CountAwaitingClose, Is.EqualTo(before));
+            var queue = new RetiredServerQueue(3);
+            Assert.DoesNotThrow(() => queue.Retire(null));
+            Assert.That(queue.CountAwaitingClose, Is.EqualTo(0));
         }
 
+        /// <summary>
+        /// The cap and the port budget are declared in different files — this one and
+        /// BloomServer.EnsureListening — so nothing but a test keeps them in a sensible relation.
+        /// Raising the cap towards the budget would leave no room for the server actually in use,
+        /// and the failure would arrive as EnsureListening giving up, which calls ProgramExit.Exit.
+        /// </summary>
         [Test]
-        public void Retire_GivenAServerThatNeverListened_DoesNotThrow()
+        public void TheRealCapLeavesPlentyOfPortsForTheServerInUse()
         {
-            // Nothing to wait for, but callers should not have to know that.
-            Assert.DoesNotThrow(() =>
-                RetiredTestServers.Retire(new BloomServer(new BookSelection()))
+            Assert.That(
+                RetiredTestServers.kMaxAwaitingClose,
+                Is.LessThan(RetiredTestServers.kPortsEnsureListeningTries / 2),
+                "the number of listeners we hold open must stay well under the number of ports "
+                    + "EnsureListening is willing to try"
             );
-            RetiredTestServers.CloseAllNow();
         }
     }
 }

--- a/src/BloomTests/web/controllers/EditingViewApiTests.cs
+++ b/src/BloomTests/web/controllers/EditingViewApiTests.cs
@@ -30,7 +30,7 @@ namespace BloomTests.web.controllers
         [TearDown]
         public void TearDown()
         {
-            _server?.Dispose();
+            RetiredTestServers.Retire(_server);
             _server = null;
             _api = null;
         }

--- a/src/BloomTests/web/controllers/EndpointHandlerTests.cs
+++ b/src/BloomTests/web/controllers/EndpointHandlerTests.cs
@@ -23,7 +23,7 @@ namespace BloomTests.web
         [TearDown]
         public void Teardown()
         {
-            _server.Dispose();
+            RetiredTestServers.Retire(_server);
             _server = null;
             Monitor.Exit(_portMonitor);
         }

--- a/src/BloomTests/web/controllers/FileIOApiTests.cs
+++ b/src/BloomTests/web/controllers/FileIOApiTests.cs
@@ -26,6 +26,18 @@ namespace BloomTests.web.controllers
             controller.RegisterWithApiHandler(_server.ApiHandler);
         }
 
+        [OneTimeTearDown]
+        public void FinalTearDown()
+        {
+            // This fixture's tests go through ApiTest, which makes the server listen, but nothing
+            // ever released it -- so it held one of EnsureListening's twenty ports for the whole
+            // rest of the run. Pre-existing, and harmless until the port budget started to matter;
+            // Devin spotted it while reviewing that budget. Retired rather than disposed, like
+            // every other fixture that listens (BL-16667).
+            RetiredTestServers.Retire(_server);
+            _server = null;
+        }
+
         [SetUp]
         public void Setup()
         {

--- a/src/BloomTests/web/controllers/ProblemReportApiTests.cs
+++ b/src/BloomTests/web/controllers/ProblemReportApiTests.cs
@@ -43,7 +43,7 @@ namespace BloomTests.web.controllers
         {
             if (_server != null)
             {
-                _server.Dispose();
+                RetiredTestServers.Retire(_server);
                 _server = null;
             }
         }

--- a/src/BloomTests/web/controllers/ReadersApiTests.cs
+++ b/src/BloomTests/web/controllers/ReadersApiTests.cs
@@ -30,7 +30,7 @@ namespace BloomTests.web
         [TearDown]
         public void TearDown()
         {
-            _server.Dispose();
+            RetiredTestServers.Retire(_server);
             _server = null;
         }
 


### PR DESCRIPTION
**Third approach to BL-16667, alongside #8192 and #8194 — and the only one that leaves production's runtime behaviour completely alone.** Exactly one of the three should be merged.

## The bug

A response body can still be going out after the worker thread that produced it has finished: `RequestInfo` hands the tail of the send to the framework, which finishes it on a callback whose only handler is `catch (Win32Exception)`. Closing the `HttpListener` underneath such a send makes it fail with an `ObjectDisposedException` that handler does not catch, on a thread none of ours covers. It reaches the runtime and kills the process — a run stopping part way through while still printing a cheerful summary of however many tests passed before it died. Roughly one run in three.

## Where it actually hurts

Production disposes the server **only when Bloom quits**: it's an application-level singleton, and `ProjectContext.Dispose` deliberately leaves it alone, so it survives collection switches. The tests dispose **55 per run** — measured by counting binds in `EnsureListening`.

So this PR changes *when the tests close a listener*, not how anything is sent.

## What it does

- **`BloomServer.PreDispose()`** — everything `Dispose` does except closing the listener: stop accepting requests, stop and join the threads (they're *foreground* threads, so releasing them is what lets a process exit), free the image cache. `Dispose` is now `PreDispose` + `CloseListener`, same order, same effects — **Bloom behaves exactly as before**. `IsDisposed` is deliberately not set by `PreDispose`, so the real `Dispose` can still run later.
- **`RetiredTestServers.Retire(server)`** replaces `Dispose()` in the 11 fixtures that make a server listen. A retired server is PreDisposed at once; its listener is closed later, after several more have been retired behind it. By then whatever it was serving finished long ago.

## Why a queue, not "hold them all to the end"

Because a listener holds its port until closed, and `EnsureListening` tries only **20** ports before calling `ProgramExit.Exit()`. Measured: successive un-closed listeners take 8089, 8092, 8095, … so 55 would run the suite out of ports.

The limit that actually binds, though, is not this run but the others: ports are machine-wide, and we habitually run suites in several worktrees at once. With the cap at **3**, a run holds **four** ports — the three waiting to be closed, plus the one it is using — so four concurrent runs still fit in the twenty candidates. Ports are reused as listeners close, so the footprint does not creep.

(The cap was 5 when this PR was opened, which meant six ports per run and only three concurrent runs before the fourth died. Devin caught that; `dda169daf1` brought it down.) `RetiredTestServersTests.TheRealCapLeavesRoomForSeveralConcurrentTestRuns` now holds us to the multi-run arithmetic rather than the single-process version, because the failure it prevents is not a failing test — it is `ProgramExit.Exit()` with nothing in the output to say it was about ports.

## Also included

`build/agent-dotnet.{sh,ps1}` now judge a `dotnet test` run and print a verdict as their **last** line, exiting non-zero when a run was aborted instead of letting its partial `Passed!` summary stand. Markers live in one shared `build/test-abort-markers.txt` so the two scripts can't drift. `build/Bloom.proj` fails if the NUnit results file — which the logger writes only on completion — is missing. This is how we'll find out whether CI still hits the problem.

## Honest about what this is

A **mitigation, not a proof**. It doesn't make closing a listener safe; it waits until there's nothing to be unsafe about. If an aborted run appears again the reporting above will say so plainly, and the thing to look for is a test that leaves a response half-read.

Full C# suite run **six times end to end: all six completed, 0 failed** (3066 passed, 13 skipped, 3079 total).

## Compared with the other two

| | production runtime change | fixes prod crash-at-exit | starvation risk | tests exercise shipped path |
|---|---|---|---|---|
| #8192 own the completion | ~306 lines | yes | no | yes |
| #8194 blocking send | ~20 lines | yes | **yes** | yes |
| **this PR** | **none** (pure extraction) | no | no | yes |

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16667


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8196)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8196)
<!-- Reviewable:end -->

