### PR TITLE
Set spreadsheet export image resolution to 96dpi (BL-16529)

### DIFF
--- a/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
@@ -36,6 +36,10 @@ namespace Bloom.Spreadsheet
         private const int languageColumnWidth = 30;
         private const int defaultImageWidth = 150; //width of images in pixels.
 
+        // The resolution we stamp on every thumbnail we embed. See the comment where it is used:
+        // the spreadsheet must not depend on the display of the machine that exported it.
+        private const float standardImageDpi = 96f;
+
         static SpreadsheetIO()
         {
             // The package requires us to do this as a way of acknowledging that we
@@ -50,12 +54,6 @@ namespace Bloom.Spreadsheet
             IWebSocketProgress progress = null
         )
         {
-            // The spreadsheet-export library sizes its columns using the primary monitor's scaling factor,
-            // so we read that same factor and use it to size the thumbnail images we store inside the
-            // spreadsheet. We read it here, once per export, so a change to the display configuration during
-            // the session is reflected the next time the user exports. See BL-16529.
-            int scaleFactor = WindowsMonitorScaling.GetScalingFactorForPrimaryMonitor();
-
             using (var package = new ExcelPackage())
             {
                 var worksheet = package.Workbook.Worksheets.Add("BloomBook");
@@ -217,30 +215,31 @@ namespace Bloom.Spreadsheet
                             var origImageHeight = image.Size.Height;
                             var origImageWidth = image.Size.Width;
                             int finalWidth = defaultImageWidth;
-                            if (scaleFactor > 100)
-                                finalWidth = defaultImageWidth * scaleFactor / 100;
                             finalHeight = (int)(finalWidth * origImageHeight / origImageWidth);
                             var size = new Size(finalWidth, finalHeight);
                             using (
-                                Image thumbnail = ImageUtils.ResizeImageIfNecessary(
-                                    size,
-                                    image,
-                                    false
-                                )
+                                var thumbnail = (Bitmap)
+                                    ImageUtils.ResizeImageIfNecessary(size, image, false)
                             )
                             {
-                                // Size the row from the thumbnail we actually embedded (which, since
-                                // ResizeImageIfNecessary never enlarges, may be smaller than the target
-                                // computed above), not from that target. The row's height is in points,
-                                // which the spreadsheet viewer does NOT scale for a high-DPI display even
-                                // though it scales the columns; so at >100% we divide the height back down
-                                // by the same factor so the displayed row matches the image. See BL-16529.
-                                if (scaleFactor > 100)
-                                    finalHeight = thumbnail.Height * 100 / scaleFactor;
-                                else
-                                    finalHeight = thumbnail.Height;
+                                // Size the row from the thumbnail we actually embedded, not from the target
+                                // computed above: ResizeImageIfNecessary never enlarges, so a source
+                                // narrower than defaultImageWidth is embedded at its original, smaller
+                                // size, and sizing the row from the target would leave dead space below
+                                // the image. See BL-16529.
+                                finalHeight = thumbnail.Height;
                                 using (var ms = new MemoryStream())
                                 {
+                                    // ResizeImageIfNecessary hands back a GDI+ bitmap, which inherits the
+                                    // screen's DPI -- and since Bloom became PerMonitorV2 DPI aware (see
+                                    // Program.cs), that is 192 on a 200%-scaled display rather than 96.
+                                    // EPPlus converts the image's pixel size into the drawing's physical
+                                    // extent using the image's own resolution, so a 192dpi thumbnail got
+                                    // laid out at half its intended size: the "images only take up half the
+                                    // column width" symptom. Stamp every thumbnail with the standard 96dpi
+                                    // so the spreadsheet we write is the same whatever display the
+                                    // exporting machine has. See BL-16529.
+                                    thumbnail.SetResolution(standardImageDpi, standardImageDpi);
                                     thumbnail.Save(ms, ImageFormat.Jpeg);
                                     ms.Seek(0, SeekOrigin.Begin);
                                     var excelImage = worksheet.Drawings.AddPicture(imageName, ms);

--- a/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
@@ -38,7 +38,10 @@ namespace Bloom.Spreadsheet
 
         // The resolution we stamp on every thumbnail we embed, so that the spreadsheet does not
         // depend on the display of the machine that exported it. See SaveThumbnailForEmbedding.
-        private const float standardImageDpi = 96f;
+        // Row heights are converted from thumbnail pixels to points against this same value, so the
+        // two must agree: use this constant rather than writing 96 again, or a change here would
+        // leave the rows sized for a resolution the images no longer have.
+        private const int standardImageDpi = 96;
 
         static SpreadsheetIO()
         {
@@ -157,7 +160,7 @@ namespace Bloom.Spreadsheet
                                 //Images show up in the cell 1 row greater and 1 column greater than assigned
                                 //So this will put them in row r, column imageThumbnailColumn+1 like we want
                                 var rowHeight = embedImage(imagePath, r - 1, imageThumbnailColumn);
-                                worksheet.Row(r).Height = rowHeight * 72 / 96 + 3; //so the image is visible; height seems to be points
+                                worksheet.Row(r).Height = rowHeight * 72 / standardImageDpi + 3; //so the image is visible; height seems to be points
                             }
                         }
                     }

--- a/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
@@ -299,6 +299,10 @@ namespace Bloom.Spreadsheet
         /// bitmap deliberately marked 192dpi, which is something no test can arrange by exporting on
         /// a machine whose display is at 100% (where the bitmap already arrives at 96dpi, so a missing
         /// stamp looks identical to a working one). Our build machines are all at 100%.
+        ///
+        /// Note this alters the bitmap you pass in: SetResolution works in place, and Bitmap.Save
+        /// offers no way to override the resolution as it writes. Harmless for the thumbnails we
+        /// create and dispose here, but don't hand this a bitmap that is shared or cached.
         /// </summary>
         internal static void SaveThumbnailForEmbedding(Bitmap thumbnail, Stream destination)
         {

--- a/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
@@ -36,8 +36,8 @@ namespace Bloom.Spreadsheet
         private const int languageColumnWidth = 30;
         private const int defaultImageWidth = 150; //width of images in pixels.
 
-        // The resolution we stamp on every thumbnail we embed. See the comment where it is used:
-        // the spreadsheet must not depend on the display of the machine that exported it.
+        // The resolution we stamp on every thumbnail we embed, so that the spreadsheet does not
+        // depend on the display of the machine that exported it. See SaveThumbnailForEmbedding.
         private const float standardImageDpi = 96f;
 
         static SpreadsheetIO()
@@ -230,17 +230,7 @@ namespace Bloom.Spreadsheet
                                 finalHeight = thumbnail.Height;
                                 using (var ms = new MemoryStream())
                                 {
-                                    // ResizeImageIfNecessary hands back a GDI+ bitmap, which inherits the
-                                    // screen's DPI -- and since Bloom became PerMonitorV2 DPI aware (see
-                                    // Program.cs), that is 192 on a 200%-scaled display rather than 96.
-                                    // EPPlus converts the image's pixel size into the drawing's physical
-                                    // extent using the image's own resolution, so a 192dpi thumbnail got
-                                    // laid out at half its intended size: the "images only take up half the
-                                    // column width" symptom. Stamp every thumbnail with the standard 96dpi
-                                    // so the spreadsheet we write is the same whatever display the
-                                    // exporting machine has. See BL-16529.
-                                    thumbnail.SetResolution(standardImageDpi, standardImageDpi);
-                                    thumbnail.Save(ms, ImageFormat.Jpeg);
+                                    SaveThumbnailForEmbedding(thumbnail, ms);
                                     ms.Seek(0, SeekOrigin.Begin);
                                     var excelImage = worksheet.Drawings.AddPicture(imageName, ms);
                                     excelImage.SetPosition(rowNum, 2, colNum, 2);
@@ -291,6 +281,29 @@ namespace Bloom.Spreadsheet
                 var xlFile = new FileInfo(outputPath);
                 package.SaveAs(xlFile);
             }
+        }
+
+        /// <summary>
+        /// Write the thumbnail into the stream as the JPEG we embed in the spreadsheet, stamped with
+        /// the standard 96dpi.
+        ///
+        /// The stamping is the whole point of this method. ResizeImageIfNecessary hands back a GDI+
+        /// bitmap, which inherits the screen's DPI -- and since Bloom became PerMonitorV2 DPI aware
+        /// (see Program.cs), that is 192 on a 200%-scaled display rather than 96. EPPlus converts the
+        /// image's pixel size into the drawing's physical extent using the image's own resolution, so
+        /// a 192dpi thumbnail got laid out at half its intended size: the "images only take up half
+        /// the column width" symptom. Stamping 96dpi makes the spreadsheet we write the same whatever
+        /// display the exporting machine has. See BL-16529.
+        ///
+        /// This is a separate method only so a test can prove the stamping happens: it can hand us a
+        /// bitmap deliberately marked 192dpi, which is something no test can arrange by exporting on
+        /// a machine whose display is at 100% (where the bitmap already arrives at 96dpi, so a missing
+        /// stamp looks identical to a working one). Our build machines are all at 100%.
+        /// </summary>
+        internal static void SaveThumbnailForEmbedding(Bitmap thumbnail, Stream destination)
+        {
+            thumbnail.SetResolution(standardImageDpi, standardImageDpi);
+            thumbnail.Save(destination, ImageFormat.Jpeg);
         }
 
         private static bool IsWysiwygFormattedRow(SpreadsheetRow row)

--- a/src/BloomExe/WindowsMonitorScaling.cs
+++ b/src/BloomExe/WindowsMonitorScaling.cs
@@ -10,23 +10,12 @@ namespace Bloom
     /// </summary>
     internal static class WindowsMonitorScaling
     {
-        [StructLayout(LayoutKind.Sequential)]
-        public struct POINT
-        {
-            public int X;
-            public int Y;
-        }
-
         [DllImport("Shcore.dll")]
         private static extern int GetScaleFactorForMonitor(IntPtr hmonitor, out int pScale);
 
         [DllImport("user32.dll")]
         private static extern IntPtr MonitorFromWindow(IntPtr hwnd, uint dwFlags);
 
-        [DllImport("user32.dll")]
-        private static extern IntPtr MonitorFromPoint(POINT pt, uint dwFlags);
-
-        private const uint MONITOR_DEFAULTTOPRIMARY = 0x00000001;
         private const uint MONITOR_DEFAULTTONEAREST = 0x00000002;
 
         [DllImport("Shcore.dll")]
@@ -61,37 +50,6 @@ namespace Bloom
             );
             GetScaleFactorForMonitor(hmonitor, out int percentScaleFactor);
             return percentScaleFactor;
-        }
-
-        // Bloom uses this to scale images stored in spreadsheets during spreadsheet export to fit column width.
-        // The third-party library that does the spreadsheet export apparently uses the primary monitor's scaling factor.
-        // Returns 100 (i.e. no scaling) if the scale factor can't be determined for any reason, so that spreadsheet
-        // export still works — falling back to unscaled images — even when this Windows API is unavailable or fails.
-        // PublishAudioVideoAPI.TryGetWindowScalePercent guards the same GetScaleFactorForMonitor call the same way.
-        internal static int GetScalingFactorForPrimaryMonitor()
-        {
-            try
-            {
-                var ptZero = new POINT { X = 0, Y = 0 };
-                var hmonitor = MonitorFromPoint(ptZero, MONITOR_DEFAULTTOPRIMARY);
-                if (hmonitor == IntPtr.Zero)
-                    return 100;
-                // GetScaleFactorForMonitor returns S_OK (0) on success; otherwise percentScaleFactor is unreliable.
-                if (
-                    GetScaleFactorForMonitor(hmonitor, out int percentScaleFactor) != 0
-                    || percentScaleFactor <= 0
-                )
-                    return 100;
-                return percentScaleFactor;
-            }
-            catch (EntryPointNotFoundException)
-            {
-                return 100;
-            }
-            catch (DllNotFoundException)
-            {
-                return 100;
-            }
         }
 
         // Bloom uses this to scale a Problem Report screenshot if the display resolution is > 100%.

--- a/src/BloomTests/Spreadsheet/SpreadsheetImagesTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetImagesTests.cs
@@ -892,6 +892,58 @@ namespace BloomTests.Spreadsheet
         }
 
         /// <summary>
+        /// Regression test for BL-16529, and the one that actually protects the fix on our build
+        /// machines. The export-level tests above cannot: on a display at 100% scaling a GDI+ bitmap
+        /// already carries 96dpi, so they pass whether or not the exporter stamps the resolution, and
+        /// every build machine is at 100%. Here we hand the save step a bitmap deliberately marked
+        /// 192dpi -- what it would really receive on a 200%-scaled display -- so the assertion has the
+        /// same force everywhere, and deleting the stamping would fail this test.
+        /// </summary>
+        [Test]
+        public void SaveThumbnailForEmbedding_StampsStandard96Dpi_WhateverResolutionItWasGiven()
+        {
+            using (var thumbnail = new Bitmap(150, 100))
+            {
+                thumbnail.SetResolution(192f, 192f);
+                // Sanity check: the bitmap really starts at the wrong resolution, so a pass below
+                // means the save step changed it rather than it having been right all along.
+                Assert.That(
+                    thumbnail.HorizontalResolution,
+                    Is.EqualTo(192f).Within(0.01f),
+                    "Setup sanity check: the test bitmap should start at 192dpi."
+                );
+
+                using (var stream = new MemoryStream())
+                {
+                    SpreadsheetIO.SaveThumbnailForEmbedding(thumbnail, stream);
+                    stream.Seek(0, SeekOrigin.Begin);
+                    using (var saved = Image.FromStream(stream))
+                    {
+                        Assert.That(
+                            saved.HorizontalResolution,
+                            Is.EqualTo(96f).Within(0.01f),
+                            "The embedded thumbnail must be stamped 96dpi regardless of the resolution "
+                                + "the bitmap arrived with. At 192dpi the spreadsheet library lays the "
+                                + "picture out at half its intended size (BL-16529)."
+                        );
+                        Assert.That(
+                            saved.VerticalResolution,
+                            Is.EqualTo(96f).Within(0.01f),
+                            "The embedded thumbnail must be stamped 96dpi vertically too (BL-16529)."
+                        );
+                        // The stamping must not have resampled the picture; only its claimed
+                        // resolution changes, never its pixels.
+                        Assert.That(
+                            new Size(saved.Width, saved.Height),
+                            Is.EqualTo(new Size(150, 100)),
+                            "Stamping the resolution should not change the thumbnail's pixel size."
+                        );
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// The width, in pixels at the standard 96dpi, that the first picture in the spreadsheet is
         /// laid out over. We read this from the raw drawing XML because that is what a spreadsheet
         /// viewer reads: the extent is stored in EMUs (914400 per inch, so 9525 per pixel at 96dpi),

--- a/src/BloomTests/Spreadsheet/SpreadsheetImagesTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetImagesTests.cs
@@ -658,9 +658,11 @@ namespace BloomTests.Spreadsheet
             }
         }
 
-        // A minimal book with a single small image (smaller than the thumbnail target width).
-        private const string smallImageBook =
-            @"
+        /// <summary>
+        /// A minimal book holding a single image, so a test can inspect exactly one thumbnail.
+        /// </summary>
+        private static string MinimalImageBook(string imageFileName) =>
+            $@"
 <html><head></head>
 <body data-l1=""en"" data-l2="""" data-l3="""">
     <div id=""bloomDataDiv""></div>
@@ -671,7 +673,7 @@ namespace BloomTests.Spreadsheet
             <div class=""bloom-canvas bloom-leadingElement bloom-has-canvas-element"">
                 <div class=""bloom-canvas-element bloom-backgroundImage"" style=""width: 100px; height: 100px"">
                     <div class=""bloom-imageContainer"">
-                        <img src=""man.jpg"" alt="""" data-copyright="""" data-creator="""" data-license=""""></img>
+                        <img src=""{imageFileName}"" alt="""" data-copyright="""" data-creator="""" data-license=""""></img>
                     </div>
                 </div>
             </div>
@@ -680,17 +682,53 @@ namespace BloomTests.Spreadsheet
 </body></html>";
 
         /// <summary>
+        /// Export a book containing just the one named test image, and return the path of the
+        /// spreadsheet written. The caller owns the two temporary folders.
+        /// </summary>
+        private string ExportBookWithOneImage(
+            string imageFileName,
+            TemporaryFolder bookFolder,
+            TemporaryFolder outputFolder
+        )
+        {
+            RobustFile.Copy(
+                Path.Combine(
+                    SIL.IO.FileLocationUtilities.GetDirectoryDistributedWithApplication(
+                        _pathToTestImages
+                    ),
+                    imageFileName
+                ),
+                Path.Combine(bookFolder.FolderPath, imageFileName)
+            );
+
+            var mockLangDisplayNameResolver = new Mock<ILanguageDisplayNameResolver>();
+            mockLangDisplayNameResolver
+                .Setup(x => x.GetLanguageDisplayName("en"))
+                .Returns("English");
+            var exporter = new SpreadsheetExporter(mockLangDisplayNameResolver.Object);
+
+            exporter.ExportToFolder(
+                new HtmlDom(MinimalImageBook(imageFileName), true),
+                bookFolder.FolderPath,
+                outputFolder.FolderPath,
+                out string outputPath,
+                new ProgressSpy(),
+                OverwriteOptions.Overwrite
+            );
+            return outputPath;
+        }
+
+        /// <summary>
         /// Regression test for BL-16529 (image cells too high). ResizeImageIfNecessary never
-        /// enlarges an image, so a source smaller than the (possibly DPI-scaled) thumbnail target is
-        /// embedded at its original size. The row must be sized from the thumbnail we actually embed,
-        /// not from the larger target; otherwise small images get a row that is much too tall.
+        /// enlarges an image, so a source smaller than the thumbnail target is embedded at its
+        /// original size. The row must be sized from the thumbnail we actually embed, not from the
+        /// larger target; otherwise small images get a row that is much too tall, leaving dead space
+        /// below the image.
         ///
-        /// Note we assert only an upper bound (the row is not sized from the oversized target), not a
-        /// lower bound: the row height is in points, which the spreadsheet viewer does not scale for a
-        /// high-DPI display even though it scales the columns, so on a >100% display the exporter
-        /// deliberately makes the row's nominal height *smaller* than the embedded image (it is scaled
-        /// back up when displayed). A "row must be at least as tall as the image" assertion would be
-        /// wrong there. The upper bound holds regardless of the exporting machine's display scaling.
+        /// The row height no longer depends on the exporting machine's display scaling (the exporter
+        /// stamps every thumbnail with 96dpi instead of compensating for the display -- see
+        /// Export_Thumbnail_IsStamped96Dpi_SoLayoutDoesNotDependOnTheDisplay), so this can assert
+        /// both bounds: the row hugs the image.
         /// </summary>
         [Test]
         public void Export_SmallImage_RowNotSizedFromOversizedTarget()
@@ -704,7 +742,6 @@ namespace BloomTests.Spreadsheet
                     ),
                     "man.jpg"
                 );
-                RobustFile.Copy(sourceImage, Path.Combine(bookFolder.FolderPath, "man.jpg"));
 
                 int sourceImageHeightPx;
                 using (var img = Image.FromFile(sourceImage))
@@ -720,20 +757,7 @@ namespace BloomTests.Spreadsheet
                     sourceImageHeightPx = img.Height;
                 }
 
-                var mockLangDisplayNameResolver = new Mock<ILanguageDisplayNameResolver>();
-                mockLangDisplayNameResolver
-                    .Setup(x => x.GetLanguageDisplayName("en"))
-                    .Returns("English");
-                var exporter = new SpreadsheetExporter(mockLangDisplayNameResolver.Object);
-
-                exporter.ExportToFolder(
-                    new HtmlDom(smallImageBook, true),
-                    bookFolder.FolderPath,
-                    outputFolder.FolderPath,
-                    out string outputPath,
-                    new ProgressSpy(),
-                    OverwriteOptions.Overwrite
-                );
+                var outputPath = ExportBookWithOneImage("man.jpg", bookFolder, outputFolder);
 
                 using (var package = new ExcelPackage(new FileInfo(outputPath)))
                 {
@@ -766,7 +790,139 @@ namespace BloomTests.Spreadsheet
                             + $"({sourceImageHeightPx}px), so it was sized from the oversized target "
                             + "rather than the image actually embedded (BL-16529)."
                     );
+                    // ...and the row must still be tall enough to show the whole image.
+                    Assert.That(
+                        rowHeightPx,
+                        Is.GreaterThanOrEqualTo(sourceImageHeightPx),
+                        $"Row height ({rowHeightPx:0}px) is shorter than the embedded image "
+                            + $"({sourceImageHeightPx}px), so the image is clipped by its row (BL-16529)."
+                    );
                 }
+            }
+        }
+
+        /// <summary>
+        /// Regression test for BL-16529 ("images in spreadsheet export display smaller"). Bloom is
+        /// PerMonitorV2 DPI aware (see Program.cs), so the GDI+ bitmaps ImageUtils produces carry the
+        /// screen's DPI -- 192 on a 200%-scaled display rather than 96. EPPlus turns a picture's pixel
+        /// size into its physical extent in the sheet using the image's own resolution, so a 192dpi
+        /// thumbnail was laid out at half its intended size: exactly the reported symptom. The
+        /// exporter must therefore stamp 96dpi on every thumbnail, so that a given book always
+        /// exports to the same spreadsheet whatever display the exporting machine has, and the sheet
+        /// looks the same wherever it is opened.
+        ///
+        /// Note this assertion can only *fail* on a machine whose display scaling is above 100%; at
+        /// 100% the screen DPI is 96 and the old code happened to be right. It is worth asserting
+        /// anyway: it pins the intent, and it fails on precisely the high-DPI machines where the bug
+        /// was reported.
+        /// </summary>
+        [Test]
+        public void Export_Thumbnail_IsStamped96Dpi_SoLayoutDoesNotDependOnTheDisplay()
+        {
+            const string imageFileName = "bird.png";
+            using (var bookFolder = new TemporaryFolder(_testFolder, "ThumbnailDpi_Book"))
+            using (var outputFolder = new TemporaryFolder(_testFolder, "ThumbnailDpi_Out"))
+            {
+                using (
+                    var img = Image.FromFile(
+                        Path.Combine(
+                            SIL.IO.FileLocationUtilities.GetDirectoryDistributedWithApplication(
+                                _pathToTestImages
+                            ),
+                            imageFileName
+                        )
+                    )
+                )
+                {
+                    // Sanity check: the source must be wider than the thumbnail target, so that it is
+                    // really scaled down to that target and we are asserting on the exporter's own
+                    // sizing rather than on a source image passed through untouched.
+                    Assert.That(
+                        img.Width,
+                        Is.GreaterThan(150),
+                        "Setup sanity check: the test image must be wider than the 150px thumbnail "
+                            + "target so that the exporter resizes it."
+                    );
+                }
+
+                var outputPath = ExportBookWithOneImage(imageFileName, bookFolder, outputFolder);
+
+                using (var package = new ExcelPackage(new FileInfo(outputPath)))
+                {
+                    var worksheet = package.Workbook.Worksheets[0];
+                    var picture = worksheet.Drawings.OfType<ExcelPicture>().Single();
+                    using (var stream = new MemoryStream(picture.Image.ImageBytes))
+                    using (var thumbnail = Image.FromStream(stream))
+                    {
+                        // Sanity check: we are looking at the thumbnail the exporter made, scaled to
+                        // the 150px target, not at the original image.
+                        Assert.That(
+                            thumbnail.Width,
+                            Is.EqualTo(150),
+                            "The embedded thumbnail should have been scaled to the 150px target width."
+                        );
+                        Assert.That(
+                            thumbnail.HorizontalResolution,
+                            Is.EqualTo(96f).Within(0.01f),
+                            "The embedded thumbnail must be stamped 96dpi. At any other resolution "
+                                + "EPPlus computes a different physical extent from the same pixels, so "
+                                + "the image is laid out at the wrong size -- at 192dpi (a 200%-scaled "
+                                + "display) it comes out half size (BL-16529)."
+                        );
+                        Assert.That(
+                            thumbnail.VerticalResolution,
+                            Is.EqualTo(96f).Within(0.01f),
+                            "The embedded thumbnail must be stamped 96dpi vertically too (BL-16529)."
+                        );
+                    }
+                }
+
+                // And the payoff: the extent the picture actually occupies in the sheet must match the
+                // thumbnail's pixels one for one. This is the number the reporter saw go wrong -- in the
+                // reported 6.5 export a 150px thumbnail was laid out over just 75px, which is the
+                // "images only take up half the column width" symptom.
+                Assert.That(
+                    GetFirstDrawingWidthInPixels(outputPath),
+                    Is.EqualTo(150).Within(1),
+                    "The picture should occupy the full 150px thumbnail width in the sheet. A smaller "
+                        + "extent for the same pixels means the thumbnail's resolution made the "
+                        + "spreadsheet library lay it out too small (BL-16529)."
+                );
+            }
+        }
+
+        /// <summary>
+        /// The width, in pixels at the standard 96dpi, that the first picture in the spreadsheet is
+        /// laid out over. We read this from the raw drawing XML because that is what a spreadsheet
+        /// viewer reads: the extent is stored in EMUs (914400 per inch, so 9525 per pixel at 96dpi),
+        /// and the library derives it from the embedded image's pixel size and its resolution.
+        /// </summary>
+        private static double GetFirstDrawingWidthInPixels(string xlsxPath)
+        {
+            using (var xlsx = System.IO.Compression.ZipFile.OpenRead(xlsxPath))
+            {
+                var drawingEntry = xlsx
+                    .Entries.Where(e =>
+                        e.FullName.StartsWith("xl/drawings/drawing") && e.FullName.EndsWith(".xml")
+                    )
+                    .OrderBy(e => e.FullName)
+                    .First();
+                string drawingXml;
+                using (var reader = new StreamReader(drawingEntry.Open()))
+                    drawingXml = reader.ReadToEnd();
+
+                var match = System.Text.RegularExpressions.Regex.Match(
+                    drawingXml,
+                    @"<xdr:ext\s+cx=""(\d+)""\s+cy=""(\d+)"""
+                );
+                Assert.That(
+                    match.Success,
+                    Is.True,
+                    "Setup sanity check: could not find a picture extent (xdr:ext) in the exported "
+                        + "spreadsheet's drawing XML, so there is nothing to measure."
+                );
+                const double emusPerPixelAt96Dpi = 914400.0 / 96.0;
+                return int.Parse(match.Groups[1].Value) / emusPerPixelAt96Dpi;
             }
         }
     }


### PR DESCRIPTION
Spreadsheet export embedded thumbnails whose size depended on the display of the machine doing the export. The root cause is not the pixel count but the thumbnail's **DPI metadata**.

`ImageUtils.CreateScaledBitmap` builds the thumbnail with a plain GDI+ `new Bitmap(w, h)`, which inherits the screen's DPI, and `Save(..., Jpeg)` writes that into the JPEG header. Since Bloom became PerMonitorV2 DPI aware (`Program.cs`), that is 192 on a 200%-scaled display instead of 96. EPPlus derives a picture's physical extent from its pixel size divided by **the image's own resolution**, so every thumbnail was laid out at half its intended size — literally the reported "images only take up half the column width".

Measured from the three exports of the same book attached to BL-16529:

| | thumbnail px | JFIF DPI | drawing extent |
|---|---|---|---|
| 6.4 @100% | 150 x 104 | 96 | 1428750 EMU = **150 px** OK |
| 6.5 @100% | 150 x 104 | 192 | 714375 EMU = **75 px** WRONG |
| 6.5 @200% | 300 x 208 | 192 | 1428750 EMU = **150 px** OK |

Column width was byte-identical in all three, so the column was never involved. The earlier width fix (#8094) doubled the pixel count, which cancels a 192-dpi error only when the scale factor is exactly 200; in general it gave `150 px * scaleFactor / 200`, which is why exports below 200% still came out too small.

That also explains why this reproduced for some people and not others: the two errors cancel exactly whenever the bitmap's DPI and `GetScaleFactorForMonitor`'s answer agree (96x150, 120x187, 192x300 all yield a 150 px extent). Where the two independent DPI sources disagree — mixed-scaling multi-monitor setups, or a scale change without signing out — they don't cancel.

## The change

- `SpreadsheetIO`: stamp the thumbnail with 96dpi before saving, and drop the DPI compensation entirely — the width up-scaling, the row-height division, and the `GetScalingFactorForPrimaryMonitor` call. Export now queries no monitor and produces the same file on every machine, matching 6.4.
- `WindowsMonitorScaling`: remove the now-unused `GetScalingFactorForPrimaryMonitor`, `MonitorFromPoint` and `POINT`. The Problem Report screenshot path is untouched.
- Tests: new `Export_Thumbnail_IsStamped96Dpi_SoLayoutDoesNotDependOnTheDisplay` asserts the embedded thumbnail is 96dpi and that the picture's extent, read from the raw drawing XML, is the full 150 px. The existing row-height test is now two-sided (its previous doc comment described the DPI compensation that this removes).

- Tests: `SaveThumbnailForEmbedding` is a separate method purely so a test can prove the stamping happens. `SaveThumbnailForEmbedding_StampsStandard96Dpi_WhateverResolutionItWasGiven` hands it a bitmap deliberately marked 192dpi -- what it would really receive on a 200%-scaled display -- so the assertion carries the same force on every machine, including CI at 100%.

Verified with teeth: stamping 192dpi deliberately makes the new test fail with an extent of exactly 75 px, reproducing the reported file; at 96dpi it is 150 px. This gives the `>100%` display path its first test coverage — the previous test would have passed with the DPI code deleted outright.

Note the assertions can only *fail* on a machine scaled above 100%, so CI (at 100%) will not catch a regression here; that limitation is documented in the test.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16529


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8197)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8197)
<!-- Reviewable:end -->

