### PR TITLE
Gear icon dodge follows the page number's real position (BL-14901)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -923,17 +923,23 @@ div.textWholePage ul {
 // Now sometimes, the format button lands under the page number.
 // Changing the z-index did not help. So we allow themes to "dodge" it.
 // Kind of a hack, I know. See BL-13206.
+// The dodge only makes sense when the page number actually sits at the bottom left,
+// which depends on two things (BL-14901):
+//  - the theme's automatic placement, expressed as --formatButton-pageNumber-dodge on
+//    the page (themes set it to 0 on pages where they move the number elsewhere,
+//    e.g. pictureOnRight);
+//  - the user's Book Settings > Page Numbers choice, which beats the theme. It reaches
+//    CSS as the pageNumber margin overrides (see AppearanceSettings.SetPageNumberProperties):
+//    Center sets both overrides to 50%; Right sets the left override to deliberately-invalid;
+//    Left sets the right override to deliberately-invalid; Automatic/Hidden set neither.
+// The rules below fold all of that into --formatButton-pageNumber-dodge-effective,
+// which is what the margin actually uses.
 @container style(--pageNumber-show-multiplicand:1) {
-    .split-pane-component.position-right
-        .split-pane-component-inner
-        > .bloom-translationGroup
-        > #formatButton,
-    .split-pane-component.position-top
-        .split-pane-component-inner
-        > .bloom-translationGroup
-        > #formatButton {
-        // don't need this dodge if the page number can't be in this text area
-        --formatButton-pageNumber-dodge: 0px;
+    #formatButton {
+        // Default: the theme's automatic-placement decision.
+        --formatButton-pageNumber-dodge-effective: var(
+            --formatButton-pageNumber-dodge
+        );
     }
     .split-pane-component.position-left
         > .split-pane-component-inner
@@ -949,7 +955,44 @@ div.textWholePage ul {
         > .bloom-translationGroup
         > #formatButton {
         // this "3px" is there from long ago, nothing to do with this nudging
-        margin-left: calc(3px + var(--formatButton-pageNumber-dodge));
+        margin-left: calc(3px + var(--formatButton-pageNumber-dodge-effective));
+    }
+}
+// The user put the page number at the center or the right: nothing to dodge,
+// whatever the theme wanted.
+@container style(--pageNumber-left-margin-override: 50%) or
+    style(--pageNumber-left-margin-override: deliberately-invalid) {
+    #formatButton {
+        --formatButton-pageNumber-dodge-effective: 0px;
+    }
+}
+// The user forced the page number to the left: dodge, even on pages where the theme's
+// automatic placement would have moved the number away (e.g. pictureOnRight). Themes
+// that waive the dodge per-page publish the distance to use in this situation as
+// --formatButton-pageNumber-dodge-when-forced-left; stylesheets that never waive it
+// per-page (e.g. the EFL migration books' customBookStyles.css) don't define it, so
+// fall back to their ordinary dodge value.
+@container style(--pageNumber-right-margin-override: deliberately-invalid) {
+    #formatButton {
+        --formatButton-pageNumber-dodge-effective: var(
+            --formatButton-pageNumber-dodge-when-forced-left,
+            var(--formatButton-pageNumber-dodge)
+        );
+    }
+}
+// These selectors are more specific than the plain #formatButton rules above, so this
+// wins regardless of the page-number position: a text pane in the right/top half of the
+// page can never sit over a bottom-left page number, so it never needs the dodge.
+@container style(--pageNumber-show-multiplicand:1) {
+    .split-pane-component.position-right
+        .split-pane-component-inner
+        > .bloom-translationGroup
+        > #formatButton,
+    .split-pane-component.position-top
+        .split-pane-component-inner
+        > .bloom-translationGroup
+        > #formatButton {
+        --formatButton-pageNumber-dodge-effective: 0px;
     }
 }
 

--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -936,9 +936,13 @@ div.textWholePage ul {
 // which is what the margin actually uses.
 @container style(--pageNumber-show-multiplicand:1) {
     #formatButton {
-        // Default: the theme's automatic-placement decision.
+        // Default: the theme's automatic-placement decision. The 0px fallback matters:
+        // legacy-theme books get no appearance-theme-default.css block (see
+        // AppearanceSettings.ToCss), so nothing defines the variable there, and an
+        // undefined var() would invalidate the margin calc() below entirely.
         --formatButton-pageNumber-dodge-effective: var(
-            --formatButton-pageNumber-dodge
+            --formatButton-pageNumber-dodge,
+            0px
         );
     }
     .split-pane-component.position-left
@@ -976,22 +980,21 @@ div.textWholePage ul {
     #formatButton {
         --formatButton-pageNumber-dodge-effective: var(
             --formatButton-pageNumber-dodge-when-forced-left,
-            var(--formatButton-pageNumber-dodge)
+            var(--formatButton-pageNumber-dodge, 0px)
         );
     }
 }
-// These selectors are more specific than the plain #formatButton rules above, so this
-// wins regardless of the page-number position: a text pane in the right/top half of the
-// page can never sit over a bottom-left page number, so it never needs the dodge.
+// A text box with any position-right or position-top split among its ancestors sits
+// somewhere in the right or top portion of the page, so it can never be over a
+// bottom-left page number and never needs the dodge — whatever the rules above decided.
+// Deliberately no child combinators: however deep the origami nesting, one top/right
+// ancestor is enough. (The margin rule above does use child combinators, and there they
+// matter: they anchor the dodge to a pane's own immediate text box and keep
+// canvas-element text boxes out of it.) These selectors still out-rank the plain
+// #formatButton rules above.
 @container style(--pageNumber-show-multiplicand:1) {
-    .split-pane-component.position-right
-        .split-pane-component-inner
-        > .bloom-translationGroup
-        > #formatButton,
-    .split-pane-component.position-top
-        .split-pane-component-inner
-        > .bloom-translationGroup
-        > #formatButton {
+    .split-pane-component.position-right #formatButton,
+    .split-pane-component.position-top #formatButton {
         --formatButton-pageNumber-dodge-effective: 0px;
     }
 }

--- a/src/content/appearanceThemes/appearance-theme-default.css
+++ b/src/content/appearanceThemes/appearance-theme-default.css
@@ -125,8 +125,9 @@
     --marginBox-border-width: medium; /* must not be 0px/0mm/0in to have a border. 'medium' is a keyword. */
 
     /* In some themes, at edit-
-    time, the format button lands under the page number. See BL-13206. The name is is intentionally vague about direction and what we do with it. */
-    --formatButton-pageNumber-dodge: 0;
+    time, the format button lands under the page number. See BL-13206. The name is is intentionally vague about direction and what we do with it.
+    Must have a unit: this feeds a calc() with px, where a unitless 0 makes the whole expression invalid (BL-14901). */
+    --formatButton-pageNumber-dodge: 0px;
 }
 
 /* this rule might not always be what we need for every kind of interactive page, but it's a good default.

--- a/src/content/appearanceThemes/appearance-theme-rounded-border-ebook.css
+++ b/src/content/appearanceThemes/appearance-theme-rounded-border-ebook.css
@@ -28,8 +28,14 @@
        This has the effect of increasing the text padding on the edges. */
     --page-and-marginBox-are-same-color-multiplicand: 0;
 
-    /* move so that page number doesn't it hide it if the text box is in the lower left */
+    /* move so that page number doesn't it hide it if the text box is in the lower left
+       (this theme puts the number at the bottom left in both orientations, except the
+       pictureOnRight pages below) */
     --formatButton-pageNumber-dodge: 20px;
+    /* how far the format button moves when the user's Page Numbers setting forces the
+       number to the bottom left; editMode.less applies it in that situation whatever
+       the per-page rules decide (BL-14901) */
+    --formatButton-pageNumber-dodge-when-forced-left: 20px;
 }
 
 /* using "where:" so that the user's custom appearance can override the theme if specified */

--- a/src/content/appearanceThemes/appearance-theme-zero-margin-ebook.css
+++ b/src/content/appearanceThemes/appearance-theme-zero-margin-ebook.css
@@ -77,6 +77,13 @@ Note that hiding the page numbers is done by a setting in appearance.json, not h
 .numberedPage:where([class*="Device"]:not(.bloom-interactive-page)) {
     --topLevel-text-padding: 0.5em;
 }
+[class*="Ebook"].numberedPage:not(.bloom-interactive-page),
+[class*="Device"].numberedPage:not(.bloom-interactive-page) {
+    /* how far the format button moves to clear this theme's page number when the user's
+       Page Numbers setting forces the number to the bottom left; editMode.less applies
+       it in that situation whatever the rules below decide (BL-14901) */
+    --formatButton-pageNumber-dodge-when-forced-left: 20px;
+}
 .Ebook7x5Landscape.numberedPage:not(.bloom-interactive-page),
 .Device16x9Landscape.numberedPage:not(.bloom-interactive-page) {
     /* move so that page number doesn't hide it if the text box is in the lower left.

--- a/src/content/appearanceThemes/appearance-theme-zero-margin-ebook.css
+++ b/src/content/appearanceThemes/appearance-theme-zero-margin-ebook.css
@@ -77,9 +77,11 @@ Note that hiding the page numbers is done by a setting in appearance.json, not h
 .numberedPage:where([class*="Device"]:not(.bloom-interactive-page)) {
     --topLevel-text-padding: 0.5em;
 }
-[class*="Ebook"].numberedPage:not(.bloom-interactive-page),
-[class*="Device"].numberedPage:not(.bloom-interactive-page) {
-    /* move so that page number doesn't it hide it if the text box is in the lower left */
+.Ebook7x5Landscape.numberedPage:not(.bloom-interactive-page),
+.Device16x9Landscape.numberedPage:not(.bloom-interactive-page) {
+    /* move so that page number doesn't hide it if the text box is in the lower left.
+       Landscape only: on portrait pages this theme leaves the page number centered
+       (the default for these page sizes), so there is nothing to dodge (BL-14901) */
     --formatButton-pageNumber-dodge: 20px;
 }
 .Ebook7x5Landscape.numberedPage.pictureOnRight.pictureOnRight,


### PR DESCRIPTION
Follow-up to #8182 (the landscape Picture-on-Right fix): the tester found the gear icon (format cog) still displaced away from the margin on portrait ebook pages, and the same pointless dodge occurred whenever the Book Settings "Page Numbers" control moved the number away from the bottom left.

Two commits:

1. **Zero Margin portrait fix.** That theme only places its page number at the bottom left on landscape pages; on portrait pages the number is centered (the device-size default), yet its 20px dodge applied everywhere. The dodge is now scoped to landscape. Also gave the default theme's dodge a unit (`0` → `0px`): the unitless zero made the cog's `margin-left: calc(3px + var(...))` invalid, so in every default-theme book the cog sat at 0 instead of the intended 3px (harmless but wrong since ~6.0).

2. **The dodge now honors the Page Numbers setting.** `editMode.less` folds everything that determines where the number actually sits into one effective dodge, reading the same margin-override variables the appearance system writes for that setting (via container style queries): Center or Right ⇒ nothing to dodge, whatever the theme wanted; Left ⇒ the theme's full dodge even on pages whose theme moved the number elsewhere (e.g. pictureOnRight); Automatic ⇒ the theme's per-page decision, as before. Both ebook themes publish the new `--formatButton-pageNumber-dodge-when-forced-left`; the EFL migration books' baked-in stylesheets fall back to their ordinary dodge.

Verified live in Bloom with a 12-case matrix (both ebook themes × both orientations × all four Page Numbers settings, measuring the cog's computed margin on a Picture-on-Right page and a text-bottom control page): every case the tester reported now puts the cog at the margin, and every case where the number genuinely sits bottom-left still dodges, including landscape regression checks.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-14901

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8198)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8198)
<!-- Reviewable:end -->
