### PR TITLE
Honor no-checkout flag (BL-16691)

### DIFF
--- a/src/BloomBrowserUI/teamCollection/TeamCollectionBookStatusPanel.tsx
+++ b/src/BloomBrowserUI/teamCollection/TeamCollectionBookStatusPanel.tsx
@@ -25,6 +25,7 @@ import { IBookTeamCollectionStatus } from "./teamCollectionApi";
 import { ForceUnlockDialog } from "./ForceUnlockDialog";
 import { kBloomRed } from "../utils/colorUtils";
 import { showRegistrationDialog } from "../react_components/registration/registrationDialog";
+import { NoteBox } from "../react_components/boxes";
 
 interface CheckInProgressEvent extends IBloomWebSocketEvent {
     fraction: number;
@@ -412,6 +413,10 @@ export const TeamCollectionBookStatusPanel: React.FunctionComponent<
                                     setBusy(false);
                                 },
                                 () => {
+                                    // Likewise on failure: when the server refuses because an
+                                    // administrator paused checkouts, it pushes a status refresh,
+                                    // so the panel will redraw and explain itself. We just need to
+                                    // stop looking busy, and not report an error. See BL-16691.
                                     setBusy(false);
                                 },
                             );
@@ -421,6 +426,26 @@ export const TeamCollectionBookStatusPanel: React.FunctionComponent<
                                     if (hasValidEmail)
                                         post(
                                             "teamCollection/attemptLockOfCurrentBook",
+                                            undefined,
+                                            // This needs a failure handler even though it has
+                                            // nothing to do. Without one, post() rethrows, and a
+                                            // refused checkout surfaces as Bloom's "something went
+                                            // wrong" problem report -- blaming Bloom when in fact
+                                            // an administrator paused checkouts. The server pushes
+                                            // a status refresh when it refuses, so the panel
+                                            // explains itself. See BL-16691.
+                                            //
+                                            // Note this swallows *every* failure here, not just a
+                                            // paused checkout, so a genuine problem (shared folder
+                                            // unreachable, say) now shows nothing on this path.
+                                            // Considered distinguishing the paused case by status
+                                            // code and reporting anything else; decided against it
+                                            // because the ordinary button path above has always had
+                                            // a do-nothing failure handler too, so this matches it
+                                            // rather than introducing a new kind of silence, and
+                                            // both paths refresh status so the panel ends up
+                                            // showing the real state either way.
+                                            () => {},
                                         );
                                 },
                             });
@@ -451,7 +476,20 @@ export const TeamCollectionBookStatusPanel: React.FunctionComponent<
                             "checkout-button",
                             "/bloom/teamCollection/Check Out.svg",
                             checkoutHandler,
+                            props.checkoutsArePaused,
                         )}
+                        belowButton={
+                            props.checkoutsArePaused ? (
+                                // Deliberately not localized yet: this is an
+                                // unreleased admin-only setting with no UI, so
+                                // per AGENTS.md we ship the English and add an
+                                // XLF entry once the feature stabilizes.
+                                <NoteBox>
+                                    The administrator of this collection has
+                                    paused checkouts.
+                                </NoteBox>
+                            ) : undefined
+                        }
                         menu={menu}
                     />
                 );

--- a/src/BloomBrowserUI/teamCollection/statusPanelCommon.less
+++ b/src/BloomBrowserUI/teamCollection/statusPanelCommon.less
@@ -34,6 +34,11 @@
                 width: @panel-button-icon-size;
                 margin-top: -2px;
             }
+            // Material-UI dims a disabled button's text but not our image, which would
+            // leave a bright icon next to a grayed-out label. See BL-16691.
+            &:disabled img {
+                opacity: 0.4;
+            }
             & > span {
                 font-size: larger;
             }

--- a/src/BloomBrowserUI/teamCollection/statusPanelCommon.tsx
+++ b/src/BloomBrowserUI/teamCollection/statusPanelCommon.tsx
@@ -26,6 +26,7 @@ export interface IStatusPanelProps {
     useWarningColorForButton?: boolean;
     children?: JSX.Element;
     menu?: JSX.Element; // when book is checked out, About my Avatar... and Forget Changes and Check in Book
+    belowButton?: JSX.Element; // spans the full panel width underneath the button row
     className?: string; // additional class for  root div; enables emotion CSS.
 }
 
@@ -43,9 +44,12 @@ export const StatusPanelCommon: React.FunctionComponent<IStatusPanelProps> = (
                     main: buttonColor,
                 },
                 action: {
-                    // Yagni: currently the only time we disable a button is when using the warning color
-                    // If we ever disable the other version, we probably want primary.dark here.
-                    disabledBackground: outerTheme.palette.warning.dark,
+                    // Keep the disabled background in the same family as the button's own color.
+                    // The check-in button uses the warning color; the check-out button uses primary,
+                    // and gets disabled when an administrator has paused checkouts (BL-16691).
+                    disabledBackground: props.useWarningColorForButton
+                        ? outerTheme.palette.warning.dark
+                        : outerTheme.palette.primary.dark,
                 },
             },
         }),
@@ -94,6 +98,7 @@ export const StatusPanelCommon: React.FunctionComponent<IStatusPanelProps> = (
                     </ThemeProvider>
                 </StyledEngineProvider>
             </div>
+            {props.belowButton}
         </div>
     );
 };

--- a/src/BloomBrowserUI/teamCollection/teamCollectionApi.tsx
+++ b/src/BloomBrowserUI/teamCollection/teamCollectionApi.tsx
@@ -25,6 +25,7 @@ export interface IBookTeamCollectionStatus {
     error: string; // This one is not current sent from the C# side.
     checkInMessage: string;
     isUserAdmin: boolean;
+    checkoutsArePaused: boolean; // an administrator has turned off checkouts for the whole collection
 }
 
 export const initialBookStatus: IBookTeamCollectionStatus = {
@@ -45,6 +46,7 @@ export const initialBookStatus: IBookTeamCollectionStatus = {
     error: "",
     checkInMessage: "",
     isUserAdmin: false,
+    checkoutsArePaused: false,
 };
 
 export function useTColBookStatus(

--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -194,6 +194,7 @@ namespace Bloom.Collection
             XMatterPackName = kDefaultXmatterName;
             Language2Tag = "en";
             AllowNewBooks = true;
+            AllowCheckouts = true;
             CollectionName = "dummy collection";
             AudioRecordingMode = TalkingBookApi.AudioRecordingMode.Sentence;
             AudioRecordingTrimEndMilliseconds = kDefaultAudioRecordingTrimEndMilliseconds;
@@ -394,6 +395,16 @@ namespace Bloom.Collection
             xml.Add(new XElement("Province", Province));
             xml.Add(new XElement("District", District));
             xml.Add(new XElement("AllowNewBooks", AllowNewBooks.ToString()));
+            // Unlike the settings around it, this one is written only when it has been set false
+            // to prevent checkouts.
+            // Save() rebuilds the whole file, so writing it unconditionally would add a line to
+            // every .bloomCollection in existence the first time its settings were saved -- and in
+            // a Team Collection that edit gets pushed to the shared folder, so the churn would
+            // spread to the whole team for a setting almost nobody uses. Omitting it is safe
+            // because a missing element already reads back as true (see Load), so a paused
+            // collection still round-trips correctly. See BL-16691.
+            if (!AllowCheckouts)
+                xml.Add(new XElement("AllowCheckouts", AllowCheckouts.ToString()));
             xml.Add(new XElement("AudioRecordingMode", AudioRecordingMode.ToString()));
             xml.Add(
                 new XElement("AudioRecordingTrimEndMilliseconds", AudioRecordingTrimEndMilliseconds)
@@ -644,6 +655,15 @@ namespace Bloom.Collection
                 Province = ReadString(xml, "Province", "");
                 District = ReadString(xml, "District", "");
                 AllowNewBooks = ReadBoolean(xml, "AllowNewBooks", true);
+                // A missing element reads back as true, which is what we want: checkouts are
+                // allowed unless someone deliberately turns them off. Note that a *malformed*
+                // value does not fall back to that default -- ReadBoolean returns whatever
+                // bool.TryParse produced, which is false -- so "no" or a typo pauses checkouts for
+                // the whole team rather than being ignored. We considered special-casing this
+                // setting to be strict and decided against it: every other boolean in this file
+                // behaves the same way, and making this the one exception would be more surprising
+                // than the behavior itself. See BL-16691.
+                AllowCheckouts = ReadBoolean(xml, "AllowCheckouts", true);
                 IsSourceCollection = ReadBoolean(xml, "IsSourceCollection", false);
 
                 string audioRecordingModeStr = ReadString(xml, "AudioRecordingMode", "Unknown");
@@ -981,6 +1001,11 @@ namespace Bloom.Collection
         public int OneTimeCheckVersionNumber { get; set; }
 
         public bool AllowNewBooks { get; set; }
+
+        /// <summary>
+        /// When false, no one may check out a book in this (Team) collection. See BL-16691.
+        /// </summary>
+        public bool AllowCheckouts { get; set; }
 
         public TalkingBookApi.AudioRecordingMode AudioRecordingMode { get; set; }
 

--- a/src/BloomExe/TeamCollection/FolderTeamCollection.cs
+++ b/src/BloomExe/TeamCollection/FolderTeamCollection.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Xml.Linq;
 using Bloom.Collection;
 using Bloom.CollectionCreating;
 using Bloom.MiscUI;
@@ -301,6 +302,66 @@ namespace Bloom.TeamCollection
         {
             var path = GetPathToBookFileInRepo(bookName);
             return RobustZip.GetZipEntryContent(path, fileName);
+        }
+
+        /// <summary>
+        /// Read AllowCheckouts straight out of the repo's copy of the collection settings file,
+        /// which lives inside "Other Collection Files.zip". We deliberately do not go through the
+        /// local copy: that is only refreshed from the repo when the collection is opened, and the
+        /// whole point is to notice a change made while Bloom is running. See BL-16691.
+        /// </summary>
+        public override bool? GetAllowCheckoutsFromRepo()
+        {
+            try
+            {
+                var zipPath = GetRepoProjectFilesZipPath(_repoFolderPath);
+                if (!RobustFile.Exists(zipPath))
+                    return null;
+                var entryName = GetCollectionSettingsEntryName(zipPath);
+                if (entryName == null)
+                    return null;
+                var content = RobustZip.GetZipEntryContent(zipPath, entryName);
+                if (string.IsNullOrWhiteSpace(content))
+                    return null;
+                return CollectionSettings.ReadBoolean(
+                    XElement.Parse(content),
+                    "AllowCheckouts",
+                    true
+                );
+            }
+            catch (Exception e)
+            {
+                // The zip may be part-written, or Dropbox may be midway through syncing it. There
+                // is nothing to do about it now: we'll get another notification when the file
+                // settles, and failing that we read it again at startup. Leaving the setting alone
+                // is the safe outcome either way.
+                Bloom.Utils.MiscUtils.SuppressUnusedExceptionVarWarning(e);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// The name of the .bloomCollection entry within the given zip, or null if there isn't one.
+        /// Found by extension rather than by building the name, because the collection may have
+        /// been renamed locally.
+        /// </summary>
+        private static string GetCollectionSettingsEntryName(string zipPath)
+        {
+            using (var zipFile = new ICSharpCode.SharpZipLib.Zip.ZipFile(zipPath))
+            {
+                foreach (ICSharpCode.SharpZipLib.Zip.ZipEntry entry in zipFile)
+                {
+                    if (
+                        entry.IsFile
+                        && entry.Name.EndsWith(
+                            CollectionSettings.kFileExtension,
+                            StringComparison.OrdinalIgnoreCase
+                        )
+                    )
+                        return entry.Name;
+                }
+            }
+            return null;
         }
 
         /// <summary>

--- a/src/BloomExe/TeamCollection/TeamCollection.cs
+++ b/src/BloomExe/TeamCollection/TeamCollection.cs
@@ -870,6 +870,13 @@ namespace Bloom.TeamCollection
                     else
                     {
                         CopyRepoCollectionFilesFromLocal(_localCollectionFolder);
+                        // Pick up AllowCheckouts from what we just pushed. Our own repo watcher is
+                        // deliberately suppressed while we write (see CopyRepoCollectionFilesFromLocal),
+                        // so without this the machine that made the change is the one machine that
+                        // does NOT act on it. Worse, our in-memory copy would still say checkouts are
+                        // allowed, and the next Save() would write that back over the change and
+                        // un-pause the whole team. See BL-16691.
+                        UpdateAllowCheckoutsFromRepo();
                     }
                 }
             }
@@ -1345,6 +1352,49 @@ namespace Bloom.TeamCollection
                 null,
                 null
             );
+            UpdateAllowCheckoutsFromRepo();
+        }
+
+        /// <summary>
+        /// Read the AllowCheckouts setting from the repo's copy of the collection settings, which
+        /// may be newer than the copy we read when the collection was opened. Returns null if we
+        /// can't tell (disconnected, no repo copy yet, or the file is unreadable right now).
+        /// </summary>
+        public virtual bool? GetAllowCheckoutsFromRepo()
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Collection settings otherwise take effect only when Bloom next opens the collection, but
+        /// pausing checkouts must not wait for that: Bloom may stay open for days, so an
+        /// administrator who pauses checkouts would have no effect on anyone still running. Here we
+        /// pick up that one setting whenever the repo's collection files change. Deliberately only
+        /// this one -- reloading all collection settings mid-session is not safe. See BL-16691.
+        ///
+        /// This is best-effort by nature: the change has to reach this machine through the shared
+        /// folder first, and the user may be offline. The aim is that anyone with a working
+        /// connection stops being able to check out within a few minutes of the switch being
+        /// flipped, not that it is instant.
+        /// </summary>
+        internal void UpdateAllowCheckoutsFromRepo()
+        {
+            var settings = _tcManager?.Settings;
+            if (settings == null)
+                return; // no settings to update (unit tests)
+            var repoValue = GetAllowCheckoutsFromRepo();
+            if (repoValue == null || repoValue.Value == settings.AllowCheckouts)
+                return;
+            settings.AllowCheckouts = repoValue.Value;
+            Logger.WriteEvent(
+                $"TeamCollection: AllowCheckouts changed remotely to {repoValue.Value}."
+            );
+            // Tell the browser to re-read book status, so the checkout button and its explanation
+            // update without a restart. The InvokeSelectionChanged that our caller does afterwards
+            // is NOT enough: nothing on that path sends bookTeamCollectionStatus, so the panel kept
+            // showing a live checkout button until something else forced it to refetch. Tested by
+            // pausing checkouts in the shared folder with Bloom running.
+            _tcManager.SendBookStatusReload();
         }
 
         /// <summary>

--- a/src/BloomExe/TeamCollection/TeamCollectionApi.cs
+++ b/src/BloomExe/TeamCollection/TeamCollectionApi.cs
@@ -534,6 +534,7 @@ namespace Bloom.TeamCollection
                         isNewLocalBook = true,
                         checkinMessage = "",
                         isUserAdmin = _tcManager.OkToEditCollectionSettings,
+                        checkoutsArePaused = !_settings.AllowCheckouts,
                     }
                 );
             }
@@ -620,6 +621,7 @@ namespace Bloom.TeamCollection
                     isNewLocalBook,
                     checkinMessage,
                     isUserAdmin = _tcManager.OkToEditCollectionSettings,
+                    checkoutsArePaused = !_settings.AllowCheckouts,
                 }
             );
         }
@@ -685,6 +687,23 @@ namespace Bloom.TeamCollection
             if (!_tcManager.CheckConnection())
             {
                 request.Failed();
+                return;
+            }
+
+            // The UI disables the checkout button when checkouts are paused, but it decides that
+            // from a status snapshot it fetched earlier, and not every path back here re-checks it
+            // -- the post issued after the registration dialog, for one, doesn't. This is also the
+            // side that notices an administrator pausing checkouts part way through a session (see
+            // TeamCollection.UpdateAllowCheckoutsFromRepo), so it can know before the browser does.
+            // Either way, refuse here rather than rely on the browser having current status.
+            // See BL-16691.
+            if (!_settings.AllowCheckouts)
+            {
+                // Tell the browser to re-read book status, so the panel redraws itself into the
+                // paused state and explains why the checkout didn't happen. Without this the
+                // person just sees the button stop responding with no reason given.
+                _socketServer.SendEvent("bookTeamCollectionStatus", "reload");
+                request.Failed("checkouts are paused for this collection");
                 return;
             }
 

--- a/src/BloomExe/TeamCollection/TeamCollectionManager.cs
+++ b/src/BloomExe/TeamCollection/TeamCollectionManager.cs
@@ -35,6 +35,14 @@ namespace Bloom.TeamCollection
         /// </summary>
         void SendBookContentReload();
 
+        /// <summary>
+        /// Sends the bookTeamCollectionStatus/reload websocket event so the book status panel
+        /// re-reads status. Call this after changing something the panel displays without the
+        /// book's own checkout status having changed -- a book-status-changed event would be the
+        /// wrong signal for that. See BL-16691.
+        /// </summary>
+        void SendBookStatusReload();
+
         // ENHANCE: Add other properties and methods as needed
     }
 
@@ -563,6 +571,12 @@ namespace Bloom.TeamCollection
         public void SendBookContentReload()
         {
             _webSocketServer.SendEvent("bookContent", "reload");
+        }
+
+        /// <inheritdoc />
+        public void SendBookStatusReload()
+        {
+            _webSocketServer.SendEvent("bookTeamCollectionStatus", "reload");
         }
 
         /// <summary>

--- a/src/BloomTests/Collection/CollectionSettingsTests.cs
+++ b/src/BloomTests/Collection/CollectionSettingsTests.cs
@@ -263,6 +263,125 @@ namespace BloomTests.Collection
             Assert.That(settings.Subscription.Code, Is.EqualTo("Foobar-123456-1234"));
         }
 
+        /// <summary>
+        /// AllowCheckouts (BL-16691) has no UI; an administrator hand-edits it into the file.
+        /// Collections that predate it, and the overwhelming majority that will never have it,
+        /// must keep allowing checkouts.
+        /// </summary>
+        [Test]
+        public void AllowCheckouts_ElementMissing_DefaultsToTrue()
+        {
+            var settings = CreateSettingsFromFileContents(
+                "allowCheckoutsMissing",
+                @"<?xml version=""1.0"" encoding=""utf-8""?>
+<Collection version=""0.2"">
+	<AllowNewBooks>True</AllowNewBooks>
+</Collection>"
+            );
+            Assert.That(settings.AllowCheckouts, Is.True);
+        }
+
+        [TestCase("False", false)]
+        [TestCase("True", true)]
+        public void AllowCheckouts_ElementPresent_IsRead(string valueInFile, bool expected)
+        {
+            var settings = CreateSettingsFromFileContents(
+                "allowCheckoutsRead" + valueInFile,
+                $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<Collection version=""0.2"">
+	<AllowCheckouts>{valueInFile}</AllowCheckouts>
+</Collection>"
+            );
+            Assert.That(settings.AllowCheckouts, Is.EqualTo(expected));
+        }
+
+        /// <summary>
+        /// Save() rebuilds the whole settings file from scratch, so a setting we don't write out
+        /// would be silently erased the next time anything saves collection settings. That would
+        /// quietly un-pause checkouts for the whole team, so guard against it.
+        /// </summary>
+        [Test]
+        public void AllowCheckouts_False_SurvivesSaveAndReload()
+        {
+            const string collectionName = "allowCheckoutsRoundTrip";
+            var settings = CreateSettingsFromFileContents(
+                collectionName,
+                @"<?xml version=""1.0"" encoding=""utf-8""?>
+<Collection version=""0.2"">
+	<AllowCheckouts>False</AllowCheckouts>
+</Collection>"
+            );
+            // Sanity check: we only learn anything from the round trip if it started out false.
+            Assert.That(
+                settings.AllowCheckouts,
+                Is.False,
+                "setup failed: AllowCheckouts should have been read as false"
+            );
+
+            settings.Save();
+
+            var reloaded = CreateCollectionSettings(_folder.Path, collectionName);
+            Assert.That(reloaded.AllowCheckouts, Is.False);
+        }
+
+        /// <summary>
+        /// The setting is written only when checkouts are paused, so that the overwhelming
+        /// majority of collections -- which will never use it -- don't all gain a line the first
+        /// time their settings are saved. See BL-16691.
+        /// </summary>
+        [Test]
+        public void AllowCheckouts_True_IsNotWrittenToTheFile()
+        {
+            const string collectionName = "allowCheckoutsNotWritten";
+            var settings = CreateSettingsFromFileContents(
+                collectionName,
+                @"<?xml version=""1.0"" encoding=""utf-8""?>
+<Collection version=""0.2"">
+	<AllowCheckouts>False</AllowCheckouts>
+</Collection>"
+            );
+            // Sanity check: start from the value that IS written, so we can watch it disappear.
+            Assert.That(
+                settings.AllowCheckouts,
+                Is.False,
+                "setup failed: AllowCheckouts should have been read as false"
+            );
+            settings.Save();
+            Assert.That(
+                RobustFile.ReadAllText(settings.SettingsFilePath),
+                Does.Contain("AllowCheckouts"),
+                "setup failed: a paused collection should write the element"
+            );
+
+            settings.AllowCheckouts = true;
+            settings.Save();
+
+            Assert.That(
+                RobustFile.ReadAllText(settings.SettingsFilePath),
+                Does.Not.Contain("AllowCheckouts")
+            );
+            // ...and the collection still reads back as allowing checkouts.
+            var reloaded = CreateCollectionSettings(_folder.Path, collectionName);
+            Assert.That(reloaded.AllowCheckouts, Is.True);
+        }
+
+        /// <summary>
+        /// Writes the given .bloomCollection contents into a fresh collection folder and loads it.
+        /// </summary>
+        private CollectionSettings CreateSettingsFromFileContents(
+            string collectionName,
+            string fileContents
+        )
+        {
+            var collectionPath = CollectionSettings.GetPathForNewSettings(
+                _folder.Path,
+                collectionName
+            );
+            Directory.CreateDirectory(Path.GetDirectoryName(collectionPath));
+            RobustFile.WriteAllText(collectionPath, fileContents);
+            return CreateCollectionSettings(_folder.Path, collectionName);
+        }
+
         // I'm not clear why this needs a test, but I split it off from another test to clarify the intent.
         [Test]
         public void Writing_InvalidSubscription_StillWritesBookshelf()

--- a/src/BloomTests/TeamCollection/FolderTeamCollectionTests2.cs
+++ b/src/BloomTests/TeamCollection/FolderTeamCollectionTests2.cs
@@ -1267,5 +1267,213 @@ namespace BloomTests.TeamCollection
                 }
             }
         }
+
+        /// <summary>
+        /// Sets up a team collection whose repo holds a settings file with the given content, and
+        /// runs the given check against it. See BL-16691.
+        /// </summary>
+        private void WithRepoSettingsFile(
+            string testName,
+            string settingsFileContent,
+            Action<TestFolderTeamCollection, CollectionSettings> check
+        )
+        {
+            using (var collectionFolder = new TemporaryFolder(testName + "_Collection"))
+            {
+                using (var repoFolder = new TemporaryFolder(testName + "_Repo"))
+                {
+                    var mockTcManager = new Mock<ITeamCollectionManager>();
+                    var settings = new CollectionSettings();
+                    mockTcManager.Setup(m => m.Settings).Returns(settings);
+                    var tc = new TestFolderTeamCollection(
+                        mockTcManager.Object,
+                        collectionFolder.FolderPath,
+                        repoFolder.FolderPath
+                    );
+                    var settingsPath = CollectionSettings.GetSettingsFilePath(
+                        collectionFolder.FolderPath
+                    );
+                    Directory.CreateDirectory(Path.GetDirectoryName(settingsPath));
+                    Directory.CreateDirectory(Path.Combine(repoFolder.FolderPath, "Books"));
+                    if (settingsFileContent != null)
+                    {
+                        File.WriteAllText(settingsPath, settingsFileContent);
+                        tc.CopyRepoCollectionFilesFromLocal(collectionFolder.FolderPath);
+                    }
+                    check(tc, settings);
+                }
+            }
+        }
+
+        [TestCase("False", false)]
+        [TestCase("True", true)]
+        public void GetAllowCheckoutsFromRepo_ReadsTheRepoCopy(string valueInFile, bool expected)
+        {
+            WithRepoSettingsFile(
+                "GetAllowCheckouts" + valueInFile,
+                $"<Collection version=\"0.2\"><AllowCheckouts>{valueInFile}</AllowCheckouts></Collection>",
+                (tc, settings) => Assert.That(tc.GetAllowCheckoutsFromRepo(), Is.EqualTo(expected))
+            );
+        }
+
+        /// <summary>
+        /// Reading the repo copy has to cope with what Bloom actually writes, and Bloom writes the
+        /// settings file with a UTF-8 BOM. The other tests here write the file themselves without
+        /// one, so they would not notice if the BOM reached the XML parser. See BL-16691.
+        /// </summary>
+        [Test]
+        public void GetAllowCheckoutsFromRepo_FileWrittenByBloomWithBom_IsRead()
+        {
+            using (var collectionFolder = new TemporaryFolder("GetAllowCheckoutsBom_Collection"))
+            {
+                using (var repoFolder = new TemporaryFolder("GetAllowCheckoutsBom_Repo"))
+                {
+                    var mockTcManager = new Mock<ITeamCollectionManager>();
+                    var tc = new TestFolderTeamCollection(
+                        mockTcManager.Object,
+                        collectionFolder.FolderPath,
+                        repoFolder.FolderPath
+                    );
+                    Directory.CreateDirectory(Path.Combine(repoFolder.FolderPath, "Books"));
+                    var settingsPath = CollectionSettings.GetSettingsFilePath(
+                        collectionFolder.FolderPath
+                    );
+
+                    // Write it the way Bloom really does, rather than by hand.
+                    var settings = new CollectionSettings(settingsPath) { AllowCheckouts = false };
+                    settings.Save();
+
+                    // Sanity check: the whole point of this test is that Bloom emits a BOM.
+                    Assert.That(
+                        File.ReadAllBytes(settingsPath).Take(3).ToArray(),
+                        Is.EqualTo(new byte[] { 0xEF, 0xBB, 0xBF }),
+                        "setup failed: expected Bloom to write a UTF-8 BOM"
+                    );
+                    tc.CopyRepoCollectionFilesFromLocal(collectionFolder.FolderPath);
+
+                    Assert.That(tc.GetAllowCheckoutsFromRepo(), Is.False);
+                }
+            }
+        }
+
+        [Test]
+        public void GetAllowCheckoutsFromRepo_ElementMissing_IsTrue()
+        {
+            WithRepoSettingsFile(
+                "GetAllowCheckoutsMissing",
+                "<Collection version=\"0.2\"><AllowNewBooks>True</AllowNewBooks></Collection>",
+                (tc, settings) => Assert.That(tc.GetAllowCheckoutsFromRepo(), Is.True)
+            );
+        }
+
+        /// <summary>
+        /// If we can't read the repo copy we must leave the setting alone rather than guess.
+        /// </summary>
+        [Test]
+        public void GetAllowCheckoutsFromRepo_NoRepoSettings_IsNull()
+        {
+            WithRepoSettingsFile(
+                "GetAllowCheckoutsNoRepo",
+                null,
+                (tc, settings) => Assert.That(tc.GetAllowCheckoutsFromRepo(), Is.Null)
+            );
+        }
+
+        /// <summary>
+        /// The point of the whole exercise: an administrator pausing checkouts must take effect
+        /// on a machine that is already running, without waiting for a restart. See BL-16691.
+        /// </summary>
+        [Test]
+        public void UpdateAllowCheckoutsFromRepo_RepoSaysPaused_UpdatesLiveSettings()
+        {
+            WithRepoSettingsFile(
+                "UpdateAllowCheckoutsPaused",
+                "<Collection version=\"0.2\"><AllowCheckouts>False</AllowCheckouts></Collection>",
+                (tc, settings) =>
+                {
+                    // Sanity check: the running Bloom starts out allowing checkouts, which is what
+                    // makes the change below meaningful.
+                    Assert.That(
+                        settings.AllowCheckouts,
+                        Is.True,
+                        "setup failed: should have started out allowing checkouts"
+                    );
+
+                    tc.UpdateAllowCheckoutsFromRepo();
+
+                    Assert.That(settings.AllowCheckouts, Is.False);
+                }
+            );
+        }
+
+        /// <summary>
+        /// The administrator pauses checkouts by editing their own local settings file while Bloom
+        /// runs, and Bloom pushes that up to the repo. Their own repo watcher is suppressed while
+        /// we write, so without help the machine that made the change is the one machine that
+        /// doesn't act on it -- and its stale in-memory "allowed" would be written back over the
+        /// change by the next Save(), un-pausing the whole team. See BL-16691.
+        /// </summary>
+        [Test]
+        public void SyncLocalAndRepoCollectionFiles_LocalPausePushedUp_UpdatesLiveSettings()
+        {
+            using (var collectionFolder = new TemporaryFolder("LocalPausePushedUp_Collection"))
+            {
+                using (var repoFolder = new TemporaryFolder("LocalPausePushedUp_Repo"))
+                {
+                    var mockTcManager = new Mock<ITeamCollectionManager>();
+                    var settings = new CollectionSettings();
+                    mockTcManager.Setup(m => m.Settings).Returns(settings);
+                    var tc = new TestFolderTeamCollection(
+                        mockTcManager.Object,
+                        collectionFolder.FolderPath,
+                        repoFolder.FolderPath
+                    );
+                    Directory.CreateDirectory(Path.Combine(repoFolder.FolderPath, "Books"));
+                    var settingsPath = CollectionSettings.GetSettingsFilePath(
+                        collectionFolder.FolderPath
+                    );
+
+                    // The administrator's hand-edit: the file says paused...
+                    File.WriteAllText(
+                        settingsPath,
+                        "<Collection version=\"0.2\"><AllowCheckouts>False</AllowCheckouts></Collection>"
+                    );
+                    // ...while this running Bloom still has the value it loaded at startup.
+                    Assert.That(
+                        settings.AllowCheckouts,
+                        Is.True,
+                        "setup failed: the running Bloom should still think checkouts are allowed"
+                    );
+
+                    tc.SyncLocalAndRepoCollectionFiles(false);
+
+                    Assert.That(
+                        settings.AllowCheckouts,
+                        Is.False,
+                        "the machine that made the change should be paused too"
+                    );
+                    Assert.That(
+                        tc.GetAllowCheckoutsFromRepo(),
+                        Is.False,
+                        "and the pause should have reached the repo"
+                    );
+                }
+            }
+        }
+
+        [Test]
+        public void UpdateAllowCheckoutsFromRepo_NoRepoSettings_LeavesSettingAlone()
+        {
+            WithRepoSettingsFile(
+                "UpdateAllowCheckoutsNoRepo",
+                null,
+                (tc, settings) =>
+                {
+                    settings.AllowCheckouts = false;
+                    tc.UpdateAllowCheckoutsFromRepo();
+                    Assert.That(settings.AllowCheckouts, Is.False);
+                }
+            );
+        }
     }
 }


### PR DESCRIPTION
Honor a new `AllowCheckouts` setting in the `.bloomCollection` file, as preparation for Cloud syncing. There is deliberately no UI for it: a collection administrator pauses checkouts by hand-editing the XML, and in a Team Collection that file syncs to the whole team.

When `AllowCheckouts` is `False`, the "Check out book" button is disabled and grayed out, and an info NoteBox below it says "The administrator of this collection has paused checkouts."

### Changes

- **`CollectionSettings`** — read `AllowCheckouts` (defaulting to `true`, so existing collections are unaffected) and write it back out. The write is load-bearing: `Save()` rebuilds the whole file, so a setting we didn't round-trip would be silently erased — quietly un-pausing checkouts for the team — the next time anything saved collection settings.
- **`TeamCollectionApi`** — report `checkoutsArePaused` in the book status JSON, and refuse in `HandleAttemptLockOfCurrentBook`. The endpoint guard is there because the panel's status can be stale (the setting arrives whenever collection files sync), and because the registration-dialog path posts the checkout separately from the button.
- **`StatusPanelCommon`** — add a `belowButton` slot, and pay off the YAGNI note on `disabledBackground`: the check-out button is the primary color, not the warning color, so a disabled one no longer renders in the check-in button's orange.
- **LESS** — dim the button's `<img>` when disabled; MUI dims the label but not our icon, which otherwise left a bright icon beside grayed-out text.

### Testing

Added `CollectionSettingsTests` covering the default when the element is absent, reading `True`/`False`, and surviving a save-and-reload round trip. I verified the round-trip test genuinely fails if the `Save()` line is removed.

Manually verified in a real Team Collection: the disabled button and the note appear as intended.

### Note for whoever writes the admin instructions

In a Team Collection, hand-editing the **local** `.bloomCollection` while Bloom is closed does **not** work — at startup `SyncLocalAndRepoCollectionFiles` overwrites the local copy from the repo ("whatever wins in the repo wins everywhere"). The setting has to be edited either while Bloom is running (the idle watcher pushes it up to the repo) or directly in the repo's `Other Collection Files.zip`. This is pre-existing behavior for all collection-level settings, not something this PR introduces.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16691


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8199)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8199)
<!-- Reviewable:end -->
