### PR TITLE
Honor a minimum Bloom version in collection settings (BL-16690)

### DIFF
--- a/src/BloomBrowserUI/utils/BloomMessageBox.tsx
+++ b/src/BloomBrowserUI/utils/BloomMessageBox.tsx
@@ -6,6 +6,7 @@ import BloomButton from "../react_components/bloomButton";
 import { postString } from "./bloomApi";
 import WarningOutlinedIcon from "@mui/icons-material/WarningOutlined";
 import InfoIcon from "@mui/icons-material/Info";
+import LaunchIcon from "@mui/icons-material/Launch";
 import {
     BloomDialog,
     DialogBottomButtons,
@@ -24,6 +25,10 @@ export interface IMessageBoxButton {
     text: string;
     id: string;
     default: boolean; // Only one button should have this true
+    // Effectively an enumeration, which we will add to as needed.
+    // "launch" is the same icon the Help menu uses on its "website" item, to warn the
+    // user that clicking will take them out to a web page.
+    icon?: "launch";
 }
 
 // This function is only used from Typescript-land to give us control over repeated opening and closing.
@@ -74,6 +79,11 @@ export const BloomMessageBox: React.FunctionComponent<{
             alreadyLocalized={true}
             hasText={true}
             variant={button.default ? "contained" : "outlined"}
+            endIcon={
+                button.icon === "launch" ? (
+                    <LaunchIcon fontSize="small" />
+                ) : undefined
+            }
             onClick={() => closeDialogForButton(button.id)}
             // I have nothing against ripple, but when a default button shows with a ripple even though
             // you're not clicking or even pointing at it... it looks dumb.

--- a/src/BloomBrowserUI/utils/BloomMessageBox.tsx
+++ b/src/BloomBrowserUI/utils/BloomMessageBox.tsx
@@ -26,8 +26,8 @@ export interface IMessageBoxButton {
     id: string;
     default: boolean; // Only one button should have this true
     // Effectively an enumeration, which we will add to as needed.
-    // "launch" is the same icon the Help menu uses on its "website" item, to warn the
-    // user that clicking will take them out to a web page.
+    // "launch" is the same icon, in the same leading position, that the Help menu uses on
+    // its "website" item, to warn the user that clicking will take them out to a web page.
     icon?: "launch";
 }
 
@@ -79,7 +79,7 @@ export const BloomMessageBox: React.FunctionComponent<{
             alreadyLocalized={true}
             hasText={true}
             variant={button.default ? "contained" : "outlined"}
-            endIcon={
+            iconBeforeText={
                 button.icon === "launch" ? (
                     <LaunchIcon fontSize="small" />
                 ) : undefined

--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -72,6 +72,20 @@ namespace Bloom.Collection
         // if this is null, relevant code uses the default, so we don't have to initialize it here
         public string BadgeQrCodeLabel;
 
+        /// <summary>
+        /// The oldest version of Bloom that is allowed to open this collection, e.g. "6.5".
+        /// Empty means any version may open it. At this point there is no UI for setting this;
+        /// it has to be added by editing the .bloomCollection file by hand. See BL-16690.
+        /// The gate that actually enforces it is MinimumBloomVersionCheck.
+        /// </summary>
+        public string MinimumBloomVersion = "";
+
+        /// <summary>
+        /// The name of the element in the .bloomCollection file that holds MinimumBloomVersion.
+        /// MinimumBloomVersionCheck reads it without loading the whole CollectionSettings.
+        /// </summary>
+        public const string kMinimumBloomVersionElementName = "MinimumBloomVersion";
+
         public static readonly Dictionary<string, string> CssNumberStylesToCultureOrDigits =
             new Dictionary<string, string>()
             {
@@ -408,6 +422,10 @@ namespace Bloom.Collection
             xml.Add(BulkPublishBloomPubSettings.ToXElement());
             xml.Add(new XElement("ShowBlorgLanguageQrCode", ShowBlorgLanguageQrCode));
             xml.Add(new XElement("BadgeQrCodeLabel", BadgeQrCodeLabel));
+            // Only write this if it is actually in use. Save() builds the file from scratch, so if we
+            // didn't write it back, the first save after someone hand-added it would silently lose it.
+            if (!string.IsNullOrWhiteSpace(MinimumBloomVersion))
+                xml.Add(new XElement(kMinimumBloomVersionElementName, MinimumBloomVersion));
             RobustIO.SaveXElement(xml, SettingsFilePath);
 
             // Color palette settings are stored in a separate Json file
@@ -685,6 +703,7 @@ namespace Bloom.Collection
 
                 ShowBlorgLanguageQrCode = ReadBoolean(xml, "ShowBlorgLanguageQrCode", true);
                 BadgeQrCodeLabel = ReadString(xml, "BadgeQrCodeLabel", "");
+                MinimumBloomVersion = ReadString(xml, kMinimumBloomVersionElementName, "");
 
                 LoadDictionary(xml, "Palette", ColorPalettes);
             }

--- a/src/BloomExe/Collection/MinimumBloomVersionCheck.cs
+++ b/src/BloomExe/Collection/MinimumBloomVersionCheck.cs
@@ -179,7 +179,7 @@ namespace Bloom.Collection
         /// </summary>
         private static void ShowDownloadsPage()
         {
-            var url = UrlLookup.LookupUrl(UrlType.LibrarySite, null) + "/installers";
+            var url = UrlLookup.LookupUrl(UrlType.LibrarySite, null) + "/downloads";
             if (SIL.PlatformUtilities.Platform.IsWindows)
                 // Let the default browser open the link.
                 ProcessExtra.SafeStartInFront(url);

--- a/src/BloomExe/Collection/MinimumBloomVersionCheck.cs
+++ b/src/BloomExe/Collection/MinimumBloomVersionCheck.cs
@@ -198,8 +198,11 @@ namespace Bloom.Collection
         /// <summary>
         /// The version of Bloom we are running. We use the assembly version rather than
         /// Application.ProductVersion because the latter can carry a non-numeric suffix.
+        /// A loaded assembly always has a version, so we don't guard against it being missing:
+        /// any fallback we picked would be a lie, and a low one would lock the user out of every
+        /// collection that declares a minimum -- the opposite of what this class is careful to do.
         /// </summary>
         private static Version RunningBloomVersion =>
-            typeof(MinimumBloomVersionCheck).Assembly?.GetName()?.Version ?? new Version(1, 0, 0);
+            typeof(MinimumBloomVersionCheck).Assembly.GetName().Version;
     }
 }

--- a/src/BloomExe/Collection/MinimumBloomVersionCheck.cs
+++ b/src/BloomExe/Collection/MinimumBloomVersionCheck.cs
@@ -26,12 +26,19 @@ namespace Bloom.Collection
         /// Decide whether this Bloom is allowed to open the given collection.
         /// </summary>
         /// <param name="settingsFilePath">Path to the .bloomCollection file</param>
-        /// <param name="minimumVersion">What the collection asked for, when we say no</param>
+        /// <param name="minimumVersion">What the collection asked for, as major.minor, when we say no</param>
         /// <returns>true if the collection demands a newer Bloom than we are</returns>
         public static bool IsThisBloomTooOld(string settingsFilePath, out string minimumVersion)
         {
-            minimumVersion = ReadMinimumBloomVersion(settingsFilePath);
-            return !IsVersionSufficient(minimumVersion, RunningBloomVersion);
+            var declaredVersion = ReadMinimumBloomVersion(settingsFilePath);
+            if (IsVersionSufficient(declaredVersion, RunningBloomVersion))
+            {
+                minimumVersion = "";
+                return false;
+            }
+            // We can only get here if it parsed, since anything we can't parse counts as satisfied.
+            minimumVersion = ToMajorMinor(Version.Parse(declaredVersion.Trim()));
+            return true;
         }
 
         /// <summary>
@@ -119,8 +126,8 @@ namespace Bloom.Collection
                 ),
                 // The message is HTML, and a collection name can perfectly well contain an ampersand.
                 System.Net.WebUtility.HtmlEncode(collectionName),
-                System.Net.WebUtility.HtmlEncode(minimumVersion),
-                RunningBloomVersion.ToString(3)
+                minimumVersion,
+                ToMajorMinor(RunningBloomVersion)
             );
             var upgradeButtonText = LocalizationManager.GetString(
                 "Collection.UpgradeBloom",
@@ -133,7 +140,13 @@ namespace Bloom.Collection
 
             var buttons = new[]
             {
-                new MessageBoxButton() { Text = upgradeButtonText, Id = kUpgradeButtonId },
+                new MessageBoxButton()
+                {
+                    Text = upgradeButtonText,
+                    Id = kUpgradeButtonId,
+                    // Warn the user that this takes them out to a web page.
+                    Icon = "launch",
+                },
                 new MessageBoxButton()
                 {
                     Text = chooseOtherButtonText,
@@ -172,6 +185,13 @@ namespace Bloom.Collection
             else
                 ProcessExtra.SafeStartInFront("xdg-open", Uri.EscapeUriString(url));
         }
+
+        /// <summary>
+        /// Format a version the way we actually compare it: major and minor only. Showing the user a
+        /// build number we don't look at would misrepresent the rule, and invites them to compare
+        /// the wrong digits ("6.5 required, but I have 6.4.900, and 900 is more than 5").
+        /// </summary>
+        private static string ToMajorMinor(Version version) => $"{version.Major}.{version.Minor}";
 
         /// <summary>
         /// The version of Bloom we are running. We use the assembly version rather than

--- a/src/BloomExe/Collection/MinimumBloomVersionCheck.cs
+++ b/src/BloomExe/Collection/MinimumBloomVersionCheck.cs
@@ -107,9 +107,9 @@ namespace Bloom.Collection
         /// upgrade, or open some other collection. If they choose to upgrade we send them to the
         /// downloads page and quit, since they can't install over a running Bloom anyway.
         /// </summary>
-        /// <remarks>If we return, the caller should abandon opening this collection; its callers
-        /// already fall back to showing the collection chooser.</remarks>
-        public static void ReportCollectionNeedsNewerBloom(
+        /// <returns>true if the user chose to upgrade, in which case we have already asked Bloom to
+        /// quit and the caller must not start any more UI.</returns>
+        public static bool ReportCollectionNeedsNewerBloom(
             string collectionName,
             string minimumVersion
         )
@@ -165,8 +165,10 @@ namespace Bloom.Collection
             {
                 ShowDownloadsPage();
                 ProgramExit.Exit();
+                return true;
             }
-            // Otherwise just return; the caller will put the collection chooser back up.
+            // Otherwise the caller will put the collection chooser back up.
+            return false;
         }
 
         private const string kUpgradeButtonId = "upgrade";

--- a/src/BloomExe/Collection/MinimumBloomVersionCheck.cs
+++ b/src/BloomExe/Collection/MinimumBloomVersionCheck.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Text;
+using System.Windows.Forms;
+using System.Xml.Linq;
+using Bloom.MiscUI;
+using Bloom.ToPalaso;
+using Bloom.web;
+using L10NSharp;
+using SIL.IO;
+using SIL.Reporting;
+
+namespace Bloom.Collection
+{
+    /// <summary>
+    /// A collection can declare, via the MinimumBloomVersion element of its .bloomCollection file,
+    /// the oldest version of Bloom that is allowed to open it. This is in preparation for Cloud
+    /// syncing: once a collection has been touched by a version of Bloom that knows how to sync it,
+    /// letting an older Bloom loose on it could do real damage.
+    ///
+    /// At this point there is no UI for setting the flag; it has to be added to the file by hand.
+    /// See BL-16690.
+    /// </summary>
+    public static class MinimumBloomVersionCheck
+    {
+        /// <summary>
+        /// Decide whether this Bloom is allowed to open the given collection.
+        /// </summary>
+        /// <param name="settingsFilePath">Path to the .bloomCollection file</param>
+        /// <param name="minimumVersion">What the collection asked for, when we say no</param>
+        /// <returns>true if the collection demands a newer Bloom than we are</returns>
+        public static bool IsThisBloomTooOld(string settingsFilePath, out string minimumVersion)
+        {
+            minimumVersion = ReadMinimumBloomVersion(settingsFilePath);
+            return !IsVersionSufficient(minimumVersion, RunningBloomVersion);
+        }
+
+        /// <summary>
+        /// Compare a collection's declared minimum version against the version we are running.
+        /// We compare only major and minor, like the other version gates in Bloom
+        /// (BookStorage's feature requirements and BookDownload's minVersion), so a minimum of
+        /// "6.5" is satisfied by any 6.5.x or later, and a build number in the minimum is ignored.
+        ///
+        /// The channel (Alpha/Beta/Release) deliberately plays no part: 6.5 means the same thing on
+        /// every channel, so an alpha tester who is running ahead of the release is correctly let in.
+        /// </summary>
+        /// <remarks>Separated out from the file reading so it can be unit tested.</remarks>
+        internal static bool IsVersionSufficient(string minimumVersion, Version runningVersion)
+        {
+            if (string.IsNullOrWhiteSpace(minimumVersion))
+                return true; // the normal case: the collection doesn't care
+
+            // Version.TryParse needs at least "major.minor", so a bare "6" lands here too.
+            if (!Version.TryParse(minimumVersion.Trim(), out var requiredVersion))
+            {
+                // Someone hand-edited the file and mistyped. Locking them out of their own
+                // collection over a typo would be worse than ignoring it, so just complain to the log.
+                Logger.WriteEvent(
+                    $"Ignoring unparseable {CollectionSettings.kMinimumBloomVersionElementName} '{minimumVersion}' in collection settings."
+                );
+                return true;
+            }
+
+            if (runningVersion.Major != requiredVersion.Major)
+                return runningVersion.Major > requiredVersion.Major;
+            return runningVersion.Minor >= requiredVersion.Minor;
+        }
+
+        /// <summary>
+        /// Read just the minimum version out of the settings file. We can't use CollectionSettings
+        /// for this, because we have to answer the question before we commit to building a
+        /// ProjectContext around the collection.
+        /// </summary>
+        internal static string ReadMinimumBloomVersion(string settingsFilePath)
+        {
+            try
+            {
+                if (!RobustFile.Exists(settingsFilePath))
+                    return "";
+                var settingsContent = RobustFile.ReadAllText(settingsFilePath, Encoding.UTF8);
+                var xml = XElement.Parse(settingsContent);
+                return CollectionSettings.ReadString(
+                    xml,
+                    CollectionSettings.kMinimumBloomVersionElementName,
+                    ""
+                );
+            }
+            catch (Exception ex)
+            {
+                // A settings file we can't even parse is a real problem, but this is not the place to
+                // report it. Let the normal open fail and give the user its much better error report.
+                Logger.WriteEvent(
+                    $"Could not read {CollectionSettings.kMinimumBloomVersionElementName} from {settingsFilePath}: {ex.Message}"
+                );
+                return "";
+            }
+        }
+
+        /// <summary>
+        /// Tell the user that this collection needs a newer Bloom, and give them the two ways forward:
+        /// upgrade, or open some other collection. If they choose to upgrade we send them to the
+        /// downloads page and quit, since they can't install over a running Bloom anyway.
+        /// </summary>
+        /// <remarks>If we return, the caller should abandon opening this collection; its callers
+        /// already fall back to showing the collection chooser.</remarks>
+        public static void ReportCollectionNeedsNewerBloom(
+            string collectionName,
+            string minimumVersion
+        )
+        {
+            var header = LocalizationManager.GetString(
+                "Collection.NewerVersionNeededHeader",
+                "This collection needs a newer version of Bloom."
+            );
+            var explanation = string.Format(
+                LocalizationManager.GetString(
+                    "Collection.CollectionRequiresNewerVersion",
+                    "The collection \"{0}\" requires Bloom {1} or greater. You are running Bloom {2}.",
+                    "{0} is the name of the collection, {1} is the version it requires, {2} is the version of Bloom that is running."
+                ),
+                // The message is HTML, and a collection name can perfectly well contain an ampersand.
+                System.Net.WebUtility.HtmlEncode(collectionName),
+                System.Net.WebUtility.HtmlEncode(minimumVersion),
+                RunningBloomVersion.ToString(3)
+            );
+            var upgradeButtonText = LocalizationManager.GetString(
+                "Collection.UpgradeBloom",
+                "Upgrade Bloom"
+            );
+            var chooseOtherButtonText = LocalizationManager.GetString(
+                "Collection.OpenDifferentCollection",
+                "Open a Different Collection"
+            );
+
+            var buttons = new[]
+            {
+                new MessageBoxButton() { Text = upgradeButtonText, Id = kUpgradeButtonId },
+                new MessageBoxButton()
+                {
+                    Text = chooseOtherButtonText,
+                    Id = "chooseOther",
+                    Default = true,
+                },
+            };
+            var result = BloomMessageBox.Show(
+                null,
+                $"<strong>{header}</strong><br/><br/>{explanation}",
+                buttons,
+                MessageBoxIcon.Warning
+            );
+
+            if (result == kUpgradeButtonId)
+            {
+                ShowDownloadsPage();
+                ProgramExit.Exit();
+            }
+            // Otherwise just return; the caller will put the collection chooser back up.
+        }
+
+        private const string kUpgradeButtonId = "upgrade";
+
+        /// <summary>
+        /// Send the user to the page where they can get a newer Bloom. This is the same thing the
+        /// app/showDownloadsPage API does for the equivalent message about a book, but we can't use
+        /// that API here because we have no book preview browser to put the link in.
+        /// </summary>
+        private static void ShowDownloadsPage()
+        {
+            var url = UrlLookup.LookupUrl(UrlType.LibrarySite, null) + "/installers";
+            if (SIL.PlatformUtilities.Platform.IsWindows)
+                // Let the default browser open the link.
+                ProcessExtra.SafeStartInFront(url);
+            else
+                ProcessExtra.SafeStartInFront("xdg-open", Uri.EscapeUriString(url));
+        }
+
+        /// <summary>
+        /// The version of Bloom we are running. We use the assembly version rather than
+        /// Application.ProductVersion because the latter can carry a non-numeric suffix.
+        /// </summary>
+        private static Version RunningBloomVersion =>
+            typeof(MinimumBloomVersionCheck).Assembly?.GetName()?.Version ?? new Version(1, 0, 0);
+    }
+}

--- a/src/BloomExe/Collection/MinimumBloomVersionCheck.cs
+++ b/src/BloomExe/Collection/MinimumBloomVersionCheck.cs
@@ -138,19 +138,18 @@ namespace Bloom.Collection
                 "Open a Different Collection"
             );
 
+            // Order matters: the buttons appear left to right in this order, and the default one is
+            // drawn filled and takes the initial focus. Upgrading is what we actually want the user
+            // to do, so it goes last (the rightmost, primary position) and is the default.
             var buttons = new[]
             {
+                new MessageBoxButton() { Text = chooseOtherButtonText, Id = "chooseOther" },
                 new MessageBoxButton()
                 {
                     Text = upgradeButtonText,
                     Id = kUpgradeButtonId,
                     // Warn the user that this takes them out to a web page.
                     Icon = "launch",
-                },
-                new MessageBoxButton()
-                {
-                    Text = chooseOtherButtonText,
-                    Id = "chooseOther",
                     Default = true,
                 },
             };

--- a/src/BloomExe/MiscUI/BloomMessageBox.cs
+++ b/src/BloomExe/MiscUI/BloomMessageBox.cs
@@ -137,5 +137,13 @@ namespace Bloom.MiscUI
 
         [JsonProperty("default")]
         public bool Default;
+
+        /// <summary>
+        /// Optional icon for the button. Currently the only value the Typescript side knows is
+        /// "launch", which shows the same icon the Help menu uses on its "website" item, to warn
+        /// the user that clicking will take them out to a web page.
+        /// </summary>
+        [JsonProperty("icon")]
+        public string Icon;
     }
 }

--- a/src/BloomExe/MiscUI/BloomMessageBox.cs
+++ b/src/BloomExe/MiscUI/BloomMessageBox.cs
@@ -139,9 +139,9 @@ namespace Bloom.MiscUI
         public bool Default;
 
         /// <summary>
-        /// Optional icon for the button. Currently the only value the Typescript side knows is
-        /// "launch", which shows the same icon the Help menu uses on its "website" item, to warn
-        /// the user that clicking will take them out to a web page.
+        /// Optional icon, shown before the text. Currently the only value the Typescript side
+        /// knows is "launch", which shows the same icon the Help menu uses on its "website"
+        /// item, to warn the user that clicking will take them out to a web page.
         /// </summary>
         [JsonProperty("icon")]
         public string Icon;

--- a/src/BloomExe/MiscUI/StartupScreenManager.cs
+++ b/src/BloomExe/MiscUI/StartupScreenManager.cs
@@ -301,6 +301,29 @@ namespace Bloom.MiscUI
             ConsiderCurrentTaskDone();
         }
 
+        /// <summary>
+        /// Get the splash screen out of the way of a dialog we are about to show, without doing the
+        /// things that belong to startup actually being over. In particular
+        /// DoLastOfAllAfterClosingSplashScreen brings the main window to the front, which is both
+        /// wrong here (there may not be one yet) and wasteful, since it is a one-shot: consuming it
+        /// now means the main window doesn't come to the front when it finally does open.
+        /// This does the same thing DoStartupAction does for a task with ShouldHideSplashScreen.
+        /// </summary>
+        public static void HideSplashScreenForDialog()
+        {
+            if (_splashForm != null)
+            {
+                _splashForm.Hide();
+                _splashForm = null; // it's gone, not needed again
+            }
+
+            if (_doWhenSplashScreenShouldClose != null)
+            {
+                _doWhenSplashScreenShouldClose();
+                _doWhenSplashScreenShouldClose = null;
+            }
+        }
+
         public static void PutSplashAbove(Form aboveThis)
         {
             if (_splashForm != null)

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -1643,7 +1643,7 @@ namespace Bloom
                 {
                     // We're normally still showing the splash screen at this point, and it would sit on
                     // top of our dialog. Also, the dialog is a ReactDialog, so it needs the server.
-                    StartupScreenManager.CloseSplashScreen();
+                    StartupScreenManager.HideSplashScreenForDialog();
                     _applicationContainer.BloomServer.EnsureListening();
                     MinimumBloomVersionCheck.ReportCollectionNeedsNewerBloom(
                         Path.GetFileNameWithoutExtension(path),

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -1663,6 +1663,8 @@ namespace Bloom
                         // Bloom to quit. Claim success, not because we opened anything, but so that
                         // no caller puts up the collection chooser while we are shutting down. Doing
                         // so would start a fresh modal message loop and could keep Bloom alive.
+                        // The flag lets OpenCollection tell this apart from a real open.
+                        _quittingBecauseBloomIsTooOld = true;
                         return true;
                     }
                     return false;
@@ -1871,10 +1873,24 @@ namespace Bloom
             }
         }
 
+        /// <summary>
+        /// Set when we told Bloom to quit instead of opening a collection, because the user chose to
+        /// go and upgrade. OpenProjectWindow reports success in that case so that nobody puts up the
+        /// collection chooser during shutdown, but it is not a real open, so anything that records a
+        /// successful open has to know the difference.
+        /// </summary>
+        private static bool _quittingBecauseBloomIsTooOld;
+
         private static bool OpenCollection(string path)
         {
             if (OpenProjectWindow(path))
             {
+                // Don't remember a collection we never actually opened. Otherwise, choosing a
+                // too-new collection and then clicking "Upgrade Bloom" would leave it as the
+                // most-recently-used one, and a user who abandoned the download would come back to
+                // the blocked collection instead of the one they were really working in.
+                if (_quittingBecauseBloomIsTooOld)
+                    return true;
                 Settings.Default.MruProjects.AddNewPath(path);
                 Settings.Default.Save();
                 return true;

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -1634,6 +1634,24 @@ namespace Bloom
                     return false;
                 }
 
+                // The collection may declare a minimum Bloom version. Check that before we go to the
+                // trouble of building a ProjectContext around it. This is the one place all the ways of
+                // opening a collection funnel through, and every caller already responds to a false
+                // return by putting up the collection chooser, which is one of the two choices we offer
+                // the user here. See BL-16690.
+                if (MinimumBloomVersionCheck.IsThisBloomTooOld(path, out var minimumBloomVersion))
+                {
+                    // We're normally still showing the splash screen at this point, and it would sit on
+                    // top of our dialog. Also, the dialog is a ReactDialog, so it needs the server.
+                    StartupScreenManager.CloseSplashScreen();
+                    _applicationContainer.BloomServer.EnsureListening();
+                    MinimumBloomVersionCheck.ReportCollectionNeedsNewerBloom(
+                        Path.GetFileNameWithoutExtension(path),
+                        minimumBloomVersion
+                    );
+                    return false;
+                }
+
                 //NB: initially, you could have multiple blooms, if they were different projects.
                 //however, then we switched to the embedded http image server, which can't share
                 //a port. So we could fix that (get different ports), but for now, I'm just going

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -1635,20 +1635,29 @@ namespace Bloom
                 }
 
                 // The collection may declare a minimum Bloom version. Check that before we go to the
-                // trouble of building a ProjectContext around it. This is the one place all the ways of
-                // opening a collection funnel through, and every caller already responds to a false
-                // return by putting up the collection chooser, which is one of the two choices we offer
-                // the user here. See BL-16690.
+                // trouble of building a ProjectContext around it. This is the one place all the ways
+                // of opening a collection funnel through, and each caller responds to a false return
+                // by putting up the collection chooser, which is one of the two choices we offer the
+                // user here. See BL-16690.
                 if (MinimumBloomVersionCheck.IsThisBloomTooOld(path, out var minimumBloomVersion))
                 {
                     // We're normally still showing the splash screen at this point, and it would sit on
                     // top of our dialog. Also, the dialog is a ReactDialog, so it needs the server.
                     StartupScreenManager.HideSplashScreenForDialog();
                     _applicationContainer.BloomServer.EnsureListening();
-                    MinimumBloomVersionCheck.ReportCollectionNeedsNewerBloom(
-                        Path.GetFileNameWithoutExtension(path),
-                        minimumBloomVersion
-                    );
+                    if (
+                        MinimumBloomVersionCheck.ReportCollectionNeedsNewerBloom(
+                            Path.GetFileNameWithoutExtension(path),
+                            minimumBloomVersion
+                        )
+                    )
+                    {
+                        // The user chose to upgrade, so we've opened the downloads page and asked
+                        // Bloom to quit. Claim success, not because we opened anything, but so that
+                        // no caller puts up the collection chooser while we are shutting down. Doing
+                        // so would start a fresh modal message loop and could keep Bloom alive.
+                        return true;
+                    }
                     return false;
                 }
 
@@ -1902,7 +1911,14 @@ namespace Bloom
         private static void ReopenProject(object sender, EventArgs e)
         {
             Application.Idle -= ReopenProject;
-            OpenCollection(Settings.Default.MruProjects.Latest);
+            if (!OpenCollection(Settings.Default.MruProjects.Latest))
+            {
+                // The shell is already closed by the time we get here, so if the re-open failed
+                // we must put the chooser up or the user is left with no window at all. This can
+                // happen now that a collection can refuse to open: a Team Collection member on a
+                // newer Bloom can add a MinimumBloomVersion that syncs down mid-session.
+                ChooseACollection();
+            }
         }
 
         private static void OpenCollectionChosenInDialog(object sender, EventArgs e)

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -1639,6 +1639,13 @@ namespace Bloom
                 // of opening a collection funnel through, and each caller responds to a false return
                 // by putting up the collection chooser, which is one of the two choices we offer the
                 // user here. See BL-16690.
+                //
+                // Deliberately, this gates only the interactive ways of opening a collection. The
+                // command-line commands and BulkUploader build a ProjectContext directly and so are
+                // not stopped by a minimum version. We decided to leave it that way: those tools have
+                // no user to read a dialog or choose another collection, and failing an overnight
+                // upload job is its own kind of damage. If the flag ever needs to protect the files
+                // themselves rather than warn a person, this is the decision to revisit.
                 if (MinimumBloomVersionCheck.IsThisBloomTooOld(path, out var minimumBloomVersion))
                 {
                     // We're normally still showing the splash screen at this point, and it would sit on

--- a/src/BloomTests/Collection/MinimumBloomVersionCheckTests.cs
+++ b/src/BloomTests/Collection/MinimumBloomVersionCheckTests.cs
@@ -75,16 +75,29 @@ namespace BloomTests.Collection
         /// number we don't actually enforce would misrepresent the rule. Version 99 is used so these
         /// stay true however far Bloom's real version advances.
         /// </summary>
-        [TestCase("99.0", "99.0")]
-        [TestCase("99.0.132", "99.0", Description = "build number dropped, since we ignore it")]
-        [TestCase("  99.0  ", "99.0", Description = "surrounding whitespace tolerated")]
+        // Each case needs its own collection name: two of these differ only by whitespace, so
+        // deriving the name from the value would have them share a folder and overwrite each other.
+        [TestCase("99.0", "99.0", "ReportedPlain")]
+        [TestCase(
+            "99.0.132",
+            "99.0",
+            "ReportedWithBuild",
+            Description = "build number dropped, since we ignore it"
+        )]
+        [TestCase(
+            "  99.0  ",
+            "99.0",
+            "ReportedPadded",
+            Description = "surrounding whitespace tolerated"
+        )]
         public void IsThisBloomTooOld_TooOld_ReportsRequirementAsMajorMinor(
             string declaredVersion,
-            string expectedReported
+            string expectedReported,
+            string collectionName
         )
         {
             var path = WriteSettingsFile(
-                "Reported" + declaredVersion.Trim().Replace('.', '_'),
+                collectionName,
                 $"<MinimumBloomVersion>{declaredVersion}</MinimumBloomVersion>"
             );
 

--- a/src/BloomTests/Collection/MinimumBloomVersionCheckTests.cs
+++ b/src/BloomTests/Collection/MinimumBloomVersionCheckTests.cs
@@ -1,0 +1,190 @@
+using System;
+using System.IO;
+using Bloom.Collection;
+using NUnit.Framework;
+using SIL.IO;
+using SIL.TestUtilities;
+
+namespace BloomTests.Collection
+{
+    /// <summary>
+    /// Tests the gate that keeps an older Bloom from opening a collection that declares
+    /// a MinimumBloomVersion. See BL-16690.
+    /// </summary>
+    [TestFixture]
+    public class MinimumBloomVersionCheckTests
+    {
+        private TemporaryFolder _folder;
+
+        [OneTimeSetUp]
+        public void FixtureSetup()
+        {
+            _folder = new TemporaryFolder("MinimumBloomVersionCheckTests");
+        }
+
+        [OneTimeTearDown]
+        public void Cleanup()
+        {
+            _folder.Dispose();
+        }
+
+        // No requirement at all: everything is allowed in.
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        // A requirement we can't make sense of is ignored rather than locking the user out.
+        [TestCase("banana")]
+        [TestCase("6")] // Version.TryParse insists on at least major.minor
+        [TestCase("6.5-beta")]
+        public void IsVersionSufficient_NoUsableRequirement_AllowsAnyVersion(string minimumVersion)
+        {
+            Assert.That(
+                MinimumBloomVersionCheck.IsVersionSufficient(minimumVersion, new Version(1, 0, 0)),
+                Is.True,
+                "Even an ancient Bloom should be allowed in when there is no usable requirement."
+            );
+        }
+
+        [TestCase("6.5", "6.5.0.0", true, Description = "exactly the required version")]
+        [TestCase("6.5", "6.5.132.0", true, Description = "same minor, later build")]
+        [TestCase("6.5", "6.6.0.0", true, Description = "later minor")]
+        [TestCase("6.5", "7.0.0.0", true, Description = "later major")]
+        [TestCase("6.5", "6.4.900.0", false, Description = "earlier minor, even with a high build")]
+        [TestCase("6.5", "5.9.0.0", false, Description = "earlier major")]
+        [TestCase("7.0", "6.9.0.0", false, Description = "earlier major, higher minor")]
+        // We compare major.minor only, matching Bloom's other version gates, so a build number
+        // in the requirement is deliberately ignored.
+        [TestCase("6.5.132", "6.5.10.0", true, Description = "build number in requirement ignored")]
+        public void IsVersionSufficient_ComparesMajorAndMinor(
+            string minimumVersion,
+            string runningVersion,
+            bool expected
+        )
+        {
+            Assert.That(
+                MinimumBloomVersionCheck.IsVersionSufficient(
+                    minimumVersion,
+                    Version.Parse(runningVersion)
+                ),
+                Is.EqualTo(expected)
+            );
+        }
+
+        [Test]
+        public void ReadMinimumBloomVersion_ElementPresent_ReturnsIt()
+        {
+            var path = WriteSettingsFile(
+                "MinimumVersionPresent",
+                "<MinimumBloomVersion>6.5</MinimumBloomVersion>"
+            );
+
+            Assert.That(MinimumBloomVersionCheck.ReadMinimumBloomVersion(path), Is.EqualTo("6.5"));
+        }
+
+        [Test]
+        public void ReadMinimumBloomVersion_ElementAbsent_ReturnsEmpty()
+        {
+            var path = WriteSettingsFile("MinimumVersionAbsent", "");
+
+            Assert.That(MinimumBloomVersionCheck.ReadMinimumBloomVersion(path), Is.Empty);
+        }
+
+        /// <summary>
+        /// A settings file we can't parse is a real problem, but it is not this check's problem to
+        /// report; the normal open will fail and give the user a much better error report.
+        /// </summary>
+        [Test]
+        public void ReadMinimumBloomVersion_UnparseableFile_ReturnsEmptyRatherThanThrowing()
+        {
+            var path = Path.Combine(_folder.Path, "Garbage.bloomCollection");
+            RobustFile.WriteAllText(path, "this is not xml at all");
+
+            Assert.That(MinimumBloomVersionCheck.ReadMinimumBloomVersion(path), Is.Empty);
+        }
+
+        [Test]
+        public void ReadMinimumBloomVersion_NoSuchFile_ReturnsEmpty()
+        {
+            var path = Path.Combine(_folder.Path, "NotThere.bloomCollection");
+            Assert.That(
+                RobustFile.Exists(path),
+                Is.False,
+                "Test setup problem: this file was supposed to not exist."
+            );
+
+            Assert.That(MinimumBloomVersionCheck.ReadMinimumBloomVersion(path), Is.Empty);
+        }
+
+        /// <summary>
+        /// Save() rebuilds the settings file from scratch, so a hand-added MinimumBloomVersion would be
+        /// silently lost the first time the user changed anything in Collection Settings, unless we
+        /// write it back out. That would be a nasty way to lose the protection.
+        /// </summary>
+        [Test]
+        public void CollectionSettings_MinimumBloomVersion_SurvivesLoadAndSave()
+        {
+            var path = WriteSettingsFile(
+                "RoundTrip",
+                "<MinimumBloomVersion>6.5</MinimumBloomVersion>"
+            );
+
+            var settings = new CollectionSettings(path);
+            Assert.That(
+                settings.MinimumBloomVersion,
+                Is.EqualTo("6.5"),
+                "Should have read the minimum version from the file we just wrote."
+            );
+
+            settings.Save();
+
+            Assert.That(
+                MinimumBloomVersionCheck.ReadMinimumBloomVersion(path),
+                Is.EqualTo("6.5"),
+                "Save() dropped the minimum version, which would leave the collection unprotected."
+            );
+        }
+
+        /// <summary>
+        /// We don't want to add a meaningless empty element to every collection settings file in the world.
+        /// </summary>
+        [Test]
+        public void CollectionSettings_NoMinimumBloomVersion_NotWrittenOnSave()
+        {
+            var path = WriteSettingsFile("NoMinimum", "");
+
+            var settings = new CollectionSettings(path);
+            Assert.That(
+                settings.MinimumBloomVersion,
+                Is.Empty,
+                "Test setup problem: there should be no minimum version yet."
+            );
+
+            settings.Save();
+
+            Assert.That(
+                RobustFile.ReadAllText(path),
+                Does.Not.Contain(CollectionSettings.kMinimumBloomVersionElementName)
+            );
+        }
+
+        /// <summary>
+        /// Writes a minimal .bloomCollection file in its own folder, since CollectionSettings
+        /// expects the folder to be named after the collection.
+        /// </summary>
+        private string WriteSettingsFile(string collectionName, string extraElements)
+        {
+            var collectionFolder = Path.Combine(_folder.Path, collectionName);
+            Directory.CreateDirectory(collectionFolder);
+            var path = Path.Combine(collectionFolder, collectionName + ".bloomCollection");
+            RobustFile.WriteAllText(
+                path,
+                $@"<?xml version='1.0' encoding='utf-8'?>
+<Collection version='0.2'>
+  <Language1Iso639Code>xyz</Language1Iso639Code>
+  {extraElements}
+</Collection>"
+            );
+            return path;
+        }
+    }
+}

--- a/src/BloomTests/Collection/MinimumBloomVersionCheckTests.cs
+++ b/src/BloomTests/Collection/MinimumBloomVersionCheckTests.cs
@@ -70,6 +70,48 @@ namespace BloomTests.Collection
             );
         }
 
+        /// <summary>
+        /// We compare major.minor only, so that is what the user should be shown. Reporting a build
+        /// number we don't actually enforce would misrepresent the rule. Version 99 is used so these
+        /// stay true however far Bloom's real version advances.
+        /// </summary>
+        [TestCase("99.0", "99.0")]
+        [TestCase("99.0.132", "99.0", Description = "build number dropped, since we ignore it")]
+        [TestCase("  99.0  ", "99.0", Description = "surrounding whitespace tolerated")]
+        public void IsThisBloomTooOld_TooOld_ReportsRequirementAsMajorMinor(
+            string declaredVersion,
+            string expectedReported
+        )
+        {
+            var path = WriteSettingsFile(
+                "Reported" + declaredVersion.Trim().Replace('.', '_'),
+                $"<MinimumBloomVersion>{declaredVersion}</MinimumBloomVersion>"
+            );
+
+            Assert.That(
+                MinimumBloomVersionCheck.IsThisBloomTooOld(path, out var minimumVersion),
+                Is.True,
+                "No conceivable Bloom version satisfies a requirement of 99.x."
+            );
+            Assert.That(minimumVersion, Is.EqualTo(expectedReported));
+        }
+
+        [Test]
+        public void IsThisBloomTooOld_RequirementSatisfied_ReturnsFalse()
+        {
+            var path = WriteSettingsFile(
+                "AncientRequirement",
+                "<MinimumBloomVersion>0.1</MinimumBloomVersion>"
+            );
+
+            Assert.That(
+                MinimumBloomVersionCheck.IsThisBloomTooOld(path, out var minimumVersion),
+                Is.False,
+                "Every Bloom that has ever shipped is newer than 0.1."
+            );
+            Assert.That(minimumVersion, Is.Empty);
+        }
+
         [Test]
         public void ReadMinimumBloomVersion_ElementPresent_ReturnsIt()
         {


### PR DESCRIPTION
Honors a `MinimumBloomVersion` element in a collection's `.bloomCollection` file, in preparation for Cloud syncing. If the collection requires a newer Bloom than the one running, we refuse to open it and offer the user the two choices the card asks for: upgrade Bloom, or open a different collection.

There is no UI for setting the flag yet — it has to be added to the file by hand, as the card specifies.

### How it works

- **`CollectionSettings`** reads `MinimumBloomVersion`, and writes it back out on `Save()` when non-empty. The write-back matters: `Save()` rebuilds the file from scratch, so without it a hand-added flag would silently disappear the first time the user changed anything in Collection Settings.

- **`MinimumBloomVersionCheck`** (new) does the gating. It reads just the one element rather than loading a whole `CollectionSettings`, since we have to answer the question before committing to build a `ProjectContext`. A missing, empty, or unparseable value imposes no restriction — locking someone out of their own collection over a typo would be worse than ignoring it.

- **The gate lives in `Program.OpenProjectWindow`**, the single point all the ways of opening a collection funnel through (startup from MRU, the collection chooser, a command-line path, switching collections mid-session). Every one of those callers already responds to a `false` return by putting up the collection chooser, so "open a different collection" needed no new plumbing.

- **`HideSplashScreenForDialog`** (new, in `StartupScreenManager`) clears the splash out of the way without consuming the one-shot `DoLastOfAllAfterClosingSplashScreen`, which is what brings the main window to the front. `CloseSplashScreen()` would have spent it at the gate, so the main window would never come forward when a collection finally opened.

### Decisions worth flagging for review

- **Major.minor comparison only**, matching Bloom's other two version gates (`BookStorage`'s feature requirements and `BookDownload`'s `minVersion`). So `6.5` is satisfied by any 6.5.x or later, and a build number in the requirement is ignored. Both versions are *reported* as major.minor too, so we don't claim to enforce a build number we don't look at.

- **Channel plays no part.** A version number means the same thing on every channel, so an alpha tester running ahead of the release is correctly let in. (This was the card's open question.)

- **"Upgrade Bloom" opens the installers page and quits**, rather than doing an in-app Velopack update. Velopack reports progress solely through toasts, and `ToastHost` is mounted only in `app/App.tsx`, which does not exist before a collection opens. More decisively, Velopack only offers the latest build on the user's *own channel*, so a Release user blocked by a 6.5 requirement would be told they are up to date and left with no way forward.

- **No XLF entries** — the strings use `LocalizationManager.GetString` with English fallbacks, per the `AGENTS.md` allowance for experimental features.

### Testing

24 new tests in `MinimumBloomVersionCheckTests` cover the comparison table, reading the element, unparseable/absent files, that the setting survives a `Load`/`Save` round trip, and that the requirement is reported as major.minor. Verified in the running app that the dialog reads *'The collection "Fake TC Books" requires Bloom 6.6 or greater. You are running Bloom 6.4.'*

Note the base branch is **Version6.4**, not master.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16690


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8200)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8200)
<!-- Reviewable:end -->
