### PR TITLE
Stop SelectBook persisting the selected book, and save settings promptly (BL-16660)

### DIFF
--- a/src/BloomExe/ApplicationContainer.cs
+++ b/src/BloomExe/ApplicationContainer.cs
@@ -41,8 +41,13 @@ namespace Bloom
 
             if (Settings.Default.MruProjects == null)
             {
+                // Deliberately not saved: every CLI verb constructs an ApplicationContainer too
+                // (see the RunningInConsoleMode test below), so saving here would let `bloom
+                // upload`, `hydrate` and friends rewrite the user's settings file on any machine
+                // whose profile has no MRU list yet - a harvester or service account, say - which
+                // is the very thing BL-16660 is about. Nothing needs it: the list is registered
+                // with the container either way, and the GUI saves it when it adds a path.
                 Settings.Default.MruProjects = new MostRecentPathsList();
-                Settings.Default.Save();
             }
             builder.RegisterInstance(Settings.Default.MruProjects).SingleInstance();
 

--- a/src/BloomExe/ApplicationContainer.cs
+++ b/src/BloomExe/ApplicationContainer.cs
@@ -42,6 +42,7 @@ namespace Bloom
             if (Settings.Default.MruProjects == null)
             {
                 Settings.Default.MruProjects = new MostRecentPathsList();
+                Settings.Default.Save();
             }
             builder.RegisterInstance(Settings.Default.MruProjects).SingleInstance();
 

--- a/src/BloomExe/Book/BookSelection.cs
+++ b/src/BloomExe/Book/BookSelection.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Bloom.Api;
 using Bloom.Collection;
-using Bloom.Properties;
 using SIL.Progress;
 
 namespace Bloom.Book
@@ -15,6 +14,17 @@ namespace Bloom.Book
         public event EventHandler<BookSelectionChangedEventArgs> SelectionChanged;
         public event EventHandler<BookSelectionChangedEventArgs> SelectionChangedHighPriority;
 
+        /// <summary>
+        /// Make this the selected book, and notify subscribers.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately has no other side effects outside this object. In particular, it does NOT
+        /// remember the book for the next launch: that is WorkspaceView's job (see
+        /// PersistSelectedBookPath there), because only a selection made in the running UI, of a
+        /// book we could actually restore, is worth persisting. This method used to write
+        /// Settings.Default.CurrentBookPath itself, which meant every caller wrote global settings
+        /// whether that made sense or not (BL-16660). Please don't put it back.
+        /// </remarks>
         public void SelectBook(Book book, bool aboutToEdit = false)
         {
             if (_currentSelection == book)
@@ -38,8 +48,6 @@ namespace Bloom.Book
             _currentSelection = book;
 
             InvokeSelectionChanged(aboutToEdit);
-            Settings.Default.CurrentBookPath = book?.FolderPath ?? "";
-            Settings.Default.Save();
         }
 
         public void ClearSelectionWithoutNotifications()

--- a/src/BloomExe/Collection/CollectionSettingsDialog.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.cs
@@ -417,6 +417,7 @@ namespace Bloom.Collection
 
             Settings.Default.AutoUpdate =
                 PendingAutomaticallyUpdate && AutoUpdateSupportedOnThisPlatform;
+            Settings.Default.Save();
             UpdateExperimentalBookSources();
             UpdateTeamCollectionAllowed();
             UpdateAppBuilderAllowed();

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -157,6 +157,9 @@ namespace Bloom.Edit
                 (oldToNewPath) =>
                 {
                     // If the selected book is renamed, we should update our saved CurrentBookPath.
+                    // Each branch below saves the settings itself: it used to be enough to change
+                    // the value in memory, because the next SelectBook() would flush it, but
+                    // SelectBook() no longer writes settings at all (BL-16660).
                     if (model.CurrentBook == null)
                     {
                         // Note: possibly all we need is this branch, which doesn't actually depend
@@ -168,12 +171,14 @@ namespace Bloom.Edit
                         if (oldToNewPath.Key == Settings.Default.CurrentBookPath)
                         {
                             Settings.Default.CurrentBookPath = oldToNewPath.Value;
+                            Settings.Default.Save();
                         }
                     }
                     else if (oldToNewPath.Value == _model.CurrentBook?.FolderPath)
                     {
                         // This is the usual path, updating the settings to match the model's current book.
                         Settings.Default.CurrentBookPath = oldToNewPath.Value;
+                        Settings.Default.Save();
                     }
                     UpdatePageList(true);
                     if (_model.CurrentBook != null)

--- a/src/BloomExe/ExperimentalFeatures.cs
+++ b/src/BloomExe/ExperimentalFeatures.cs
@@ -35,6 +35,10 @@ namespace Bloom
             // I'm actually leaving the code as much like it previously was as possible
             // so we can reinstate it easily if we want to.
             SetValue(kExperimentalSourceBooks, false);
+
+            // The two settings we changed directly above (rather than through SetValue) need
+            // saving, or the "once and once only" migration would run again next time.
+            Settings.Default.Save();
         }
 
         public static void SetValue(string featureName, bool isEnabled)
@@ -53,6 +57,7 @@ namespace Bloom
             }
             Settings.Default.EnabledExperimentalFeatures =
                 Settings.Default.EnabledExperimentalFeatures.Trim(',');
+            Settings.Default.Save();
         }
 
         public static bool IsFeatureEnabled(string featureName)

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -569,6 +569,7 @@ namespace Bloom
                             Settings.Default.MruProjects = new MostRecentPathsList();
                         }
 
+                        // The Save() below covers both this and the list we may just have created.
                         Settings.Default.MruProjects.AddNewPath(newCollection);
                         Settings.Default.Save();
 
@@ -2048,6 +2049,9 @@ namespace Bloom
                 );
 
                 Settings.Default.UserInterfaceLanguage = LocalizationManager.UILanguageId;
+                // Saves this and the UserInterfaceLanguageSetExplicitly set above; GetDesiredUiLanguage
+                // reads both on the next launch.
+                Settings.Default.Save();
 
                 // Per BL-6449, these two languages should try Spanish before English if a localization is missing.
                 // (If they ever get localized enough to show up in our list.)

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -2050,8 +2050,13 @@ namespace Bloom
 
                 Settings.Default.UserInterfaceLanguage = LocalizationManager.UILanguageId;
                 // Saves this and the UserInterfaceLanguageSetExplicitly set above; GetDesiredUiLanguage
-                // reads both on the next launch.
-                Settings.Default.Save();
+                // reads both on the next launch. But not before Main has migrated the previous
+                // version's settings: we run well before its "if (NeedUpgrade) { Upgrade();
+                // Reload(); }" block, and Reload() would throw away what we wrote anyway, so saving
+                // now would gain nothing while writing the new version's settings file earlier than
+                // the migration expects.
+                if (!Settings.Default.NeedUpgrade)
+                    Settings.Default.Save();
 
                 // Per BL-6449, these two languages should try Spanish before English if a localization is missing.
                 // (If they ever get localized enough to show up in our list.)

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -2049,14 +2049,16 @@ namespace Bloom
                 );
 
                 Settings.Default.UserInterfaceLanguage = LocalizationManager.UILanguageId;
-                // Saves this and the UserInterfaceLanguageSetExplicitly set above; GetDesiredUiLanguage
-                // reads both on the next launch. But not before Main has migrated the previous
-                // version's settings: we run well before its "if (NeedUpgrade) { Upgrade();
-                // Reload(); }" block, and Reload() would throw away what we wrote anyway, so saving
-                // now would gain nothing while writing the new version's settings file earlier than
-                // the migration expects.
-                if (!Settings.Default.NeedUpgrade)
-                    Settings.Default.Save();
+                // Deliberately NOT saved here, unlike the other settings this branch made save
+                // promptly. This runs on every startup path, and very early: before Main sets
+                // RunningInConsoleMode and dispatches the command-line verbs, so saving would make
+                // `bloom upload`, `hydrate` and friends rewrite the user's settings file - a smaller
+                // version of the very problem BL-16660 is about - and would risk failing an
+                // unattended run at startup. It is also before Main migrates the previous version's
+                // settings, whose Reload() would discard whatever we wrote anyway.
+                // Nothing is lost: this is a value derived at startup, not a user's choice, and
+                // GetDesiredUiLanguage derives it again next launch. When the user actually picks a
+                // language, WorkspaceView.ApplyUiLanguageChange saves both settings immediately.
 
                 // Per BL-6449, these two languages should try Spanish before English if a localization is missing.
                 // (If they ever get localized enough to show up in our list.)

--- a/src/BloomExe/Publish/BloomPub/PublishToBloomPubApi.cs
+++ b/src/BloomExe/Publish/BloomPub/PublishToBloomPubApi.cs
@@ -87,6 +87,7 @@ namespace Bloom.Publish.BloomPub
                     else // post
                     {
                         Settings.Default.PublishAndroidMethod = request.RequiredPostString();
+                        Settings.Default.Save();
 #if __MonoCS__
                         if (Settings.Default.PublishAndroidMethod == "usb")
                         {

--- a/src/BloomExe/Shell.cs
+++ b/src/BloomExe/Shell.cs
@@ -534,6 +534,7 @@ namespace Bloom
         public void SetAlwaysMeasurePerformance(bool value)
         {
             Settings.Default.AlwaysMeasurePerformance = value;
+            Settings.Default.Save();
             UpdatePerformanceMeasurementStatus();
         }
 

--- a/src/BloomExe/Workspace/WorkspaceView.Designer.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.Designer.cs
@@ -19,6 +19,14 @@ namespace Bloom.Workspace
 		{
 			if (disposing)
 			{
+				// _bookSelection outlives us (it is application-level, and we are recreated when
+				// the user switches collections), so stop it calling us. It matters for this
+				// subscriber in particular: deciding whether a selection is worth remembering
+				// depends on _collectionSettings, which for a disposed view describes the
+				// collection we have just left. See BL-16660.
+				if (_bookSelection != null)
+					_bookSelection.SelectionChanged -= PersistSelectedBookPath;
+
 				Current = null;
 				_editingView?.Dispose();
 				_editingView = null;

--- a/src/BloomExe/Workspace/WorkspaceView.Designer.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.Designer.cs
@@ -20,12 +20,14 @@ namespace Bloom.Workspace
 			if (disposing)
 			{
 				// _bookSelection outlives us (it is application-level, and we are recreated when
-				// the user switches collections), so stop it calling us. It matters for this
-				// subscriber in particular: deciding whether a selection is worth remembering
-				// depends on _collectionSettings, which for a disposed view describes the
-				// collection we have just left. See BL-16660.
+				// the user switches collections), so stop it calling us. Both handlers depend on
+				// _collectionSettings and _model, which for a disposed view describe the collection
+				// we have just left, so neither should still be answering. See BL-16660.
 				if (_bookSelection != null)
+				{
 					_bookSelection.SelectionChanged -= PersistSelectedBookPath;
+					_bookSelection.SelectionChangedHighPriority -= HandleBookSelectionChanged;
+				}
 
 				Current = null;
 				_editingView?.Dispose();

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -210,6 +210,13 @@ namespace Bloom.Workspace
             // We'll need to do something even trickier if there start to be slow things that
             // happen in response to the book selection changed websocket message.
             bookSelection.SelectionChangedHighPriority += HandleBookSelectionChanged;
+
+            // Remembering the selection for the next launch belongs here rather than in
+            // SelectBook() (BL-16660). It goes on the ordinary (low) priority list because saving
+            // settings writes a file, and per the comment above the button highlighting must not
+            // wait for that.
+            bookSelection.SelectionChanged += PersistSelectedBookPath;
+
             bookStatusChangeEvent.Subscribe(args =>
             {
                 HandleBookStatusChange(args);
@@ -316,8 +323,7 @@ namespace Bloom.Workspace
                     return;
                 }
 
-                Settings.Default.CurrentBookPath = resolvedPath;
-                Settings.Default.Save();
+                SaveCurrentBookPath(resolvedPath);
             }
             catch (Exception e) when (e is IOException || e is UnauthorizedAccessException)
             {
@@ -362,21 +368,69 @@ namespace Bloom.Workspace
             }
         }
 
+        /// <summary>
+        /// Remember the newly selected book, so that SelectBookAtStartup can restore it next time.
+        /// </summary>
+        /// <remarks>
+        /// BookSelection.SelectBook() used to do this itself, which meant that anything selecting a
+        /// book wrote global, persisted settings: unit tests left later tests looking at books in
+        /// deleted temporary folders, and the command-line bulk uploader replaced the user's
+        /// remembered book with each book it uploaded. See BL-16660. Doing it here means only the
+        /// running UI persists a selection, and only one that startup could actually make use of.
+        /// </remarks>
+        private void PersistSelectedBookPath(object sender, BookSelectionChangedEventArgs e)
+        {
+            var book = _bookSelection.CurrentSelection;
+            if (book == null)
+            {
+                // Nothing is selected (e.g. the selected book was just deleted), so there is
+                // nothing to restore next time.
+                SaveCurrentBookPath("");
+                return;
+            }
+            // SelectBookAtStartup applies this same test and refuses to restore a book that fails
+            // it, so storing such a path could only do harm: a path we can't use is a known source
+            // of trouble (BL-11678, BL-16327). We leave any good value already stored alone rather
+            // than clearing it, because the main way to get here is the stale selection left over
+            // from the previous collection while we are switching collections (BL-14313).
+            if (IsSelectedBookObsoleteOrInvalid(book.FolderPath))
+                return;
+            SaveCurrentBookPath(book.FolderPath);
+        }
+
+        /// <summary>
+        /// Store a new value for the remembered book path, doing nothing if it is already correct.
+        /// </summary>
+        private static void SaveCurrentBookPath(string path)
+        {
+            if (Settings.Default.CurrentBookPath == path)
+                return; // no change, so no need to rewrite the settings file
+            try
+            {
+                Settings.Default.CurrentBookPath = path;
+                Settings.Default.Save();
+            }
+            catch (Exception e)
+                when (e is IOException || e is UnauthorizedAccessException || e is ArgumentException
+                )
+            {
+                // Failing to remember the book is not worth interrupting the user's work over.
+                // ArgumentException belongs here because Save() throws it when the path contains a
+                // surrogate pair, i.e. the book's folder name contains an emoji or similar; the
+                // shutdown code at the end of Program.Run has to cope with the same thing. Without
+                // this, selecting such a book would throw out of SelectBook to whoever called it,
+                // and the recovery path in SelectBookAtStartup below could not do its job.
+                Logger.WriteError("Unable to save the current book path.", e);
+            }
+        }
+
         private static void ClearCurrentBookPathIfMissing()
         {
             var currentBookPath = Settings.Default.CurrentBookPath;
             if (string.IsNullOrEmpty(currentBookPath) || Directory.Exists(currentBookPath))
                 return;
 
-            try
-            {
-                Settings.Default.CurrentBookPath = null;
-                Settings.Default.Save();
-            }
-            catch (Exception e) when (e is IOException || e is UnauthorizedAccessException)
-            {
-                Logger.WriteError("Unable to clear stale current book path.", e);
-            }
+            SaveCurrentBookPath(null);
         }
 
         private static ReactControlAdditionalHtml GetWorkspaceAdditionalHtml()
@@ -564,8 +618,8 @@ window.showWorkspaceInitializationFailure = function(message) {
                 // We certainly don't want to crash because we had a problem doing so.
                 // One scenario we know of which causes this is if the book at
                 // Settings.Default.CurrentBookPath gets corrupted, such as having no .htm file.
-                // See BL-11678.
-                Settings.Default.CurrentBookPath = null;
+                // See BL-11678. Save it, or we would meet the same book again next launch.
+                SaveCurrentBookPath(null);
 
                 MiscUtils.SuppressUnusedExceptionVarWarning(e);
             }
@@ -812,7 +866,10 @@ window.showWorkspaceInitializationFailure = function(message) {
             if (onlyActiveItem)
             {
                 if (String.IsNullOrEmpty(Settings.Default.UserInterfaceLanguage))
+                {
                     Settings.Default.UserInterfaceLanguage = "en"; // See BL-13545.
+                    Settings.Default.Save();
+                }
                 items.Add(CreateLanguageItem(Settings.Default.UserInterfaceLanguage));
             }
             else
@@ -965,8 +1022,12 @@ window.showWorkspaceInitializationFailure = function(message) {
         {
             var current = Settings.Default.UserInterfaceLanguage;
             if (String.IsNullOrEmpty(current))
+            {
+                // Store the default we are falling back to, so the rest of Bloom sees it too.
                 current = "en";
-            Settings.Default.UserInterfaceLanguage = current;
+                Settings.Default.UserInterfaceLanguage = current;
+                Settings.Default.Save();
+            }
             return current;
         }
 

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -380,31 +380,49 @@ namespace Bloom.Workspace
         /// </remarks>
         private void PersistSelectedBookPath(object sender, BookSelectionChangedEventArgs e)
         {
-            var book = _bookSelection.CurrentSelection;
-            if (book == null)
+            // We are one link in the SelectionChanged chain, so anything that escapes from here
+            // escapes from SelectBook() to whoever selected the book. Deciding whether the book is
+            // worth remembering reads the collection folders from disk, so it can fail for reasons
+            // that have nothing to do with the user's actual task; and failing to remember the
+            // book is not worth interrupting that task over.
+            try
             {
-                // Nothing is selected (e.g. the selected book was just deleted), so there is
-                // nothing to restore next time.
-                SaveCurrentBookPath("");
-                return;
+                var book = _bookSelection.CurrentSelection;
+                if (book == null)
+                {
+                    // Nothing is selected (e.g. the selected book was just deleted), so there is
+                    // nothing to restore next time.
+                    SaveCurrentBookPath(null);
+                    return;
+                }
+                // SelectBookAtStartup applies this same test and refuses to restore a book that
+                // fails it, so storing such a path could only do harm: a path we can't use is a
+                // known source of trouble (BL-11678, BL-16327). We leave any good value already
+                // stored alone rather than clearing it, because the main way to get here is the
+                // stale selection left over from the previous collection while we are switching
+                // collections (BL-14313).
+                if (IsSelectedBookObsoleteOrInvalid(book.FolderPath))
+                    return;
+                SaveCurrentBookPath(book.FolderPath);
             }
-            // SelectBookAtStartup applies this same test and refuses to restore a book that fails
-            // it, so storing such a path could only do harm: a path we can't use is a known source
-            // of trouble (BL-11678, BL-16327). We leave any good value already stored alone rather
-            // than clearing it, because the main way to get here is the stale selection left over
-            // from the previous collection while we are switching collections (BL-14313).
-            if (IsSelectedBookObsoleteOrInvalid(book.FolderPath))
-                return;
-            SaveCurrentBookPath(book.FolderPath);
+            catch (Exception error)
+                when (error is IOException || error is UnauthorizedAccessException)
+            {
+                Logger.WriteError("Unable to work out which book to remember.", error);
+            }
         }
 
         /// <summary>
         /// Store a new value for the remembered book path, doing nothing if it is already correct.
+        /// Pass null or "" to mean "nothing to restore"; they are stored identically, so that
+        /// callers using one don't cause a pointless rewrite for callers using the other.
         /// </summary>
         private static void SaveCurrentBookPath(string path)
         {
-            if (Settings.Default.CurrentBookPath == path)
+            path = path ?? "";
+            if ((Settings.Default.CurrentBookPath ?? "") == path)
                 return; // no change, so no need to rewrite the settings file
+            var previous = Settings.Default.CurrentBookPath;
             try
             {
                 Settings.Default.CurrentBookPath = path;
@@ -420,6 +438,12 @@ namespace Bloom.Workspace
                 // shutdown code at the end of Program.Run has to cope with the same thing. Without
                 // this, selecting such a book would throw out of SelectBook to whoever called it,
                 // and the recovery path in SelectBookAtStartup below could not do its job.
+                // Put the old value back: Save() writes the whole settings object, so leaving the
+                // value we could not save in it would make every later Settings.Default.Save()
+                // anywhere in Bloom fail the same way, turning this into a broken Collection
+                // Settings dialog, publish tab, or rename. The old value saved before, so it is
+                // safe to go back to.
+                Settings.Default.CurrentBookPath = previous;
                 Logger.WriteError("Unable to save the current book path.", e);
             }
         }

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -5,6 +5,7 @@ using System.Drawing;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using Bloom.Api;
 using Bloom.Book;
@@ -406,8 +407,17 @@ namespace Bloom.Workspace
                 SaveCurrentBookPath(book.FolderPath);
             }
             catch (Exception error)
-                when (error is IOException || error is UnauthorizedAccessException)
+                when (error is IOException
+                    || error is UnauthorizedAccessException
+                    || error is ArgumentException
+                    || error is COMException
+                )
             {
+                // ArgumentException because IsSelectedBookObsoleteOrInvalid calls
+                // Path.GetDirectoryName, and COMException because listing the source collections
+                // resolves .lnk shortcuts. Note this is belt-and-braces rather than the thing
+                // standing between the user and a crash: HandleBookSelectionChanged is on the
+                // high-priority list, so it calls the same predicate, unguarded, before we run.
                 Logger.WriteError("Unable to work out which book to remember.", error);
             }
         }

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
@@ -439,7 +440,10 @@ namespace Bloom.Workspace
                 Settings.Default.Save();
             }
             catch (Exception e)
-                when (e is IOException || e is UnauthorizedAccessException || e is ArgumentException
+                when (e is IOException
+                    || e is UnauthorizedAccessException
+                    || e is ArgumentException
+                    || e is ConfigurationErrorsException
                 )
             {
                 // Failing to remember the book is not worth interrupting the user's work over.

--- a/src/BloomTests/Book/BookSelectionTests.cs
+++ b/src/BloomTests/Book/BookSelectionTests.cs
@@ -1,0 +1,65 @@
+using Bloom.Properties;
+using NUnit.Framework;
+
+namespace BloomTests.Book
+{
+    [TestFixture]
+    public class BookSelectionTests
+    {
+        /// <summary>
+        /// SelectBook() must not touch Settings.Default.CurrentBookPath. That setting is persisted
+        /// and process-wide, so when SelectBook() wrote it, a test that selected a book in a
+        /// temporary folder left later tests looking at a folder that no longer existed, and the
+        /// command-line bulk uploader replaced the user's remembered book with each book it
+        /// uploaded. Remembering the selection is now WorkspaceView's job. See BL-16660.
+        /// </summary>
+        [Test]
+        public void SelectBook_DoesNotChangeCurrentBookPathSetting()
+        {
+            const string sentinel = @"C:\a\path\that\SelectBook\must\leave\alone";
+            var originalPath = Settings.Default.CurrentBookPath;
+            Settings.Default.CurrentBookPath = sentinel;
+            try
+            {
+                Assert.That(
+                    Settings.Default.CurrentBookPath,
+                    Is.EqualTo(sentinel),
+                    "Setup failed: could not put a known value in the setting"
+                );
+
+                var selection = new Bloom.Book.BookSelection();
+                var book = new Bloom.Book.Book();
+                selection.SelectBook(book);
+
+                // Sanity check, so that a SelectBook() which did nothing at all could not pass.
+                Assert.That(
+                    selection.CurrentSelection,
+                    Is.SameAs(book),
+                    "SelectBook() did not actually select the book"
+                );
+                Assert.That(
+                    Settings.Default.CurrentBookPath,
+                    Is.EqualTo(sentinel),
+                    "SelectBook() must not write the remembered book path"
+                );
+
+                selection.SelectBook(null);
+
+                Assert.That(
+                    selection.CurrentSelection,
+                    Is.Null,
+                    "SelectBook(null) did not actually clear the selection"
+                );
+                Assert.That(
+                    Settings.Default.CurrentBookPath,
+                    Is.EqualTo(sentinel),
+                    "SelectBook(null) must not clear the remembered book path"
+                );
+            }
+            finally
+            {
+                Settings.Default.CurrentBookPath = originalPath;
+            }
+        }
+    }
+}

--- a/src/BloomTests/ExperimentalFeaturesTests.cs
+++ b/src/BloomTests/ExperimentalFeaturesTests.cs
@@ -1,4 +1,5 @@
 ﻿using Bloom;
+using Bloom.Properties;
 using NUnit.Framework;
 
 namespace BloomTests
@@ -6,6 +7,31 @@ namespace BloomTests
     [TestFixture]
     public class ExperimentalFeaturesTests
     {
+        private string _originalEnabledFeatures;
+
+        /// <summary>
+        /// SetValue() saves the settings, so this fixture writes state that outlives the test.
+        /// Establish the starting value rather than assuming it: relying on it being empty meant
+        /// that a run which died part way through (see "*** TEST RUN ABORTED ***" in AGENTS.md)
+        /// left a value behind that failed this fixture on every later run.
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            _originalEnabledFeatures = Settings.Default.EnabledExperimentalFeatures;
+            Settings.Default.EnabledExperimentalFeatures = "";
+        }
+
+        /// <summary>
+        /// Put back whatever we found, on disk as well as in memory, so we don't affect anything else.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            Settings.Default.EnabledExperimentalFeatures = _originalEnabledFeatures;
+            Settings.Default.Save();
+        }
+
         /// <summary>
         /// Test the SetValue and IsFeatureEnabled methods as well as the
         /// TokensOfEnabledFeatures property.
@@ -13,7 +39,7 @@ namespace BloomTests
         [Test]
         public void SetValueWorksProperly()
         {
-            // In the test setup, this setting always starts out empty (the default value).
+            // Sanity check that SetUp has put us in the state the rest of the test assumes.
             Assert.AreEqual("", ExperimentalFeatures.TokensOfEnabledFeatures);
             Assert.IsFalse(ExperimentalFeatures.IsFeatureEnabled("testing"));
 


### PR DESCRIPTION
`BookSelection.SelectBook()` did more than its name suggests: it ended by writing
`Settings.Default.CurrentBookPath` and saving. Every caller therefore wrote persisted,
process-wide user settings, whether or not that made sense:

- **Unit tests** that selected a book in a `TemporaryFolder` left later tests looking at a folder
  that no longer existed (BL-16660 documents 47 such failures, found by bisection).
- The **command-line bulk uploader** builds a throwaway `BookSelection` per book just to satisfy
  constructors, so a `bloom upload` run replaced the user's remembered book with each book it
  uploaded.
- The write was **unfiltered** while the restore path is heavily filtered, so the reader had grown
  a pile of defensive cleanup (BL-11678, BL-16327) to cope with paths that should never have been
  stored.

## What changed

Remembering the selection now belongs to `WorkspaceView`, as a handler on `BookSelection`'s
low-priority `SelectionChanged` event, guarded by the same `IsSelectedBookObsoleteOrInvalid`
predicate `SelectBookAtStartup` applies when restoring:

- tests and console mode have no `WorkspaceView`, so they no longer write settings at all;
- a book outside the current and source collections is not stored, since startup would refuse to
  restore it anyway — and an existing good value is left alone rather than overwritten, because the
  main way to reach that case is the stale cross-collection selection of BL-14313;
- a `null` selection still clears the setting, as before;
- `SaveCurrentBookPath` skips the write when the value is unchanged, so startup restore and
  re-selection no longer rewrite the settings file.

It goes on the *low*-priority list deliberately: the high-priority list exists so button
highlighting responds quickly, and this writes a file.

## Also fixed: settings changed but never saved

Several places assigned a `Settings.Default` property and never called `Save()`. They were relying
on some later, unrelated save to flush them — most often the per-selection save this PR removes,
which was never a guarantee in either direction. Our intent is to save changed settings
immediately, so each now saves its own:

- `WorkspaceView.SelectBookAtStartup`'s catch block — BL-11678's fix nulls the corrupt book path
  but never persisted it, so **Bloom would meet the same corrupt book again on the next launch**.
- `EditingView`'s book-renamed fixup (`CurrentBookPath`).
- `ExperimentalFeatures.SetValue` and `MigrateFromOldSettings` — without the latter, the
  "once and once only" migration could run again.
- `WorkspaceView`'s two "default the UI language to en" normalizations, restructured so they only
  write when the value actually changes.
- `CollectionSettingsDialog` (`AutoUpdate`), `PublishToBloomPubApi` (`PublishAndroidMethod`),
  `Shell.SetAlwaysMeasurePerformance`.

### Two places where "save immediately" is the wrong rule

Both were tried and deliberately reverted, because they run on **every** startup path — including
the command-line verbs — and so would reintroduce, in miniature, the very problem this PR fixes.
Each carries a comment saying so:

- **`Program.SetUpLocalization`** (`UserInterfaceLanguage`, `UserInterfaceLanguageSetExplicitly`).
  It runs before `Main` sets `RunningInConsoleMode` and dispatches the verbs, so saving made `bloom
  upload`/`hydrate` rewrite the user's settings file, and could fail an unattended run at startup.
  It also runs before the settings migration, whose `Reload()` discards these values anyway. Nothing
  is lost: these are derived at startup rather than chosen by the user, `GetDesiredUiLanguage`
  derives them again next launch, and `ApplyUiLanguageChange` already saves immediately when the
  user actually picks a language.
- **`ApplicationContainer` (`MruProjects`)** — the same trap: all five CLI verbs construct an
  `ApplicationContainer`, so on a profile with no MRU list yet (a harvester or service account) a
  CLI run would rewrite the whole settings file. The list is registered with the container either
  way, and the GUI saves it when it adds a path.

Three near-identical assign-save-log blocks in `WorkspaceView` now share `SaveCurrentBookPath`.

`SaveCurrentBookPath` enumerates the ways saving can fail — `IOException`,
`UnauthorizedAccessException`, `ArgumentException` (thrown when the path contains a surrogate pair,
i.e. a book folder named with an emoji, which is why the shutdown code at the end of `Program.Run`
copes with the same thing) and `ConfigurationErrorsException` (a corrupt `user.config`) — because
remembering the book must never interrupt what the user was doing. Crucially it **puts the old value
back** when the save fails: `Save()` writes the whole settings object, so leaving an unsaveable value
in it would make every later save anywhere in Bloom fail the same way, turning this into a broken
Collection Settings dialog, publish tab or rename. `PersistSelectedBookPath` guards its own body too,
since deciding whether a book is worth remembering reads collection folders from disk.

## Tests

New `BookSelectionTests.SelectBook_DoesNotChangeCurrentBookPathSetting` locks in the fix for both a
book and `null`, with sanity checks that the selection really changed. It fails against the old code.

`ExperimentalFeaturesTests` no longer assumes `EnabledExperimentalFeatures` starts out empty. That
held only because nothing persisted it; now that `SetValue` saves, a run that died part way through
(AGENTS.md documents `*** TEST RUN ABORTED ***` as a real occurrence) left a value behind that
failed the fixture on **every** later run until someone hand-edited the test host's `user.config` —
the same hazard BL-16660 removes from `SelectBook`, and it would have been reintroduced here. The
fixture now establishes its starting value and restores what it found. Verified by injecting a
leftover value into the test host config: the reworked fixture passes, the old one fails with
`But was: "leftover-from-aborted-run"`.

Full C# suite green (3093 passed, 0 failed) before these last two fixes; re-run against final HEAD
reported in the preflight summary.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16660

---
[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8203)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8203)
<!-- Reviewable:end -->
