### PR TITLE
BL-16690 Honor a collection's minimum Bloom version, upgrading in place

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -314,6 +314,38 @@
         <source xml:lang="en">There was a problem while saving. Please return to the previous page and make sure it looks correct.</source>
         <note>ID: Browser.ProblemSaving</note>
       </trans-unit>
+      <trans-unit id="Collection.CollectionRequiresNewerVersion" translate="no">
+        <source xml:lang="en">The collection "{0}" requires Bloom {1} or greater. You are running Bloom {2}.</source>
+        <note>ID: Collection.CollectionRequiresNewerVersion</note>
+        <note>{0} is the name of the collection, {1} is the version it requires, {2} is the version of Bloom that is running.</note>
+      </trans-unit>
+      <trans-unit id="Collection.NewerVersionNeededHeader" translate="no">
+        <source xml:lang="en">This collection needs a newer version of Bloom.</source>
+        <note>ID: Collection.NewerVersionNeededHeader</note>
+      </trans-unit>
+      <trans-unit id="Collection.NothingNewerAvailable" translate="no">
+        <source xml:lang="en">This collection needs Bloom {0}, but there is no newer Bloom available to you yet. You are already on the newest one for the kind of Bloom you have installed.</source>
+        <note>ID: Collection.NothingNewerAvailable</note>
+        <note>{0} is the version the collection requires.</note>
+      </trans-unit>
+      <trans-unit id="Collection.OpenDifferentCollection" translate="no">
+        <source xml:lang="en">Open a Different Collection</source>
+        <note>ID: Collection.OpenDifferentCollection</note>
+      </trans-unit>
+      <trans-unit id="Collection.UpgradeBloom" translate="no">
+        <source xml:lang="en">Upgrade Bloom</source>
+        <note>ID: Collection.UpgradeBloom</note>
+      </trans-unit>
+      <trans-unit id="Collection.UpgradeDownloaded" translate="no">
+        <source xml:lang="en">Bloom {0} has been downloaded. Bloom will now close to install it; please start it again.</source>
+        <note>ID: Collection.UpgradeDownloaded</note>
+        <note>{0} is the version number of the Bloom that was downloaded.</note>
+      </trans-unit>
+      <trans-unit id="Collection.UpgradeIsAStepButNotEnough" translate="no">
+        <source xml:lang="en">Bloom {0} has been downloaded, but this collection needs {1}, so you will need to upgrade again later. Bloom will now close to install it; please start it again.</source>
+        <note>ID: Collection.UpgradeIsAStepButNotEnough</note>
+        <note>{0} is the version number that was downloaded, {1} is the version the collection requires.</note>
+      </trans-unit>
       <trans-unit id="CollectionSettingsDialog.AboutBloomSubscriptions">
         <source xml:lang="en">About Bloom Subscriptions</source>
         <note>ID: CollectionSettingsDialog.AboutBloomSubscriptions</note>
@@ -5808,6 +5840,11 @@ is mostly status, which shows on the Collection Tab -->
         <note>ID: TeamCollection.ConflictingEdit</note>
       </trans-unit>
 -->
+      <trans-unit id="TeamCollection.MinimumVersionSetRemotely" sil:dynamic="true" translate="no">
+        <source xml:lang="en">This collection now requires a newer version of Bloom than the one you are running.</source>
+        <note>ID: TeamCollection.MinimumVersionSetRemotely</note>
+        <note>Shown in the Team Collection message log when the administrator sets a minimum Bloom version that this Bloom does not meet.</note>
+      </trans-unit>
       <trans-unit id="TemplateBooks.BookName.Activity" sil:dynamic="true">
         <source xml:lang="en">Activity</source>
         <note>ID: TemplateBooks.BookName.Activity</note>

--- a/src/BloomExe/ApplicationUpdateSupport.cs
+++ b/src/BloomExe/ApplicationUpdateSupport.cs
@@ -41,6 +41,54 @@ namespace Bloom
             Verbose,
         }
 
+        /// <summary>
+        /// What came of an attempt to update Bloom without any toast UI. See
+        /// TryDownloadUpdateWithoutToasts.
+        /// </summary>
+        internal enum SilentUpdateOutcome
+        {
+            /// A newer Bloom was downloaded and will be installed when Bloom exits.
+            Downloaded,
+
+            /// We reached the update feed, and there is nothing newer on this channel.
+            NothingNewer,
+
+            /// We can't update this copy of Bloom at all: a developer build, one an administrator
+            /// manages, or one running under the debugger.
+            CannotUpdateThisBloom,
+
+            /// We tried and something went wrong -- most likely we couldn't reach the feed.
+            Failed,
+        }
+
+        /// <summary>
+        /// What happened, plus the words to say about it. Since this path has no toasts, the caller
+        /// shows Message in a message box; it is already the same wording the toast would have used,
+        /// so the user hears the same thing either way.
+        /// </summary>
+        internal class SilentUpdateResult
+        {
+            public readonly SilentUpdateOutcome Outcome;
+
+            /// Ready to show, or null when the outcome speaks for itself and the caller has
+            /// something better to say (Downloaded, NothingNewer).
+            public readonly string Message;
+
+            /// The version we downloaded; only set for Downloaded.
+            public readonly string DownloadedVersion;
+
+            public SilentUpdateResult(
+                SilentUpdateOutcome outcome,
+                string message,
+                string downloadedVersion = null
+            )
+            {
+                Outcome = outcome;
+                Message = message;
+                DownloadedVersion = downloadedVersion;
+            }
+        }
+
         enum UploadStatus
         {
             // First call this session, or previous call(s) completed and found no updates
@@ -228,6 +276,11 @@ namespace Bloom
                 // When we exit, apply the updates. (If autoupdate is false, this is still appropriate,
                 // because the user responded to the message about updates available by clicking "Update Now",
                 // so we're just completing something already approved).
+                // Check the flag as well as setting it, so the "only one exit handler" rule holds
+                // whichever path got here first.
+                if (_willInstallUpdateOnExit)
+                    return;
+                _willInstallUpdateOnExit = true;
                 Application.ApplicationExit += (sender, args) =>
                 {
                     // Write a file so that if the update fails (e.g., a running process prevents it),
@@ -252,6 +305,225 @@ namespace Bloom
                     e
                 );
             }
+#endif
+        }
+
+        /// <summary>
+        /// Download an update, if there is one, without using any toast UI.
+        ///
+        /// Everything else in this class talks to the user through toasts, and those are only
+        /// rendered by ToastHost, which lives in the main workspace. This method exists for callers
+        /// that run before a collection is open -- notably the "this collection needs a newer Bloom"
+        /// dialog -- where there is no workspace and so a toast would go nowhere at all.
+        ///
+        /// It behaves as if the user had clicked the "Update Now" toast: it finds the update and
+        /// downloads it, and the caller is expected to shut Bloom down afterwards, at which point
+        /// Velopack installs it (see ArrangeToInstallDownloadedUpdateOnExit).
+        ///
+        /// Do not call this on the UI thread without wrapping it in Task.Run: it awaits network
+        /// work, and blocking the UI thread on that would deadlock.
+        /// </summary>
+        internal static async Task<SilentUpdateResult> TryDownloadUpdateWithoutToasts()
+        {
+#if __MonoCS__
+            // Nothing in this class works off Windows.
+            return new SilentUpdateResult(
+                SilentUpdateOutcome.CannotUpdateThisBloom,
+                "Bloom can only update itself on Windows."
+            );
+#else
+            // The same three situations WorkspaceView.CheckForUpdatesImpl refuses to update in, with
+            // the same explanations, since the user is owed the same information either way.
+            if (Debugger.IsAttached)
+                return new SilentUpdateResult(
+                    SilentUpdateOutcome.CannotUpdateThisBloom,
+                    "Sorry, you cannot check for updates from the debugger."
+                );
+            if (InstallerSupport.SharedByAllUsers())
+                return new SilentUpdateResult(
+                    SilentUpdateOutcome.CannotUpdateThisBloom,
+                    LocalizationManager.GetString(
+                        "CollectionTab.AdminManagesUpdates",
+                        "Your system administrator manages Bloom updates for this computer."
+                    )
+                );
+            if (IsDev)
+                return new SilentUpdateResult(
+                    SilentUpdateOutcome.CannotUpdateThisBloom,
+                    "Checking for updates is disabled on developer builds. No relevant channel."
+                );
+
+            // Another part of Bloom may already be partway through an update effort of its own,
+            // using the very statics we are about to write. (The workspace checks for updates on a
+            // timer, so in the Team Collection lock-out case it has had a whole session to get
+            // going.) CheckForAVelopackUpdate has a switch just like this one, and for the same
+            // reason: whoever got here first owns _bloomUpdateManager and _newVersion, and
+            // overwriting them behind their back would strand the update they had already lined up.
+            switch (_status)
+            {
+                case UploadStatus.NothingKnown:
+                    break; // nothing else is going on, so do the whole job ourselves
+                case UploadStatus.FoundUpdates:
+                    // The timer already found an update and is waiting for the user to accept it.
+                    // They just have, in our dialog, so download the one it found.
+                    return await DownloadTheUpdateWeAlreadyKnowAbout();
+                case UploadStatus.DownloadedWaitingForRestart:
+                    // Already downloaded, and installing-on-exit is already arranged. Telling the
+                    // caller it is Downloaded is exactly right: quitting will install it.
+                    return new SilentUpdateResult(
+                        SilentUpdateOutcome.Downloaded,
+                        null,
+                        _newVersion?.TargetFullRelease?.Version?.ToString()
+                    );
+                case UploadStatus.LookingForUpdates:
+                case UploadStatus.Downloading:
+                    // Joining in would mean two downloads of the same thing.
+                    return new SilentUpdateResult(
+                        SilentUpdateOutcome.Failed,
+                        LocalizationManager.GetString(
+                            "CollectionTab.UpdateCheckInProgress",
+                            "Bloom is already working on checking for updates."
+                        )
+                    );
+                case UploadStatus.Failed:
+                    // The same words the normal path's error toast uses.
+                    return new SilentUpdateResult(
+                        SilentUpdateOutcome.Failed,
+                        "Restart Bloom to try checking for updates again"
+                    );
+            }
+
+            try
+            {
+                // Quiet matters: with Verbose, GetUpdateUrl reports failures by toast.
+                if (!GetUpdateUrl(BloomUpdateMessageVerbosity.Quiet, out var updateUrl))
+                {
+                    // Overwhelmingly the reason we can't work out where to look is that we can't
+                    // reach the server, which is what the normal path says here too.
+                    return new SilentUpdateResult(
+                        SilentUpdateOutcome.Failed,
+                        LocalizationManager.GetString(
+                            "CollectionTab.UnableToCheckForUpdate",
+                            "Could not connect to the server to check for an update. Are you connected to the internet?",
+                            "Shown when Bloom tries to check for an update but can't, for example because it can't connect to the internet, or a problems with our server, etc."
+                        )
+                    );
+                }
+
+                _status = UploadStatus.LookingForUpdates;
+                _bloomUpdateManager = new UpdateManager(
+                    updateUrl,
+                    new UpdateOptions { MaximumDeltasBeforeFallback = 2 }
+                );
+
+                try
+                {
+                    _newVersion = await _bloomUpdateManager.CheckForUpdatesAsync();
+                }
+                catch (Exception e)
+                {
+                    Logger.WriteError("Could not check for a Velopack update without toasts", e);
+                    _status = UploadStatus.Failed;
+                    // The same words the "check failed" toast uses.
+                    return new SilentUpdateResult(
+                        SilentUpdateOutcome.Failed,
+                        "Bloom was unable to check for updates. Restart to try again."
+                    );
+                }
+
+                if (_newVersion == null)
+                {
+                    // Nothing newer on this channel. That is a real outcome here rather than good
+                    // news: the caller only asked because this Bloom is too old for the collection.
+                    // Clearing these is safe only because the switch above established that nobody
+                    // else had an update in hand when we started.
+                    _bloomUpdateManager = null;
+                    _status = UploadStatus.NothingKnown;
+                    return new SilentUpdateResult(SilentUpdateOutcome.NothingNewer, null);
+                }
+
+                return await DownloadTheUpdateWeAlreadyKnowAbout();
+            }
+            catch (Exception e)
+            {
+                Logger.WriteError("Velopack update without toasts failed unexpectedly", e);
+                _status = UploadStatus.Failed;
+                return new SilentUpdateResult(
+                    SilentUpdateOutcome.Failed,
+                    "Bloom was unable to check for updates. Restart to try again."
+                );
+            }
+#endif
+        }
+
+#if !__MonoCS__
+        /// <summary>
+        /// Download the update we have already found (_newVersion), reporting the outcome the way
+        /// TryDownloadUpdateWithoutToasts does. Shared by the case where we found it ourselves and
+        /// the case where the workspace's timer found it and was waiting for the user to accept.
+        /// </summary>
+        private static async Task<SilentUpdateResult> DownloadTheUpdateWeAlreadyKnowAbout()
+        {
+            try
+            {
+                _status = UploadStatus.Downloading;
+                await _bloomUpdateManager.DownloadUpdatesAsync(_newVersion);
+            }
+            catch (Exception e)
+            {
+                Logger.WriteError("Could not download a Velopack update without toasts", e);
+                _status = UploadStatus.Failed;
+                // The same words the "download failed" toast uses.
+                return new SilentUpdateResult(
+                    SilentUpdateOutcome.Failed,
+                    "Bloom was unable to download and install updates. Restart to try again."
+                );
+            }
+
+            _status = UploadStatus.DownloadedWaitingForRestart;
+            return new SilentUpdateResult(
+                SilentUpdateOutcome.Downloaded,
+                null,
+                _newVersion.TargetFullRelease?.Version?.ToString()
+            );
+        }
+#endif
+
+        /// <summary>
+        /// True once something has arranged to install a downloaded update as Bloom exits. Both
+        /// the toast path and the silent path do that, and they must not both do it, or Bloom
+        /// would try to apply the same update twice on the way out.
+        /// </summary>
+        private static bool _willInstallUpdateOnExit;
+
+        /// <summary>
+        /// Arrange for an update downloaded by TryDownloadUpdateWithoutToasts to be installed when
+        /// Bloom exits. Call this on the UI thread, then shut Bloom down. Does nothing if the
+        /// normal update path has already arranged it.
+        /// </summary>
+        internal static void ArrangeToInstallDownloadedUpdateOnExit()
+        {
+#if !__MonoCS__
+            if (_willInstallUpdateOnExit)
+                return;
+            _willInstallUpdateOnExit = true;
+            Application.ApplicationExit += (sender, args) =>
+            {
+                // So that a failed install (e.g. a running process got in the way) can be spotted
+                // and reported on the next launch, exactly as the normal update path does.
+                WriteUpdateAttemptFile(_newVersion.TargetFullRelease.Version.ToString());
+                // Shutting down is not instant -- Shell.OnClosing cancels the first close while it
+                // saves -- so the restart toast can appear and be clicked in the meantime, and that
+                // has already asked for the install. Applying the same update twice is how an
+                // upgrade fails or restarts Bloom when nobody asked it to. Same guard, same reason,
+                // as the normal update path above.
+                if (_restartingAfterToastClicked)
+                    return;
+                // false = don't restart Bloom for us. The user was trying to open a collection this
+                // Bloom can't handle, so there is nothing useful to come back to until the new
+                // version is in place; they start Bloom again themselves.
+                _bloomUpdateManager.WaitExitThenApplyUpdates(null, true, false);
+            };
 #endif
         }
 

--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -72,6 +72,20 @@ namespace Bloom.Collection
         // if this is null, relevant code uses the default, so we don't have to initialize it here
         public string BadgeQrCodeLabel;
 
+        /// <summary>
+        /// The oldest version of Bloom that is allowed to open this collection, e.g. "6.5".
+        /// Empty means any version may open it. At this point there is no UI for setting this;
+        /// it has to be added by editing the .bloomCollection file by hand. See BL-16690.
+        /// The gate that actually enforces it is MinimumBloomVersionCheck.
+        /// </summary>
+        public string MinimumBloomVersion = "";
+
+        /// <summary>
+        /// The name of the element in the .bloomCollection file that holds MinimumBloomVersion.
+        /// MinimumBloomVersionCheck reads it without loading the whole CollectionSettings.
+        /// </summary>
+        public const string kMinimumBloomVersionElementName = "MinimumBloomVersion";
+
         public static readonly Dictionary<string, string> CssNumberStylesToCultureOrDigits =
             new Dictionary<string, string>()
             {
@@ -419,6 +433,10 @@ namespace Bloom.Collection
             xml.Add(BulkPublishBloomPubSettings.ToXElement());
             xml.Add(new XElement("ShowBlorgLanguageQrCode", ShowBlorgLanguageQrCode));
             xml.Add(new XElement("BadgeQrCodeLabel", BadgeQrCodeLabel));
+            // Only write this if it is actually in use. Save() builds the file from scratch, so if we
+            // didn't write it back, the first save after someone hand-added it would silently lose it.
+            if (!string.IsNullOrWhiteSpace(MinimumBloomVersion))
+                xml.Add(new XElement(kMinimumBloomVersionElementName, MinimumBloomVersion));
             RobustIO.SaveXElement(xml, SettingsFilePath);
 
             // Color palette settings are stored in a separate Json file
@@ -705,6 +723,7 @@ namespace Bloom.Collection
 
                 ShowBlorgLanguageQrCode = ReadBoolean(xml, "ShowBlorgLanguageQrCode", true);
                 BadgeQrCodeLabel = ReadString(xml, "BadgeQrCodeLabel", "");
+                MinimumBloomVersion = ReadString(xml, kMinimumBloomVersionElementName, "");
 
                 LoadDictionary(xml, "Palette", ColorPalettes);
             }

--- a/src/BloomExe/Collection/MinimumBloomVersionCheck.cs
+++ b/src/BloomExe/Collection/MinimumBloomVersionCheck.cs
@@ -1,0 +1,582 @@
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using System.Xml.Linq;
+using Bloom.MiscUI;
+using L10NSharp;
+using SIL.IO;
+using SIL.Reporting;
+
+namespace Bloom.Collection
+{
+    /// <summary>
+    /// A collection can declare, via the MinimumBloomVersion element of its .bloomCollection file,
+    /// the oldest version of Bloom that is allowed to open it. This is in preparation for Cloud
+    /// syncing: once a collection has been touched by a version of Bloom that knows how to sync it,
+    /// letting an older Bloom loose on it could do real damage.
+    ///
+    /// At this point there is no UI for setting the flag; it has to be added to the file by hand.
+    /// See BL-16690.
+    /// </summary>
+    public static class MinimumBloomVersionCheck
+    {
+        /// <summary>
+        /// Decide whether this Bloom is allowed to open the given collection.
+        /// </summary>
+        /// <param name="settingsFilePath">Path to the .bloomCollection file</param>
+        /// <param name="minimumVersion">What the collection asked for, as major.minor, when we say no</param>
+        /// <returns>true if the collection demands a newer Bloom than we are</returns>
+        public static bool IsThisBloomTooOld(string settingsFilePath, out string minimumVersion)
+        {
+            // When this is a Team Collection and we can actually read the repository, the repository
+            // decides -- including when it says there is no requirement at all. It has to be able to
+            // LIFT a requirement, not just impose one: a member who is being refused never opens the
+            // collection, so the startup sync that would refresh their own copy never runs, and an
+            // administrator's mistaken requirement would shut them out on every launch for ever,
+            // fixable only by hand-editing the file on each machine.
+            //
+            // Otherwise -- an ordinary collection, or a shared folder we cannot reach right now --
+            // we fall back to what we have: the file on this computer and anything the repository
+            // told us earlier this session, taking whichever demands more. Not being able to see the
+            // repository is not the same as the repository saying "no requirement", so in that case
+            // we keep the protection rather than quietly dropping it.
+            var declaredVersion =
+                MinimumVersionInTeamCollectionRepo(settingsFilePath)
+                ?? MoreDemandingOf(
+                    ReadMinimumBloomVersion(settingsFilePath),
+                    MinimumVersionLearnedFromRepo(settingsFilePath)
+                );
+            if (IsVersionSufficient(declaredVersion, RunningBloomVersion))
+            {
+                minimumVersion = "";
+                return false;
+            }
+            // We can only get here if it parsed, since anything we can't parse counts as satisfied.
+            minimumVersion = ToMajorMinor(Version.Parse(declaredVersion.Trim()));
+            return true;
+        }
+
+        /// <summary>
+        /// Compare a collection's declared minimum version against the version we are running.
+        /// We compare only major and minor, like the other version gates in Bloom
+        /// (BookStorage's feature requirements and BookDownload's minVersion), so a minimum of
+        /// "6.5" is satisfied by any 6.5.x or later, and a build number in the minimum is ignored.
+        ///
+        /// The channel (Alpha/Beta/Release) deliberately plays no part: 6.5 means the same thing on
+        /// every channel, so an alpha tester who is running ahead of the release is correctly let in.
+        /// </summary>
+        /// <remarks>Separated out from the file reading so it can be unit tested.</remarks>
+        internal static bool IsVersionSufficient(string minimumVersion, Version runningVersion)
+        {
+            if (string.IsNullOrWhiteSpace(minimumVersion))
+                return true; // the normal case: the collection doesn't care
+
+            // Version.TryParse needs at least "major.minor", so a bare "6" lands here too.
+            if (!Version.TryParse(minimumVersion.Trim(), out var requiredVersion))
+            {
+                // Someone hand-edited the file and mistyped. Locking them out of their own
+                // collection over a typo would be worse than ignoring it, so just complain to the log.
+                Logger.WriteEvent(
+                    $"Ignoring unparseable {CollectionSettings.kMinimumBloomVersionElementName} '{minimumVersion}' in collection settings."
+                );
+                return true;
+            }
+
+            if (runningVersion.Major != requiredVersion.Major)
+                return runningVersion.Major > requiredVersion.Major;
+            return runningVersion.Minor >= requiredVersion.Minor;
+        }
+
+        /// <summary>
+        /// What a Team Collection's repository says, read straight from the shared folder, or null
+        /// for an ordinary collection or a repository we cannot reach.
+        ///
+        /// This is what closes the first-launch gap. The local copy of a Team Collection's settings
+        /// is only refreshed from the repository later in startup, well after this gate, so a member
+        /// whose administrator set a minimum version while they were closed would otherwise be
+        /// judged on yesterday's file, let in, and only stopped the launch after that. Asking the
+        /// repository directly costs one small read, and only for collections that are actually in
+        /// a Team Collection. See BL-16690.
+        /// </summary>
+        private static string MinimumVersionInTeamCollectionRepo(string settingsFilePath)
+        {
+            var collectionFolder = System.IO.Path.GetDirectoryName(settingsFilePath);
+            string repoSettings;
+            try
+            {
+                // The shared folder may be on a network share that has gone away, where even asking
+                // whether a folder exists can block for a long time -- and we are at the one moment
+                // in startup with no window and nothing to show a user who is wondering why nothing
+                // is happening. So give it a few seconds and no more. Not answering in time means
+                // "we don't know", which falls back to the local copy, and the next launch will
+                // very likely get a straight answer.
+                var read = Task.Run(() =>
+                    Bloom.TeamCollection.FolderTeamCollection.GetRepoCollectionSettingsForCollectionFolder(
+                        collectionFolder
+                    )
+                );
+                if (!read.Wait(TimeSpan.FromSeconds(5)))
+                {
+                    Logger.WriteEvent(
+                        "Timed out reading the Team Collection repo settings while checking the minimum Bloom version; using the local copy instead."
+                    );
+                    return null;
+                }
+                repoSettings = read.Result;
+            }
+            catch (Exception ex)
+            {
+                Logger.WriteEvent(
+                    $"Could not read the Team Collection repo settings while checking the minimum Bloom version: {ex.Message}"
+                );
+                return null;
+            }
+
+            if (string.IsNullOrWhiteSpace(repoSettings))
+                return null;
+            try
+            {
+                return ParseMinimumBloomVersion(repoSettings);
+            }
+            catch (Exception ex)
+            {
+                // Settings we can't parse tell us nothing; let the local file speak.
+                Logger.WriteEvent(
+                    $"Could not read {CollectionSettings.kMinimumBloomVersionElementName} from the Team Collection repo settings: {ex.Message}"
+                );
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Of two declared minimums, whichever demands more. Anything empty or unparseable counts as
+        /// no requirement at all, the same rule IsVersionSufficient applies, so a typo in one source
+        /// simply leaves the other to speak.
+        /// </summary>
+        private static string MoreDemandingOf(string one, string other)
+        {
+            var oneVersion = ParseOrNull(one?.Trim());
+            var otherVersion = ParseOrNull(other?.Trim());
+            if (oneVersion == null)
+                return other;
+            if (otherVersion == null)
+                return one;
+            return oneVersion >= otherVersion ? one : other;
+        }
+
+        /// <summary>
+        /// Minimum versions we have learned from a Team Collection repository during this run, keyed
+        /// by the collection's settings file path.
+        ///
+        /// Bloom deliberately does not rewrite local collection settings mid-session, so once an
+        /// administrator sets a minimum version the file on this computer goes on saying nothing
+        /// about it until the next startup sync. Without this record, someone we had just shut out
+        /// could walk straight back in by choosing the same collection from the chooser: the gate
+        /// would read the stale file, see no requirement, and open it. See BL-16690.
+        ///
+        /// Concurrent because the two writers are on different threads: the Team Collection startup
+        /// sync runs on the progress dialog's background worker, while a repository change
+        /// notification is handled on the UI thread.
+        /// </summary>
+        private static readonly System.Collections.Concurrent.ConcurrentDictionary<
+            string,
+            string
+        > _minimumVersionsFromRepo = new System.Collections.Concurrent.ConcurrentDictionary<
+            string,
+            string
+        >(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Record what the repository says this collection's minimum version is, which may be newer
+        /// than what its file on this computer says.
+        ///
+        /// Pass the empty string when the repository declares no requirement. This record only
+        /// matters when we cannot reach the shared folder at the moment of the check: if we can,
+        /// IsThisBloomTooOld reads the repository afresh and that answer governs. When we cannot,
+        /// this and the local file are all we have, and we take whichever demands more, so a
+        /// withdrawal recorded here does not by itself cancel a requirement the local file still
+        /// carries.
+        /// </summary>
+        public static void RememberMinimumVersionFromRepo(
+            string settingsFilePath,
+            string minimumVersion
+        )
+        {
+            if (string.IsNullOrEmpty(settingsFilePath))
+                return;
+            _minimumVersionsFromRepo[NormalizePath(settingsFilePath)] = minimumVersion ?? "";
+        }
+
+        /// <summary>
+        /// What the repository told us about this collection during this run, or null if it never
+        /// did. Both null and "" end up meaning "no requirement from this source" once
+        /// MoreDemandingOf has had them, so the distinction is only for the reader: null is silence,
+        /// "" is the repository actively declaring no minimum.
+        /// </summary>
+        private static string MinimumVersionLearnedFromRepo(string settingsFilePath)
+        {
+            if (string.IsNullOrEmpty(settingsFilePath))
+                return null;
+            return _minimumVersionsFromRepo.TryGetValue(
+                NormalizePath(settingsFilePath),
+                out var version
+            )
+                ? version
+                : null;
+        }
+
+        /// <summary>
+        /// So that the same collection reached by two spellings of its path lands on one entry.
+        /// The 8.3 short form matters here and GetFullPath does not expand it: the startup gate is
+        /// handed a path that has already been through LongPathAware.GetLongPath, while what we
+        /// record comes straight from the Team Collection's own folder, so the two could otherwise
+        /// disagree and the remembered requirement would simply not be found.
+        /// </summary>
+        private static string NormalizePath(string path)
+        {
+            try
+            {
+                return Utils.LongPathAware.GetLongPath(System.IO.Path.GetFullPath(path));
+            }
+            catch (Exception)
+            {
+                // A path we can't even canonicalize is not going to match anything either way.
+                return path;
+            }
+        }
+
+        /// <summary>
+        /// Read just the minimum version out of the settings file. We can't use CollectionSettings
+        /// for this, because we have to answer the question before we commit to building a
+        /// ProjectContext around the collection.
+        /// </summary>
+        internal static string ReadMinimumBloomVersion(string settingsFilePath)
+        {
+            try
+            {
+                if (!RobustFile.Exists(settingsFilePath))
+                    return "";
+                return ParseMinimumBloomVersion(
+                    RobustFile.ReadAllText(settingsFilePath, Encoding.UTF8)
+                );
+            }
+            catch (Exception ex)
+            {
+                // A settings file we can't even parse is a real problem, but this is not the place to
+                // report it. Let the normal open fail and give the user its much better error report.
+                Logger.WriteEvent(
+                    $"Could not read {CollectionSettings.kMinimumBloomVersionElementName} from {settingsFilePath}: {ex.Message}"
+                );
+                return "";
+            }
+        }
+
+        /// <summary>
+        /// Pull the minimum version out of the text of a collection settings file. Separate from
+        /// reading the file so that a Team Collection can ask about the copy in the repository, which
+        /// lives inside a zip and has never been written to this computer.
+        /// </summary>
+        internal static string ParseMinimumBloomVersion(string settingsXml)
+        {
+            if (string.IsNullOrEmpty(settingsXml))
+                return "";
+            return CollectionSettings.ReadString(
+                XElement.Parse(settingsXml),
+                CollectionSettings.kMinimumBloomVersionElementName,
+                ""
+            );
+        }
+
+        /// <summary>
+        /// Like IsThisBloomTooOld, but for settings we have in hand rather than in a file.
+        /// </summary>
+        public static bool IsThisBloomTooOldForSettings(
+            string settingsXml,
+            out string minimumVersion
+        )
+        {
+            minimumVersion = "";
+            string declaredVersion;
+            try
+            {
+                declaredVersion = ParseMinimumBloomVersion(settingsXml);
+            }
+            catch (Exception ex)
+            {
+                Logger.WriteEvent(
+                    $"Could not read {CollectionSettings.kMinimumBloomVersionElementName} from settings content: {ex.Message}"
+                );
+                return false;
+            }
+            if (IsVersionSufficient(declaredVersion, RunningBloomVersion))
+                return false;
+            minimumVersion = ToMajorMinor(Version.Parse(declaredVersion.Trim()));
+            return true;
+        }
+
+        /// <summary>
+        /// Tell the user that this collection needs a newer Bloom, and give them the two ways forward:
+        /// upgrade, or open some other collection. Upgrading happens in place; if we can't manage it
+        /// we say why and they are left to choose a different collection instead. We never send them
+        /// off to the website.
+        /// </summary>
+        /// <returns>true if we downloaded an upgrade, in which case we have already asked Bloom to
+        /// quit so it can be installed, and the caller must not start any more UI.</returns>
+        public static bool ReportCollectionNeedsNewerBloom(
+            string collectionName,
+            string minimumVersion
+        )
+        {
+            var header = LocalizationManager.GetString(
+                "Collection.NewerVersionNeededHeader",
+                "This collection needs a newer version of Bloom."
+            );
+            var explanation = string.Format(
+                LocalizationManager.GetString(
+                    "Collection.CollectionRequiresNewerVersion",
+                    "The collection \"{0}\" requires Bloom {1} or greater. You are running Bloom {2}.",
+                    "{0} is the name of the collection, {1} is the version it requires, {2} is the version of Bloom that is running."
+                ),
+                // The message is HTML, and a collection name can perfectly well contain an ampersand.
+                System.Net.WebUtility.HtmlEncode(collectionName),
+                minimumVersion,
+                ToMajorMinor(RunningBloomVersion)
+            );
+            var upgradeButtonText = LocalizationManager.GetString(
+                "Collection.UpgradeBloom",
+                "Upgrade Bloom"
+            );
+            var chooseOtherButtonText = LocalizationManager.GetString(
+                "Collection.OpenDifferentCollection",
+                "Open a Different Collection"
+            );
+
+            // Order matters: the buttons appear left to right in this order, and the default one is
+            // drawn filled and takes the initial focus. Upgrading is what we actually want the user
+            // to do, so it goes last (the rightmost, primary position) and is the default.
+            // No external-link icon on this button: this upgrades Bloom in place and never opens a
+            // browser, so marking it as leaving Bloom would simply be wrong.
+            var buttons = new[]
+            {
+                new MessageBoxButton() { Text = chooseOtherButtonText, Id = "chooseOther" },
+                new MessageBoxButton()
+                {
+                    Text = upgradeButtonText,
+                    Id = kUpgradeButtonId,
+                    Default = true,
+                },
+            };
+            var result = BloomMessageBox.Show(
+                null,
+                $"<strong>{header}</strong><br/><br/>{explanation}",
+                buttons,
+                MessageBoxIcon.Warning
+            );
+
+            if (result == kUpgradeButtonId && UpgradeBloom(minimumVersion))
+            {
+                ProgramExit.Exit();
+                return true;
+            }
+            // Either they asked for a different collection, or they wanted to upgrade and we could
+            // not manage it -- in which case we have already explained why. Either way the caller
+            // takes over, and puts the collection chooser up.
+            return false;
+        }
+
+        private const string kUpgradeButtonId = "upgrade";
+
+        /// <summary>
+        /// The collection we are in the middle of shutting someone out of, if any. Keyed by name
+        /// rather than a plain flag for two reasons: the repository can report the same change more
+        /// than once, including while Bloom is shutting down, and we must not stack up dialogs; but
+        /// if the user moves on to a *different* collection in the same session, that one deserves
+        /// its own lock-out.
+        /// </summary>
+        private static string _collectionBeingLockedOut;
+
+        /// <summary>
+        /// Shut the user out of a collection they already have open, because a minimum version they
+        /// don't meet has just arrived -- in practice, a Team Collection administrator set one while
+        /// they were working. They get the same dialog as at startup, and the same two ways out:
+        /// upgrade, or go to a different collection. There is deliberately no third option: the
+        /// dialog has no close box, and cancelling the collection chooser brings the dialog back
+        /// rather than dropping them into a collection this Bloom is not allowed to touch.
+        /// </summary>
+        /// <returns>false if a lock-out for this collection is already under way, so the caller
+        /// should carry on as usual rather than assume the collection is being torn down.</returns>
+        public static bool LockUserOutOfOpenCollection(string collectionName, string minimumVersion)
+        {
+            if (_collectionBeingLockedOut == collectionName)
+                return false;
+            _collectionBeingLockedOut = collectionName;
+
+            if (ReportCollectionNeedsNewerBloom(collectionName, minimumVersion))
+                return true; // upgrading; Bloom is already on its way down
+
+            // They want a different collection -- or they wanted to upgrade and we couldn't manage
+            // it, and have already been told why. This is the same route as Open/Create Collection
+            // on the toolbar: it closes the current one and puts up the chooser.
+            if (Program.ChooseACollection(Shell.GetShellOrOtherOpenForm() as Shell))
+                return true;
+
+            // They cancelled the chooser. Staying in this collection is the one thing they can't
+            // do -- but quitting must stay possible. Someone with nothing newer to upgrade to and
+            // no other collection to open would otherwise have no way out of Bloom at all except
+            // Task Manager, since this dialog deliberately has no close box. Cancelling here means
+            // "none of the above", which is exactly how the startup path reads it too.
+            ProgramExit.Exit();
+            return true;
+        }
+
+        /// <summary>
+        /// Called when a collection has actually been opened, which ends any lock-out we were in
+        /// the middle of. The flag has to be cleared by something outside the lock-out itself:
+        /// clearing it on the way out would let a repeat notification (they arrive during shutdown)
+        /// put the dialog straight back up.
+        /// </summary>
+        public static void NoteCollectionOpened()
+        {
+            _collectionBeingLockedOut = null;
+        }
+
+        /// <summary>
+        /// Get the user onto a newer Bloom, in place. We never send them to the website: if we can't
+        /// upgrade them we say why, in the same words the update toast would have used, and let them
+        /// pick a different collection instead.
+        /// </summary>
+        /// <returns>true if a new Bloom was downloaded and the caller should now shut Bloom down so
+        /// it can be installed.</returns>
+        private static bool UpgradeBloom(string minimumVersion)
+        {
+            // Task.Run because this awaits network work: awaiting it directly on the UI thread and
+            // blocking would deadlock.
+            // Blocking does mean Bloom stops responding for the length of the download. That is
+            // invisible at startup, where there is no window yet, but not when we are locking
+            // someone out of a collection they already have open. The wait cursor is the least we
+            // can do; a real progress window is still wanted here.
+            ApplicationUpdateSupport.SilentUpdateResult result;
+            Application.UseWaitCursor = true;
+            try
+            {
+                result = Task.Run(() => ApplicationUpdateSupport.TryDownloadUpdateWithoutToasts())
+                    .GetAwaiter()
+                    .GetResult();
+            }
+            finally
+            {
+                Application.UseWaitCursor = false;
+            }
+
+            if (result.Outcome == ApplicationUpdateSupport.SilentUpdateOutcome.Downloaded)
+            {
+                // Install it whatever version it turns out to be. Velopack can only offer the newest
+                // build on this user's channel -- it has no notion of "at least version X" -- so what
+                // we have may still be short of what this collection needs. Take it anyway: getting
+                // as far as the channel allows is real progress, and if it isn't far enough the user
+                // meets this same dialog on the next launch and can decide again from there.
+                ApplicationUpdateSupport.ArrangeToInstallDownloadedUpdateOnExit();
+
+                var downloadedVersion = ParseOrNull(result.DownloadedVersion);
+                if (
+                    downloadedVersion != null
+                    && IsVersionSufficient(minimumVersion, downloadedVersion)
+                )
+                    ReportUpgradeDownloaded(result.DownloadedVersion);
+                else
+                    ReportUpgradeIsAStepButNotEnough(result.DownloadedVersion, minimumVersion);
+                return true;
+            }
+
+            if (result.Outcome == ApplicationUpdateSupport.SilentUpdateOutcome.NothingNewer)
+                ReportNothingNewerAvailable(minimumVersion);
+            else
+                // A developer/administered build, or something went wrong. The update code already
+                // worked out what to say; it just had no way to say it, since its usual toast has
+                // nowhere to appear before a collection is open.
+                BloomMessageBox.ShowWarning(System.Net.WebUtility.HtmlEncode(result.Message));
+
+            return false;
+        }
+
+        private static Version ParseOrNull(string version) =>
+            Version.TryParse(version ?? "", out var v) ? v : null;
+
+        /// <summary>
+        /// Tell the user we have their new Bloom and are closing to install it. Without this the
+        /// window would simply vanish, which looks like a crash rather than an upgrade.
+        /// </summary>
+        private static void ReportUpgradeDownloaded(string downloadedVersion)
+        {
+            var message = string.Format(
+                LocalizationManager.GetString(
+                    "Collection.UpgradeDownloaded",
+                    "Bloom {0} has been downloaded. Bloom will now close to install it; please start it again.",
+                    "{0} is the version number of the Bloom that was downloaded."
+                ),
+                downloadedVersion
+            );
+            BloomMessageBox.ShowInfo(System.Net.WebUtility.HtmlEncode(message));
+        }
+
+        /// <summary>
+        /// Tell the user we are installing an upgrade that gets them closer but not all the way.
+        /// Saying so plainly is the point: otherwise they would upgrade, come back, and meet the same
+        /// "too old" dialog with no idea why the upgrade they just did hadn't solved it.
+        /// </summary>
+        private static void ReportUpgradeIsAStepButNotEnough(
+            string downloadedVersion,
+            string minimumVersion
+        )
+        {
+            var message = string.Format(
+                LocalizationManager.GetString(
+                    // Kept short on purpose: every Bloom message box is a fixed 500x200, and this is
+                    // the longest thing we ask it to hold. See BL-16690.
+                    "Collection.UpgradeIsAStepButNotEnough",
+                    "Bloom {0} has been downloaded, but this collection needs {1}, so you will need to upgrade again later. Bloom will now close to install it; please start it again.",
+                    "{0} is the version number that was downloaded, {1} is the version the collection requires."
+                ),
+                downloadedVersion,
+                minimumVersion
+            );
+            BloomMessageBox.ShowInfo(System.Net.WebUtility.HtmlEncode(message));
+        }
+
+        /// <summary>
+        /// Tell the user there is simply nothing newer for them to have. Being specific matters:
+        /// "your Bloom is up to date", which is what the normal update path would say, would be a
+        /// baffling thing to hear right after being told this Bloom is too old.
+        /// </summary>
+        private static void ReportNothingNewerAvailable(string minimumVersion)
+        {
+            var message = string.Format(
+                LocalizationManager.GetString(
+                    "Collection.NothingNewerAvailable",
+                    "This collection needs Bloom {0}, but there is no newer Bloom available to you yet. You are already on the newest one for the kind of Bloom you have installed.",
+                    "{0} is the version the collection requires."
+                ),
+                minimumVersion
+            );
+            BloomMessageBox.ShowWarning(System.Net.WebUtility.HtmlEncode(message));
+        }
+
+        /// <summary>
+        /// Format a version the way we actually compare it: major and minor only. Showing the user a
+        /// build number we don't look at would misrepresent the rule, and invites them to compare
+        /// the wrong digits ("6.5 required, but I have 6.4.900, and 900 is more than 5").
+        /// </summary>
+        private static string ToMajorMinor(Version version) => $"{version.Major}.{version.Minor}";
+
+        /// <summary>
+        /// The version of Bloom we are running. We use the assembly version rather than
+        /// Application.ProductVersion because the latter can carry a non-numeric suffix.
+        /// A loaded assembly always has a version, so we don't guard against it being missing:
+        /// any fallback we picked would be a lie, and a low one would lock the user out of every
+        /// collection that declares a minimum -- the opposite of what this class is careful to do.
+        /// </summary>
+        private static Version RunningBloomVersion =>
+            typeof(MinimumBloomVersionCheck).Assembly.GetName().Version;
+    }
+}

--- a/src/BloomExe/MiscUI/StartupScreenManager.cs
+++ b/src/BloomExe/MiscUI/StartupScreenManager.cs
@@ -301,6 +301,29 @@ namespace Bloom.MiscUI
             ConsiderCurrentTaskDone();
         }
 
+        /// <summary>
+        /// Get the splash screen out of the way of a dialog we are about to show, without doing the
+        /// things that belong to startup actually being over. In particular
+        /// DoLastOfAllAfterClosingSplashScreen brings the main window to the front, which is both
+        /// wrong here (there may not be one yet) and wasteful, since it is a one-shot: consuming it
+        /// now means the main window doesn't come to the front when it finally does open.
+        /// This does the same thing DoStartupAction does for a task with ShouldHideSplashScreen.
+        /// </summary>
+        public static void HideSplashScreenForDialog()
+        {
+            if (_splashForm != null)
+            {
+                _splashForm.Hide();
+                _splashForm = null; // it's gone, not needed again
+            }
+
+            if (_doWhenSplashScreenShouldClose != null)
+            {
+                _doWhenSplashScreenShouldClose();
+                _doWhenSplashScreenShouldClose = null;
+            }
+        }
+
         public static void PutSplashAbove(Form aboveThis)
         {
             if (_splashForm != null)

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -1634,6 +1634,48 @@ namespace Bloom
                     return false;
                 }
 
+                // The collection may declare a minimum Bloom version. Check that before we go to the
+                // trouble of building a ProjectContext around it. This is the one place all the ways
+                // of opening a collection funnel through, and each caller responds to a false return
+                // by putting up the collection chooser, which is one of the two choices we offer the
+                // user here. See BL-16690.
+                //
+                // Deliberately, this gates only the interactive ways of opening a collection. The
+                // command-line commands and BulkUploader build a ProjectContext directly and so are
+                // not stopped by a minimum version. We decided to leave it that way: those tools have
+                // no user to read a dialog or choose another collection, and failing an overnight
+                // upload job is its own kind of damage. If the flag ever needs to protect the files
+                // themselves rather than warn a person, this is the decision to revisit.
+                if (MinimumBloomVersionCheck.IsThisBloomTooOld(path, out var minimumBloomVersion))
+                {
+                    // We're normally still showing the splash screen at this point, and it would sit on
+                    // top of our dialog. Also, the dialog is a ReactDialog, so it needs the server.
+                    StartupScreenManager.HideSplashScreenForDialog();
+                    _applicationContainer.BloomServer.EnsureListening();
+                    if (
+                        MinimumBloomVersionCheck.ReportCollectionNeedsNewerBloom(
+                            Path.GetFileNameWithoutExtension(path),
+                            minimumBloomVersion
+                        )
+                    )
+                    {
+                        // The user chose to upgrade: a newer Bloom has been downloaded and we have
+                        // asked Bloom to quit so it can be installed. Claim success, not because we
+                        // opened anything, but so that no caller puts up the collection chooser
+                        // while we are shutting down -- that would start a fresh modal message loop
+                        // and could keep Bloom alive.
+                        //
+                        // NOTE for anyone adding a caller: this is the one path where we return true
+                        // with _projectContext still null. It suits today's callers, which only use
+                        // the result to decide whether to offer the chooser (and recording this
+                        // collection as most-recently-used is right, since the upgraded Bloom should
+                        // reopen it). A caller that goes on to use _projectContext would need a
+                        // three-way result -- opened / refused / quitting -- instead of this bool.
+                        return true;
+                    }
+                    return false;
+                }
+
                 //NB: initially, you could have multiple blooms, if they were different projects.
                 //however, then we switched to the embedded http image server, which can't share
                 //a port. So we could fix that (get different ports), but for now, I'm just going
@@ -1656,6 +1698,11 @@ namespace Bloom
                 if (BloomThreadCancelService != null)
                     BloomThreadCancelService.Dispose();
                 BloomThreadCancelService = new CancellationTokenSource();
+
+                // We have a collection open, so no lock-out is in progress any more. Without this,
+                // a user locked out of collection A who moved to B and later came back to A would
+                // find that A could never lock them out again this session. See BL-16690.
+                MinimumBloomVersionCheck.NoteCollectionOpened();
 
                 return true;
             }
@@ -1841,6 +1888,11 @@ namespace Bloom
         {
             if (OpenProjectWindow(path))
             {
+                // Note that OpenProjectWindow also reports success when the user chose to upgrade
+                // rather than open anything. Recording the collection is right in that case too: an
+                // upgrade has been downloaded and will be installed as Bloom closes, so the next
+                // Bloom to start really can open this collection, and landing straight back in it is
+                // exactly what the user was trying to do.
                 Settings.Default.MruProjects.AddNewPath(path);
                 Settings.Default.Save();
                 return true;
@@ -1884,7 +1936,14 @@ namespace Bloom
         private static void ReopenProject(object sender, EventArgs e)
         {
             Application.Idle -= ReopenProject;
-            OpenCollection(Settings.Default.MruProjects.Latest);
+            if (!OpenCollection(Settings.Default.MruProjects.Latest))
+            {
+                // The shell is already closed by the time we get here, so if the re-open failed
+                // we must put the chooser up or the user is left with no window at all. This can
+                // happen now that a collection can refuse to open: a Team Collection member on a
+                // newer Bloom can add a MinimumBloomVersion that syncs down mid-session.
+                ChooseACollection();
+            }
         }
 
         private static void OpenCollectionChosenInDialog(object sender, EventArgs e)

--- a/src/BloomExe/TeamCollection/FolderTeamCollection.cs
+++ b/src/BloomExe/TeamCollection/FolderTeamCollection.cs
@@ -365,6 +365,50 @@ namespace Bloom.TeamCollection
         }
 
         /// <summary>
+        /// The repository's copy of the collection settings for a local collection folder, or null if
+        /// this is not a Team Collection or we cannot reach the repository right now.
+        ///
+        /// Static, and taking a plain folder path, because the minimum-version gate has to ask this
+        /// before any TeamCollection object exists -- indeed before Bloom has committed to opening
+        /// the collection at all. Otherwise a member whose repository has just gained a minimum
+        /// version would be judged on their own stale copy and let in for the whole session, since
+        /// the repository is not copied down until later in startup. See BL-16690.
+        /// </summary>
+        internal static string GetRepoCollectionSettingsForCollectionFolder(
+            string localCollectionFolder
+        )
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(localCollectionFolder))
+                    return null;
+                var linkPath = TeamCollectionManager.GetTcLinkPathFromLcPath(localCollectionFolder);
+                if (!RobustFile.Exists(linkPath))
+                    return null; // an ordinary collection; nothing to consult
+                var repoFolder = TeamCollectionManager.RepoFolderPathFromLinkPath(linkPath);
+                if (string.IsNullOrWhiteSpace(repoFolder) || !Directory.Exists(repoFolder))
+                    return null; // disconnected, or the shared folder has moved
+                var zipPath = GetRepoProjectFilesZipPath(repoFolder);
+                if (!RobustFile.Exists(zipPath))
+                    return null;
+                var entryName = GetCollectionSettingsEntryName(zipPath);
+                if (entryName == null)
+                    return null;
+                return RobustZip.GetZipEntryContent(zipPath, entryName);
+            }
+            catch (Exception e)
+            {
+                // Offline, a part-written zip, a network share that has gone away: none of that is a
+                // good reason to stop someone opening a collection. The local file still has its say.
+                Logger.WriteError(
+                    "Could not read the Team Collection repo settings while checking the minimum Bloom version",
+                    e
+                );
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Return a list of all the books currently in the repo. (It will not update as changes are made,
         /// either locally or remotely. Beware that conceivably a book in the list might be removed
         /// before you get around to processing it.)
@@ -469,6 +513,26 @@ namespace Bloom.TeamCollection
         {
             var destPath = GetRepoProjectFilesZipPath(_repoFolderPath);
             RobustZip.WriteFilesToZip(names, _localCollectionFolder, destPath);
+        }
+
+        /// <summary>
+        /// Read the collection settings straight out of the repo's zip of collection files, without
+        /// unpacking anything or disturbing the local copy. Used to notice a minimum Bloom version
+        /// arriving from an administrator while the user has the collection open.
+        /// </summary>
+        protected override string GetRepoCollectionSettingsContent()
+        {
+            var zipPath = GetRepoProjectFilesZipPath(_repoFolderPath);
+            if (!RobustFile.Exists(zipPath))
+                return null;
+            // Find the entry by its extension rather than building the name from the local
+            // collection path: the collection may have been renamed locally, in which case the
+            // name we would build is not the one in the repo. (Shared with BL-16691, which reads
+            // AllowCheckouts out of the same file.)
+            var entryName = GetCollectionSettingsEntryName(zipPath);
+            if (entryName == null)
+                return null;
+            return RobustZip.GetZipEntryContent(zipPath, entryName);
         }
 
         protected override DateTime LastRepoCollectionFileModifyTime

--- a/src/BloomExe/TeamCollection/TeamCollection.cs
+++ b/src/BloomExe/TeamCollection/TeamCollection.cs
@@ -877,6 +877,21 @@ namespace Bloom.TeamCollection
                         // allowed, and the next Save() would write that back over the change and
                         // un-pause the whole team. See BL-16691.
                         UpdateAllowCheckoutsFromRepo();
+                        // MinimumBloomVersion is hand-edited into the local file by exactly the same
+                        // administrator workflow, and would be erased by exactly the same next Save().
+                        // We only take the value; we deliberately do NOT lock the administrator out
+                        // from here. This runs while the collection is still being opened, with no
+                        // Shell to own a dialog and nowhere sensible to send them. Their own gate
+                        // catches it at the next launch, by which time the local file says so. See
+                        // BL-16690.
+                        //
+                        // Read it from the local file rather than by reading back the zip we have
+                        // just written. That zip can briefly refuse to open -- Dropbox mid-sync, a
+                        // part-written file -- and a failed read would leave our in-memory copy
+                        // empty, which is exactly how the next ordinary Save() would delete the
+                        // administrator's requirement for the whole team. The local file is where
+                        // the value came from a moment ago, so it cannot fail us that way.
+                        RememberRepoMinimumBloomVersion(TryReadLocalCollectionSettingsContent());
                     }
                 }
             }
@@ -1211,7 +1226,29 @@ namespace Bloom.TeamCollection
             _pendingRepoChanges.Enqueue(args);
         }
 
+        private bool _handlingRepoChangeOnIdle;
+
         internal void HandleRemoteBookChangesOnIdle(object sender, EventArgs e)
+        {
+            // Handling a change can put up a modal dialog (a lock-out, for one), and while that
+            // dialog is up the message pump keeps delivering Idle events, so we would re-enter and
+            // start processing further repo changes on top of the one we are still in the middle
+            // of -- against a collection we may be busy closing. Whatever is left in the queue can
+            // wait for the next Idle after we return.
+            if (_handlingRepoChangeOnIdle)
+                return;
+            _handlingRepoChangeOnIdle = true;
+            try
+            {
+                HandleOneRemoteBookChange();
+            }
+            finally
+            {
+                _handlingRepoChangeOnIdle = false;
+            }
+        }
+
+        private void HandleOneRemoteBookChange()
         {
             if (_pendingRepoChanges.TryDequeue(out RepoChangeEventArgs args))
             {
@@ -1225,8 +1262,13 @@ namespace Bloom.TeamCollection
                     HandleDeletedRepoFileAfterPause(delArgs);
                 else if (args is BookRepoChangeEventArgs changeArgs)
                     HandleModifiedFile(changeArgs);
-                else
-                    HandleCollectionSettingsChange(args);
+                else if (HandleCollectionSettingsChange(args))
+                {
+                    // We just shut the user out of this collection, so Bloom is either quitting or
+                    // closing the collection down. Don't go on to poke at the book selection of a
+                    // collection that is being torn down.
+                    return;
+                }
                 // These "HandleX" methods above send a C# event, which is helpful for the C# end of things.
                 // Unfortunately, a websocket message is needed to make sure that javascript-land is up-to-date
                 // with any remote changes, for example, that the TeamCollection button updates (See BL-10270).
@@ -1343,7 +1385,9 @@ namespace Bloom.TeamCollection
             UpdateBookStatus(bookBaseName, true);
         }
 
-        internal void HandleCollectionSettingsChange(RepoChangeEventArgs result)
+        /// <returns>true if we are shutting the user out of this collection, so the caller should
+        /// stop working with it.</returns>
+        internal bool HandleCollectionSettingsChange(RepoChangeEventArgs result)
         {
             _tcLog.WriteMessage(
                 MessageAndMilestoneType.NewStuff,
@@ -1352,7 +1396,159 @@ namespace Bloom.TeamCollection
                 null,
                 null
             );
+            // Check this first. It can shut the user out of the collection altogether, and it
+            // blocks in a modal dialog until they decide, so there would be no point updating a
+            // setting on a collection they are in the middle of leaving.
+            if (CheckWhetherRepoNowRequiresANewerBloom())
+                return true;
+
             UpdateAllowCheckoutsFromRepo();
+            return false;
+        }
+
+        /// <summary>
+        /// The change a teammate just made may have been to set a minimum Bloom version that this
+        /// Bloom doesn't meet. Unlike other collection settings, that one can't wait until the next
+        /// restart to take effect: the whole point of it is to stop this Bloom touching the
+        /// collection, and the user is in it right now. So we shut them out immediately.
+        ///
+        /// Note that we read the repository's copy of the settings, not the local one. Bloom
+        /// deliberately doesn't overwrite local collection settings mid-session, so the local file
+        /// still says what it said when the collection was opened.
+        /// </summary>
+        /// <returns>true if we shut the user out of the collection.</returns>
+        private bool CheckWhetherRepoNowRequiresANewerBloom()
+        {
+            var repoSettings = TryGetRepoCollectionSettingsContent();
+
+            RememberRepoMinimumBloomVersion(repoSettings);
+
+            if (
+                !MinimumBloomVersionCheck.IsThisBloomTooOldForSettings(
+                    repoSettings,
+                    out var minimumVersion
+                )
+            )
+                return false;
+
+            // ErrorNoReload rather than Error: reloading is exactly what cannot help here, since the
+            // reloaded collection meets the same gate. This entry usually spends no time on screen,
+            // because the lock-out dialog takes over immediately -- but it stays visible if the
+            // lock-out is skipped because one is already under way for this collection.
+            _tcLog.WriteMessage(
+                MessageAndMilestoneType.ErrorNoReload,
+                "TeamCollection.MinimumVersionSetRemotely",
+                "This collection now requires a newer version of Bloom than the one you are running.",
+                null,
+                null
+            );
+
+            return MinimumBloomVersionCheck.LockUserOutOfOpenCollection(
+                Path.GetFileNameWithoutExtension(CollectionPath(_localCollectionFolder)),
+                minimumVersion
+            );
+        }
+
+        /// <summary>
+        /// This computer's own copy of the collection settings, or null if we cannot read it. Used
+        /// straight after we have pushed the local files up, when the local file is by definition
+        /// what the repository now holds and is the more reliable of the two to read.
+        /// </summary>
+        private string TryReadLocalCollectionSettingsContent()
+        {
+            try
+            {
+                var path = CollectionPath(_localCollectionFolder);
+                if (!RobustFile.Exists(path))
+                    return null;
+                return RobustFile.ReadAllText(path, Encoding.UTF8);
+            }
+            catch (Exception e)
+            {
+                Logger.WriteError("TeamCollection could not read the local collection settings", e);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// The repository's copy of the collection settings, or null if we cannot get at it just
+        /// now -- there is no repo copy yet, the zip is part-written, Dropbox is mid-sync. Never
+        /// throws: failing to read it is a normal transient condition, and no caller should
+        /// interrupt someone's work over it. If the collection really does require a newer Bloom,
+        /// we find out at the next start.
+        /// </summary>
+        private string TryGetRepoCollectionSettingsContent()
+        {
+            try
+            {
+                return GetRepoCollectionSettingsContent();
+            }
+            catch (Exception e)
+            {
+                Logger.WriteError("TeamCollection could not read the repo collection settings", e);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Copy the repository's minimum version into the settings we are holding in memory. This
+        /// matters even when this Bloom is new enough to carry on: CollectionSettings.Save() rebuilds
+        /// the file from scratch and writes MinimumBloomVersion out of memory, and plenty of ordinary
+        /// actions save mid-session. If our copy were still the empty value we loaded before the
+        /// administrator's change arrived, the next save would drop the element from the local file,
+        /// and the Team Collection would push that up -- quietly removing the protection for the
+        /// whole team, from the very Bloom it was meant to keep out.
+        /// </summary>
+        private void RememberRepoMinimumBloomVersion(string repoSettings)
+        {
+            var settings = _tcManager?.Settings;
+            if (settings == null)
+                return; // no settings to update (unit tests)
+
+            // Not knowing what the repo says is quite different from the repo saying "no minimum".
+            // Only the second of those should clear what we are holding.
+            if (string.IsNullOrWhiteSpace(repoSettings))
+                return;
+
+            string repoValue;
+            try
+            {
+                repoValue = MinimumBloomVersionCheck.ParseMinimumBloomVersion(repoSettings);
+            }
+            catch (Exception e)
+            {
+                Logger.WriteError(
+                    "TeamCollection could not parse the repo collection settings to read its minimum Bloom version",
+                    e
+                );
+                return;
+            }
+
+            // Record it against the collection as well as in the settings object. The local
+            // .bloomCollection is deliberately not rewritten mid-session, so without this the
+            // startup gate would read the stale file and let someone we had just shut out back in
+            // by picking the same collection from the chooser. See BL-16690.
+            MinimumBloomVersionCheck.RememberMinimumVersionFromRepo(
+                CollectionPath(_localCollectionFolder),
+                repoValue
+            );
+
+            if (repoValue == settings.MinimumBloomVersion)
+                return;
+            Logger.WriteEvent(
+                $"TeamCollection: MinimumBloomVersion changed remotely to '{repoValue}'."
+            );
+            settings.MinimumBloomVersion = repoValue;
+        }
+
+        /// <summary>
+        /// The text of the collection settings file as it stands in the repository right now, or
+        /// null if we have no way to get at it. Subclasses that keep the collection files somewhere
+        /// we can read should override this.
+        /// </summary>
+        protected virtual string GetRepoCollectionSettingsContent()
+        {
+            return null;
         }
 
         /// <summary>

--- a/src/BloomTests/Collection/MinimumBloomVersionCheckTests.cs
+++ b/src/BloomTests/Collection/MinimumBloomVersionCheckTests.cs
@@ -1,0 +1,387 @@
+using System;
+using System.IO;
+using Bloom.Collection;
+using NUnit.Framework;
+using SIL.IO;
+using SIL.TestUtilities;
+
+namespace BloomTests.Collection
+{
+    /// <summary>
+    /// Tests the gate that keeps an older Bloom from opening a collection that declares
+    /// a MinimumBloomVersion. See BL-16690.
+    /// </summary>
+    [TestFixture]
+    public class MinimumBloomVersionCheckTests
+    {
+        private TemporaryFolder _folder;
+
+        [OneTimeSetUp]
+        public void FixtureSetup()
+        {
+            _folder = new TemporaryFolder("MinimumBloomVersionCheckTests");
+        }
+
+        [OneTimeTearDown]
+        public void Cleanup()
+        {
+            _folder.Dispose();
+        }
+
+        // No requirement at all: everything is allowed in.
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        // A requirement we can't make sense of is ignored rather than locking the user out.
+        [TestCase("banana")]
+        [TestCase("6")] // Version.TryParse insists on at least major.minor
+        [TestCase("6.5-beta")]
+        public void IsVersionSufficient_NoUsableRequirement_AllowsAnyVersion(string minimumVersion)
+        {
+            Assert.That(
+                MinimumBloomVersionCheck.IsVersionSufficient(minimumVersion, new Version(1, 0, 0)),
+                Is.True,
+                "Even an ancient Bloom should be allowed in when there is no usable requirement."
+            );
+        }
+
+        [TestCase("6.5", "6.5.0.0", true, Description = "exactly the required version")]
+        [TestCase("6.5", "6.5.132.0", true, Description = "same minor, later build")]
+        [TestCase("6.5", "6.6.0.0", true, Description = "later minor")]
+        [TestCase("6.5", "7.0.0.0", true, Description = "later major")]
+        [TestCase("6.5", "6.4.900.0", false, Description = "earlier minor, even with a high build")]
+        [TestCase("6.5", "5.9.0.0", false, Description = "earlier major")]
+        [TestCase("7.0", "6.9.0.0", false, Description = "earlier major, higher minor")]
+        // We compare major.minor only, matching Bloom's other version gates, so a build number
+        // in the requirement is deliberately ignored.
+        [TestCase("6.5.132", "6.5.10.0", true, Description = "build number in requirement ignored")]
+        public void IsVersionSufficient_ComparesMajorAndMinor(
+            string minimumVersion,
+            string runningVersion,
+            bool expected
+        )
+        {
+            Assert.That(
+                MinimumBloomVersionCheck.IsVersionSufficient(
+                    minimumVersion,
+                    Version.Parse(runningVersion)
+                ),
+                Is.EqualTo(expected)
+            );
+        }
+
+        /// <summary>
+        /// We compare major.minor only, so that is what the user should be shown. Reporting a build
+        /// number we don't actually enforce would misrepresent the rule. Version 99 is used so these
+        /// stay true however far Bloom's real version advances.
+        /// </summary>
+        // Each case needs its own collection name: two of these differ only by whitespace, so
+        // deriving the name from the value would have them share a folder and overwrite each other.
+        [TestCase("99.0", "99.0", "ReportedPlain")]
+        [TestCase(
+            "99.0.132",
+            "99.0",
+            "ReportedWithBuild",
+            Description = "build number dropped, since we ignore it"
+        )]
+        [TestCase(
+            "  99.0  ",
+            "99.0",
+            "ReportedPadded",
+            Description = "surrounding whitespace tolerated"
+        )]
+        public void IsThisBloomTooOld_TooOld_ReportsRequirementAsMajorMinor(
+            string declaredVersion,
+            string expectedReported,
+            string collectionName
+        )
+        {
+            var path = WriteSettingsFile(
+                collectionName,
+                $"<MinimumBloomVersion>{declaredVersion}</MinimumBloomVersion>"
+            );
+
+            Assert.That(
+                MinimumBloomVersionCheck.IsThisBloomTooOld(path, out var minimumVersion),
+                Is.True,
+                "No conceivable Bloom version satisfies a requirement of 99.x."
+            );
+            Assert.That(minimumVersion, Is.EqualTo(expectedReported));
+        }
+
+        [Test]
+        public void IsThisBloomTooOld_RequirementSatisfied_ReturnsFalse()
+        {
+            var path = WriteSettingsFile(
+                "AncientRequirement",
+                "<MinimumBloomVersion>0.1</MinimumBloomVersion>"
+            );
+
+            Assert.That(
+                MinimumBloomVersionCheck.IsThisBloomTooOld(path, out var minimumVersion),
+                Is.False,
+                "Every Bloom that has ever shipped is newer than 0.1."
+            );
+            Assert.That(minimumVersion, Is.Empty);
+        }
+
+        /// <summary>
+        /// A Team Collection has to judge the settings sitting in the repository, which it reads out
+        /// of a zip and never writes to disk, so the same check has to work on content in hand.
+        /// </summary>
+        [Test]
+        public void IsThisBloomTooOldForSettings_RequirementNoBloomCanMeet_SaysSoAndReportsIt()
+        {
+            var xml = SettingsXml("<MinimumBloomVersion>99.0</MinimumBloomVersion>");
+
+            Assert.That(
+                MinimumBloomVersionCheck.IsThisBloomTooOldForSettings(xml, out var minimumVersion),
+                Is.True,
+                "No conceivable Bloom version satisfies a requirement of 99.x."
+            );
+            Assert.That(minimumVersion, Is.EqualTo("99.0"));
+        }
+
+        [Test]
+        public void IsThisBloomTooOldForSettings_NoRequirement_LetsUsIn()
+        {
+            Assert.That(
+                MinimumBloomVersionCheck.IsThisBloomTooOldForSettings(SettingsXml(""), out _),
+                Is.False
+            );
+        }
+
+        /// <summary>
+        /// Nothing to read means we know nothing, which must not be mistaken for "you are locked
+        /// out" -- that would shut a Team Collection user out of their work over a read failure.
+        /// </summary>
+        [TestCase(null)]
+        [TestCase("")]
+        public void IsThisBloomTooOldForSettings_NothingToRead_LetsUsIn(string xml)
+        {
+            Assert.That(
+                MinimumBloomVersionCheck.IsThisBloomTooOldForSettings(xml, out _),
+                Is.False
+            );
+        }
+
+        [Test]
+        public void IsThisBloomTooOldForSettings_UnparseableXml_LetsUsInRatherThanThrowing()
+        {
+            Assert.That(
+                MinimumBloomVersionCheck.IsThisBloomTooOldForSettings("not xml at all", out _),
+                Is.False
+            );
+        }
+
+        private static string SettingsXml(string extraElements) =>
+            $@"<?xml version='1.0' encoding='utf-8'?>
+<Collection version='0.2'>
+  <Language1Iso639Code>xyz</Language1Iso639Code>
+  {extraElements}
+</Collection>";
+
+        [Test]
+        public void ReadMinimumBloomVersion_ElementPresent_ReturnsIt()
+        {
+            var path = WriteSettingsFile(
+                "MinimumVersionPresent",
+                "<MinimumBloomVersion>6.5</MinimumBloomVersion>"
+            );
+
+            Assert.That(MinimumBloomVersionCheck.ReadMinimumBloomVersion(path), Is.EqualTo("6.5"));
+        }
+
+        [Test]
+        public void ReadMinimumBloomVersion_ElementAbsent_ReturnsEmpty()
+        {
+            var path = WriteSettingsFile("MinimumVersionAbsent", "");
+
+            Assert.That(MinimumBloomVersionCheck.ReadMinimumBloomVersion(path), Is.Empty);
+        }
+
+        /// <summary>
+        /// A settings file we can't parse is a real problem, but it is not this check's problem to
+        /// report; the normal open will fail and give the user a much better error report.
+        /// </summary>
+        [Test]
+        public void ReadMinimumBloomVersion_UnparseableFile_ReturnsEmptyRatherThanThrowing()
+        {
+            var path = Path.Combine(_folder.Path, "Garbage.bloomCollection");
+            RobustFile.WriteAllText(path, "this is not xml at all");
+
+            Assert.That(MinimumBloomVersionCheck.ReadMinimumBloomVersion(path), Is.Empty);
+        }
+
+        [Test]
+        public void ReadMinimumBloomVersion_NoSuchFile_ReturnsEmpty()
+        {
+            var path = Path.Combine(_folder.Path, "NotThere.bloomCollection");
+            Assert.That(
+                RobustFile.Exists(path),
+                Is.False,
+                "Test setup problem: this file was supposed to not exist."
+            );
+
+            Assert.That(MinimumBloomVersionCheck.ReadMinimumBloomVersion(path), Is.Empty);
+        }
+
+        /// <summary>
+        /// Save() rebuilds the settings file from scratch, so a hand-added MinimumBloomVersion would be
+        /// silently lost the first time the user changed anything in Collection Settings, unless we
+        /// write it back out. That would be a nasty way to lose the protection.
+        /// </summary>
+        [Test]
+        public void CollectionSettings_MinimumBloomVersion_SurvivesLoadAndSave()
+        {
+            var path = WriteSettingsFile(
+                "RoundTrip",
+                "<MinimumBloomVersion>6.5</MinimumBloomVersion>"
+            );
+
+            var settings = new CollectionSettings(path);
+            Assert.That(
+                settings.MinimumBloomVersion,
+                Is.EqualTo("6.5"),
+                "Should have read the minimum version from the file we just wrote."
+            );
+
+            settings.Save();
+
+            Assert.That(
+                MinimumBloomVersionCheck.ReadMinimumBloomVersion(path),
+                Is.EqualTo("6.5"),
+                "Save() dropped the minimum version, which would leave the collection unprotected."
+            );
+        }
+
+        /// <summary>
+        /// We don't want to add a meaningless empty element to every collection settings file in the world.
+        /// </summary>
+        [Test]
+        public void CollectionSettings_NoMinimumBloomVersion_NotWrittenOnSave()
+        {
+            var path = WriteSettingsFile("NoMinimum", "");
+
+            var settings = new CollectionSettings(path);
+            Assert.That(
+                settings.MinimumBloomVersion,
+                Is.Empty,
+                "Test setup problem: there should be no minimum version yet."
+            );
+
+            settings.Save();
+
+            Assert.That(
+                RobustFile.ReadAllText(path),
+                Does.Not.Contain(CollectionSettings.kMinimumBloomVersionElementName)
+            );
+        }
+
+        /// <summary>
+        /// When a Team Collection administrator sets a minimum version mid-session, the copy of the
+        /// settings on this computer deliberately isn't rewritten, so it goes on saying nothing about
+        /// it. Someone we had just shut out could otherwise walk straight back in by choosing the same
+        /// collection from the chooser -- the gate would read the stale file and see no requirement.
+        /// See BL-16690.
+        /// </summary>
+        [Test]
+        public void IsThisBloomTooOld_RepoSaidNewerThanTheLocalFileDoes_StillSaysTooOld()
+        {
+            var path = WriteSettingsFile("RepoBeatsStaleFile", "");
+
+            // Sanity check: on the file alone, this collection is wide open.
+            Assert.That(
+                MinimumBloomVersionCheck.IsThisBloomTooOld(path, out _),
+                Is.False,
+                "Test setup problem: the file itself should demand nothing."
+            );
+
+            MinimumBloomVersionCheck.RememberMinimumVersionFromRepo(path, "99.0");
+
+            Assert.That(
+                MinimumBloomVersionCheck.IsThisBloomTooOld(path, out var minimumVersion),
+                Is.True
+            );
+            Assert.That(minimumVersion, Is.EqualTo("99.0"));
+        }
+
+        /// <summary>
+        /// The two sources can disagree, and neither wins outright: we take whichever demands more.
+        /// The repository copy lives in a zip that can be mid-sync and momentarily missing the
+        /// element, and this is a protection, so the failure we can live with is keeping someone out
+        /// a little longer than necessary rather than letting them in when we should not have.
+        /// </summary>
+        [Test]
+        public void IsThisBloomTooOld_RepoSaysNoRequirementButFileDoes_StillSaysTooOld()
+        {
+            var path = WriteSettingsFile(
+                "RepoSilentFileDemands",
+                "<MinimumBloomVersion>99.0</MinimumBloomVersion>"
+            );
+
+            // Sanity check: the file on its own shuts us out.
+            Assert.That(
+                MinimumBloomVersionCheck.IsThisBloomTooOld(path, out _),
+                Is.True,
+                "Test setup problem: the file should demand a version no Bloom has."
+            );
+
+            MinimumBloomVersionCheck.RememberMinimumVersionFromRepo(path, "");
+
+            Assert.That(
+                MinimumBloomVersionCheck.IsThisBloomTooOld(path, out var minimumVersion),
+                Is.True
+            );
+            Assert.That(minimumVersion, Is.EqualTo("99.0"));
+        }
+
+        /// <summary>
+        /// The other direction of the same rule: a requirement in the file we already meet must not
+        /// water down a stiffer one the repository has since told us about.
+        /// </summary>
+        [Test]
+        public void IsThisBloomTooOld_FileAsksLessThanTheRepoDoes_TakesTheRepoRequirement()
+        {
+            var path = WriteSettingsFile(
+                "FileAsksLess",
+                "<MinimumBloomVersion>1.0</MinimumBloomVersion>"
+            );
+
+            // Sanity check: on the file alone, any Bloom is welcome.
+            Assert.That(
+                MinimumBloomVersionCheck.IsThisBloomTooOld(path, out _),
+                Is.False,
+                "Test setup problem: the file should demand nothing this Bloom can't meet."
+            );
+
+            MinimumBloomVersionCheck.RememberMinimumVersionFromRepo(path, "99.0");
+
+            Assert.That(
+                MinimumBloomVersionCheck.IsThisBloomTooOld(path, out var minimumVersion),
+                Is.True
+            );
+            Assert.That(minimumVersion, Is.EqualTo("99.0"));
+        }
+
+        /// <summary>
+        /// Writes a minimal .bloomCollection file in its own folder, since CollectionSettings
+        /// expects the folder to be named after the collection.
+        /// </summary>
+        private string WriteSettingsFile(string collectionName, string extraElements)
+        {
+            var collectionFolder = Path.Combine(_folder.Path, collectionName);
+            Directory.CreateDirectory(collectionFolder);
+            var path = Path.Combine(collectionFolder, collectionName + ".bloomCollection");
+            RobustFile.WriteAllText(
+                path,
+                $@"<?xml version='1.0' encoding='utf-8'?>
+<Collection version='0.2'>
+  <Language1Iso639Code>xyz</Language1Iso639Code>
+  {extraElements}
+</Collection>"
+            );
+            return path;
+        }
+    }
+}

--- a/src/BloomTests/TeamCollection/FolderTeamCollectionTests2.cs
+++ b/src/BloomTests/TeamCollection/FolderTeamCollectionTests2.cs
@@ -1461,6 +1461,237 @@ namespace BloomTests.TeamCollection
             }
         }
 
+        /// <summary>
+        /// The first-launch gap. An administrator sets a minimum version while a teammate's Bloom is
+        /// closed. When that teammate starts up, their own copy of the settings is still yesterday's
+        /// -- Bloom does not copy the repository's collection files down until later in startup, well
+        /// after the gate has decided whether to open the collection. So the gate has to ask the
+        /// repository itself, or the teammate gets the whole session inside a collection they are no
+        /// longer allowed in. See BL-16690.
+        /// </summary>
+        [Test]
+        public void IsThisBloomTooOld_OnlyTheRepoKnowsAboutTheRequirement_StillSaysTooOld()
+        {
+            using (var collectionFolder = new TemporaryFolder("RepoOnlyRequirement_Collection"))
+            {
+                using (var repoFolder = new TemporaryFolder("RepoOnlyRequirement_Repo"))
+                {
+                    var mockTcManager = new Mock<ITeamCollectionManager>();
+                    var settings = new CollectionSettings();
+                    mockTcManager.Setup(m => m.Settings).Returns(settings);
+                    var tc = new TestFolderTeamCollection(
+                        mockTcManager.Object,
+                        collectionFolder.FolderPath,
+                        repoFolder.FolderPath
+                    );
+                    Directory.CreateDirectory(Path.Combine(repoFolder.FolderPath, "Books"));
+                    var settingsPath = CollectionSettings.GetSettingsFilePath(
+                        collectionFolder.FolderPath
+                    );
+
+                    // The administrator's edit, pushed to the repository...
+                    File.WriteAllText(
+                        settingsPath,
+                        "<Collection version=\"0.2\"><MinimumBloomVersion>99.0</MinimumBloomVersion></Collection>"
+                    );
+                    tc.CopyRepoCollectionFilesFromLocal(collectionFolder.FolderPath);
+                    FolderTeamCollection.CreateTeamCollectionLinkFile(
+                        collectionFolder.FolderPath,
+                        repoFolder.FolderPath
+                    );
+
+                    // ...while this teammate's own copy still says nothing about it, exactly as it
+                    // would on the morning after the administrator made the change.
+                    File.WriteAllText(settingsPath, "<Collection version=\"0.2\"></Collection>");
+                    Assert.That(
+                        MinimumBloomVersionCheck.ReadMinimumBloomVersion(settingsPath),
+                        Is.Empty,
+                        "setup failed: the local file should not know about the requirement"
+                    );
+
+                    Assert.That(
+                        MinimumBloomVersionCheck.IsThisBloomTooOld(
+                            settingsPath,
+                            out var minimumVersion
+                        ),
+                        Is.True,
+                        "the repository's requirement should be honoured on the very first launch"
+                    );
+                    Assert.That(minimumVersion, Is.EqualTo("99.0"));
+                }
+            }
+        }
+
+        /// <summary>
+        /// A Team Collection whose repository copy cannot be read at all. Used to prove that
+        /// picking up the administrator's newly pushed requirement does not depend on reading back
+        /// the zip we have just written -- that zip can briefly refuse to open while Dropbox is
+        /// syncing it, and losing the value there is what would let the next save erase the
+        /// administrator's protection for the whole team. See BL-16690.
+        /// </summary>
+        private class TeamCollectionWhoseRepoReadFails : TestFolderTeamCollection
+        {
+            public TeamCollectionWhoseRepoReadFails(
+                ITeamCollectionManager tcManager,
+                string localCollectionFolder,
+                string repoFolderPath
+            )
+                : base(tcManager, localCollectionFolder, repoFolderPath) { }
+
+            protected override string GetRepoCollectionSettingsContent()
+            {
+                throw new IOException("pretending the repo zip is mid-sync");
+            }
+        }
+
+        [Test]
+        public void SyncLocalAndRepoCollectionFiles_RepoReadFails_StillRemembersWhatWePushed()
+        {
+            using (var collectionFolder = new TemporaryFolder("RepoReadFails_Collection"))
+            {
+                using (var repoFolder = new TemporaryFolder("RepoReadFails_Repo"))
+                {
+                    var mockTcManager = new Mock<ITeamCollectionManager>();
+                    var settings = new CollectionSettings();
+                    mockTcManager.Setup(m => m.Settings).Returns(settings);
+                    var tc = new TeamCollectionWhoseRepoReadFails(
+                        mockTcManager.Object,
+                        collectionFolder.FolderPath,
+                        repoFolder.FolderPath
+                    );
+                    Directory.CreateDirectory(Path.Combine(repoFolder.FolderPath, "Books"));
+                    var settingsPath = CollectionSettings.GetSettingsFilePath(
+                        collectionFolder.FolderPath
+                    );
+
+                    File.WriteAllText(
+                        settingsPath,
+                        "<Collection version=\"0.2\"><MinimumBloomVersion>1.0</MinimumBloomVersion></Collection>"
+                    );
+                    Assert.That(
+                        settings.MinimumBloomVersion,
+                        Is.Empty,
+                        "setup failed: the running Bloom should not know about it yet"
+                    );
+
+                    tc.SyncLocalAndRepoCollectionFiles(false);
+
+                    Assert.That(
+                        settings.MinimumBloomVersion,
+                        Is.EqualTo("1.0"),
+                        "a repo read failure must not lose the requirement we just pushed, or the next save deletes it for everyone"
+                    );
+                }
+            }
+        }
+
+        /// <summary>
+        /// The administrator must be able to undo a mistake. Once a member is being refused, they
+        /// never open the collection, so the startup sync that would refresh their own copy of the
+        /// settings never runs -- which means a requirement lifted in the repository has to be
+        /// honoured from the repository, or that member is shut out on every launch for ever, with
+        /// no way back in from inside Bloom. See BL-16690.
+        /// </summary>
+        [Test]
+        public void IsThisBloomTooOld_RepoHasWithdrawnTheRequirement_LetsThemBackIn()
+        {
+            using (var collectionFolder = new TemporaryFolder("RepoWithdrewRequirement_Collection"))
+            {
+                using (var repoFolder = new TemporaryFolder("RepoWithdrewRequirement_Repo"))
+                {
+                    var mockTcManager = new Mock<ITeamCollectionManager>();
+                    var settings = new CollectionSettings();
+                    mockTcManager.Setup(m => m.Settings).Returns(settings);
+                    var tc = new TestFolderTeamCollection(
+                        mockTcManager.Object,
+                        collectionFolder.FolderPath,
+                        repoFolder.FolderPath
+                    );
+                    Directory.CreateDirectory(Path.Combine(repoFolder.FolderPath, "Books"));
+                    var settingsPath = CollectionSettings.GetSettingsFilePath(
+                        collectionFolder.FolderPath
+                    );
+
+                    // The administrator has thought better of it, so the repository asks for nothing...
+                    File.WriteAllText(settingsPath, "<Collection version=\"0.2\"></Collection>");
+                    tc.CopyRepoCollectionFilesFromLocal(collectionFolder.FolderPath);
+                    FolderTeamCollection.CreateTeamCollectionLinkFile(
+                        collectionFolder.FolderPath,
+                        repoFolder.FolderPath
+                    );
+
+                    // ...but this member's own copy still carries the requirement they were refused
+                    // by, and always will, because being refused is what stops it being refreshed.
+                    File.WriteAllText(
+                        settingsPath,
+                        "<Collection version=\"0.2\"><MinimumBloomVersion>99.0</MinimumBloomVersion></Collection>"
+                    );
+                    Assert.That(
+                        MinimumBloomVersionCheck.ReadMinimumBloomVersion(settingsPath),
+                        Is.EqualTo("99.0"),
+                        "setup failed: the local file should still carry the old requirement"
+                    );
+
+                    Assert.That(
+                        MinimumBloomVersionCheck.IsThisBloomTooOld(settingsPath, out _),
+                        Is.False,
+                        "the administrator lifting the requirement must let the member back in"
+                    );
+                }
+            }
+        }
+
+        /// <summary>
+        /// The same workflow, and the same trap, for MinimumBloomVersion: the administrator adds it
+        /// to their own local settings file while Bloom runs. Their in-memory copy is still empty,
+        /// so the next Save() would rewrite the file without it and push that up, erasing the
+        /// requirement for the whole team. We deliberately only take the value here -- locking the
+        /// administrator out mid-sync is not this method's job. See BL-16690.
+        /// </summary>
+        [Test]
+        public void SyncLocalAndRepoCollectionFiles_LocalMinimumVersionPushedUp_UpdatesLiveSettings()
+        {
+            using (var collectionFolder = new TemporaryFolder("LocalMinVersionPushedUp_Collection"))
+            {
+                using (var repoFolder = new TemporaryFolder("LocalMinVersionPushedUp_Repo"))
+                {
+                    var mockTcManager = new Mock<ITeamCollectionManager>();
+                    var settings = new CollectionSettings();
+                    mockTcManager.Setup(m => m.Settings).Returns(settings);
+                    var tc = new TestFolderTeamCollection(
+                        mockTcManager.Object,
+                        collectionFolder.FolderPath,
+                        repoFolder.FolderPath
+                    );
+                    Directory.CreateDirectory(Path.Combine(repoFolder.FolderPath, "Books"));
+                    var settingsPath = CollectionSettings.GetSettingsFilePath(
+                        collectionFolder.FolderPath
+                    );
+
+                    // The administrator's hand-edit. 1.0 is old enough that nothing here will try to
+                    // shut them out, which would want a dialog we cannot show from a unit test.
+                    File.WriteAllText(
+                        settingsPath,
+                        "<Collection version=\"0.2\"><MinimumBloomVersion>1.0</MinimumBloomVersion></Collection>"
+                    );
+                    // ...while this running Bloom still has the value it loaded at startup.
+                    Assert.That(
+                        settings.MinimumBloomVersion,
+                        Is.Empty,
+                        "setup failed: the running Bloom should not know about the minimum version yet"
+                    );
+
+                    tc.SyncLocalAndRepoCollectionFiles(false);
+
+                    Assert.That(
+                        settings.MinimumBloomVersion,
+                        Is.EqualTo("1.0"),
+                        "the machine that made the change should know about it too, or its next save will erase it"
+                    );
+                }
+            }
+        }
+
         [Test]
         public void UpdateAllowCheckoutsFromRepo_NoRepoSettings_LeavesSettingAlone()
         {
@@ -1472,6 +1703,72 @@ namespace BloomTests.TeamCollection
                     settings.AllowCheckouts = false;
                     tc.UpdateAllowCheckoutsFromRepo();
                     Assert.That(settings.AllowCheckouts, Is.False);
+                }
+            );
+        }
+
+        /// <summary>
+        /// Picking up the repo's minimum version matters even when this Bloom is new enough to carry
+        /// on working. CollectionSettings.Save() rebuilds the file from memory, so if we were still
+        /// holding the empty value we loaded at startup, the next ordinary save would drop the
+        /// element and the Team Collection would push that up -- removing the administrator's
+        /// protection for everybody. See BL-16690.
+        /// </summary>
+        [Test]
+        public void HandleCollectionSettingsChange_RepoDeclaresAMinimumWeMeet_RemembersIt()
+        {
+            WithRepoSettingsFile(
+                "RememberMinimumVersion",
+                "<Collection version=\"0.2\"><MinimumBloomVersion>1.0</MinimumBloomVersion></Collection>",
+                (tc, settings) =>
+                {
+                    // Sanity check: we must start out not knowing about it, or the test proves nothing.
+                    Assert.That(
+                        settings.MinimumBloomVersion,
+                        Is.Empty,
+                        "setup failed: should have started with no minimum version"
+                    );
+                    // And this Bloom really must satisfy the 1.0 below. On a build where the
+                    // version was never stamped in (0.0.x) it would not, and the code under test
+                    // would try to lock the user out -- which from a unit test means a dialog and a
+                    // hang rather than a failure. Better to say so plainly here.
+                    Assert.That(
+                        typeof(CollectionSettings).Assembly.GetName().Version,
+                        Is.GreaterThanOrEqualTo(new Version(1, 0)),
+                        "setup failed: this Bloom's assembly version is not stamped, so the test cannot tell a met minimum from an unmet one"
+                    );
+
+                    // 1.0 is old enough that this cannot try to lock anyone out (which would want a dialog).
+                    var lockedOut = tc.HandleCollectionSettingsChange(new RepoChangeEventArgs());
+
+                    Assert.That(
+                        lockedOut,
+                        Is.False,
+                        "should not shut anyone out over a minimum this Bloom easily meets"
+                    );
+                    Assert.That(settings.MinimumBloomVersion, Is.EqualTo("1.0"));
+                }
+            );
+        }
+
+        /// <summary>
+        /// Not being able to read the repo copy is quite different from the repo saying there is no
+        /// minimum, and only the second should clear what we are holding. Getting this wrong would
+        /// turn a transient read failure into the loss of the setting. See BL-16690.
+        /// </summary>
+        [Test]
+        public void HandleCollectionSettingsChange_NoRepoSettings_LeavesMinimumVersionAlone()
+        {
+            WithRepoSettingsFile(
+                "RememberMinimumVersionNoRepo",
+                null,
+                (tc, settings) =>
+                {
+                    settings.MinimumBloomVersion = "1.0";
+
+                    tc.HandleCollectionSettingsChange(new RepoChangeEventArgs());
+
+                    Assert.That(settings.MinimumBloomVersion, Is.EqualTo("1.0"));
                 }
             );
         }


### PR DESCRIPTION
Honors a `MinimumBloomVersion` element in a `.bloomCollection` file (set by hand today, in
preparation for Cloud syncing). If the running Bloom is older than that, it refuses to open the
collection and offers two ways forward: upgrade Bloom, or choose a different collection.

**Upgrading happens in place, through Velopack** — the same machinery behind the usual "a new
version is available" toast, driven directly so it works before any collection is open (there is no
toast host that early). We never send the user to the website: if there is nothing newer on their
channel, or the update fails, they are told so in a message box using the wording the toast would
have used, and are left to pick another collection.

An update that doesn't reach the required version is still installed — getting as far as the channel
allows is real progress, and the message says plainly that they will be asked again next launch.

**Team Collections** are locked out mid-session too: if the administrator sets a minimum version
while a teammate is working, the same modal dialog appears as soon as the change arrives, and the
only ways out are to upgrade or to switch collections. The repository's copy of the settings is read
straight out of the repo zip, since Bloom deliberately doesn't overwrite local collection settings
mid-session. A read failure never locks anyone out.

Version comparison is major.minor only, matching `BookStorage.CurrentBloomDesktopVersion` and the
book-download gate. An empty or unparseable value is treated as "no requirement" — we never lock
someone out of their own collection over a typo. Channel plays no part: a version number means the
same thing on every channel.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16690

Caveat for the reviewer: none of the Velopack path or the Team Collection lock-out has been
exercised against a live update feed or a real Team Collection.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8206)
<!-- Reviewable:end -->


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8206)
