### PR TITLE
Fix concurrent writes of the same AI image history file (BL-16702)

### DIFF
--- a/src/BloomExe/web/controllers/AiImageEditorApi.cs
+++ b/src/BloomExe/web/controllers/AiImageEditorApi.cs
@@ -632,7 +632,12 @@ namespace Bloom.web.controllers
         /// The lock object that serializes CHANGES to one file of the AI image editor's folder
         /// (see <see cref="WriteRequestBodyToFile"/> for why they have to be serialized). A GET
         /// deliberately doesn't take it: a read can't corrupt anything, and making a response
-        /// stream wait behind a multi-MB upload would cost more than it saves.
+        /// stream wait behind a multi-MB upload would cost more than it saves. What a read can
+        /// hit is the moment of the swap — RobustFile.Move(overWrite) is a delete followed by a
+        /// move, not an atomic replace, so a GET landing in that window can 404 — but that
+        /// window is as old as this endpoint, and nothing reads a file while writing it: the AI
+        /// image editor GETs history files when it starts, and writes them when it generates or
+        /// commits.
         /// </summary>
         private static object GetFileLock(string fullPath)
         {
@@ -680,15 +685,54 @@ namespace Bloom.web.controllers
             lock (GetFileLock(fullPath))
             {
                 var tempPath = fullPath + ".tmp";
-                using (body)
-                using (var output = RobustFile.Create(tempPath))
+                var swapped = false;
+                try
                 {
-                    // The body stream is null for an empty body (no entity body); that still
-                    // means "save an empty file" here, so just leave the freshly created temp
-                    // file empty rather than copying.
-                    body?.CopyTo(output);
+                    using (body)
+                    using (var output = RobustFile.Create(tempPath))
+                    {
+                        // The body stream is null for an empty body (no entity body); that
+                        // still means "save an empty file" here, so just leave the freshly
+                        // created temp file empty rather than copying.
+                        body?.CopyTo(output);
+                    }
+                    RobustFile.Move(tempPath, fullPath, true); // true: overwrite
+                    swapped = true;
                 }
-                RobustFile.Move(tempPath, fullPath, true); // true: overwrite
+                finally
+                {
+                    // A write that dies partway (the client goes away, the disk fills up) must
+                    // not leave its half-written temp behind. Nothing would ever serve or
+                    // enumerate it — the name is neither allow-listed nor an image extension —
+                    // but it can be multi-MB, and it would sit in the book's folder for the
+                    // life of the book. Whatever file it was going to replace is untouched,
+                    // which is the whole point of writing through a temp, so the temp is all
+                    // there is to clean up.
+                    if (!swapped)
+                        DeleteTempFileIgnoringErrors(tempPath);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Removes the temp file left by a failed write. Deliberately swallows anything that
+        /// goes wrong: we are already on our way out with the real exception — the one the
+        /// caller needs and the one that becomes the request's error — and failing to tidy up
+        /// must not replace it with a less informative one.
+        /// </summary>
+        private static void DeleteTempFileIgnoringErrors(string tempPath)
+        {
+            try
+            {
+                if (RobustFile.Exists(tempPath))
+                    RobustFile.Delete(tempPath);
+            }
+            catch (Exception e)
+            {
+                Logger.WriteError(
+                    $"AiImageEditorApi: could not remove the temp file {tempPath} left behind by a failed write",
+                    e
+                );
             }
         }
 

--- a/src/BloomExe/web/controllers/AiImageEditorApi.cs
+++ b/src/BloomExe/web/controllers/AiImageEditorApi.cs
@@ -676,6 +676,14 @@ namespace Bloom.web.controllers
         /// to write host file", and since it writes all the files before posting the commit,
         /// ONE such failure abandoned the whole commit: the user's Replace did nothing at all.
         ///
+        /// Note that serializing those duplicate writes is all we do about them: the AI image
+        /// editor still sends the same bytes once per slot, so one image in four slots posts the
+        /// same few MB four times. We are deliberately not asking it to send each result only
+        /// once (JohnThomson's call, BL-16702): using one picture in several places is expected
+        /// to be rare, and when it happens the picture is likely to be a small decorative one,
+        /// so the wasted bandwidth isn't worth optimizing — especially as it is bandwidth to
+        /// localhost.
+        ///
         /// Internal for testing.
         /// </summary>
         internal static void WriteRequestBodyToFile(string fullPath, Stream body)

--- a/src/BloomExe/web/controllers/AiImageEditorApi.cs
+++ b/src/BloomExe/web/controllers/AiImageEditorApi.cs
@@ -595,31 +595,18 @@ namespace Bloom.web.controllers
                     break;
 
                 case HttpMethods.Post:
-                    var dir = Path.GetDirectoryName(fullPath);
-                    if (!Directory.Exists(dir))
-                        Directory.CreateDirectory(dir);
-                    // Stream the body straight to disk: history images are multi-MB, so don't
-                    // buffer them whole in memory (RawPostData would). Land the bytes in a
-                    // temp file and swap it in, so an upload that dies partway can't leave a
-                    // truncated file where a previous good one was. An empty body is a valid
-                    // save of an empty file, not a no-op: the AI image editor must never be
-                    // told "saved" while stale content survives on disk.
-                    var tempPath = fullPath + ".tmp";
-                    using (var input = request.RawPostStream)
-                    using (var output = RobustFile.Create(tempPath))
-                    {
-                        // RawPostStream is null for an empty body (no entity body); that
-                        // still means "save an empty file" here, so just leave the freshly
-                        // created temp file empty rather than copying.
-                        input?.CopyTo(output);
-                    }
-                    RobustFile.Move(tempPath, fullPath, true); // true: overwrite
+                    WriteRequestBodyToFile(fullPath, request.RawPostStream);
                     request.PostSucceeded();
                     break;
 
                 case HttpMethods.Delete:
-                    if (RobustFile.Exists(fullPath))
-                        RobustFile.Delete(fullPath);
+                    // Under the file's lock like the write, so a delete can't land in the
+                    // middle of one (see WriteRequestBodyToFile).
+                    lock (GetFileLock(fullPath))
+                    {
+                        if (RobustFile.Exists(fullPath))
+                            RobustFile.Delete(fullPath);
+                    }
                     request.PostSucceeded();
                     break;
 
@@ -629,6 +616,79 @@ namespace Bloom.web.controllers
                         "Method not allowed"
                     );
                     break;
+            }
+        }
+
+        // One lock object per file this session has written or deleted under
+        // .ai-image-editor. Tiny (a handful of history files per book) and never cleaned up,
+        // deliberately: a lock we discarded while a request still held it would be no lock at
+        // all. Case-insensitive because the keys are Windows paths.
+        private static readonly Dictionary<string, object> _locksByFilePath = new Dictionary<
+            string,
+            object
+        >(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// The lock object that serializes CHANGES to one file of the AI image editor's folder
+        /// (see <see cref="WriteRequestBodyToFile"/> for why they have to be serialized). A GET
+        /// deliberately doesn't take it: a read can't corrupt anything, and making a response
+        /// stream wait behind a multi-MB upload would cost more than it saves.
+        /// </summary>
+        private static object GetFileLock(string fullPath)
+        {
+            lock (_locksByFilePath)
+            {
+                if (!_locksByFilePath.TryGetValue(fullPath, out var fileLock))
+                {
+                    fileLock = new object();
+                    _locksByFilePath[fullPath] = fileLock;
+                }
+                return fileLock;
+            }
+        }
+
+        /// <summary>
+        /// Saves a POST to <see cref="HandleFile"/> at <paramref name="fullPath"/>, creating
+        /// its folder if needed. Takes ownership of <paramref name="body"/> (the request's post
+        /// stream) and disposes it.
+        ///
+        /// The body is streamed straight to disk, because history images are multi-MB and we
+        /// don't want to buffer them whole in memory (RawPostData would). It lands in a temp
+        /// file which is then swapped in, so an upload that dies partway can't leave a
+        /// truncated file where a previous good one was. An empty body is a valid save of an
+        /// empty file, not a no-op: the AI image editor must never be told "saved" while stale
+        /// content survives on disk.
+        ///
+        /// Writes to a given file are SERIALIZED, because two of them for the same file are
+        /// ordinary traffic from the AI image editor, not a pathological case (BL-16702): one
+        /// generated image assigned to two book-image slots makes its commit call putFile once
+        /// per slot, concurrently (Promise.all), and both calls name the same
+        /// history/&lt;resultId&gt;.png. Unserialized, the two collided on the shared temp path
+        /// — RobustFile.Create opens with FileShare.None and, unlike most of RobustFile, does
+        /// not retry — so the loser threw IOException, which the API layer turns into a 503
+        /// "Cannot access ..." plus a yellow box. The AI image editor reports that as "Failed
+        /// to write host file", and since it writes all the files before posting the commit,
+        /// ONE such failure abandoned the whole commit: the user's Replace did nothing at all.
+        ///
+        /// Internal for testing.
+        /// </summary>
+        internal static void WriteRequestBodyToFile(string fullPath, Stream body)
+        {
+            var directory = Path.GetDirectoryName(fullPath);
+            if (!Directory.Exists(directory))
+                Directory.CreateDirectory(directory);
+            lock (GetFileLock(fullPath))
+            {
+                var tempPath = fullPath + ".tmp";
+                using (body)
+                using (var output = RobustFile.Create(tempPath))
+                {
+                    // The body stream is null for an empty body (no entity body); that still
+                    // means "save an empty file" here, so just leave the freshly created temp
+                    // file empty rather than copying.
+                    body?.CopyTo(output);
+                }
+                RobustFile.Move(tempPath, fullPath, true); // true: overwrite
             }
         }
 

--- a/src/BloomExe/web/controllers/AiImageEditorApi.cs
+++ b/src/BloomExe/web/controllers/AiImageEditorApi.cs
@@ -664,7 +664,8 @@ namespace Bloom.web.controllers
         /// empty file, not a no-op: the AI image editor must never be told "saved" while stale
         /// content survives on disk.
         ///
-        /// Writes to a given file are SERIALIZED, because two of them for the same file are
+        /// Writes to a given file are SERIALIZED within this process (which is all Bloom needs:
+        /// one Bloom has a given collection open), because two of them for the same file are
         /// ordinary traffic from the AI image editor, not a pathological case (BL-16702): one
         /// generated image assigned to two book-image slots makes its commit call putFile once
         /// per slot, concurrently (Promise.all), and both calls name the same
@@ -685,7 +686,7 @@ namespace Bloom.web.controllers
             lock (GetFileLock(fullPath))
             {
                 var tempPath = fullPath + ".tmp";
-                var swapped = false;
+                var reachedTheSwap = false;
                 try
                 {
                     using (body)
@@ -696,19 +697,25 @@ namespace Bloom.web.controllers
                         // created temp file empty rather than copying.
                         body?.CopyTo(output);
                     }
+                    reachedTheSwap = true;
                     RobustFile.Move(tempPath, fullPath, true); // true: overwrite
-                    swapped = true;
                 }
                 finally
                 {
-                    // A write that dies partway (the client goes away, the disk fills up) must
-                    // not leave its half-written temp behind. Nothing would ever serve or
+                    // An upload that died partway (the client went away, the disk filled up)
+                    // must not leave its half-written temp behind. Nothing would ever serve or
                     // enumerate it — the name is neither allow-listed nor an image extension —
                     // but it can be multi-MB, and it would sit in the book's folder for the
-                    // life of the book. Whatever file it was going to replace is untouched,
-                    // which is the whole point of writing through a temp, so the temp is all
-                    // there is to clean up.
-                    if (!swapped)
+                    // life of the book. The file it was going to replace is untouched, so the
+                    // temp is all there is to clean up.
+                    //
+                    // A failure in the SWAP is the one case we leave alone, because there the
+                    // temp may be the only copy of the bytes left: Move(overWrite) deletes the
+                    // destination and then moves, so a failure between those two steps has
+                    // already taken the old file with it. A stray temp is much the lesser evil
+                    // — and the next write of this file overwrites it anyway. (Devin spotted
+                    // that tidying up unconditionally could throw away both copies.)
+                    if (!reachedTheSwap)
                         DeleteTempFileIgnoringErrors(tempPath);
                 }
             }

--- a/src/BloomTests/web/controllers/AiImageEditorApiTests.cs
+++ b/src/BloomTests/web/controllers/AiImageEditorApiTests.cs
@@ -391,6 +391,56 @@ namespace BloomTests.web.controllers
             Assert.That(new FileInfo(path).Length, Is.EqualTo(0));
         }
 
+        // A body that hands over some bytes and then fails, standing in for a client that goes
+        // away mid-upload.
+        private class FailingStream : MemoryStream
+        {
+            public FailingStream(byte[] initialBytes)
+                : base(initialBytes) { }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                var read = base.Read(buffer, offset, count);
+                if (Position >= Length)
+                    throw new IOException("the client went away");
+                return read;
+            }
+        }
+
+        [Test]
+        public void WriteRequestBodyToFile_WriteFails_KeepsTheOldFileAndLeavesNoTempBehind()
+        {
+            // Writing through a temp file exists so a half-finished upload can't destroy the
+            // good file that was there. The temp itself must not survive either: nothing would
+            // serve or enumerate it, but it can be multi-MB and would sit in the book's folder
+            // for the life of the book.
+            var path = HistoryFilePath("result.png");
+            var good = new byte[] { 1, 2, 3 };
+            AiImageEditorApi.WriteRequestBodyToFile(path, new MemoryStream(good));
+            Assert.That(File.ReadAllBytes(path), Is.EqualTo(good), "setup: the good file is there");
+
+            Assert.That(
+                () =>
+                    AiImageEditorApi.WriteRequestBodyToFile(
+                        path,
+                        new FailingStream(new byte[5000])
+                    ),
+                Throws.InstanceOf<IOException>(),
+                "a failed body read must still fail the request"
+            );
+
+            Assert.That(
+                File.ReadAllBytes(path),
+                Is.EqualTo(good),
+                "the file that was there must be untouched"
+            );
+            Assert.That(
+                Directory.EnumerateFiles(Path.GetDirectoryName(path), "*.tmp"),
+                Is.Empty,
+                "the failed write's temp file must have been cleaned up"
+            );
+        }
+
         [Test]
         public void WriteRequestBodyToFile_ConcurrentWritesOfTheSameFile_AllSucceed()
         {

--- a/src/BloomTests/web/controllers/AiImageEditorApiTests.cs
+++ b/src/BloomTests/web/controllers/AiImageEditorApiTests.cs
@@ -1,8 +1,11 @@
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using Bloom.Book;
 using Bloom.web.controllers;
 using NUnit.Framework;
@@ -345,6 +348,95 @@ namespace BloomTests.web.controllers
                 File.Exists(Path.Combine(_bookFolder.Path, newName)),
                 Is.True,
                 "a corrupt image must still be copied rather than silently dropped"
+            );
+        }
+
+        // ------------------------------------------------------------------
+        // WriteRequestBodyToFile: the /file POST endpoint's save. Two saves of the SAME file
+        // at once are ordinary traffic from the AI image editor (BL-16702) — one generated
+        // image assigned to two book-image slots makes its commit call putFile once per slot,
+        // concurrently — so they must not be able to trip over each other's temp file.
+        // ------------------------------------------------------------------
+
+        // The path a history image would be written to, under a fresh .ai-image-editor folder
+        // that does not exist yet (so these also cover creating it).
+        private string HistoryFilePath(string fileName) =>
+            Path.Combine(_bookFolder.Path, ".ai-image-editor", "history", fileName);
+
+        [Test]
+        public void WriteRequestBodyToFile_WritesTheBodyAndCreatesTheFolder()
+        {
+            var path = HistoryFilePath("result.png");
+            // Sanity: neither the file nor its folder exists yet, so what we find afterwards
+            // was made by the call.
+            Assert.That(Directory.Exists(Path.GetDirectoryName(path)), Is.False, "setup");
+            var bytes = new byte[] { 1, 2, 3, 4, 5 };
+
+            AiImageEditorApi.WriteRequestBodyToFile(path, new MemoryStream(bytes));
+
+            Assert.That(File.ReadAllBytes(path), Is.EqualTo(bytes));
+        }
+
+        [Test]
+        public void WriteRequestBodyToFile_NoBody_SavesAnEmptyFile()
+        {
+            // An empty body means "save an empty file", not "leave what's there": the AI image
+            // editor must never be told "saved" while stale content survives on disk.
+            var path = HistoryFilePath("result.png");
+            AiImageEditorApi.WriteRequestBodyToFile(path, new MemoryStream(new byte[] { 1, 2 }));
+            Assert.That(new FileInfo(path).Length, Is.EqualTo(2), "setup: the file has content");
+
+            AiImageEditorApi.WriteRequestBodyToFile(path, null);
+
+            Assert.That(new FileInfo(path).Length, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void WriteRequestBodyToFile_ConcurrentWritesOfTheSameFile_AllSucceed()
+        {
+            // BL-16702: the AI image editor POSTs history/<resultId>.png once per slot the
+            // result was assigned to, all at the same time. Before this was serialized, the
+            // writes collided on the shared "<file>.tmp" path (RobustFile.Create opens with
+            // FileShare.None and does not retry), so all but one threw IOException — which the
+            // API layer turns into a 503, and which made the AI image editor abandon the whole
+            // commit before it ever asked Bloom to replace anything.
+            var path = HistoryFilePath("result.png");
+            // Big enough that the writes really do overlap rather than finishing one after
+            // another, like the multi-MB PNG an AI service returns.
+            var bytes = new byte[4 * 1024 * 1024];
+            for (var i = 0; i < bytes.Length; i++)
+                bytes[i] = (byte)i;
+
+            var exceptions = new ConcurrentBag<Exception>();
+            var writers = Enumerable
+                .Range(0, 4)
+                .Select(_ => new Thread(() =>
+                {
+                    try
+                    {
+                        AiImageEditorApi.WriteRequestBodyToFile(path, new MemoryStream(bytes));
+                    }
+                    catch (Exception e)
+                    {
+                        exceptions.Add(e);
+                    }
+                }))
+                .ToList();
+            writers.ForEach(t => t.Start());
+            writers.ForEach(t => t.Join());
+
+            Assert.That(
+                exceptions,
+                Is.Empty,
+                "no concurrent write of the same file should fail: "
+                    + string.Join("; ", exceptions.Select(e => e.Message))
+            );
+            // And the survivor must be the whole file, not a partly-written one.
+            Assert.That(File.ReadAllBytes(path), Is.EqualTo(bytes));
+            Assert.That(
+                Directory.EnumerateFiles(Path.GetDirectoryName(path), "*.tmp"),
+                Is.Empty,
+                "no temp file should be left behind"
             );
         }
 

--- a/src/BloomTests/web/controllers/AiImageEditorApiTests.cs
+++ b/src/BloomTests/web/controllers/AiImageEditorApiTests.cs
@@ -457,11 +457,21 @@ namespace BloomTests.web.controllers
             for (var i = 0; i < bytes.Length; i++)
                 bytes[i] = (byte)i;
 
+            const int writerCount = 4;
             var exceptions = new ConcurrentBag<Exception>();
+            // Release all the writers at once, and record when each was in the call, so the
+            // assertions below can say whether the writes really were concurrent. Without that,
+            // a green result could just mean the threads happened to run one after another and
+            // never tested anything (see AGENTS.md on guarding against falsely passing tests).
+            var startLine = new Barrier(writerCount);
+            var spans = new ConcurrentBag<Tuple<long, long>>();
+            var clock = System.Diagnostics.Stopwatch.StartNew();
             var writers = Enumerable
-                .Range(0, 4)
+                .Range(0, writerCount)
                 .Select(_ => new Thread(() =>
                 {
+                    startLine.SignalAndWait();
+                    var from = clock.ElapsedTicks;
                     try
                     {
                         AiImageEditorApi.WriteRequestBodyToFile(path, new MemoryStream(bytes));
@@ -470,6 +480,7 @@ namespace BloomTests.web.controllers
                     {
                         exceptions.Add(e);
                     }
+                    spans.Add(Tuple.Create(from, clock.ElapsedTicks));
                 }))
                 .ToList();
             writers.ForEach(t => t.Start());
@@ -480,6 +491,15 @@ namespace BloomTests.web.controllers
                 Is.Empty,
                 "no concurrent write of the same file should fail: "
                     + string.Join("; ", exceptions.Select(e => e.Message))
+            );
+            // Sanity check: at least two of the calls really did overlap in time, so the empty
+            // `exceptions` above means the serialization was exercised rather than dodged.
+            var ordered = spans.OrderBy(s => s.Item1).ToList();
+            Assert.That(ordered.Count, Is.EqualTo(writerCount), "every writer should have run");
+            Assert.That(
+                ordered.Zip(ordered.Skip(1), (earlier, later) => earlier.Item2 > later.Item1),
+                Has.Some.True,
+                "the writes did not overlap, so this run did not actually test concurrency"
             );
             // And the survivor must be the whole file, not a partly-written one.
             Assert.That(File.ReadAllBytes(path), Is.EqualTo(bytes));

--- a/src/BloomTests/web/controllers/AiImageEditorApiTests.cs
+++ b/src/BloomTests/web/controllers/AiImageEditorApiTests.cs
@@ -391,8 +391,10 @@ namespace BloomTests.web.controllers
             Assert.That(new FileInfo(path).Length, Is.EqualTo(0));
         }
 
-        // A body that hands over some bytes and then fails, standing in for a client that goes
-        // away mid-upload.
+        // A body that hands over its first chunk and then fails, standing in for a client that
+        // goes away mid-upload. It lets one read through so bytes really do land in the temp
+        // file — Stream.CopyTo uses an 80KB buffer, so a body that dies on its first read would
+        // leave the temp empty and the test would not be exercising a truncated write at all.
         private class FailingStream : MemoryStream
         {
             public FailingStream(byte[] initialBytes)
@@ -400,10 +402,9 @@ namespace BloomTests.web.controllers
 
             public override int Read(byte[] buffer, int offset, int count)
             {
-                var read = base.Read(buffer, offset, count);
-                if (Position >= Length)
+                if (Position > 0)
                     throw new IOException("the client went away");
-                return read;
+                return base.Read(buffer, offset, count);
             }
         }
 
@@ -419,11 +420,13 @@ namespace BloomTests.web.controllers
             AiImageEditorApi.WriteRequestBodyToFile(path, new MemoryStream(good));
             Assert.That(File.ReadAllBytes(path), Is.EqualTo(good), "setup: the good file is there");
 
+            // Bigger than CopyTo's 80KB buffer, so the write really is truncated part way
+            // rather than failing before it wrote anything.
             Assert.That(
                 () =>
                     AiImageEditorApi.WriteRequestBodyToFile(
                         path,
-                        new FailingStream(new byte[5000])
+                        new FailingStream(new byte[200000])
                     ),
                 Throws.InstanceOf<IOException>(),
                 "a failed body read must still fail the request"
@@ -438,6 +441,43 @@ namespace BloomTests.web.controllers
                 Directory.EnumerateFiles(Path.GetDirectoryName(path), "*.tmp"),
                 Is.Empty,
                 "the failed write's temp file must have been cleaned up"
+            );
+        }
+
+        [Test]
+        public void WriteRequestBodyToFile_SwapFails_KeepsTheTempSoTheNewBytesSurvive()
+        {
+            // The one failure we must NOT tidy up after. Swapping the new file in is a delete
+            // of the destination followed by a move, so a failure in there can already have
+            // taken the old file with it, leaving the temp holding the only copy of the new
+            // bytes. Deleting it then would lose both. (Devin raised this against the first
+            // version of the cleanup, which deleted the temp on any failure.)
+            var path = HistoryFilePath("result.png");
+            AiImageEditorApi.WriteRequestBodyToFile(path, new MemoryStream(new byte[] { 1, 2, 3 }));
+            var newBytes = new byte[] { 9, 9, 9, 9 };
+            var historyFolder = Path.GetDirectoryName(path);
+
+            // Holding the destination open blocks the delete half of the swap, so the write
+            // gets as far as the swap and then fails — which is the case we care about.
+            using (new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+            {
+                Assert.That(
+                    () => AiImageEditorApi.WriteRequestBodyToFile(path, new MemoryStream(newBytes)),
+                    Throws.InstanceOf<IOException>(),
+                    "setup: holding the file open should make the swap fail"
+                );
+            }
+
+            var temps = Directory.EnumerateFiles(historyFolder, "*.tmp").ToList();
+            Assert.That(
+                temps,
+                Is.Not.Empty,
+                "a failed swap must leave the new bytes behind in the temp file"
+            );
+            Assert.That(
+                File.ReadAllBytes(temps[0]),
+                Is.EqualTo(newBytes),
+                "and they must be all of the new bytes"
             );
         }
 
@@ -459,19 +499,18 @@ namespace BloomTests.web.controllers
 
             const int writerCount = 4;
             var exceptions = new ConcurrentBag<Exception>();
-            // Release all the writers at once, and record when each was in the call, so the
-            // assertions below can say whether the writes really were concurrent. Without that,
-            // a green result could just mean the threads happened to run one after another and
-            // never tested anything (see AGENTS.md on guarding against falsely passing tests).
+            // The barrier is what makes this a concurrency test: every writer waits there and
+            // they are all released together, rather than each starting whenever its thread
+            // happens to get going — which could otherwise leave them running one after another,
+            // passing without testing anything (see AGENTS.md on falsely passing tests).
             var startLine = new Barrier(writerCount);
-            var spans = new ConcurrentBag<Tuple<long, long>>();
-            var clock = System.Diagnostics.Stopwatch.StartNew();
+            var arrived = new ConcurrentBag<int>();
             var writers = Enumerable
                 .Range(0, writerCount)
-                .Select(_ => new Thread(() =>
+                .Select(index => new Thread(() =>
                 {
                     startLine.SignalAndWait();
-                    var from = clock.ElapsedTicks;
+                    arrived.Add(index);
                     try
                     {
                         AiImageEditorApi.WriteRequestBodyToFile(path, new MemoryStream(bytes));
@@ -480,7 +519,6 @@ namespace BloomTests.web.controllers
                     {
                         exceptions.Add(e);
                     }
-                    spans.Add(Tuple.Create(from, clock.ElapsedTicks));
                 }))
                 .ToList();
             writers.ForEach(t => t.Start());
@@ -492,14 +530,12 @@ namespace BloomTests.web.controllers
                 "no concurrent write of the same file should fail: "
                     + string.Join("; ", exceptions.Select(e => e.Message))
             );
-            // Sanity check: at least two of the calls really did overlap in time, so the empty
-            // `exceptions` above means the serialization was exercised rather than dodged.
-            var ordered = spans.OrderBy(s => s.Item1).ToList();
-            Assert.That(ordered.Count, Is.EqualTo(writerCount), "every writer should have run");
+            // Sanity check: every writer got past the barrier, so all four really were in
+            // flight together and the empty `exceptions` above means something.
             Assert.That(
-                ordered.Zip(ordered.Skip(1), (earlier, later) => earlier.Item2 > later.Item1),
-                Has.Some.True,
-                "the writes did not overlap, so this run did not actually test concurrency"
+                arrived,
+                Is.EquivalentTo(Enumerable.Range(0, writerCount)),
+                "every writer should have been released from the barrier and run"
             );
             // And the survivor must be the whole file, not a partly-written one.
             Assert.That(File.ReadAllBytes(path), Is.EqualTo(bytes));


### PR DESCRIPTION
Assigning one AI-generated image to two book-image slots and clicking **Replace** failed with `Failed to write host file history/<id>.png:503` and a yellow "Cannot access …" box, and nothing in the book was replaced.

### Cause

The AI image editor writes each assigned result to the host **before** posting the commit, and it does so once per slot, **concurrently** (`Promise.all`). One image in two slots therefore means two simultaneous POSTs of the same `history/<resultId>.png`.

Bloom's `aiImageEditor/file` POST handler wrote through a temp file named after the target (`<file>.tmp`), so the two requests collided on that one path: `RobustFile.Create` opens with `FileShare.None` and, unlike most of `RobustFile`, does **not** retry, so the loser threw `IOException`. `ApiRequest` turns an `IOException` into a 503 "Cannot access …" plus a NonFatalProblem, the editor reports it as "Failed to write host file", and that one failure abandoned the **whole** commit before Bloom was ever asked to change an image.

Confirmed live before fixing — two concurrent POSTs of the same file name against a running Bloom returned `200` and `503`, while one on its own returned `200`. The affected book's history PNG showed the winning write's timestamp, and the book folder contained no `ai-image*.png` at all: the commit never ran.

### Fix

Serialize changes to a given file. `HandleFile`'s POST body write moves into `WriteRequestBodyToFile`, which takes a per-path lock; the DELETE branch takes the same lock. A GET deliberately doesn't — a read can't corrupt anything, and making a response stream wait behind a multi-MB upload would cost more than it saves. Nothing changes for the AI image editor, or for single-slot commits.

The rest of the "same image twice" path was already sound: `matchReplacementsToElements` handles two current-page replacements sharing an `oldSrc`, and each slot gets its own `ai-image*` copy in the book folder.

### Tests

Three new tests on `WriteRequestBodyToFile`: body written + folder created, empty body truncates, and the BL-16702 regression — four concurrent writes of one file all succeed and leave a complete file with no temp file behind. The regression test was confirmed to **fail** with the lock defeated (the very same "used by another process" `IOException` from `RobustFile.Create`) and to pass with it.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16702


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8207)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8207)
<!-- Reviewable:end -->
