### PR TITLE
Don't dodge for a forced-left page number on Zero Margin portrait pages (BL-14901)

### DIFF
--- a/src/content/appearanceThemes/appearance-theme-zero-margin-ebook.css
+++ b/src/content/appearanceThemes/appearance-theme-zero-margin-ebook.css
@@ -77,11 +77,14 @@ Note that hiding the page numbers is done by a setting in appearance.json, not h
 .numberedPage:where([class*="Device"]:not(.bloom-interactive-page)) {
     --topLevel-text-padding: 0.5em;
 }
-[class*="Ebook"].numberedPage:not(.bloom-interactive-page),
-[class*="Device"].numberedPage:not(.bloom-interactive-page) {
+.Ebook7x5Landscape.numberedPage:not(.bloom-interactive-page),
+.Device16x9Landscape.numberedPage:not(.bloom-interactive-page) {
     /* how far the format button moves to clear this theme's page number when the user's
        Page Numbers setting forces the number to the bottom left; editMode.less applies
-       it in that situation whatever the rules below decide (BL-14901) */
+       it in that situation whatever the rules below decide (BL-14901).
+       Landscape only: this theme's portrait pages reserve 12mm below the text box for
+       the page number (--pageNumber-extra-height above), so there the number sits below
+       the text box wherever it is placed horizontally, and the button need not move */
     --formatButton-pageNumber-dodge-when-forced-left: 20px;
 }
 .Ebook7x5Landscape.numberedPage:not(.bloom-interactive-page),


### PR DESCRIPTION
Follow-up to #8198, from QA's testing of it: on Zero Margin portrait pages the page number displays *below* the text box (those pages reserve 12mm under the box for it via `--pageNumber-extra-height`), so the edit-mode gear icon was stepping aside for a number that can never collide with it when Book Settings → Page Numbers is set to Left.

The theme now publishes `--formatButton-pageNumber-dodge-when-forced-left` only for its landscape sizes — whose pages put the number on the content — mirroring the scoping of its automatic dodge. Rounded Border is unchanged: it overlays the number on the content in both orientations, so its forced-left dodge is genuinely needed.

Verified live in Bloom: Zero Margin portrait + Page Numbers = Left now leaves the gear at the text box corner (computed margin 3px, was 23px), while Zero Margin landscape + Left on a Picture-on-Right page and Rounded Border portrait + Left still step aside (23px).

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-14901

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8211)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8211)
<!-- Reviewable:end -->
