### PR TITLE
Fix BL-16276 Adjust Timings dialog displays wrong when opened while audio playing

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/AdjustTimingsDialog.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/AdjustTimingsDialog.tsx
@@ -20,7 +20,6 @@ import {
 } from "../../../react_components/BloomDialog/commonDialogComponents";
 import { useL10n } from "../../../react_components/l10nHooks";
 import { getAsync, postBoolean, postJsonAsync } from "../../../utils/bloomApi";
-import { kAudioCurrent } from "./audioRecording";
 import { AdjustTimingsControl, TimedTextSegment } from "./AdjustTimingsControl";
 import {
     getUrlPrefixFromWindowHref,
@@ -440,14 +439,12 @@ function getModalContainer(): HTMLElement {
     return modalDialogContainer;
 }
 
+// The text box whose timings this dialog adjusts: the one that has the audio recording
+// highlight. We delegate to the audio recorder's method of the same name rather than just
+// taking the element that has ui-audioCurrent, because during playback the highlight is on
+// a sentence within the text box, and that method knows to walk up to the box (BL-16276).
 function getCurrentTextBox(): HTMLElement {
-    const page = parent.window.document.getElementById(
-        "page",
-    ) as HTMLIFrameElement;
-    const pageBody = page.contentWindow!.document.body;
-    const audioCurrentElements = pageBody.getElementsByClassName(kAudioCurrent);
-    const currentTextBox = audioCurrentElements.item(0) as HTMLElement;
-    return currentTextBox;
+    return getAudioRecorder().getCurrentTextBox()!;
 }
 
 // Existing code wants to be passed the actual path (not a BloomServer url) to the timings file.

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -1810,7 +1810,9 @@ export default class AudioRecording implements IAudioRecorder {
      * we RECORD rather than on whichever sub-segment was being played, the temporary
      * highlighting markup reverted, and the buttons no longer showing play as active.
      * Callers that need the page to be in a settled state before they do something else
-     * (e.g. opening the Adjust Timings dialog, BL-16276) should await this.
+     * (e.g. opening the Adjust Timings dialog, BL-16276) should await this. What the returned
+     * promise guarantees is that the PAGE has settled; refreshing the toolbox buttons is
+     * deliberately left to finish on its own (see the last line).
      */
     public async stopPlaybackAsync(): Promise<void> {
         this.stopListen();
@@ -1841,7 +1843,12 @@ export default class AudioRecording implements IAudioRecorder {
 
         // As in playEndedAsync(), Split is the natural next step. ("next" is automatically
         // substituted for "split" if we're in a mode where "split" does not apply.)
-        return this.changeStateAndSetExpectedAsync("split");
+        // Deliberately NOT awaited. This only refreshes the toolbox buttons, but it does so via
+        // API calls; if we made the returned promise wait on those, a single failed request would
+        // reject it, and our caller would never get as far as opening the Adjust Timings dialog --
+        // the click would appear to do nothing. Firing it un-awaited is also what the other
+        // callers in this file do, including this method's own caller in the #audio-split handler.
+        this.changeStateAndSetExpectedAsync("split");
     }
 
     private async playEndedAsync(): Promise<void> {

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -1821,11 +1821,20 @@ export default class AudioRecording implements IAudioRecorder {
         // While playing in text box mode we move ui-audioCurrent onto each sub-segment
         // (sentence) in turn. Put it back on the recording element, since that is what the
         // rest of the tool, and the Adjust Timings dialog, expect to find it on.
-        const currentTextBox = this.getCurrentTextBox();
-        if (currentTextBox) {
-            await this.setCurrentAudioElementBasedOnRecordingModeAsync(
-                currentTextBox,
-            );
+        // The conditions here are the same ones playEndedAsync() uses: in sentence mode the
+        // highlight is already on the element we record, so leave it wherever it was, and
+        // don't reset (and thereby activate) an element in a motion preview.
+        if (this.recordingMode === RecordingMode.TextBox) {
+            const currentTextBox = this.getCurrentTextBox();
+            if (
+                currentTextBox &&
+                !currentTextBox.closest("." + animateStyleName)
+            ) {
+                await this.setCurrentAudioElementBasedOnRecordingModeAsync(
+                    currentTextBox,
+                    false,
+                );
+            }
         }
 
         this.revertFixHighlighting();

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -287,8 +287,12 @@ export default class AudioRecording implements IAudioRecorder {
         delegationRoot
             .off("click" + ns, "#audio-split")
             .on("click" + ns, "#audio-split", async () => {
-                const mediaPlayer = this.getMediaPlayer();
-                mediaPlayer.pause();
+                // Merely pausing the audio is not enough: while playback is in progress the
+                // highlight sits on the sentence being played rather than on the text box,
+                // and the dialog would then have no segments and no audio file to show
+                // (BL-16276). Stopping properly also puts back the text we temporarily
+                // restructured for highlighting.
+                await this.stopPlaybackAsync();
                 getWorkspaceBundleExports().showAdjustTimingsDialogFromWorkspaceRoot(
                     this.split,
                     this.editTimingsFileAsync,
@@ -1792,11 +1796,43 @@ export default class AudioRecording implements IAudioRecorder {
 
     // This is currently used in Motion, which removes all the current
     // audio markup afterwards. If we use it in this tool, we need to do more,
-    // such as setting the current state of controls.
+    // such as setting the current state of controls. See stopPlaybackAsync().
     public stopListen(): void {
         this.listening = false;
         this.clearSubElementHighlightTimeout();
         this.getMediaPlayer().pause();
+    }
+
+    /**
+     * Fully stops any playback in progress (Play/Check or Listen to the Whole Page),
+     * leaving things in the state they would be in had the playback finished normally:
+     * no pending highlight timeouts, empty play queues, the highlight back on the element
+     * we RECORD rather than on whichever sub-segment was being played, the temporary
+     * highlighting markup reverted, and the buttons no longer showing play as active.
+     * Callers that need the page to be in a settled state before they do something else
+     * (e.g. opening the Adjust Timings dialog, BL-16276) should await this.
+     */
+    public async stopPlaybackAsync(): Promise<void> {
+        this.stopListen();
+        // Rewind and empty the play queues, so that a later Play starts over rather than
+        // trying to resume something we have now discarded.
+        this.resetAudioIfPaused();
+
+        // While playing in text box mode we move ui-audioCurrent onto each sub-segment
+        // (sentence) in turn. Put it back on the recording element, since that is what the
+        // rest of the tool, and the Adjust Timings dialog, expect to find it on.
+        const currentTextBox = this.getCurrentTextBox();
+        if (currentTextBox) {
+            await this.setCurrentAudioElementBasedOnRecordingModeAsync(
+                currentTextBox,
+            );
+        }
+
+        this.revertFixHighlighting();
+
+        // As in playEndedAsync(), Split is the natural next step. ("next" is automatically
+        // substituted for "split" if we're in a mode where "split" does not apply.)
+        return this.changeStateAndSetExpectedAsync("split");
     }
 
     private async playEndedAsync(): Promise<void> {

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -293,6 +293,18 @@ export default class AudioRecording implements IAudioRecorder {
                 // (BL-16276). Stopping properly also puts back the text we temporarily
                 // restructured for highlighting.
                 await this.stopPlaybackAsync();
+
+                // Which text box we end up on is not necessarily the one that was current when
+                // the user pressed Listen: "Listen to the whole page" walks through every box,
+                // and this button's enabled state is not recalculated as it goes. So on a page
+                // that mixes recording modes we can arrive here with a by-sentence box current,
+                // which would give us the very empty dialog this bug is about. The button-state
+                // refresh kicked off by stopPlaybackAsync() disables this button a moment
+                // later, so the user can see why nothing opened. (BL-16276)
+                if (!this.canAdjustTimingsForCurrentTextBox()) {
+                    return;
+                }
+
                 getWorkspaceBundleExports().showAdjustTimingsDialogFromWorkspaceRoot(
                     this.split,
                     this.editTimingsFileAsync,
@@ -1801,6 +1813,22 @@ export default class AudioRecording implements IAudioRecorder {
         this.listening = false;
         this.clearSubElementHighlightTimeout();
         this.getMediaPlayer().pause();
+    }
+
+    /**
+     * Does the Adjust Timings dialog apply to the text box that currently has the recording
+     * highlight? It only makes sense for a whole-text-box recording: a by-sentence box has one
+     * audio file per sentence and no whole-box timings, so the dialog would have no waveform
+     * and no segments to show. We ask the box itself rather than trusting the recordingMode
+     * field, which is re-derived as playback moves from box to box. (BL-16276)
+     */
+    public canAdjustTimingsForCurrentTextBox(): boolean {
+        const currentTextBox = this.getCurrentTextBox();
+        return (
+            !!currentTextBox &&
+            this.getRecordingModeOfTextBox(currentTextBox) ===
+                RecordingMode.TextBox
+        );
     }
 
     /**

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
@@ -1627,9 +1627,12 @@ describe("audio recording tests", () => {
                 "ui-audioCurrent",
             );
 
-            // recordingMode is TextBox here on purpose: that is exactly the stale value left
-            // over from the box the user had selected before pressing Listen, which is why we
-            // must ask the box itself rather than trust the field.
+            // recordingMode is set to TextBox on purpose, disagreeing with the box the
+            // highlight is actually in. In the running app the field would normally have been
+            // refreshed to Sentence by now (setSoundFrom re-derives it as playback moves from
+            // box to box), so this is a deliberately contrived state: it pins the contract that
+            // the helper answers about the CURRENT BOX and does not depend on that refresh
+            // having happened.
             const recording = makeRecorder(RecordingMode.TextBox);
 
             expect(recording.canAdjustTimingsForCurrentTextBox()).toBe(false);

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
@@ -1557,6 +1557,39 @@ describe("audio recording tests", () => {
             expect(box).toHaveClass("ui-audioCurrent");
             expect(playingSegment).not.toHaveClass("ui-audioCurrent");
         });
+
+        // In sentence mode the highlight is already on the element we record, so there is
+        // nothing to move it back to; dragging it to the first sentence would lose the
+        // user's place. (playEndedAsync() skips the same work for the same reason.)
+        it("stopPlaybackAsync leaves the highlight alone in sentence mode", async () => {
+            setupDefaultApiResponses();
+            const sentences =
+                '<p><span id="sent1" class="audio-sentence">Sentence 1.</span> <span id="sent2" class="audio-sentence ui-audioCurrent">Sentence 2.</span></p>';
+            const textBox = `<div id="box1" class="bloom-editable bloom-visibility-code-on" lang="es" data-audiorecordingmode="Sentence">${sentences}</div>`;
+            SetupIFrameFromHtml(
+                `<div class="bloom-translationGroup">${textBox}</div>`,
+            );
+
+            const recording = new AudioRecording();
+            recording.recordingMode = RecordingMode.Sentence;
+            // Simulate the tool being visible so doesCurrentToolPlayAudio() returns true.
+            (recording as unknown as { isShowing: boolean }).isShowing = true;
+
+            const first = getFrameElementById("page", "sent1")!;
+            const second = getFrameElementById("page", "sent2")!;
+            // Sanity check: the highlight starts on the second sentence, not the first.
+            expect(second, "test setup problem").toHaveClass("ui-audioCurrent");
+            expect(first, "test setup problem").not.toHaveClass(
+                "ui-audioCurrent",
+            );
+
+            // System under test
+            await recording.stopPlaybackAsync();
+
+            // Verification: still on the second sentence.
+            expect(second).toHaveClass("ui-audioCurrent");
+            expect(first).not.toHaveClass("ui-audioCurrent");
+        });
     });
 
     describe("- initializeAudioRecordingMode()", () => {

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
@@ -1592,6 +1592,64 @@ describe("audio recording tests", () => {
         });
     });
 
+    describe("- canAdjustTimingsForCurrentTextBox()", () => {
+        // BL-16276: "Listen to the whole page" walks through every text box, but the Adjust
+        // Timings button's enabled state is not recalculated as it goes. So on a page mixing
+        // recording modes the button can still be clicked while a by-sentence box is current,
+        // and opening the dialog on such a box reproduces the very blank dialog we fixed.
+        const mixedModePage = (whichBoxIsCurrent: "textBox" | "sentence") => {
+            const textBoxCurrent =
+                whichBoxIsCurrent === "textBox" ? " ui-audioCurrent" : "";
+            const sentenceCurrent =
+                whichBoxIsCurrent === "sentence" ? " ui-audioCurrent" : "";
+            // Recorded by whole text box, soft split into highlight segments.
+            const wholeBox = `<div id="wholeBox" class="bloom-editable bloom-visibility-code-on audio-sentence bloom-postAudioSplit${textBoxCurrent}" lang="es" data-audiorecordingmode="TextBox" data-audiorecordingendtimes="1.0 2.0"><p><span id="seg1" class="bloom-highlightSegment">Uno.</span> <span id="seg2" class="bloom-highlightSegment">Dos.</span></p></div>`;
+            // Recorded sentence by sentence: one audio file per sentence, no box timings.
+            const sentenceBox = `<div id="sentenceBox" class="bloom-editable bloom-visibility-code-on" lang="en" data-audiorecordingmode="Sentence"><p><span id="sent1" class="audio-sentence${sentenceCurrent}">One.</span> <span id="sent2" class="audio-sentence">Two.</span></p></div>`;
+            return `<div class="bloom-translationGroup">${wholeBox}</div><div class="bloom-translationGroup">${sentenceBox}</div>`;
+        };
+
+        const makeRecorder = (mode: RecordingMode) => {
+            const recording = new AudioRecording();
+            recording.recordingMode = mode;
+            // Simulate the tool being visible so doesCurrentToolPlayAudio() returns true.
+            (recording as unknown as { isShowing: boolean }).isShowing = true;
+            return recording;
+        };
+
+        it("says no when the current box is recorded by sentence", () => {
+            setupDefaultApiResponses();
+            SetupIFrameFromHtml(mixedModePage("sentence"));
+
+            // Sanity check the mid-Listen state: the highlight is inside the by-sentence box.
+            const current = getFrameElementById("page", "sent1")!;
+            expect(current, "test setup problem").toHaveClass(
+                "ui-audioCurrent",
+            );
+
+            // recordingMode is TextBox here on purpose: that is exactly the stale value left
+            // over from the box the user had selected before pressing Listen, which is why we
+            // must ask the box itself rather than trust the field.
+            const recording = makeRecorder(RecordingMode.TextBox);
+
+            expect(recording.canAdjustTimingsForCurrentTextBox()).toBe(false);
+        });
+
+        it("says yes when the current box is recorded by whole text box", () => {
+            setupDefaultApiResponses();
+            SetupIFrameFromHtml(mixedModePage("textBox"));
+
+            const current = getFrameElementById("page", "wholeBox")!;
+            expect(current, "test setup problem").toHaveClass(
+                "ui-audioCurrent",
+            );
+
+            const recording = makeRecorder(RecordingMode.TextBox);
+
+            expect(recording.canAdjustTimingsForCurrentTextBox()).toBe(true);
+        });
+    });
+
     describe("- initializeAudioRecordingMode()", () => {
         it("initializeAudioRecordingMode gets mode from current div if available (synchronous) (Text Box)", () => {
             SetupIFrameFromHtml(

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecordingSpec.ts
@@ -1522,6 +1522,43 @@ describe("audio recording tests", () => {
         });
     });
 
+    describe("- stopPlaybackAsync()", () => {
+        // BL-16276: clicking Adjust Timings while the audio was playing produced an empty
+        // dialog, because while playing we put ui-audioCurrent on the sentence being played
+        // instead of on the text box that the dialog needs to work from.
+        it("stopPlaybackAsync moves the highlight from the playing sentence back to the text box", async () => {
+            setupDefaultApiResponses();
+            const segments =
+                '<p><span id="seg1" class="bloom-highlightSegment">Sentence 1.</span> <span id="seg2" class="bloom-highlightSegment ui-audioCurrent">Sentence 2.</span></p>';
+            const textBox = `<div id="box1" class="bloom-editable bloom-visibility-code-on audio-sentence bloom-postAudioSplit" lang="es" data-audiorecordingmode="TextBox" data-audiorecordingendtimes="1.0 2.0">${segments}</div>`;
+            SetupIFrameFromHtml(
+                `<div class="bloom-translationGroup">${textBox}</div>`,
+            );
+
+            const recording = new AudioRecording();
+            recording.recordingMode = RecordingMode.TextBox;
+            // Simulate the tool being visible so doesCurrentToolPlayAudio() returns true.
+            (recording as unknown as { isShowing: boolean }).isShowing = true;
+
+            const box = getFrameElementById("page", "box1")!;
+            const playingSegment = getFrameElementById("page", "seg2")!;
+            // Sanity checks that we really start out in the mid-playback state this is about.
+            expect(playingSegment, "test setup problem").toHaveClass(
+                "ui-audioCurrent",
+            );
+            expect(box, "test setup problem").not.toHaveClass(
+                "ui-audioCurrent",
+            );
+
+            // System under test
+            await recording.stopPlaybackAsync();
+
+            // Verification
+            expect(box).toHaveClass("ui-audioCurrent");
+            expect(playingSegment).not.toHaveClass("ui-audioCurrent");
+        });
+    });
+
     describe("- initializeAudioRecordingMode()", () => {
         it("initializeAudioRecordingMode gets mode from current div if available (synchronous) (Text Box)", () => {
             SetupIFrameFromHtml(


### PR DESCRIPTION
Clicking **Adjust Timings** while audio was playing gave a dialog with no waveform, no text and no dividers.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16276

## Cause

While playing a whole-text-box recording, we move `ui-audioCurrent` onto each `bloom-highlightSegment` span in turn. `AdjustTimingsDialog`'s local `getCurrentTextBox()` took the first element carrying `ui-audioCurrent` **without walking up to the enclosing text box**, so mid-playback it got a sentence span. A span has no `bloom-highlightSegment` descendants and no `data-audiorecordingendtimes`, so the dialog had zero segments, and it built its audio URL from the span's id, so there was no mp3 to draw a waveform from. OK-ing that dialog also wrote `data-audiorecordingendtimes` onto the span.

The `mediaPlayer.pause()` already in the `#audio-split` handler silenced the audio but left the highlight on the sub-segment, left the sub-element highlight timeout rescheduling itself, left `fixHighlighting()`'s temporary markup in place, and left the Play button stuck in its active state.

## Changes

- **`audioRecording.ts`** — new public `stopPlaybackAsync()`, building on the existing `stopListen()` to do what its comment always said was needed for use in this tool: empty the play queues, move the highlight back onto the element we *record*, revert the temporary highlighting markup, and update the button states. Same settling `playEndedAsync()` does when playback finishes on its own, including its `recordingMode === TextBox` and motion-preview guards.
- **`audioRecording.ts`** — the `#audio-split` handler awaits `stopPlaybackAsync()` instead of just pausing. The dialog therefore opens on the text box that was playing, which is what the reporter wants ("I want to adjust the timing right when I see/hear the audio/text mismatch").
- **`AdjustTimingsDialog.tsx`** — its local `getCurrentTextBox()` now delegates to `AudioRecording.getCurrentTextBox()`, which already walks up from the highlighted element to the text box, rather than duplicating that lookup.

## Testing

Two new unit tests in `audioRecordingSpec.ts`: the highlight moves back to the text box in text-box mode, and is deliberately left alone in sentence mode. Both proven non-vacuous (the sentence-mode one fails with the guard removed). Talking-book suites: 217 passing.

Also verified against a running Bloom on a real 3-segment whole-text-box recording, via both entry points from the ticket:

| | Play → Adjust Timings | Listen to whole page → Adjust Timings |
|---|---|---|
| Confirmed genuinely mid-playback | `paused:false`, t=0.27s, button `active` | `paused:false`, t=0.24s, button `active` |
| Highlight at click time | `SPAN.bloom-highlightSegment` | `SPAN.bloom-highlightSegment` |
| What the old code would get | SPAN, **0 segments**, no endTimes, mp3 **404** | — |
| Dialog after fix | waveform + 3 correct sentence regions | waveform + 3 correct sentence regions |
| Highlight after | back on the text box div | back on the text box div |
| Audio / buttons | stopped, Play back to `enabled` | stopped, Listen back to `enabled` |
| Leftover `fixHighlighting` markup | — | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8212)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8212)
<!-- Reviewable:end -->
