### PR TITLE
Fix faulty page number placement in Zero Margin portrait ebooks (BL-16695)

### DIFF
--- a/src/BloomExe/Book/AppearanceSettings.cs
+++ b/src/BloomExe/Book/AppearanceSettings.cs
@@ -1047,6 +1047,9 @@ public class AppearanceSettings
     /// Sets the appropriate page number CSS properties based on the specified position.
     /// (Brandings and Xmattters should instead set pageNumber-left-margin, pageNumber-right-margin, and
     /// pageNumber-always-left-margin to control page number placement.)
+    /// A theme whose page margin is not a suitable distance from the page edge for a forced
+    /// left/right page number (e.g. zero-margin pages) can adjust it by setting
+    /// --pageNumber-forced-side-extra-margin (BL-16695).
     /// </summary>
     private void SetPageNumberProperties()
     {
@@ -1068,7 +1071,7 @@ public class AppearanceSettings
                 SetProperty(
                     new KeyValuePair<string, object>(
                         kPageNumberLeftMarginOverrideVar,
-                        "calc(var(--page-margin-left) + var(--pageNumber-full-bleed-extra-margin, 0px))"
+                        "calc(var(--page-margin-left) + var(--pageNumber-full-bleed-extra-margin, 0px) + var(--pageNumber-forced-side-extra-margin, 0px))"
                     )
                 );
                 SetProperty(
@@ -1092,7 +1095,7 @@ public class AppearanceSettings
                 SetProperty(
                     new KeyValuePair<string, object>(
                         kPageNumberRightMarginOverrideVar,
-                        "calc(var(--page-margin-right) + var(--pageNumber-full-bleed-extra-margin, 0px))"
+                        "calc(var(--page-margin-right) + var(--pageNumber-full-bleed-extra-margin, 0px) + var(--pageNumber-forced-side-extra-margin, 0px))"
                     )
                 );
                 SetProperty(

--- a/src/BloomTests/Book/AppearanceSettingsTests.cs
+++ b/src/BloomTests/Book/AppearanceSettingsTests.cs
@@ -396,14 +396,14 @@ namespace BloomTests.Book
         [TestCase(@"""pageNumber-position"": ""automatic""", "unset", "unset")]
         [TestCase(
             @"""pageNumber-position"": ""left""",
-            "calc(var(--page-margin-left) + var(--pageNumber-full-bleed-extra-margin, 0px))",
+            "calc(var(--page-margin-left) + var(--pageNumber-full-bleed-extra-margin, 0px) + var(--pageNumber-forced-side-extra-margin, 0px))",
             "deliberately-invalid"
         )]
         [TestCase(@"""pageNumber-position"": ""center""", "50%", "50%")]
         [TestCase(
             @"""pageNumber-position"": ""right""",
             "deliberately-invalid",
-            "calc(var(--page-margin-right) + var(--pageNumber-full-bleed-extra-margin, 0px))"
+            "calc(var(--page-margin-right) + var(--pageNumber-full-bleed-extra-margin, 0px) + var(--pageNumber-forced-side-extra-margin, 0px))"
         )]
         [TestCase(@"""pageNumber-position"": ""hidden""", "unset", "unset")]
         // [TestCase(null, null, null)]

--- a/src/content/appearanceThemes/appearance-theme-zero-margin-ebook.css
+++ b/src/content/appearanceThemes/appearance-theme-zero-margin-ebook.css
@@ -32,6 +32,11 @@ Note that hiding the page numbers is done by a setting in appearance.json, not h
     /* this rule will apply more generally than we'd prefer, but the common situation we're improving here
     is picture on top, text on the bottom, we need to make room for the page number */
     --pageNumber-extra-height: 12mm !important;
+
+    /* The page margin is zero, so a page number the user forces to the left or right would
+       sit flush against the page edge. Inset it to line up with the thin visual margin the
+       text box gets from --topLevel-text-padding (BL-16695). */
+    --pageNumber-forced-side-extra-margin: var(--topLevel-text-padding);
 }
 .bloom-fullBleed .Ebook7x5Landscape.numberedPage,
 .bloom-fullBleed .Device16x9Landscape.numberedPage {

--- a/src/content/appearanceThemes/appearance-theme-zero-margin-ebook.css
+++ b/src/content/appearanceThemes/appearance-theme-zero-margin-ebook.css
@@ -32,10 +32,14 @@ Note that hiding the page numbers is done by a setting in appearance.json, not h
     /* this rule will apply more generally than we'd prefer, but the common situation we're improving here
     is picture on top, text on the bottom, we need to make room for the page number */
     --pageNumber-extra-height: 12mm !important;
-
+}
+.Ebook2x3Portrait.numberedPage:not(.bloom-interactive-page),
+.Device16x9Portrait.numberedPage:not(.bloom-interactive-page) {
     /* The page margin is zero, so a page number the user forces to the left or right would
        sit flush against the page edge. Inset it to line up with the thin visual margin the
-       text box gets from --topLevel-text-padding (BL-16695). */
+       text box gets from --topLevel-text-padding (BL-16695).
+       Not on interactive pages: they keep a nonzero margin (the zero-margin rule above
+       excludes them), so the forced number already sits at the page margin there. */
     --pageNumber-forced-side-extra-margin: var(--topLevel-text-padding);
 }
 .bloom-fullBleed .Ebook7x5Landscape.numberedPage,


### PR DESCRIPTION
In the Zero Margin ebook theme, a page number the user forces to the Left or Right in Book Settings sat flush against the page edge on portrait content pages, because the forced placement uses `var(--page-margin-left/right)` and this theme sets that margin to 0 there. The text box, by contrast, keeps a thin visual margin from `--topLevel-text-padding`, so the number looked misaligned (BL-16695).

Fix:

- `AppearanceSettings.SetPageNumberProperties` now emits the forced left/right overrides with an extra theme-overridable term, `var(--pageNumber-forced-side-extra-margin, 0px)`. The `0px` fallback leaves every other theme's behavior unchanged. (A theme-only fix was tried first and does not work: the override is declared in the generated `.bloom-page { }` block, so its `var()` references are substituted at computed-value time on the page element — a pseudo-element redefinition of `--page-margin-left` comes too late.)
- The Zero Margin theme sets that variable to `var(--topLevel-text-padding)` on portrait numbered pages, so a forced side page number aligns with the text box's thin margin. Landscape is untouched: its flush corner circle is that theme's deliberate design.
- Updated the two affected `ToCss_SetsRelevantPageNumberPositionOverrides` test cases.

Verified in the running app (Ebook 2x3 Portrait, zero-margin theme): forced Left/Right insets the number 0.5em (≈7.3px at the 11pt page-number font) from the edge; Automatic placement still centers exactly.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16695

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8214)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8214)
<!-- Reviewable:end -->
