### PR TITLE
Make the Standard/Custom cover layout menu select instead of toggle (BL-16725)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/customPageLayoutMenu.test.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/customPageLayoutMenu.test.tsx
@@ -1,0 +1,137 @@
+import { act } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderRoot, unmountRoot } from "../../../utils/reactRender";
+import { CustomPageLayoutMenu } from "./customPageLayoutMenu";
+
+// The menu asks the server whether the CustomXMatterPage feature is available. Returning
+// undefined is what the component treats as "no information yet, so not blocked", which is the
+// state we want for these tests: both items live and clickable.
+vi.mock("../../../react_components/featureStatus", () => ({
+    useGetFeatureStatus: () => undefined,
+    useGetFeatureAvailabilityMessage: () => "",
+}));
+
+// Only the legacy-theme tooltip's link uses this; mocked so these tests don't drag in the
+// workspace frames machinery.
+vi.mock("../../js/workspaceFrames", () => ({
+    getWorkspaceBundleExports: () => ({
+        showBookSettingsDialog: () => {},
+    }),
+}));
+
+let renderedContainer: HTMLDivElement | undefined;
+
+// Renders the menu closed, then clicks its button to open it, since that is the only way to get
+// the items into the DOM. Returns the setCustom spy the items should (or should not) call.
+function renderAndOpenMenu(isCustom: boolean) {
+    const setCustom = vi.fn();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    renderedContainer = container;
+
+    // React 18's createRoot renders asynchronously; act() flushes the render and its effects.
+    act(() => {
+        renderRoot(
+            <CustomPageLayoutMenu isCustom={isCustom} setCustom={setCustom} />,
+            container,
+        );
+    });
+
+    const button = container.querySelector("button");
+    if (!button) {
+        fail(
+            "The layout menu did not render its button, so nothing can be clicked.",
+        );
+    }
+    act(() => {
+        button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    return setCustom;
+}
+
+// The MUI Menu renders into a portal on document.body, not into our container. An item's text is
+// whatever the localization lookup produced: the English label in production, but the l10n id
+// itself under the localizationManager mock in vitest.setup.ts, so accept either.
+function getMenuItem(label: "Standard" | "Custom"): HTMLElement {
+    const acceptableTexts = [label, `EditTab.CustomCover.${label}`];
+    const items = Array.from(
+        document.body.querySelectorAll<HTMLElement>('li[role="menuitem"]'),
+    );
+    const item = items.find((li) =>
+        acceptableTexts.includes(li.textContent?.trim() ?? ""),
+    );
+    if (!item) {
+        fail(
+            `Could not find a "${label}" menu item; found [${items
+                .map((li) => li.textContent?.trim())
+                .join(", ")}]. The menu probably did not open.`,
+        );
+    }
+    return item;
+}
+
+// The tick is a CheckIcon <svg>, and with no feature status there is no other svg in an item
+// (the subscription badge, which is an <img>, is not rendered in this state).
+function isTicked(item: HTMLElement): boolean {
+    return !!item.querySelector("svg");
+}
+
+function clickMenuItem(label: "Standard" | "Custom") {
+    const item = getMenuItem(label);
+    act(() => {
+        item.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+}
+
+afterEach(() => {
+    if (renderedContainer) {
+        unmountRoot(renderedContainer);
+        renderedContainer.remove();
+        renderedContainer = undefined;
+    }
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+});
+
+describe("CustomPageLayoutMenu selection", () => {
+    it("does nothing when the already-selected Custom item is clicked (BL-16725)", () => {
+        const setCustom = renderAndOpenMenu(true);
+        // Sanity check: we are testing a click on the item that carries the tick.
+        expect(isTicked(getMenuItem("Custom"))).toBe(true);
+        expect(isTicked(getMenuItem("Standard"))).toBe(false);
+        expect(setCustom).not.toHaveBeenCalled();
+
+        clickMenuItem("Custom");
+
+        expect(setCustom).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when the already-selected Standard item is clicked", () => {
+        const setCustom = renderAndOpenMenu(false);
+        expect(isTicked(getMenuItem("Standard"))).toBe(true);
+        expect(isTicked(getMenuItem("Custom"))).toBe(false);
+
+        clickMenuItem("Standard");
+
+        expect(setCustom).not.toHaveBeenCalled();
+    });
+
+    it("switches to standard when Standard is clicked while on custom", () => {
+        const setCustom = renderAndOpenMenu(true);
+
+        clickMenuItem("Standard");
+
+        expect(setCustom).toHaveBeenCalledTimes(1);
+        expect(setCustom).toHaveBeenCalledWith("standard", false);
+    });
+
+    it("switches to custom when Custom is clicked while on standard", () => {
+        const setCustom = renderAndOpenMenu(false);
+
+        clickMenuItem("Custom");
+
+        expect(setCustom).toHaveBeenCalledTimes(1);
+        expect(setCustom).toHaveBeenCalledWith("custom", false);
+    });
+});

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/customPageLayoutMenu.test.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/customPageLayoutMenu.test.tsx
@@ -71,10 +71,11 @@ function getMenuItem(label: "Standard" | "Custom"): HTMLElement {
     return item;
 }
 
-// The tick is a CheckIcon <svg>, and with no feature status there is no other svg in an item
-// (the subscription badge, which is an <img>, is not rendered in this state).
+// The tick is specifically MUI's CheckIcon, which it labels with data-testid. Matching that
+// rather than "any svg in the item" keeps these assertions meaningful if the item ever gains
+// another inline icon.
 function isTicked(item: HTMLElement): boolean {
-    return !!item.querySelector("svg");
+    return !!item.querySelector('svg[data-testid="CheckIcon"]');
 }
 
 function clickMenuItem(label: "Standard" | "Custom") {

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/customPageLayoutMenu.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/customPageLayoutMenu.tsx
@@ -49,6 +49,14 @@ export const CustomPageLayoutMenu: React.FunctionComponent<{
         selection: "standard" | "custom",
         event: React.MouseEvent<Element>,
     ) => {
+        // These items are a radio-style selection, not toggles: clicking the one that
+        // already has the tick beside it must do nothing (BL-16725). Without this, such
+        // a click switched to the other layout, and clicking "Custom" while already on
+        // Custom therefore discarded the user's custom layout.
+        if (selection === (props.isCustom ? "custom" : "standard")) {
+            handleCloseMenu();
+            return;
+        }
         const keepCustomLayoutDataWhenSwitchingToStandard =
             selection === "standard" && event.shiftKey && event.ctrlKey;
         handleCloseMenu();

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/customXmatterPage.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/customXmatterPage.tsx
@@ -494,7 +494,9 @@ export function setupPageLayoutMenu(): void {
 
     const usingLegacyTheme = isLegacyThemeCssLoaded();
     if (usingLegacyTheme && page.classList.contains("bloom-customLayout")) {
-        toggleCustomPageLayout(page.getAttribute("id")!, true);
+        // A legacy theme can't show a custom layout, so force this page back to standard,
+        // keeping the custom layout data in case the user switches to a newer theme.
+        setCustomPageLayout(page.getAttribute("id")!, "standard", true);
         return;
     }
 
@@ -506,12 +508,16 @@ export function setupPageLayoutMenu(): void {
     }
 }
 
-function toggleCustomPageLayout(
+// Ask the server to put this page into the given layout. This says what it means: asking for the
+// layout the page is already in is a no-op on the server, rather than flipping to the other one.
+function setCustomPageLayout(
     pageId: string,
+    layout: "standard" | "custom",
     keepCustomLayoutDataWhenSwitchingToStandard: boolean,
 ) {
-    return postData("editView/toggleCustomPageLayout", {
+    return postData("editView/setCustomPageLayout", {
         pageId,
+        layout,
         keepCustomLayoutDataWhenSwitchingToStandard:
             keepCustomLayoutDataWhenSwitchingToStandard ? "true" : "false",
     });
@@ -531,8 +537,9 @@ function renderPageLayoutMenu(page: HTMLElement): void {
             if (usingLegacyTheme && selection !== "standard") {
                 return;
             }
-            const response = await toggleCustomPageLayout(
+            const response = await setCustomPageLayout(
                 page.getAttribute("id")!,
+                selection,
                 keepCustomLayoutDataWhenSwitchingToStandard,
             );
             if (
@@ -548,7 +555,7 @@ function renderPageLayoutMenu(page: HTMLElement): void {
                     () => convertXmatterPageToCustom(page),
                     "customPageLayout-convertFirstTime",
                 );
-                // Persist the newly created custom layout state so a later toggle back
+                // Persist the newly created custom layout state so a later switch back
                 // to standard has matching server-side state to work from.
                 await postString(
                     "editView/jumpToPage",

--- a/src/BloomExe/web/controllers/EditingViewApi.cs
+++ b/src/BloomExe/web/controllers/EditingViewApi.cs
@@ -127,8 +127,8 @@ namespace Bloom.web.controllers
                 false
             );
             apiHandler.RegisterEndpointHandler(
-                "editView/toggleCustomPageLayout",
-                HandleToggleCustomCover,
+                "editView/setCustomPageLayout",
+                HandleSetCustomPageLayout,
                 true
             );
             apiHandler.RegisterEndpointHandler(
@@ -185,25 +185,28 @@ namespace Bloom.web.controllers
         }
 
         /// <summary>
-        /// Save the current state of the page, then toggle the book cover custom flag, and finally reload the page.
-        /// If we are in standard mode and do not have any saved state for custom mode, we return false, and
-        /// the calling code will generate a new custom page state.
+        /// Save the current state of the page, then put the page into the requested layout
+        /// ("standard" or "custom"), and finally reload the page. Asking for the layout the page is
+        /// already in does nothing: this is a "set", not a "toggle" (BL-16725).
+        /// If we are switching to custom and do not have any saved state for custom mode, we return
+        /// false, and the calling code will generate a new custom page state.
         /// </summary>
-        private void HandleToggleCustomCover(ApiRequest request)
+        private void HandleSetCustomPageLayout(ApiRequest request)
         {
-            var requestJson = request.GetPostJsonOrNull();
-            var pageId =
-                requestJson == null
-                    ? request.GetPostStringOrNull()
-                    : request.RequiredPostString("pageId");
+            var pageId = request.RequiredPostString("pageId");
+            var switchingToCustom = request.RequiredPostString("layout") == "custom";
             var keepCustomLayoutDataWhenSwitchingToStandard =
-                requestJson != null
-                && request.RequiredPostString("keepCustomLayoutDataWhenSwitchingToStandard")
-                    == "true";
+                request.RequiredPostString("keepCustomLayoutDataWhenSwitchingToStandard") == "true";
             var book = View.Model.CurrentBook;
             var page = book.GetPage(pageId);
             var pageElt = page.GetDivNodeForThisPage();
-            var switchingToCustom = !pageElt.HasClass("bloom-customLayout");
+            if (switchingToCustom == pageElt.HasClass("bloom-customLayout"))
+            {
+                // Already in the requested layout, so there is nothing to do (and in particular
+                // nothing to discard).
+                request.ReplyWithText("true");
+                return;
+            }
             var shouldRemoveCustomLayoutDataWhenSwitchingToStandard =
                 !switchingToCustom && !keepCustomLayoutDataWhenSwitchingToStandard;
             var customLayoutId = pageElt.GetAttribute("data-custom-layout-id");
@@ -225,10 +228,10 @@ namespace Bloom.web.controllers
             View.Model.SaveThen(
                 () =>
                 {
-                    if (pageElt.HasClass("bloom-customLayout"))
-                        pageElt.RemoveClass("bloom-customLayout");
-                    else
+                    if (switchingToCustom)
                         pageElt.AddClass("bloom-customLayout");
+                    else
+                        pageElt.RemoveClass("bloom-customLayout");
                     // We must capture these from the saved page before typically replacing that with a different
                     // page element.
                     var backgroundAudio = pageElt.GetAttribute(HtmlDom.musicAttrName);

--- a/src/BloomExe/web/controllers/EditingViewApi.cs
+++ b/src/BloomExe/web/controllers/EditingViewApi.cs
@@ -194,7 +194,14 @@ namespace Bloom.web.controllers
         private void HandleSetCustomPageLayout(ApiRequest request)
         {
             var pageId = request.RequiredPostString("pageId");
-            var switchingToCustom = request.RequiredPostString("layout") == "custom";
+            var layout = request.RequiredPostString("layout");
+            // Fail fast rather than letting a typo mean "standard", which is the branch that
+            // discards the saved custom layout.
+            if (layout != "standard" && layout != "custom")
+                throw new ArgumentException(
+                    $"editView/setCustomPageLayout got an unexpected layout \"{layout}\"; expected \"standard\" or \"custom\"."
+                );
+            var switchingToCustom = layout == "custom";
             var keepCustomLayoutDataWhenSwitchingToStandard =
                 request.RequiredPostString("keepCustomLayoutDataWhenSwitchingToStandard") == "true";
             var book = View.Model.CurrentBook;


### PR DESCRIPTION
The Standard/Custom cover-layout menu above a cover page drew a tick beside the layout you were on, but clicking the already-ticked item switched you to the other layout. Clicking **Custom** while already on Custom therefore threw the page back to Standard and — because that counts as a deliberate switch to Standard — **discarded the user's saved custom cover layout**, with no dialog and no undo.

Nothing compared the clicked value with the current state, and the endpoint it called was a pure toggle that ignored the choice entirely.

## What changed

- `customPageLayoutMenu.tsx` — `handleSelect` returns early (just closing the menu) when the clicked item is already the current layout. These items are a radio-style selection, not toggles.
- The API now says what it means: `editView/toggleCustomPageLayout` → **`editView/setCustomPageLayout`**, carrying the desired layout (`"standard"` | `"custom"`). The C# handler no-ops when the page is already in that layout, and sets the `bloom-customLayout` class explicitly rather than flipping it. The plain-string request-shape fallback, which no caller used, is gone.
- `setupPageLayoutMenu`'s legacy-theme force-to-standard had been exploiting toggle semantics ("I know it's custom, so toggle it"); it now asks for `"standard"` explicitly.
- New `customPageLayoutMenu.test.tsx` — covers both redundant-click cases and both real switches. Verified it fails without the guard.

## Verified in a running Bloom

Front cover of a `zero-margin-ebook` book, Enterprise subscription:

- Clicking the ticked **Custom** while on Custom → nothing changes; the custom arrangement stays intact. (This was the data-loss case.)
- Clicking the ticked **Standard** while on Standard → nothing changes.
- Standard→Custom and Custom→Standard still work, exercising both the first-time-generation (`"false"` reply) and saved-data paths.
- A plain **Standard** switch still discards the saved layout by design (`customOutsideFrontCover` data 3932 → 0 chars); **ctrl+shift+Standard** still preserves it (4017 chars survived).
- Switching the book to `legacy-5-6` while the cover was custom correctly forced it back to standard *and kept* the data — the `setupPageLayoutMenu` path through the renamed endpoint — and the menu then showed **Custom** disabled.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16725


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8216)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8216)
<!-- Reviewable:end -->
