### PR TITLE
Keep typing safe around ligatures wherever the split came from (BL-16717)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
+++ b/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
@@ -542,19 +542,20 @@ export class EditableDivUtils {
         if (!EditableDivUtils.hasAdjacentTextNodes(element)) {
             return; // nothing to merge; leave the box, and the selection, strictly alone
         }
-        if (EditableDivUtils.ckEditorIsHoldingAFillingChar(element)) {
-            // Leave the box strictly alone while ckeditor is holding a filling char.
-            // That char is a zero-width space in a text node of its own, which ckeditor
-            // inserts at a collapsed selection next to an inline element so the caret shows,
-            // and it remembers THAT NODE (setCustomData("cke-fillingChar", ...)) to take the
-            // char out again later. normalize() would fold the node into its neighbour, so
-            // ckeditor would be left writing to a detached node and the zero-width space
-            // would stay in the text and get saved into the book - the BL-16490 hazard.
-            // Skipping costs us nothing lasting: the filling char is transient, and the next
-            // keystroke brings us back here to do the repair.
-            return;
-        }
-        EditableDivUtils.mergeAdjacentTextNodeRuns(element);
+        // Leave ckeditor's filling char alone. That char is a zero-width space in a text node
+        // of its own, which ckeditor inserts at a collapsed selection next to an inline element
+        // so the caret shows, and it remembers THAT NODE
+        // (setCustomData("cke-fillingChar", ...)) to take the char out again later. normalize()
+        // would fold the node into its neighbour, so ckeditor would be left writing to a
+        // detached node and the zero-width space would stay in the text and get saved into the
+        // book - the BL-16490 hazard.
+        // We hand the node down rather than giving up on the whole box, so a filling char in
+        // one paragraph doesn't stop us repairing another: only the runs whose merge would
+        // reach it are skipped, and they come back to us on the next keystroke.
+        EditableDivUtils.mergeAdjacentTextNodeRuns(
+            element,
+            EditableDivUtils.ckEditorFillingCharNodeIn(element),
+        );
     }
 
     // Merge each run of adjacent sibling text nodes back into one.
@@ -581,7 +582,10 @@ export class EditableDivUtils {
     // can be the .bloom-editable itself, and hiding a focused contenteditable blurs it - the
     // user's next keystrokes would go nowhere - besides leaving a stray style="" attribute
     // behind in the saved book.
-    private static mergeAdjacentTextNodeRuns(element: HTMLElement): void {
+    private static mergeAdjacentTextNodeRuns(
+        element: HTMLElement,
+        fillingCharNodeToLeaveAlone?: Node,
+    ): void {
         const doc = element.ownerDocument;
         // The node each run will collapse into: normalize() appends a run's text onto its
         // first non-empty node and removes the others, so that is the node that survives, and
@@ -614,7 +618,17 @@ export class EditableDivUtils {
 
         survivorOfEachRun.forEach((survivor) => {
             // A text node always has a parent element here: we are walking inside element.
-            survivor.parentElement!.normalize();
+            const parent = survivor.parentElement!;
+            // normalize() is DEEP - it merges every text node under `parent`, not just this
+            // run - so the filling char is out of reach only if it is outside `parent`
+            // altogether. See mergeAdjacentTextNodes() for why we must not touch it.
+            if (
+                fillingCharNodeToLeaveAlone &&
+                parent.contains(fillingCharNodeToLeaveAlone)
+            ) {
+                return;
+            }
+            parent.normalize();
             if (!survivor.isConnected) {
                 return; // the whole run was empty nodes; normalize() removed them all
             }
@@ -665,27 +679,39 @@ export class EditableDivUtils {
     // We ask ckeditor rather than searching the text for a zero-width space, which was the
     // first thing I wrote: some scripts (Thai, Khmer, Myanmar) use U+200B in real text as a
     // word break, and searching for the character would have quietly turned the repair off
-    // for a whole book in those languages. It also means an ORPHANED filling char - the
-    // BL-16490 case - does not block the repair, which is right: nothing is tracking it, so
-    // nothing is going to write to it, and folding it into its neighbour loses nothing that
-    // doCkEditorCleanup's removeCkEditorFillingChars would not have stripped at save time.
-    // If a ckeditor upgrade ever renamed this key, this would stop guarding and we would be
-    // back to the behavior that shipped in the first fix for BL-16717, which merged regardless.
+    // for a whole book in those languages.
+    // Asking is not enough on its own, though: ckeditor keeps the reference as custom data on
+    // the editable DIV, so anything that rewrites the box's innerHTML (doCkEditorCleanup,
+    // cleanUpNbsps) detaches the text node while leaving the reference behind. That is the
+    // BL-16490 "orphaned filling char", and it must NOT block the repair - nothing is tracking
+    // it any more, so nothing will write to it. Hence the isConnected/contains check: what
+    // blocks us is a node ckeditor is tracking that is still in this box.
+    // If a ckeditor upgrade ever renamed this key, or changed the shape it stores, this would
+    // stop guarding and we would be back to the behavior that shipped in the first fix for
+    // BL-16717, which merged regardless.
     // (Typed locally rather than through CKEDITOR.editor: our ckeditor.d.ts only declares the
-    // editable(element) setter overloads, not the no-argument getter that actually exists.)
-    private static ckEditorIsHoldingAFillingChar(
+    // editable(element) setter overloads, not the no-argument getter that actually exists. The
+    // value is a CKEDITOR.dom.text, whose `$` is the DOM node it wraps.)
+    private static ckEditorFillingCharNodeIn(
         element: HTMLElement,
-    ): boolean {
+    ): Node | undefined {
         const ckEditorOfThisBox = (
             element as HTMLElement & {
                 bloomCkEditor?: {
-                    editable: () => { getCustomData: (key: string) => unknown };
+                    editable: () => {
+                        getCustomData: (
+                            key: string,
+                        ) => { $?: Node } | undefined;
+                    };
                 };
             }
         ).bloomCkEditor;
-        return !!ckEditorOfThisBox
+        const trackedNode = ckEditorOfThisBox
             ?.editable()
-            ?.getCustomData("cke-fillingChar");
+            ?.getCustomData("cke-fillingChar")?.$;
+        return trackedNode && element.contains(trackedNode)
+            ? trackedNode
+            : undefined;
     }
 
     public static restoreSelectionFromCkEditorBookmarks(

--- a/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
+++ b/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
@@ -500,19 +500,32 @@ export class EditableDivUtils {
         });
     }
 
-    // A ckeditor bookmark is a hidden span inserted at the insertion point, so creating one
-    // SPLITS the text node the user is typing in, and removing it again (which is what
-    // selectBookmarks does) leaves the two halves as separate, adjacent text nodes.
-    // The characters are all still there, and the DOM inspector's text view looks right, but
-    // Chromium shapes the paragraph's text as a single run and then hands out the resulting
-    // glyphs per text node. When a ligature straddles the boundary - very easy in SIL fonts
-    // such as Andika and Charis, which ligate ff, fl and ffl - that split lands in the middle
-    // of a glyph cluster and Chromium loses glyphs: letters the user typed simply stop being
-    // painted (and the caret draws in the wrong place) until something re-renders the
-    // paragraph, e.g. changing the font or reloading the page. Type "overflow", then insert a
-    // second "f" before the "f", pause for the markup timer, then type any other letter: the
-    // "fl" vanishes (BL-16717).
-    // So whenever we take bookmarks out again, put the text back the way we found it.
+    // Chromium drops glyphs from a paragraph whose text is split into two (or more) adjacent
+    // text nodes. It shapes the paragraph's text as a single run and then hands out the
+    // resulting glyphs per text node, and when a ligature straddles the boundary - very easy
+    // in SIL fonts such as Andika and Charis, which ligate ff, fl and ffl - the split lands in
+    // the middle of a glyph cluster. The characters are all still there, and the DOM
+    // inspector's text view looks right, but letters the user typed stop being painted, and the
+    // caret stops moving when they arrow through the affected letters, until something
+    // re-renders the paragraph (changing the font, reloading the page). Type "overflow", insert
+    // a second "f" before the "f", pause, then type any other letter: the "fl" vanishes
+    // (BL-16717).
+    //
+    // A great many things split a paragraph's text, and only some of them are ours:
+    //  - a ckeditor bookmark is a hidden span inserted AT the insertion point, so creating one
+    //    splits the text node the user is typing in and removing it again (which is what
+    //    selectBookmarks does) leaves the two halves as separate, adjacent text nodes;
+    //  - ckeditor makes bookmarks of its own for Enter, paste and the style commands, and
+    //    inserts a "filling char" text node next to inline elements (see below);
+    //  - long-press inserts the character it composes as a NEW text node
+    //    (jquery.longpress.js: insertPointRange.insertNode(textNode));
+    //  - Chromium's own editing commands split the node too: backspacing in the middle of a
+    //    word leaves the paragraph in two pieces.
+    // Splitting does not itself paint anything wrong: the damage appears at the NEXT edit,
+    // which for the user is simply the next letter they type. So the rule this enforces is
+    // that a .bloom-editable never sits holding adjacent text nodes, whoever split it - which
+    // means calling this without knowing, or caring, what did.
+    //
     // Note that repairing the DOM is not on its own enough to repair the display: see
     // mergeAdjacentTextNodeRuns().
     // We deliberately do NOT save and restore the insertion point around this. The DOM spec
@@ -523,11 +536,23 @@ export class EditableDivUtils {
     // hand-rolled restore was itself the bug - a character offset cannot tell the end of a
     // bold run from the start of the plain text after it, so the caret could hop back inside
     // the bold text and the user's next letters would come out bold.
-    // Callers should avoid making bookmarks at all when nothing is going to rewrite the box;
-    // this is the repair for when we genuinely needed one.
-    public static mergeTextNodesSplitByBookmarks(element: HTMLElement): void {
+    // Callers should still avoid making bookmarks at all when nothing is going to rewrite the
+    // box; this is the repair for the splits that do happen anyway.
+    public static mergeAdjacentTextNodes(element: HTMLElement): void {
         if (!EditableDivUtils.hasAdjacentTextNodes(element)) {
             return; // nothing to merge; leave the box, and the selection, strictly alone
+        }
+        if (EditableDivUtils.hasCkEditorFillingChar(element)) {
+            // Leave the box strictly alone while ckeditor is holding a filling char.
+            // That char is a zero-width space in a text node of its own, which ckeditor
+            // inserts at a collapsed selection next to an inline element so the caret shows,
+            // and it remembers THAT NODE (setCustomData("cke-fillingChar", ...)) to take the
+            // char out again later. normalize() would fold the node into its neighbour, so
+            // ckeditor would be left writing to a detached node and the zero-width space
+            // would stay in the text and get saved into the book - the BL-16490 hazard.
+            // Skipping costs us nothing lasting: the filling char is transient, and the next
+            // keystroke brings us back here to do the repair.
+            return;
         }
         EditableDivUtils.mergeAdjacentTextNodeRuns(element);
     }
@@ -633,6 +658,15 @@ export class EditableDivUtils {
         return false;
     }
 
+    // Is ckeditor currently holding a filling char (a zero-width space) in this box?
+    // See mergeAdjacentTextNodes(), which must not merge while one is there. We look for
+    // the character itself rather than asking ckeditor for the node it remembers, so that
+    // an orphaned one - which is what BL-16490 was about - counts too.
+    private static hasCkEditorFillingChar(element: HTMLElement): boolean {
+        const fillingChar = String.fromCharCode(0x200b); // U+200B ZERO WIDTH SPACE
+        return element.textContent?.includes(fillingChar) ?? false;
+    }
+
     public static restoreSelectionFromCkEditorBookmarks(
         editableDivs: HTMLDivElement[],
         ckEditorBookmarks: object[],
@@ -660,7 +694,7 @@ export class EditableDivUtils {
                             },
                         );
                     }
-                    EditableDivUtils.mergeTextNodesSplitByBookmarks(div);
+                    EditableDivUtils.mergeAdjacentTextNodes(div);
                 }
             });
         }

--- a/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
+++ b/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
@@ -542,7 +542,7 @@ export class EditableDivUtils {
         if (!EditableDivUtils.hasAdjacentTextNodes(element)) {
             return; // nothing to merge; leave the box, and the selection, strictly alone
         }
-        if (EditableDivUtils.hasCkEditorFillingChar(element)) {
+        if (EditableDivUtils.ckEditorIsHoldingAFillingChar(element)) {
             // Leave the box strictly alone while ckeditor is holding a filling char.
             // That char is a zero-width space in a text node of its own, which ckeditor
             // inserts at a collapsed selection next to an inline element so the caret shows,
@@ -643,8 +643,9 @@ export class EditableDivUtils {
         });
     }
 
-    // Does element contain two text nodes that are siblings, as removing a bookmark leaves
-    // behind? (An empty text node next to another one counts: merging folds it away.)
+    // Does element contain two text nodes that are siblings, as removing a bookmark - or a
+    // backspace, or long-press - leaves behind? (An empty text node next to another one
+    // counts: merging folds it away.)
     private static hasAdjacentTextNodes(element: HTMLElement): boolean {
         const walker = element.ownerDocument.createTreeWalker(
             element,
@@ -658,13 +659,33 @@ export class EditableDivUtils {
         return false;
     }
 
-    // Is ckeditor currently holding a filling char (a zero-width space) in this box?
-    // See mergeAdjacentTextNodes(), which must not merge while one is there. We look for
-    // the character itself rather than asking ckeditor for the node it remembers, so that
-    // an orphaned one - which is what BL-16490 was about - counts too.
-    private static hasCkEditorFillingChar(element: HTMLElement): boolean {
-        const fillingChar = String.fromCharCode(0x200b); // U+200B ZERO WIDTH SPACE
-        return element.textContent?.includes(fillingChar) ?? false;
+    // Is ckeditor currently holding a filling char in this box - that is, does it have a
+    // text node it is going to come back and edit? See mergeAdjacentTextNodes(), which must
+    // not merge one away underneath it.
+    // We ask ckeditor rather than searching the text for a zero-width space, which was the
+    // first thing I wrote: some scripts (Thai, Khmer, Myanmar) use U+200B in real text as a
+    // word break, and searching for the character would have quietly turned the repair off
+    // for a whole book in those languages. It also means an ORPHANED filling char - the
+    // BL-16490 case - does not block the repair, which is right: nothing is tracking it, so
+    // nothing is going to write to it, and folding it into its neighbour loses nothing that
+    // doCkEditorCleanup's removeCkEditorFillingChars would not have stripped at save time.
+    // If a ckeditor upgrade ever renamed this key, this would stop guarding and we would be
+    // back to the behavior that shipped in the first fix for BL-16717, which merged regardless.
+    // (Typed locally rather than through CKEDITOR.editor: our ckeditor.d.ts only declares the
+    // editable(element) setter overloads, not the no-argument getter that actually exists.)
+    private static ckEditorIsHoldingAFillingChar(
+        element: HTMLElement,
+    ): boolean {
+        const ckEditorOfThisBox = (
+            element as HTMLElement & {
+                bloomCkEditor?: {
+                    editable: () => { getCustomData: (key: string) => unknown };
+                };
+            }
+        ).bloomCkEditor;
+        return !!ckEditorOfThisBox
+            ?.editable()
+            ?.getCustomData("cke-fillingChar");
     }
 
     public static restoreSelectionFromCkEditorBookmarks(

--- a/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
+++ b/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
@@ -526,6 +526,14 @@ export class EditableDivUtils {
     // that a .bloom-editable never sits holding adjacent text nodes, whoever split it - which
     // means calling this without knowing, or caring, what did.
     //
+    // The tempting shortcut is to stop the browser forming ligatures in the edit view at all
+    // (font-variant-ligatures: none), which is what code editors do - CodeMirror disables them
+    // in its default stylesheet precisely because of the caret behavior. Do NOT do that here.
+    // Bloom's edit view has to render as nearly as possible like the published book, and
+    // ligatures change the width of a word: text that fitted the page while the user was
+    // editing would break to a different line, and could overflow, in a publication mode.
+    // A rare glitch while typing is the lesser problem, and it is the one this repairs.
+    //
     // Note that repairing the DOM is not on its own enough to repair the display: see
     // mergeAdjacentTextNodeRuns().
     // We deliberately do NOT save and restore the insertion point around this. The DOM spec

--- a/src/BloomBrowserUI/bookEdit/js/editableDivUtilsSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/editableDivUtilsSpec.ts
@@ -476,6 +476,20 @@ describe("EditableDivUtils Tests", () => {
         div.remove();
     });
 
+    // Make div look like a box whose ckeditor is tracking fillingCharNode as its filling char.
+    // ckeditor keeps that reference as custom data on the editable div and hands it back as a
+    // CKEDITOR.dom.text, whose `$` is the DOM node.
+    function stubCkEditorTracking(div: HTMLElement, fillingCharNode: Node) {
+        (div as HTMLElement & { bloomCkEditor?: object }).bloomCkEditor = {
+            editable: () => ({
+                getCustomData: (key: string) =>
+                    key === "cke-fillingChar"
+                        ? { $: fillingCharNode }
+                        : undefined,
+            }),
+        };
+    }
+
     it("mergeAdjacentTextNodes leaves the box alone while ckeditor holds a filling char", () => {
         // ckeditor's filling char is a zero-width space in a text node of its own, and
         // ckeditor remembers that node so it can take the character out again. Merging the
@@ -492,12 +506,8 @@ describe("EditableDivUtils Tests", () => {
         // Stand in for the live ckeditor: what matters is that it is TRACKING the node, which
         // is what it means for the character to be one we must not disturb. (A stray
         // zero-width space nobody is tracking is a different thing, and is fine to merge.)
-        (div as HTMLElement & { bloomCkEditor?: object }).bloomCkEditor = {
-            editable: () => ({
-                getCustomData: (key: string) =>
-                    key === "cke-fillingChar" ? fillingCharNode : undefined,
-            }),
-        };
+        // ckeditor hands back a CKEDITOR.dom.text, whose `$` is the DOM node.
+        stubCkEditorTracking(div, fillingCharNode);
         // sanity check the setup: there IS a split here, so without the filling char this
         // would certainly merge.
         expect(p.childNodes.length).toBe(2);
@@ -506,6 +516,62 @@ describe("EditableDivUtils Tests", () => {
 
         expect(p.childNodes.length).toBe(2);
         expect(p.childNodes[1]).toBe(fillingCharNode);
+
+        div.remove();
+    });
+
+    it("mergeAdjacentTextNodes is not blocked by a filling char that has been orphaned", () => {
+        // ckeditor keeps the reference on the editable DIV, so anything that rewrites the box's
+        // innerHTML (doCkEditorCleanup, cleanUpNbsps) detaches the text node and leaves the
+        // reference dangling - the BL-16490 orphan. Nothing will write to that node any more,
+        // so it must not stop us repairing the box; a first version of this guard let it stop
+        // us indefinitely, which would have left letters unpainted (Devin caught it on #8217).
+        const div = document.createElement("div");
+        const p = document.createElement("p");
+        p.appendChild(document.createTextNode("waf"));
+        p.appendChild(document.createTextNode("fle"));
+        div.appendChild(p);
+        document.body.appendChild(div);
+        const orphan = document.createTextNode(String.fromCharCode(0x200b));
+        stubCkEditorTracking(div, orphan);
+        // sanity check the setup: the tracked node is NOT in the box, which is what makes it
+        // an orphan, and there is a split here that would otherwise be blocked.
+        expect(div.contains(orphan)).toBe(false);
+        expect(p.childNodes.length).toBe(2);
+
+        EditableDivUtils.mergeAdjacentTextNodes(div);
+
+        expect(p.childNodes.length).toBe(1);
+        expect(p.textContent).toBe("waffle");
+
+        div.remove();
+    });
+
+    it("mergeAdjacentTextNodes still repairs paragraphs the filling char is not in", () => {
+        // The guard is per-run, not per-box: a filling char parked in one paragraph must not
+        // stop the others being repaired.
+        const div = document.createElement("div");
+        div.innerHTML = "<p id='guarded'></p><p id='other'></p>";
+        const guarded = div.querySelector("#guarded") as HTMLElement;
+        const other = div.querySelector("#other") as HTMLElement;
+        guarded.appendChild(document.createTextNode("waf"));
+        const fillingCharNode = document.createTextNode(
+            String.fromCharCode(0x200b),
+        );
+        guarded.appendChild(fillingCharNode);
+        other.appendChild(document.createTextNode("shuf"));
+        other.appendChild(document.createTextNode("fle"));
+        document.body.appendChild(div);
+        stubCkEditorTracking(div, fillingCharNode);
+        // sanity check the setup
+        expect(guarded.childNodes.length).toBe(2);
+        expect(other.childNodes.length).toBe(2);
+
+        EditableDivUtils.mergeAdjacentTextNodes(div);
+
+        expect(guarded.childNodes.length).toBe(2); // left alone
+        expect(other.childNodes.length).toBe(1); // repaired
+        expect(other.textContent).toBe("shuffle");
 
         div.remove();
     });

--- a/src/BloomBrowserUI/bookEdit/js/editableDivUtilsSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/editableDivUtilsSpec.ts
@@ -251,7 +251,7 @@ describe("EditableDivUtils Tests", () => {
         return div;
     }
 
-    it("mergeTextNodesSplitByBookmarks rejoins the text a removed bookmark split", () => {
+    it("mergeAdjacentTextNodes rejoins the text a removed bookmark split", () => {
         const div = makeParagraphSplitByABookmark("overfflow", 5);
         const p = div.firstChild as HTMLParagraphElement;
         // sanity check: the removed bookmark really did leave two text nodes.
@@ -259,7 +259,7 @@ describe("EditableDivUtils Tests", () => {
         expect(p.childNodes[0].textContent).toBe("overf");
         expect(p.childNodes[1].textContent).toBe("flow");
 
-        EditableDivUtils.mergeTextNodesSplitByBookmarks(div);
+        EditableDivUtils.mergeAdjacentTextNodes(div);
 
         expect(p.childNodes.length).toBe(1);
         expect(p.childNodes[0].textContent).toBe("overfflow");
@@ -267,7 +267,7 @@ describe("EditableDivUtils Tests", () => {
         div.remove();
     });
 
-    it("mergeTextNodesSplitByBookmarks keeps the original text node rather than replacing it", () => {
+    it("mergeAdjacentTextNodes keeps the original text node rather than replacing it", () => {
         // Not a detail. Replacing the text node would collapse any live Range whose boundaries
         // were inside it, and the reader tools' and Talking Book's highlights are exactly that:
         // live Ranges over these text nodes, registered by the markup pass moments before this
@@ -279,7 +279,7 @@ describe("EditableDivUtils Tests", () => {
         // sanity check the setup
         expect(originalFirstNode.textContent).toBe("overf");
 
-        EditableDivUtils.mergeTextNodesSplitByBookmarks(div);
+        EditableDivUtils.mergeAdjacentTextNodes(div);
 
         expect(p.childNodes.length).toBe(1);
         expect(p.childNodes[0].textContent).toBe("overfflow");
@@ -288,7 +288,7 @@ describe("EditableDivUtils Tests", () => {
         div.remove();
     });
 
-    it("mergeTextNodesSplitByBookmarks leaves no trace in the markup that gets saved", () => {
+    it("mergeAdjacentTextNodes leaves no trace in the markup that gets saved", () => {
         // It has to make Chromium re-shape the merged text, but whatever it does to achieve
         // that must not survive into the html: this runs on every pause in typing, and the
         // box's innerHTML is what Bloom saves into the book. Checking the serialized markup
@@ -298,7 +298,7 @@ describe("EditableDivUtils Tests", () => {
         // sanity check the setup
         expect(p.hasAttribute("style")).toBe(false);
 
-        EditableDivUtils.mergeTextNodesSplitByBookmarks(div);
+        EditableDivUtils.mergeAdjacentTextNodes(div);
 
         expect(div.innerHTML).toBe("<p>overfflow</p>");
         expect(p.hasAttribute("style")).toBe(false);
@@ -306,12 +306,12 @@ describe("EditableDivUtils Tests", () => {
         div.remove();
     });
 
-    it("mergeTextNodesSplitByBookmarks keeps a paragraph's own inline style", () => {
+    it("mergeAdjacentTextNodes keeps a paragraph's own inline style", () => {
         const div = makeParagraphSplitByABookmark("overfflow", 5);
         const p = div.firstChild as HTMLParagraphElement;
         p.style.display = "inline-block";
 
-        EditableDivUtils.mergeTextNodesSplitByBookmarks(div);
+        EditableDivUtils.mergeAdjacentTextNodes(div);
 
         expect(p.style.display).toBe("inline-block");
         expect(p.childNodes[0].textContent).toBe("overfflow");
@@ -319,7 +319,7 @@ describe("EditableDivUtils Tests", () => {
         div.remove();
     });
 
-    it("mergeTextNodesSplitByBookmarks merges only within a parent, and merges every run", () => {
+    it("mergeAdjacentTextNodes merges only within a parent, and merges every run", () => {
         const div = document.createElement("div");
         const p = document.createElement("p");
         p.appendChild(document.createTextNode("over"));
@@ -338,7 +338,7 @@ describe("EditableDivUtils Tests", () => {
 
         const originalEmFirstNode = em.childNodes[0];
 
-        EditableDivUtils.mergeTextNodesSplitByBookmarks(div);
+        EditableDivUtils.mergeAdjacentTextNodes(div);
 
         // "over"+"f" merged, " and"+" more" merged, the <em> still between them
         expect(em.childNodes[0]).toBe(originalEmFirstNode); // ranges must survive here too
@@ -359,7 +359,7 @@ describe("EditableDivUtils Tests", () => {
     // the caret both at the split itself and immediately after a <strong>. jsdom does not
     // implement those range fixups, so a test here would fail on correct code and, worse, pass
     // on the hand-rolled save/restore this code used to have - which was itself the bug.
-    it("mergeTextNodesSplitByBookmarks leaves the text byte-for-byte unchanged, whatever it ends with", () => {
+    it("mergeAdjacentTextNodes leaves the text byte-for-byte unchanged, whatever it ends with", () => {
         // It forces a repaint by appending a space and immediately deleting it. A text node's
         // data is an exact string - html whitespace collapsing is a rendering rule, not a data
         // one - so that has to round-trip exactly even when the text already ends in
@@ -383,7 +383,7 @@ describe("EditableDivUtils Tests", () => {
             // sanity check the setup
             expect(p.childNodes.length).toBe(2);
 
-            EditableDivUtils.mergeTextNodesSplitByBookmarks(div);
+            EditableDivUtils.mergeAdjacentTextNodes(div);
 
             expect(p.childNodes.length).toBe(1);
             expect((p.firstChild as Text).data).toBe("overf" + ending);
@@ -391,7 +391,7 @@ describe("EditableDivUtils Tests", () => {
         }
     });
 
-    it("mergeTextNodesSplitByBookmarks copes with an empty text node at the head of a run", () => {
+    it("mergeAdjacentTextNodes copes with an empty text node at the head of a run", () => {
         // normalize() deletes empty text nodes outright, so the node a run collapses into is
         // its first NON-empty node. Getting that wrong would leave us holding a detached node
         // and the repaint would silently do nothing - the original bug all over again.
@@ -405,7 +405,7 @@ describe("EditableDivUtils Tests", () => {
         // sanity check the setup
         expect(p.childNodes.length).toBe(3);
 
-        EditableDivUtils.mergeTextNodesSplitByBookmarks(div);
+        EditableDivUtils.mergeAdjacentTextNodes(div);
 
         expect(p.childNodes.length).toBe(1);
         expect(p.childNodes[0].textContent).toBe("overfflow");
@@ -416,7 +416,7 @@ describe("EditableDivUtils Tests", () => {
         div.remove();
     });
 
-    it("mergeTextNodesSplitByBookmarks copes with a run that is entirely empty nodes", () => {
+    it("mergeAdjacentTextNodes copes with a run that is entirely empty nodes", () => {
         const div = document.createElement("div");
         const p = document.createElement("p");
         p.appendChild(document.createTextNode(""));
@@ -425,7 +425,7 @@ describe("EditableDivUtils Tests", () => {
         document.body.appendChild(div);
         expect(p.childNodes.length).toBe(2);
 
-        EditableDivUtils.mergeTextNodesSplitByBookmarks(div);
+        EditableDivUtils.mergeAdjacentTextNodes(div);
 
         // normalize() removes them all; we must not throw trying to poke a detached node.
         expect(p.childNodes.length).toBe(0);
@@ -433,7 +433,7 @@ describe("EditableDivUtils Tests", () => {
         div.remove();
     });
 
-    it("mergeTextNodesSplitByBookmarks only touches parents that actually have a run to merge", () => {
+    it("mergeAdjacentTextNodes only touches parents that actually have a run to merge", () => {
         // What we can assert is scope: every other node in the box comes out untouched, so
         // there is nothing for the browser to have to fix up in the first place.
         const div = makeParagraphSplitByABookmark("overfflow", 5);
@@ -442,7 +442,7 @@ describe("EditableDivUtils Tests", () => {
         div.appendChild(untouched);
         const untouchedTextNode = untouched.firstChild;
 
-        EditableDivUtils.mergeTextNodesSplitByBookmarks(div);
+        EditableDivUtils.mergeAdjacentTextNodes(div);
 
         // the merge happened in the first paragraph...
         expect(div.firstChild!.childNodes.length).toBe(1);
@@ -455,12 +455,58 @@ describe("EditableDivUtils Tests", () => {
         div.remove();
     });
 
-    it("mergeTextNodesSplitByBookmarks leaves an already-normal paragraph alone", () => {
+    it("mergeAdjacentTextNodes merges a split it did not cause", () => {
+        // Nothing about the repair is specific to ckeditor bookmarks: Chromium's own
+        // backspace, and long-press inserting the character it composed, split a paragraph
+        // the same way and used to be left unrepaired (BL-16717).
+        const div = document.createElement("div");
+        const p = document.createElement("p");
+        p.appendChild(document.createTextNode("waf"));
+        p.appendChild(document.createTextNode("fle"));
+        div.appendChild(p);
+        document.body.appendChild(div);
+        // sanity check the setup
+        expect(p.childNodes.length).toBe(2);
+
+        EditableDivUtils.mergeAdjacentTextNodes(div);
+
+        expect(p.childNodes.length).toBe(1);
+        expect(p.childNodes[0].textContent).toBe("waffle");
+
+        div.remove();
+    });
+
+    it("mergeAdjacentTextNodes leaves the box alone while ckeditor holds a filling char", () => {
+        // ckeditor's filling char is a zero-width space in a text node of its own, and
+        // ckeditor remembers that node so it can take the character out again. Merging the
+        // node away would leave ckeditor writing to a detached node, and the zero-width space
+        // would survive into the saved book - the BL-16490 hazard. The split is left for the
+        // next keystroke to repair, once the filling char has gone.
+        const div = document.createElement("div");
+        const p = document.createElement("p");
+        p.appendChild(document.createTextNode("waffle"));
+        p.appendChild(document.createTextNode(String.fromCharCode(0x200b)));
+        div.appendChild(p);
+        document.body.appendChild(div);
+        const fillingCharNode = p.childNodes[1];
+        // sanity check the setup: there IS a split here, so without the filling char this
+        // would certainly merge.
+        expect(p.childNodes.length).toBe(2);
+
+        EditableDivUtils.mergeAdjacentTextNodes(div);
+
+        expect(p.childNodes.length).toBe(2);
+        expect(p.childNodes[1]).toBe(fillingCharNode);
+
+        div.remove();
+    });
+
+    it("mergeAdjacentTextNodes leaves an already-normal paragraph alone", () => {
         const div = document.createElement("div");
         div.innerHTML = "<p>over<em>ff</em>low</p>";
         const before = div.innerHTML;
 
-        EditableDivUtils.mergeTextNodesSplitByBookmarks(div);
+        EditableDivUtils.mergeAdjacentTextNodes(div);
 
         // In particular, it must not merge text across an element boundary.
         expect(div.innerHTML).toBe(before);

--- a/src/BloomBrowserUI/bookEdit/js/editableDivUtilsSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/editableDivUtilsSpec.ts
@@ -489,6 +489,15 @@ describe("EditableDivUtils Tests", () => {
         div.appendChild(p);
         document.body.appendChild(div);
         const fillingCharNode = p.childNodes[1];
+        // Stand in for the live ckeditor: what matters is that it is TRACKING the node, which
+        // is what it means for the character to be one we must not disturb. (A stray
+        // zero-width space nobody is tracking is a different thing, and is fine to merge.)
+        (div as HTMLElement & { bloomCkEditor?: object }).bloomCkEditor = {
+            editable: () => ({
+                getCustomData: (key: string) =>
+                    key === "cke-fillingChar" ? fillingCharNode : undefined,
+            }),
+        };
         // sanity check the setup: there IS a split here, so without the filling char this
         // would certainly merge.
         expect(p.childNodes.length).toBe(2);
@@ -497,6 +506,30 @@ describe("EditableDivUtils Tests", () => {
 
         expect(p.childNodes.length).toBe(2);
         expect(p.childNodes[1]).toBe(fillingCharNode);
+
+        div.remove();
+    });
+
+    it("mergeAdjacentTextNodes merges a zero-width space nobody is tracking", () => {
+        // The mirror image of the test above, and the reason it asks ckeditor rather than
+        // searching the text: Thai, Khmer and Myanmar use U+200B in real text as a word break,
+        // and treating the character itself as a filling char would have turned the repair off
+        // for a whole book in those languages.
+        const div = document.createElement("div");
+        const p = document.createElement("p");
+        p.appendChild(document.createTextNode("waf"));
+        p.appendChild(
+            document.createTextNode(`fle${String.fromCharCode(0x200b)}word`),
+        );
+        div.appendChild(p);
+        document.body.appendChild(div);
+        // sanity check the setup
+        expect(p.childNodes.length).toBe(2);
+
+        EditableDivUtils.mergeAdjacentTextNodes(div);
+
+        expect(p.childNodes.length).toBe(1);
+        expect(p.textContent).toBe(`waffle${String.fromCharCode(0x200b)}word`);
 
         div.remove();
     });

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -305,6 +305,13 @@ export class ToolBox {
                 // that character out again if they choose another one. Its own test for "the
                 // popup is showing" is the presence of .long-press-popup in the page, so we use
                 // that. An IME composition is the same kind of hazard, hence isComposing.
+                // This deliberately runs for EVERY key, not just the ones that insert text.
+                // Skipping the arrow keys the way the keyup handler below does would look like
+                // a free saving and would quietly give back half the bug: a split paragraph is
+                // also what makes the caret stop moving, so it is the arrow key's own keydown
+                // that has to repair it. Measured in a running Bloom: with "waffle" split as
+                // "waf"|"fle", three consecutive ArrowLefts left the caret drawn at the same x;
+                // repairing on the first of them restores one-character-per-press exactly.
                 const editableBeingTypedIn = event.currentTarget as HTMLElement;
                 const longPressPopupIsUp =
                     !!editableBeingTypedIn.ownerDocument.querySelector(

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -284,6 +284,41 @@ export class ToolBox {
         $(container)
             .find(".bloom-editable")
             .keydown((event) => {
+                // Repair a split paragraph BEFORE this keystroke lands in it. Chromium drops
+                // glyphs from a ligature when the paragraph's text is in two adjacent text
+                // nodes and something then edits one of them - and that "something" is normally
+                // just this keystroke, so by the time we hear the keyup the letters have already
+                // stopped being painted, and the caret has stopped moving through them
+                // (BL-16717). Doing it here means the character arrives in a box whose paragraph
+                // is one whole text node again, which Chromium shapes correctly.
+                // The splits get there without our help: backspacing in the middle of a word
+                // leaves the paragraph in two pieces, and so does long-press inserting the
+                // character it composed. So the sweep at the end of handlePageEditing's mainTask
+                // is not enough on its own: it runs half a second after the box goes quiet, and
+                // the damaging keystroke is the one that comes BEFORE that.
+                // NB: do NOT gate this on window.top[isLongPressEvaluating] the way mainTask
+                // does. Long-press sets that flag in its own keydown handler, so it is true
+                // during every keydown, and gating on it here does nothing but turn the repair
+                // off completely (measured: it never ran). What we actually have to stay out of
+                // is the window while the long-press popup is up and the user is choosing a
+                // character, because long-press composes into a text node of its own and takes
+                // that character out again if they choose another one. Its own test for "the
+                // popup is showing" is the presence of .long-press-popup in the page, so we use
+                // that. An IME composition is the same kind of hazard, hence isComposing.
+                const editableBeingTypedIn = event.currentTarget as HTMLElement;
+                const longPressPopupIsUp =
+                    !!editableBeingTypedIn.ownerDocument.querySelector(
+                        ".long-press-popup",
+                    );
+                if (
+                    !longPressPopupIsUp &&
+                    !(event.originalEvent as KeyboardEvent)?.isComposing
+                ) {
+                    EditableDivUtils.mergeAdjacentTextNodes(
+                        editableBeingTypedIn,
+                    );
+                }
+
                 // Ctrl/Cmd+V doesn't always produce a keyup we can rely on in all environments.
                 // Schedule the same markup-update side effects explicitly when paste is requested.
                 // This should not interact with longpress, which doesn't handle keypresses with ctrl.
@@ -1735,15 +1770,18 @@ function handlePageEditing(trigger: MarkupUpdateTrigger = "editing"): void {
                 // Note: causing the bookmarks to be selected actually removes the bookmark spans.
                 if (bookmarks) {
                     ckeditorOfThisBox.getSelection().selectBookmarks(bookmarks);
-
-                    // ...but removing them leaves the text that was on either side of each
-                    // bookmark as two adjacent text nodes, which makes Chromium drop glyphs from
-                    // ligatures that straddle the join (BL-16717). See
-                    // mergeTextNodesSplitByBookmarks().
-                    EditableDivUtils.mergeTextNodesSplitByBookmarks(
-                        editableDiv,
-                    );
                 }
+
+                // Removing a bookmark leaves the text that was on either side of it as two
+                // adjacent text nodes, which makes Chromium drop glyphs from ligatures near the
+                // join (BL-16717). But bookmarks are only one of the things that split a
+                // paragraph's text - Chromium's own backspace and long-press's inserted
+                // character do it too - so this is not conditional on our having made one. It
+                // is the box-is-quiet sweep that catches whatever the per-keystroke repair in
+                // ToolBox's keydown handler could not (a paste from the menu, an IME, an undo).
+                // It costs a walk of the box's text nodes and does nothing at all unless it
+                // finds a split. See mergeAdjacentTextNodes().
+                EditableDivUtils.mergeAdjacentTextNodes(editableDiv);
             }
         }
         // clear this value to prevent unnecessary calls to clearTimeout() for timeouts that have already expired.


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
## Problem

In fonts that join letters together — Andika, Bloom's default, and Charis both join `ff`, `fl`
and `ffl` — letters the user has typed sometimes stop being drawn, and the caret sometimes stops
moving as they arrow across those letters. The text is all there and saves correctly; only the
screen is wrong, and it comes back on a font change or a page reload. The first fix for this
shipped in 6.5, and the reporter still sees it on 6.5.1322, about 1% of the time when typing just
after a ligature.

## Cause

Chromium drops glyphs from a paragraph whose text sits in two adjacent text nodes: it shapes the
paragraph as a single run and then hands the glyphs out per text node, so a ligature that spans
the boundary loses glyphs — not when the split happens, but at the next edit, which for the user
is simply the next letter they type. The caret misbehaves in the same state, staying drawn in one
place for two or three arrow presses.

The first fix repaired the splits Bloom itself caused, with ckeditor bookmarks, and stopped taking
those bookmarks for ordinary typing. But bookmarks are not the only thing that splits a paragraph:
**Chromium's own backspace** in the middle of a word splits it, **long-press** composes its
character into a text node of its own, and **ckeditor** takes bookmarks of its own for Enter, paste
and the style commands. None of those were ever put back together.

## Fix

- The repair no longer depends on Bloom having caused the split:
  `mergeTextNodesSplitByBookmarks` becomes `mergeAdjacentTextNodes`, and its comment names the
  other causes.
- It runs **on keydown, before the keystroke lands**, so the character arrives in a paragraph that
  is one whole text node again. This is the part that keeps the letters on screen — the existing
  half-second sweep runs *after* the damage.
- That half-second sweep, at the end of `handlePageEditing`'s `mainTask`, now runs
  unconditionally, catching the splits no keystroke follows: a menu paste, an IME, an undo, a
  long-press the user doesn't type after.
- The merge stands down where ckeditor is holding a "filling char" — a text node ckeditor tracks
  and will come back to edit. It asks ckeditor rather than searching the text for a zero-width
  space (some scripts use one in real text), ignores a reference ckeditor has been left holding to
  a node no longer in the box, and stands down only for the paragraph the char is in.
- Both entry points are no-ops unless the box really is split: 0.056 ms to check on a
  2000-text-node box.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16717


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8217)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8217)
<!-- Reviewable:end -->

