### PR TITLE
Recover cleanly when a collection fails to open (BL-16678)

### DIFF
--- a/src/BloomExe/MiscUI/StartupScreenManager.cs
+++ b/src/BloomExe/MiscUI/StartupScreenManager.cs
@@ -180,7 +180,11 @@ namespace Bloom.MiscUI
         /// They are done in the order added, except that high priority ones go first.
         /// If there are none, and the minimum time has expired, it closes the splash screen.
         /// </summary>
-        private static void DoStartupAction(object sender, EventArgs e)
+        /// <remarks>
+        /// Internal rather than private only so that a test can drive one step of the queue without an
+        /// Application.Idle pump; see StartupScreenManagerTests.
+        /// </remarks>
+        internal static void DoStartupAction(object sender, EventArgs e)
         {
             if (_current != null)
             {
@@ -282,23 +286,61 @@ namespace Bloom.MiscUI
                 }
             }
 
-            if (_current.NeedsToRun != null)
+            try
             {
-                if (_current.NeedsToRun())
+                if (_current.NeedsToRun != null)
                 {
-                    _current.Task();
-                    _current = null; // NOT done, but will be found again.
-                    return;
+                    if (_current.NeedsToRun())
+                    {
+                        _current.Task();
+                        _current = null; // NOT done, but will be found again.
+                        return;
+                    }
+                    else
+                    {
+                        ConsiderCurrentTaskDone();
+                        return;
+                    }
                 }
-                else
-                {
-                    ConsiderCurrentTaskDone();
-                    return;
-                }
-            }
 
-            _current.Task();
+                _current.Task();
+                ConsiderCurrentTaskDone();
+            }
+            catch (Exception error)
+            {
+                HandleStartupActionFailure(error);
+            }
+        }
+
+        /// <summary>
+        /// A startup action threw. Report it, and above all get it out of the queue so the rest of
+        /// startup can go on.
+        /// </summary>
+        /// <remarks>
+        /// This is not about hiding the error -- we report it as loudly as we can -- it is about not
+        /// letting it wedge startup. DoStartupAction runs from Application.Idle and returns immediately
+        /// while _current is set, so an exception used to leave the queue dead for the rest of the run:
+        /// the splash screen never closed, no later action ever ran (including the one that offers the
+        /// Open/Create Collections dialog when a collection won't open), nothing went on to call
+        /// ProgramExit.Exit() so not even its 20-second force-quit net was armed, and Main's finally
+        /// never released the single-instance token. The user was left with an invisible Bloom they
+        /// could neither see nor quit, and the next launch was turned away with "Bloom is already
+        /// running". See BL-16678.
+        /// </remarks>
+        private static void HandleStartupActionFailure(Exception error)
+        {
+            // First, unwedge the queue. Do this before reporting, which shows a dialog and could throw
+            // in its own right.
             ConsiderCurrentTaskDone();
+
+            Logger.WriteError("A Bloom startup action failed", error);
+            NonFatalProblem.Report(
+                ModalIf.All,
+                PassiveIf.None,
+                "Bloom had a problem while starting up.",
+                null,
+                error
+            );
         }
 
         /// <summary>

--- a/src/BloomExe/MiscUI/StartupScreenManager.cs
+++ b/src/BloomExe/MiscUI/StartupScreenManager.cs
@@ -191,6 +191,27 @@ namespace Bloom.MiscUI
                 // got Idle event while startup action in progress. Wait till it finishes.
                 return;
             }
+
+            // Everything below is guarded, not just the task invocation: hiding the splash screen and
+            // running the "do this when the splash screen closes" action can throw too (both touch
+            // forms that may already be disposed), and a throw from any of it would leave the queue
+            // wedged just the same. See HandleStartupActionFailure. (BL-16678)
+            try
+            {
+                PickAndRunNextStartupAction();
+            }
+            catch (Exception error)
+            {
+                HandleStartupActionFailure(error);
+            }
+        }
+
+        /// <summary>
+        /// The body of DoStartupAction: choose the next action that should run and run it, or close the
+        /// splash screen and stand down when there are none left.
+        /// </summary>
+        private static void PickAndRunNextStartupAction()
+        {
             _current = _startupActions.FirstOrDefault(a =>
                 a.Enabled && a.Priority == StartupActionPriority.high
             );
@@ -200,9 +221,11 @@ namespace Bloom.MiscUI
             {
                 if (DateTime.Now > _earliestWeShouldCloseTheSplashScreen)
                 {
-                    CloseSplashScreen();
-                    // We can stop running altogether until some new action gets added or enabled.
+                    // Stand down first. If closing the splash screen throws, we still want to be out of
+                    // the idle queue: otherwise we would come straight back here on the next idle event
+                    // and throw again, forever. (BL-16678)
                     Application.Idle -= DoStartupAction;
+                    CloseSplashScreen();
                 }
                 return;
             }
@@ -286,30 +309,23 @@ namespace Bloom.MiscUI
                 }
             }
 
-            try
+            if (_current.NeedsToRun != null)
             {
-                if (_current.NeedsToRun != null)
+                if (_current.NeedsToRun())
                 {
-                    if (_current.NeedsToRun())
-                    {
-                        _current.Task();
-                        _current = null; // NOT done, but will be found again.
-                        return;
-                    }
-                    else
-                    {
-                        ConsiderCurrentTaskDone();
-                        return;
-                    }
+                    _current.Task();
+                    _current = null; // NOT done, but will be found again.
+                    return;
                 }
+                else
+                {
+                    ConsiderCurrentTaskDone();
+                    return;
+                }
+            }
 
-                _current.Task();
-                ConsiderCurrentTaskDone();
-            }
-            catch (Exception error)
-            {
-                HandleStartupActionFailure(error);
-            }
+            _current.Task();
+            ConsiderCurrentTaskDone();
         }
 
         /// <summary>
@@ -382,6 +398,19 @@ namespace Bloom.MiscUI
         /// dialog, we can go on with the next task as long as we know the one for which
         /// the progress dialog was launched is complete.
         /// </summary>
+        /// <summary>
+        /// Forget every queued action and any action in progress. For tests: this queue is static, so a
+        /// fixture that adds actions must clear them rather than running them out, which would execute
+        /// whatever another fixture had left queued (and close the splash screen) at an arbitrary point
+        /// in the run.
+        /// </summary>
+        internal static void ClearQueueForTests()
+        {
+            _startupActions.Clear();
+            _current = null;
+            Application.Idle -= DoStartupAction;
+        }
+
         public static void ConsiderCurrentTaskDone()
         {
             if (_current == null)

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -1634,6 +1634,84 @@ namespace Bloom
         /// ------------------------------------------------------------------------------------
         private static void StartUpShellBasedOnMostRecentUsedIfPossible()
         {
+            var opened = false;
+            try
+            {
+                opened = TryOpenMostRecentlyUsedCollection();
+            }
+            catch (Exception error)
+            {
+                // OpenProjectWindow reports and returns false for anything that goes wrong while
+                // actually opening, so reaching here means something around it threw. Report it, but
+                // carry on to the chooser below: if we let this out, we would never get there, and a
+                // startup action that throws leaves Bloom running with no window at all. (BL-16678)
+                Logger.WriteError("Error opening the most recently used collection", error);
+                NonFatalProblem.Report(
+                    ModalIf.All,
+                    PassiveIf.None,
+                    "Bloom had a problem opening the collection you were last using.",
+                    null,
+                    error
+                );
+            }
+
+            if (!opened)
+            {
+                // Rather than just adding it to the idle queue, we make sure it doesn't overlap with any other startup idle tasks
+                // and that the splash screen will be closed to make way for it.
+                StartupScreenManager.AddStartupAction(
+                    () => ChooseACollectionOrQuit(),
+                    shouldHideSplashScreen: true
+                );
+            }
+        }
+
+        /// <summary>
+        /// Offer the collection chooser, and if even that fails, quit.
+        /// </summary>
+        /// <remarks>
+        /// Use this wherever the chooser is our recovery from not having a collection open, as opposed
+        /// to the user asking for it while a collection is open. On those paths there is no Shell: if
+        /// showing the chooser throws, the exception goes to FatalExceptionHandler, which during startup
+        /// is in fallback mode and so shows a message and lets the application carry on -- carrying on
+        /// with no window and no way to quit, holding the single-instance token so that the next launch
+        /// is turned away with "Bloom is already running". Quitting is a poor outcome, but it is a much
+        /// better one than that, and ProgramExit arms the force-quit net in case shutdown is stuck too.
+        /// (BL-16678)
+        /// </remarks>
+        private static void ChooseACollectionOrQuit()
+        {
+            try
+            {
+                ChooseACollection();
+            }
+            catch (Utils.PathTooLongException)
+            {
+                // The one exception ChooseACollection raises on purpose, so that the top-level handler
+                // can show its own "that path is too long" report. Swallowing it here would replace
+                // that with a misleading message about the chooser itself. (BL-16678)
+                throw;
+            }
+            catch (Exception error)
+            {
+                Logger.WriteError("Error offering the collection chooser", error);
+                NonFatalProblem.Report(
+                    ModalIf.All,
+                    PassiveIf.None,
+                    "Bloom was not able to show you the list of collections, and has to quit.",
+                    null,
+                    error
+                );
+                ProgramExit.Exit();
+            }
+        }
+
+        /// <summary>
+        /// Open the collection the user was last in, if we have a usable one remembered.
+        /// </summary>
+        /// <returns>true if a project window is now open</returns>
+        private static bool TryOpenMostRecentlyUsedCollection()
+        {
             var path = Settings.Default.MruProjects.Latest;
 
             if (!string.IsNullOrEmpty(path))
@@ -1648,7 +1726,9 @@ namespace Bloom
                 }
                 else
                 {
-                    while (Utils.MiscUtils.IsInvalidCollectionToEdit(path))
+                    // The null check matters: once we have removed the last entry, Latest returns null,
+                    // and IsInvalidCollectionToEdit would then throw on it. (BL-16678)
+                    while (path != null && Utils.MiscUtils.IsInvalidCollectionToEdit(path))
                     {
                         // Somehow...from a previous version?...we have an invalid file in our MRU list.
                         Settings.Default.MruProjects.RemovePath(path);
@@ -1657,15 +1737,7 @@ namespace Bloom
                 }
             }
 
-            if (path == null || !OpenProjectWindow(path))
-            {
-                // Rather than just adding it to the idle queue, we make sure it doesn't overlap with any other startup idle tasks
-                // and that the splash screen will be closed to make way for it.
-                StartupScreenManager.AddStartupAction(
-                    () => ChooseACollection(),
-                    shouldHideSplashScreen: true
-                );
-            }
+            return path != null && OpenProjectWindow(path);
         }
 
         /// ------------------------------------------------------------------------------------
@@ -1794,6 +1866,60 @@ namespace Bloom
                 _projectContext = null;
             }
 
+            EnsureNoProjectStateSurvivesAFailedOpen();
+
+            try
+            {
+                ReportErrorOpeningProjectWindow(error, projectPath);
+            }
+            catch (Exception reportingError)
+            {
+                // Reporting runs inside OpenProjectWindow's catch, and its callers depend on
+                // OpenProjectWindow returning false to put up the collection chooser. If a failure to
+                // report escaped from here, it would take that recovery with it and leave Bloom running
+                // with no window and no way to quit. The user has already lost the collection they asked
+                // for; don't also cost them the way back in. (BL-16678)
+                Logger.WriteError("Error reporting a failure to open a collection", reportingError);
+            }
+        }
+
+        /// <summary>
+        /// Make sure nothing the failed project left on application-level objects can spoil the next
+        /// collection the user picks.
+        /// </summary>
+        /// <remarks>
+        /// ProjectContext.Dispose does this for itself, but only as far as it gets: if its own teardown
+        /// throws part way, the constructor logs that and carries on, and the API endpoint handlers the
+        /// failed project registered are still there. The next collection then re-registers the same
+        /// patterns and dies on a duplicate key ("An item with the same key has already been added.
+        /// Key: audio/startrecord"), so one bad collection cost the user every later one until they
+        /// restarted Bloom. This is the one place that knows we have failed and are about to offer
+        /// another collection, so make it certain here. It is cheap and idempotent. (BL-16678)
+        /// </remarks>
+        private static void EnsureNoProjectStateSurvivesAFailedOpen()
+        {
+            try
+            {
+                var server = _applicationContainer?.BloomServer;
+                Debug.Assert(
+                    server?.ApiHandler.HasProjectLevelHandlers != true,
+                    "ProjectContext.Dispose should already have removed the failed project's API endpoint handlers (BL-16678)"
+                );
+                ProjectContext.ReleaseApplicationLevelProjectState(server);
+            }
+            catch (Exception e)
+            {
+                // Same reasoning as the caller's guard: getting back to the collection chooser matters
+                // more than this cleanup succeeding.
+                Logger.WriteError(
+                    "Error clearing state left by a collection that failed to open",
+                    e
+                );
+            }
+        }
+
+        private static void ReportErrorOpeningProjectWindow(Exception error, string projectPath)
+        {
             // FileException is a Bloom exception to capture the filepath. We want to report the inner, original exception.
             Exception originalError = FileException.UnwrapIfFileException(error);
             string errorFilePath = FileException.GetFilePathIfPresent(error);
@@ -2014,11 +2140,14 @@ namespace Bloom
             Application.Idle -= ReopenProject;
             if (!OpenCollection(Settings.Default.MruProjects.Latest))
             {
-                // The shell is already closed by the time we get here, so if the re-open failed
-                // we must put the chooser up or the user is left with no window at all. This can
-                // happen now that a collection can refuse to open: a Team Collection member on a
-                // newer Bloom can add a MinimumBloomVersion that syncs down mid-session.
-                ChooseACollection();
+                // Fall back to letting the user choose again, exactly as OpenCollectionChosenInDialog
+                // does. We get here from a UI language change or from the Collection Settings dialog,
+                // and HandleProjectWindowClosed has already closed the Shell and disposed the project.
+                // Without this, a reopen that fails leaves Application.Run() with no window, and since
+                // nothing goes on to call ProgramExit.Exit(), not even its 20-second force-quit net is
+                // armed: Bloom sits there invisibly holding the single-instance token, so the next
+                // launch is turned away with "Bloom is already running". (BL-16678)
+                ChooseACollectionOrQuit();
             }
         }
 
@@ -2031,8 +2160,10 @@ namespace Bloom
             // no collection has been chosen yet, so go straight to the chooser.
             if (string.IsNullOrEmpty(pathToOpen) || !OpenCollection(pathToOpen))
             {
-                // Also comes here if opening failed: fall back to letting the user choose again.
-                ChooseACollection();
+                // If opening failed, fall back to letting the user choose again. (The Shell was closed
+                // before we got here, so if even the chooser fails we have to quit rather than leave
+                // Bloom running with no window. See ChooseACollectionOrQuit. BL-16678)
+                ChooseACollectionOrQuit();
             }
         }
 

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -1685,12 +1685,18 @@ namespace Bloom
             {
                 ChooseACollection();
             }
-            catch (Utils.PathTooLongException)
+            catch (System.IO.PathTooLongException error)
             {
-                // The one exception ChooseACollection raises on purpose, so that the top-level handler
-                // can show its own "that path is too long" report. Swallowing it here would replace
-                // that with a misleading message about the chooser itself. (BL-16678)
-                throw;
+                // ChooseACollection raises this on purpose when the collection the user picked has too
+                // long a path, so that we can say so specifically instead of blaming the chooser. Do
+                // that report here rather than letting it out: the tailored one lives in
+                // ProblemReportApi, which is not in play on these paths (no project, so we are still on
+                // the WinForms fallback reporter), and an exception let out of here reaches
+                // FatalExceptionHandler, which in fallback mode shows a message and lets Bloom carry on
+                // -- windowless, which is the very thing this method exists to prevent. (BL-16678)
+                Logger.WriteError("A collection was chosen whose path is too long", error);
+                LongPathAware.ReportLongPath(error);
+                ProgramExit.Exit();
             }
             catch (Exception error)
             {
@@ -1854,19 +1860,38 @@ namespace Bloom
         /// ------------------------------------------------------------------------------------
         private static void HandleErrorOpeningProjectWindow(Exception error, string projectPath)
         {
-            if (_projectContext != null)
+            // The finally matters. This block only runs when the failure came *after* the
+            // ProjectContext was built (the constructor's own failures never assign _projectContext,
+            // and clean up after themselves), and closing a half-working window or disposing a
+            // half-working project can throw in its own right. If that took out the two lines below it,
+            // we would be left with the failed project's API handlers still registered and a stale
+            // _projectContext -- so the next collection would hit the duplicate-key failure this whole
+            // change is about, and trip the Debug.Assert in OpenProjectWindow on the way. (BL-16678)
+            try
             {
-                if (_projectContext.ProjectWindow != null)
+                if (_projectContext != null)
                 {
-                    _projectContext.ProjectWindow.Closed -= HandleProjectWindowClosed;
-                    _projectContext.ProjectWindow.Close();
+                    if (_projectContext.ProjectWindow != null)
+                    {
+                        _projectContext.ProjectWindow.Closed -= HandleProjectWindowClosed;
+                        _projectContext.ProjectWindow.Close();
+                    }
+
+                    _projectContext.Dispose();
                 }
-
-                _projectContext.Dispose();
-                _projectContext = null;
             }
-
-            EnsureNoProjectStateSurvivesAFailedOpen();
+            catch (Exception teardownError)
+            {
+                Logger.WriteError(
+                    "Error shutting down a project that failed to open",
+                    teardownError
+                );
+            }
+            finally
+            {
+                _projectContext = null;
+                EnsureNoProjectStateSurvivesAFailedOpen();
+            }
 
             try
             {

--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -996,13 +996,18 @@ namespace Bloom
         /// </remarks>
         internal static void ReleaseApplicationLevelProjectState(BloomServer server)
         {
+            // No server means we failed before we ever got hold of one, so we had not registered any
+            // handlers and had not advertised our collection either -- there is nothing of ours to take
+            // back. Bailing out first also keeps a second Dispose() the no-op it has always been,
+            // rather than letting it clear settings that by then belong to a live project.
+            if (server == null)
+                return;
+
             // So that common/instanceInfo doesn't report a collection we are not in. Unlike the
             // server's copy, this one is read as "which collection is current", and the collection
             // chooser uses it to decide what to highlight.
             web.controllers.CommonApi.CurrentCollectionSettings = null;
 
-            if (server == null)
-                return; // we failed before we ever got hold of it, so we registered nothing
             try
             {
                 server.ApiHandler.ClearProjectLevelHandlers();
@@ -1027,11 +1032,6 @@ namespace Bloom
         /// ------------------------------------------------------------------------------------
         public void Dispose()
         {
-            if (_collectionLock != null)
-            {
-                _collectionLock.Unlock();
-            }
-
             // Disposing ProjectContext disables api functionality and disposes WorkspaceModel/View, BloomServer, et al.,
             // so we need to resort to our fallback error handler.
             ResetToFallbackHandler();
@@ -1051,6 +1051,15 @@ namespace Bloom
             // at least we avoid mysterious errors in the API handlers due to disposed objects.
             ReleaseApplicationLevelProjectState(_server);
             _server = null;
+
+            // Unlock after that, not before: CollectionLock.Unlock rethrows in a DEBUG build, and on the
+            // ordinary collection-switch path nothing catches it -- so unlocking first meant a failing
+            // unlock could leave the project's API handlers registered, which is the state this whole
+            // change exists to prevent. (BL-16678)
+            if (_collectionLock != null)
+            {
+                _collectionLock.Unlock();
+            }
 
             // We can be disposed without a scope: our constructor disposes us if it fails, and it can
             // fail in (or even before) BuildSubContainerForThisProject. Unlocking the collection above

--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -45,6 +45,13 @@ namespace Bloom
         /// </summary>
         private ILifetimeScope _scope;
 
+        /// <summary>
+        /// The application-level server we registered our project-level API endpoints on. Kept so that
+        /// Dispose can take them off again without having to resolve anything. See
+        /// ReleaseApplicationLevelProjectState. (BL-16678)
+        /// </summary>
+        private BloomServer _server;
+
         //		private CommandAvailabilityPublisher _commandAvailabilityPublisher;
         public Form ProjectWindow { get; private set; }
 
@@ -68,17 +75,21 @@ namespace Bloom
         )
         {
             Logger.WriteMinorEvent("starting to construct the project context");
-            // Settle which settings file we are really opening before anything uses the path. The
-            // caller's may not exist: the name is not always the folder's (BL-16679), and the lock
-            // below would then be aimed at a file that isn't there -- silently protecting nothing in
-            // a release build, and throwing in a DEBUG one.
-            SettingsPath = GetRealSettingsPath(projectSettingsPath);
-
-            _collectionLock = new CollectionLock(SettingsPath);
-            _collectionLock.Lock();
-
             try
             {
+                // Settle which settings file we are really opening before anything uses the path. The
+                // caller's may not exist: the name is not always the folder's (BL-16679).
+                SettingsPath = GetRealSettingsPath(projectSettingsPath);
+
+                _collectionLock = new CollectionLock(SettingsPath);
+                // Only lock a file that is there to be locked. GetRealSettingsPath hands back the path
+                // it was given when the folder holds no .bloomCollection at all, and Lock() rethrows in
+                // a DEBUG build -- which would replace the clear "could not find a .bloomCollection
+                // file in ..." that GetCollectionSettings throws with a bare FileNotFoundException
+                // about the lock, sending the next developer to look in the wrong place. (BL-16678)
+                if (RobustFile.Exists(SettingsPath))
+                    _collectionLock.Lock();
+
                 // BL-8019: A couple lines down, BuildSubContainerForThisProject() starts BloomServer with the new project.
                 // While we are starting (or restarting, in the case of switching collections) BloomServer we need to use
                 // the WinFormsExceptionHandler mechanism, which doesn't use a browser.
@@ -111,7 +122,10 @@ namespace Bloom
                 // the Shell and its WebView2 browsers, the file watchers, and the rest of the scope.
                 // Left running, those can keep Bloom from ever exiting, which is part of what left it
                 // lingering as a zombie process. (BloomServer itself is application-level, resolved
-                // from the parent container, so it is not ours to shut down.) (BL-16679)
+                // from the parent container, so it is not ours to shut down -- but the endpoint handlers
+                // we registered on it are ours to remove, and failing to is what stopped the next
+                // collection from opening. See ReleaseApplicationLevelProjectState.)
+                // (BL-16679, BL-16678)
                 try
                 {
                     Dispose();
@@ -252,39 +266,36 @@ namespace Bloom
                     //*every* collection has a "*.BloomCollection" settings file. But the one we make the most use of is the one editable collection
                     //That's why we're registering it... it gets used all over. At the moment (May 2012), we don't ever read the
                     //settings file of the collections we're using for sources.
-                    try
-                    {
-                        // It's important to create the TC manager before we create CollectionSettings, as its constructor makes sure
-                        // we have a current version of the file that CollectionSettings is built from.
-                        builder
-                            .Register<TeamCollectionManager>(c => new TeamCollectionManager(
-                                projectSettingsPath,
-                                c.Resolve<BloomWebSocketServer>(),
-                                c.Resolve<BookStatusChangeEvent>(),
-                                c.Resolve<BookSelection>(),
-                                c.Resolve<CollectionClosing>(),
-                                c.Resolve<BookCollectionHolder>(),
-                                _collectionLock,
-                                c.Resolve<BookRenamedEvent>()
-                            ))
-                            .InstancePerLifetimeScope();
-                        builder
-                            .Register<ITeamCollectionManager>(c =>
-                                c.Resolve<TeamCollectionManager>()
-                            )
-                            .InstancePerLifetimeScope();
-                        builder
-                            .Register<CollectionSettings>(c =>
-                            {
-                                c.Resolve<TeamCollectionManager>();
-                                return GetCollectionSettings(projectSettingsPath);
-                            })
-                            .InstancePerLifetimeScope();
-                    }
-                    catch (Exception)
-                    {
-                        return;
-                    }
+                    // It's important to create the TC manager before we create CollectionSettings, as its constructor makes sure
+                    // we have a current version of the file that CollectionSettings is built from.
+                    builder
+                        .Register<TeamCollectionManager>(c => new TeamCollectionManager(
+                            projectSettingsPath,
+                            c.Resolve<BloomWebSocketServer>(),
+                            c.Resolve<BookStatusChangeEvent>(),
+                            c.Resolve<BookSelection>(),
+                            c.Resolve<CollectionClosing>(),
+                            c.Resolve<BookCollectionHolder>(),
+                            _collectionLock,
+                            c.Resolve<BookRenamedEvent>()
+                        ))
+                        .InstancePerLifetimeScope();
+                    builder
+                        .Register<ITeamCollectionManager>(c => c.Resolve<TeamCollectionManager>())
+                        .InstancePerLifetimeScope();
+                    builder
+                        .Register<CollectionSettings>(c =>
+                        {
+                            c.Resolve<TeamCollectionManager>();
+                            return GetCollectionSettings(projectSettingsPath);
+                        })
+                        .InstancePerLifetimeScope();
+                    // (There used to be a try/catch around the three registrations above whose catch
+                    // just returned. Registering doesn't run any of these lambdas, so it could hardly
+                    // fire; if it ever did, returning here abandoned every registration below, and the
+                    // user got an Autofac ComponentNotRegisteredException naming some unrelated type
+                    // instead of the real cause. The constructor now disposes and reports properly, so
+                    // letting the exception out is both safe and much easier to diagnose. BL-16678)
 
                     builder
                         .Register<CollectionModel>(c => new CollectionModel(
@@ -432,9 +443,19 @@ namespace Bloom
                     MessageBoxIcon.Error
                 );
                 ProgramExit.Exit();
+                // Don't fall through. This used to, straight into code that dereferences the _scope we
+                // just failed to build, so what the user and Sentry actually got was a
+                // NullReferenceException naming nothing useful instead of the missing file. Throwing
+                // lets our constructor dispose us and the real exception reach the log and the report.
+                // (BL-16678)
+                throw;
             }
 
-            var server = parentContainer.Resolve<BloomServer>();
+            // Remember the server in a field as well: it is application-level, so the endpoint handlers
+            // we are about to register on it outlive us, and Dispose has to be able to take them off
+            // again even when resolving things has stopped working. See
+            // ReleaseApplicationLevelProjectState. (BL-16678)
+            var server = _server = parentContainer.Resolve<BloomServer>();
             var collectionSettings = _scope.Resolve<CollectionSettings>();
             server.SetCollectionSettingsDuringInitialization(collectionSettings);
             // Let the application-level CommonApi (which can't take a project dependency in its
@@ -952,6 +973,57 @@ namespace Bloom
             FatalExceptionHandler.UseFallback = true;
         }
 
+        /// <summary>
+        /// Undo the marks a project leaves on objects that outlive it: the API endpoint handlers it
+        /// registered on the application-level server, and the collection it advertised to the
+        /// application-level CommonApi. Safe to call repeatedly, and with no server.
+        /// </summary>
+        /// <remarks>
+        /// This is not just tidiness. The next project registers the same endpoint patterns, and
+        /// RegisterEndpointHandler throws on a duplicate key -- deliberately, since a real double
+        /// registration is a programming error. So handlers left behind by a project that failed to
+        /// finish being built make every later collection in that run fail too, with an error naming
+        /// whichever endpoint happens to be registered first ("An item with the same key has already
+        /// been added. Key: audio/startrecord"), until Bloom is restarted. That is BL-16678, and it is
+        /// why this is done from a field rather than by resolving the server, and outside any try that
+        /// something else could fail out of first.
+        ///
+        /// Note that we deliberately do NOT clear the server's own CurrentCollectionSettings. Several
+        /// places in BloomServer read it unguarded to serve files relative to the collection folder, so
+        /// between one project closing and the next opening -- which is exactly when the Open/Create
+        /// Collections dialog is up -- settings describing the collection we just left are a better
+        /// answer than null. The next project overwrites them.
+        /// </remarks>
+        internal static void ReleaseApplicationLevelProjectState(BloomServer server)
+        {
+            // So that common/instanceInfo doesn't report a collection we are not in. Unlike the
+            // server's copy, this one is read as "which collection is current", and the collection
+            // chooser uses it to decide what to highlight.
+            web.controllers.CommonApi.CurrentCollectionSettings = null;
+
+            if (server == null)
+                return; // we failed before we ever got hold of it, so we registered nothing
+            try
+            {
+                server.ApiHandler.ClearProjectLevelHandlers();
+            }
+            catch (ObjectDisposedException)
+            {
+                // During application shutdown, WinForms can fire Application.ApplicationExit (for
+                // example as a worker thread's message context is torn down while publish artifacts are
+                // being created, as in the harvester's CreateArtifacts flow). That disposes the
+                // ApplicationContainer, so the server and its API handlers may already be gone, in
+                // which case there is nothing project-scoped left to clean up.
+            }
+            catch (Exception e)
+            {
+                // Anything else is unexpected, so say so -- but this is called from Dispose, ahead of
+                // disposing our scope, and letting it out would skip that. (Before this method existed,
+                // that was guaranteed by a finally.)
+                Logger.WriteError("Error clearing a project's application-level API handlers", e);
+            }
+        }
+
         /// ------------------------------------------------------------------------------------
         public void Dispose()
         {
@@ -964,6 +1036,22 @@ namespace Bloom
             // so we need to resort to our fallback error handler.
             ResetToFallbackHandler();
 
+            // Give the application-level objects back the state they had before this project existed.
+            // This runs before anything below that could throw, and without resolving anything, because
+            // it is the one part of our teardown that the *next* collection the user opens depends on.
+            // (BL-16678)
+            //
+            // The order also matters, and is why this comes before disposing the scope. Browsers could
+            // still be running and trying to call APIs while we are shutting down. Disposing the scope
+            // disposes the browsers, after which they shouldn't be able to make requests, but some
+            // requests might still be queued up in the server. If we clear the project level handlers
+            // first, then those requests could fail because no handler is registered. If we dispose the
+            // scope first, then those requests will find the handlers, but they may rely on objects that
+            // have been disposed. On the whole, I think it's best to clear the handlers first; that way,
+            // at least we avoid mysterious errors in the API handlers due to disposed objects.
+            ReleaseApplicationLevelProjectState(_server);
+            _server = null;
+
             // We can be disposed without a scope: our constructor disposes us if it fails, and it can
             // fail in (or even before) BuildSubContainerForThisProject. Unlocking the collection above
             // is then all there is to do. This also makes Dispose safe to call twice. (BL-16679)
@@ -973,46 +1061,8 @@ namespace Bloom
                 return;
             }
 
-            // We now keep BloomApiHandler alive for the application lifetime, but many endpoints are project-scoped.
-            // Disposing the ProjectContext should fully shut down the project (including webviews) before we clear
-            // those project-scoped endpoints.
-            try
-            {
-                // During application shutdown, WinForms can fire Application.ApplicationExit (for example as a
-                // worker thread's message context is torn down while publish artifacts are being created, as in
-                // the harvester's CreateArtifacts flow). That disposes the ApplicationContainer, which is the
-                // parent of _scope, before this Dispose runs. When that has happened, BloomServer (an
-                // application-level singleton) and all its API handlers are already gone, so resolving it throws
-                // ObjectDisposedException and there is nothing project-scoped left to clean up. In that case we
-                // just fall through to disposing our own scope.
-                var server = _scope.Resolve<BloomServer>();
-
-                // The order of these is tricky. The problem is that browsers could still be
-                // running and trying to call APIs while we are shutting down.
-                // Disposing the scope disposes the browsers, after which they shouldn't be able
-                // to make requests. But some requests might still be queued up in the server.
-                // If we clear the project level handlers first, then those requests could fail
-                // because no handler is registered. If we dispose the scope first, then those
-                // requests will find the handlers, but they may rely on objects that have been
-                // disposed. On the whole, I think it's best to clear the handlers first; that way,
-                // at least we avoid mysterious errors in the API handlers due to disposed objects.
-                server.ApiHandler.ClearProjectLevelHandlers();
-                // Clear the project-scoped collection settings we set on the application-level CommonApi
-                // (see constructor), so common/instanceInfo doesn't report stale collection info after the
-                // project is closed. A reload disposes this context before creating the next one, which
-                // sets it again, so clearing here is safe.
-                web.controllers.CommonApi.CurrentCollectionSettings = null;
-            }
-            catch (ObjectDisposedException)
-            {
-                // The application container was already disposed (see above); nothing project-scoped
-                // remains to clean up, so proceed to dispose our own scope below.
-            }
-            finally
-            {
-                _scope.Dispose();
-                _scope = null;
-            }
+            _scope.Dispose();
+            _scope = null;
 
             //REVIEW: by debugging, I see that _httpServer is already (and properly) disposed of by the
             //_scope.Dispose() above.

--- a/src/BloomExe/web/BloomApiHandler.cs
+++ b/src/BloomExe/web/BloomApiHandler.cs
@@ -72,6 +72,24 @@ namespace Bloom.Api
         }
 
         /// <summary>
+        /// True if any handler registered by a project context is still registered. Used to check that
+        /// a project that failed to open really did take its handlers with it: if it did not, the next
+        /// project re-registers the same patterns and RegisterEndpointHandler throws. See BL-16678.
+        /// </summary>
+        internal bool HasProjectLevelHandlers
+        {
+            get
+            {
+                lock (_endpointRegistrationsLock)
+                {
+                    return _exactEndpointRegistrations.Keys.Any(key =>
+                        !_applicationLevelRegistrationKeys.Contains(key)
+                    );
+                }
+            }
+        }
+
+        /// <summary>
         /// Clear all handlers that were not marked as application level handlers
         /// </summary>
         public void ClearProjectLevelHandlers()

--- a/src/BloomTests/MiscUI/StartupScreenManagerTests.cs
+++ b/src/BloomTests/MiscUI/StartupScreenManagerTests.cs
@@ -16,13 +16,21 @@ namespace BloomTests.MiscUI
             StartupScreenManager.DoStartupAction(null, EventArgs.Empty);
         }
 
+        [SetUp]
+        public void SetUp()
+        {
+            // The queue is static, so start from a known-empty one rather than inheriting whatever
+            // another fixture may have left queued.
+            StartupScreenManager.ClearQueueForTests();
+        }
+
         [TearDown]
         public void TearDown()
         {
-            // The queue is static, so drain anything a test left behind rather than letting it run
-            // during some later fixture. Bounded so a bug here can't hang the test run.
-            for (var i = 0; i < 20; i++)
-                Tick();
+            // Clear rather than tick the queue empty: ticking would *run* any action still queued, and
+            // an empty tick closes the splash screen, so draining has side effects on global state that
+            // clearing does not.
+            StartupScreenManager.ClearQueueForTests();
         }
 
         /// <summary>

--- a/src/BloomTests/MiscUI/StartupScreenManagerTests.cs
+++ b/src/BloomTests/MiscUI/StartupScreenManagerTests.cs
@@ -1,0 +1,99 @@
+using System;
+using Bloom;
+using Bloom.MiscUI;
+using NUnit.Framework;
+
+namespace BloomTests.MiscUI
+{
+    [TestFixture]
+    public class StartupScreenManagerTests
+    {
+        /// <summary>
+        /// Run one step of the queue, the way an Application.Idle event would.
+        /// </summary>
+        private static void Tick()
+        {
+            StartupScreenManager.DoStartupAction(null, EventArgs.Empty);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            // The queue is static, so drain anything a test left behind rather than letting it run
+            // during some later fixture. Bounded so a bug here can't hang the test run.
+            for (var i = 0; i < 20; i++)
+                Tick();
+        }
+
+        /// <summary>
+        /// A startup action that throws must not stop the ones behind it.
+        /// </summary>
+        /// <remarks>
+        /// DoStartupAction returns immediately while an action is in progress, so an exception used to
+        /// leave the queue dead for the rest of the run: the splash screen never closed, no later action
+        /// ran -- including the one that offers the Open/Create Collections dialog when a collection
+        /// won't open -- nothing called ProgramExit.Exit() so not even its 20-second force-quit net was
+        /// armed, and the single-instance token was never released. Bloom was left invisible and
+        /// unquittable, and the next launch was turned away with "Bloom is already running".
+        /// See BL-16678.
+        /// </remarks>
+        [Test]
+        public void DoStartupAction_ActionThrows_LaterActionsStillRun()
+        {
+            var secondRan = false;
+            using (new NonFatalProblem.ExpectedByUnitTest())
+            {
+                StartupScreenManager.AddStartupAction(() =>
+                    throw new ApplicationException("deliberate failure for the test")
+                );
+                StartupScreenManager.AddStartupAction(() => secondRan = true);
+
+                Tick(); // runs, and fails, the first action
+                Assert.That(
+                    secondRan,
+                    Is.False,
+                    "one tick should run only one action; otherwise this test proves nothing"
+                );
+
+                Tick();
+            }
+
+            Assert.That(
+                secondRan,
+                Is.True,
+                "an action that threw must not wedge the queue behind it"
+            );
+        }
+
+        [Test]
+        public void DoStartupAction_ActionThrows_ReportsTheProblem()
+        {
+            StartupScreenManager.AddStartupAction(() =>
+                throw new ApplicationException("deliberate failure for the test")
+            );
+
+            // Throws on dispose if nothing was reported, which is the assertion we want: the failure is
+            // not silently swallowed.
+            using (new NonFatalProblem.ExpectedByUnitTest())
+            {
+                Tick();
+            }
+        }
+
+        [Test]
+        public void DoStartupAction_ActionSucceeds_ActionRunsOnceAndQueueMovesOn()
+        {
+            var firstCount = 0;
+            var secondCount = 0;
+            StartupScreenManager.AddStartupAction(() => firstCount++);
+            StartupScreenManager.AddStartupAction(() => secondCount++);
+
+            Tick();
+            Tick();
+            Tick(); // nothing left to do
+
+            Assert.That(firstCount, Is.EqualTo(1));
+            Assert.That(secondCount, Is.EqualTo(1));
+        }
+    }
+}

--- a/src/BloomTests/ProjectContextTests.cs
+++ b/src/BloomTests/ProjectContextTests.cs
@@ -259,32 +259,66 @@ namespace BloomTests
 
         /// <summary>
         /// The constructor disposes itself when it fails, and it can fail before it ever gets hold of
-        /// the server, so this has to cope with having no server to clean up. See BL-16678.
+        /// the server, so this has to cope with having none. With no server there is also nothing of
+        /// ours to take back -- we had registered no handlers and advertised no collection -- so it must
+        /// leave what it finds alone rather than clearing it. See BL-16678.
         /// </summary>
         [Test]
-        public void ReleaseApplicationLevelProjectState_NoServer_StillForgetsTheCollection()
+        public void ReleaseApplicationLevelProjectState_NoServer_ChangesNothing()
         {
-            CommonApi.CurrentCollectionSettings = new CollectionSettings();
+            var settings = new CollectionSettings();
+            CommonApi.CurrentCollectionSettings = settings;
 
             Assert.That(
                 () => ProjectContext.ReleaseApplicationLevelProjectState(null),
                 Throws.Nothing
             );
 
-            Assert.That(CommonApi.CurrentCollectionSettings, Is.Null);
+            Assert.That(CommonApi.CurrentCollectionSettings, Is.SameAs(settings));
         }
 
+        /// <summary>
+        /// A second Dispose must be a no-op. It is easy for it not to be: this runs before the check
+        /// that we still have a scope, so if it cleared the "which collection is current" setting
+        /// unconditionally, disposing an already-disposed context would blank that out for whichever
+        /// project is live by then. See BL-16678.
+        /// </summary>
         [Test]
-        public void ReleaseApplicationLevelProjectState_CalledTwice_DoesNotThrow()
+        public void ReleaseApplicationLevelProjectState_CalledTwice_LeavesTheSecondCallerAlone()
         {
             var server = new BloomServer(new BookSelection());
+            server.ApiHandler.RegisterEndpointHandler("common/instanceInfo", request => { }, false);
+            server.ApiHandler.RecordApplicationLevelHandlers();
             server.ApiHandler.RegisterEndpointHandler("audio/startRecord", request => { }, false);
 
             ProjectContext.ReleaseApplicationLevelProjectState(server);
+            Assert.That(server.ApiHandler.HasProjectLevelHandlers, Is.False);
+
+            // Stand in for a later project that has since opened and set these up again.
+            var nextCollection = new CollectionSettings();
+            CommonApi.CurrentCollectionSettings = nextCollection;
+
+            // Disposing the old context a second time (it no longer has a server) must not touch any
+            // of that.
+            Assert.That(
+                () => ProjectContext.ReleaseApplicationLevelProjectState(null),
+                Throws.Nothing
+            );
 
             Assert.That(
-                () => ProjectContext.ReleaseApplicationLevelProjectState(server),
-                Throws.Nothing
+                CommonApi.CurrentCollectionSettings,
+                Is.SameAs(nextCollection),
+                "a second Dispose must not forget the collection a later project has opened"
+            );
+            Assert.That(
+                () =>
+                    server.ApiHandler.RegisterEndpointHandler(
+                        "common/instanceInfo",
+                        request => { },
+                        false
+                    ),
+                Throws.ArgumentException,
+                "the application-level handlers must still be registered"
             );
         }
     }

--- a/src/BloomTests/ProjectContextTests.cs
+++ b/src/BloomTests/ProjectContextTests.cs
@@ -1,6 +1,9 @@
 using System.IO;
 using Bloom;
+using Bloom.Api;
+using Bloom.Book;
 using Bloom.Collection;
+using Bloom.web.controllers;
 using BloomTemp;
 using NUnit.Framework;
 using SIL.IO;
@@ -211,6 +214,78 @@ namespace BloomTests
                 Assert.That(settings.SettingsFilePath, Is.EqualTo(expectedSettingsPath));
                 Assert.That(settings.Language1Tag, Is.EqualTo("fr"));
             }
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            // Some tests below set this application-level static; don't leave it set for other fixtures.
+            CommonApi.CurrentCollectionSettings = null;
+        }
+
+        /// <summary>
+        /// Everything a project leaves on application-level objects has to come off again, whether the
+        /// project shut down tidily or blew up half built. If the endpoint handlers stay registered, the
+        /// next collection the user opens dies on a duplicate key and they are stuck until they restart
+        /// Bloom. See BL-16678.
+        /// </summary>
+        [Test]
+        public void ReleaseApplicationLevelProjectState_RemovesOnlyWhatTheProjectAdded()
+        {
+            var server = new BloomServer(new BookSelection());
+            server.ApiHandler.RegisterEndpointHandler("common/instanceInfo", request => { }, false);
+            server.ApiHandler.RecordApplicationLevelHandlers();
+            server.ApiHandler.RegisterEndpointHandler("audio/startRecord", request => { }, false);
+            CommonApi.CurrentCollectionSettings = new CollectionSettings();
+            // Sanity checks on the state we are asking it to undo.
+            Assert.That(server.ApiHandler.HasProjectLevelHandlers, Is.True);
+            Assert.That(CommonApi.CurrentCollectionSettings, Is.Not.Null);
+
+            ProjectContext.ReleaseApplicationLevelProjectState(server);
+
+            Assert.That(server.ApiHandler.HasProjectLevelHandlers, Is.False);
+            Assert.That(CommonApi.CurrentCollectionSettings, Is.Null);
+            Assert.That(
+                () =>
+                    server.ApiHandler.RegisterEndpointHandler(
+                        "common/instanceInfo",
+                        request => { },
+                        false
+                    ),
+                Throws.ArgumentException,
+                "the application-level handler should still be registered"
+            );
+        }
+
+        /// <summary>
+        /// The constructor disposes itself when it fails, and it can fail before it ever gets hold of
+        /// the server, so this has to cope with having no server to clean up. See BL-16678.
+        /// </summary>
+        [Test]
+        public void ReleaseApplicationLevelProjectState_NoServer_StillForgetsTheCollection()
+        {
+            CommonApi.CurrentCollectionSettings = new CollectionSettings();
+
+            Assert.That(
+                () => ProjectContext.ReleaseApplicationLevelProjectState(null),
+                Throws.Nothing
+            );
+
+            Assert.That(CommonApi.CurrentCollectionSettings, Is.Null);
+        }
+
+        [Test]
+        public void ReleaseApplicationLevelProjectState_CalledTwice_DoesNotThrow()
+        {
+            var server = new BloomServer(new BookSelection());
+            server.ApiHandler.RegisterEndpointHandler("audio/startRecord", request => { }, false);
+
+            ProjectContext.ReleaseApplicationLevelProjectState(server);
+
+            Assert.That(
+                () => ProjectContext.ReleaseApplicationLevelProjectState(server),
+                Throws.Nothing
+            );
         }
     }
 }

--- a/src/BloomTests/web/BloomApiHandlerTests.cs
+++ b/src/BloomTests/web/BloomApiHandlerTests.cs
@@ -1,0 +1,123 @@
+using Bloom.Api;
+using Bloom.Book;
+using NUnit.Framework;
+
+namespace BloomTests.web
+{
+    /// <summary>
+    /// Tests of the application-level/project-level split in the endpoint registrations.
+    /// </summary>
+    /// <remarks>
+    /// This is the mechanism collection switching depends on. Every ProjectContext registers the same
+    /// set of project-level endpoint patterns, and RegisterEndpointHandler throws on a duplicate key --
+    /// deliberately, since a real double registration is a programming error. So the handler table has
+    /// to be back to its application-level contents before the next project is built. When a project
+    /// failed part way through being built and did not manage that, every later collection in that run
+    /// died with "An item with the same key has already been added. Key: audio/startrecord" until Bloom
+    /// was restarted. See BL-16678.
+    /// </remarks>
+    [TestFixture]
+    public class BloomApiHandlerTests
+    {
+        private BloomApiHandler _handler;
+
+        // Two of the patterns a real project registers, and one the ApplicationContainer registers
+        // before any project exists.
+        private const string kProjectPattern = "audio/startRecord";
+        private const string kOtherProjectPattern = "collections/list";
+        private const string kApplicationPattern = "common/instanceInfo";
+
+        [SetUp]
+        public void Setup()
+        {
+            _handler = new BloomApiHandler(new BookSelection());
+        }
+
+        private void Register(string pattern)
+        {
+            _handler.RegisterEndpointHandler(pattern, request => { }, false);
+        }
+
+        /// <summary>
+        /// The sanity check for the tests below: registering the same pattern twice really does throw,
+        /// so a test that re-registers without failing is telling us something.
+        /// </summary>
+        [Test]
+        public void RegisterEndpointHandler_SamePatternTwice_Throws()
+        {
+            Register(kProjectPattern);
+
+            Assert.That(() => Register(kProjectPattern), Throws.ArgumentException);
+        }
+
+        /// <summary>
+        /// The invariant a project's teardown has to restore. See the remarks on this fixture.
+        /// </summary>
+        [Test]
+        public void ClearProjectLevelHandlers_ThenRegisterAgain_DoesNotThrow()
+        {
+            Register(kApplicationPattern);
+            _handler.RecordApplicationLevelHandlers();
+            Register(kProjectPattern);
+            Register(kOtherProjectPattern);
+            // Sanity check: without the clear, this is the failure the user saw.
+            Assert.That(
+                () => Register(kProjectPattern),
+                Throws.ArgumentException,
+                "the point of the test is that re-registering is what used to fail"
+            );
+
+            _handler.ClearProjectLevelHandlers();
+
+            Assert.That(() => Register(kProjectPattern), Throws.Nothing);
+            Assert.That(() => Register(kOtherProjectPattern), Throws.Nothing);
+        }
+
+        [Test]
+        public void ClearProjectLevelHandlers_LeavesApplicationLevelHandlersRegistered()
+        {
+            Register(kApplicationPattern);
+            _handler.RecordApplicationLevelHandlers();
+            Register(kProjectPattern);
+
+            _handler.ClearProjectLevelHandlers();
+
+            // Still there, so re-registering it is still an error. The application-level handlers are
+            // registered once by the ApplicationContainer and must survive every collection switch;
+            // the collection chooser itself is served by them.
+            Assert.That(() => Register(kApplicationPattern), Throws.ArgumentException);
+        }
+
+        [Test]
+        public void HasProjectLevelHandlers_OnlyWhenAProjectHasRegisteredSomething()
+        {
+            Register(kApplicationPattern);
+            _handler.RecordApplicationLevelHandlers();
+            Assert.That(
+                _handler.HasProjectLevelHandlers,
+                Is.False,
+                "application-level handlers should not count as project-level ones"
+            );
+
+            Register(kProjectPattern);
+            Assert.That(_handler.HasProjectLevelHandlers, Is.True);
+
+            _handler.ClearProjectLevelHandlers();
+            Assert.That(_handler.HasProjectLevelHandlers, Is.False);
+        }
+
+        /// <summary>
+        /// Bloom's startup registers application-level handlers before it knows anything about a
+        /// collection, so nothing should be treated as project-level until that snapshot is taken.
+        /// </summary>
+        [Test]
+        public void ClearProjectLevelHandlers_BeforeSnapshotWasTaken_ClearsEverything()
+        {
+            Register(kApplicationPattern);
+
+            _handler.ClearProjectLevelHandlers();
+
+            Assert.That(() => Register(kApplicationPattern), Throws.Nothing);
+        }
+    }
+}


### PR DESCRIPTION
After one collection fails to open, every later collection in the same run used to die with **`An item with the same key has already been added. Key: audio/startrecord`**. `ProjectContext` registers its ~65 project-level API endpoints on the **application-level** `BloomServer.ApiHandler`, so a project that failed part way through construction left them registered, and the next project's identical registrations hit a duplicate key.

### #8204 (BL-16679) already fixes the reported symptom

It made the constructor dispose itself on failure, and `Dispose` already called `ClearProjectLevelHandlers()`. `_scope` is assigned well before the first `RegisterWithApiHandler`, so the clear is reached on the reported path. The log attached to the card confirms the boundary: the empty `Bad Collection.bloomCollection` failed at `_scope.Resolve<CollectionSettings>()`, *before* any registration, and poisoned nothing; the BL-16679 collection failed at `_scope.Resolve<TeamCollectionApi>()`, *after*, and poisoned everything.

So this PR is the hardening: recovery no longer *depends* on `Dispose` getting far enough, and it closes two other ways a failed open left Bloom running with no window and no way to quit.

### 1. The application-level reset can no longer be skipped

`Dispose` did the reset inside a `try` whose first statement was `_scope.Resolve<BloomServer>()` and whose `catch` only tolerated `ObjectDisposedException`. If that resolve threw anything else, `ClearProjectLevelHandlers()` was skipped, the exception was swallowed by the constructor's inner catch, and the next collection was poisoned again.

The server is now kept in a field, and the reset — extracted as `ReleaseApplicationLevelProjectState` — runs from that field, before anything that touches `_scope`.

We deliberately do **not** clear the server's own `CurrentCollectionSettings`. `BloomServer` reads it unguarded (e.g. to serve `writingSystemDisplayForUI.css` and files relative to the collection folder), so between one project closing and the next opening — exactly when the Open/Create Collections dialog is up — settings describing the collection we just left are a better answer than null. The next project overwrites them.

### 2. A clean slate is guaranteed at the recovery point

`Program.HandleErrorOpeningProjectWindow` is the one place that knows we failed and are about to offer another collection, so it repeats the reset (idempotent), with a `Debug.Assert` that `Dispose` should already have done it.

Its reporting half is now separate and guarded. It runs *inside* `OpenProjectWindow`'s catch, and the callers depend on `OpenProjectWindow` returning `false` to put up the chooser — so a failure to *report* used to take the user's way back into the app with it.

### 3. One throw no longer wedges startup permanently

`StartupScreenManager.DoStartupAction` ran `_current.Task()` unguarded, and returns immediately on every later idle while `_current` is set. A throw therefore killed the queue for the rest of the run: the splash screen never closed, `ChooseACollection()` never ran, nothing called `ProgramExit.Exit()` so not even its 20-second force-quit net was armed, and `Main`'s `finally` never released the `UniqueToken` — so the **next launch** was turned away with "Bloom is already running". That is the shape the card's title describes.

`FatalExceptionHandler` cannot save this: during collection open `UseFallback` is true, so it shows a message and *returns*, letting the process carry on windowless.

### 4. `ReopenProject` gets the fallback its sibling already had

`ReopenProject` called `OpenCollection(MruProjects.Latest)` with nothing on failure, unlike `OpenCollectionChosenInDialog` — although it also runs with the Shell already closed (it is reached from a UI language change and from the Collection Settings dialog). New `ChooseACollectionOrQuit` is used at all three recovery sites, so a chooser that itself fails quits rather than idling invisibly.

### 5. Two diagnosis traps, and a null hole

- `catch (FileNotFoundException)` showed the "Bloom was not able to find all its bits" message, called `ProgramExit.Exit()`, then **fell through** into code dereferencing the `_scope` it had just failed to build — so what the user and Sentry actually saw was a `NullReferenceException` naming nothing useful.
- `catch (Exception) { return; }` inside the `BeginLifetimeScope` lambda would have abandoned every remaining registration, turning any failure there into an unrelated Autofac `ComponentNotRegisteredException`.
- The startup MRU pruning loop called `IsInvalidCollectionToEdit(path)` after `path` could have become null.

### Testing

New `BloomApiHandlerTests` (5 tests) covers the application-level/project-level split the whole recovery depends on, and nothing covered it before. It includes a sanity check that re-registering *without* the clear really does throw the card's `ArgumentException`, so it cannot pass falsely. New `StartupScreenManagerTests` (3) covers a throwing startup action not wedging the queue. `ProjectContextTests` gains 3 tests for the new reset.

Full C# suite green (3155 passed). No TypeScript in the diff, so the front-end suite was not run.

Also verified by hand in the running app: with a deliberate failure staged just after `audio/startRecord` is registered, the card's repro now recovers — error dialog, chooser, and the good collection opens — and no windowless Bloom is left behind. With the self-dispose disabled to simulate the pre-#8204 state, Bloom did not survive at all, consistent with the card's reports.

### Deliberately not done

- **The MRU never demotes a collection that failed to open**, so every launch retries it, reports, and offers the chooser. Leaving it: `MostRecentPathsList.Paths` already prunes on serialization and `AddNewPath` refuses to re-add, so demoting on one failure would drop a user's Team Collection from the Open/Create dialog after a transient network blip. Annoying but always recoverable beats silently losing a collection.
- `Program.cs` writes a double-clicked `.bloomCollection` to the MRU *before* trying to open it.
- `CollectionSettings.DoDefenderFolderProtectionCheck` calls `Environment.Exit(-1)` from inside the `CollectionSettings` constructor, skipping `ReleaseBloomToken()` — a read-only collection folder is currently unrecoverable, and the Defender-specific wording will mislead. Worth its own card.
- No `--no-collection` / Shift-at-startup escape hatch for a poisoned MRU.
- `FileSystemWatcher.EnableRaisingEvents` is called unguarded in `TeamCollection.StartMonitoring` and `FolderTeamCollection`, and nothing subscribes to `FileSystemWatcher.Error`.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16678


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8220)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8220)
<!-- Reviewable:end -->
