### PR TITLE
Rewrite a resized image's reference with the encoder that wrote it (BL-16669)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/buildCanvasElementControlRegistryContext.test.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/buildCanvasElementControlRegistryContext.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "vitest";
+
+import { buildCanvasElementControlRegistryContext } from "./buildCanvasElementControlRegistryContext";
+
+// Tests for `canChooseAudioForElement`, the flag behind the canvas element menu's
+// "play when touched" item. The item went missing from ordinary pages when the canvas
+// controls became a declarative registry: the flag was gated on being inside a draggable
+// game, which left no way at all to attach a click sound to a picture on a normal page.
+// These tests pin the gate where it belongs -- on having an image, not on the kind of page.
+
+// Build a page containing one canvas element, and return that element.
+// `activity` set to a "drag-*" value makes it a draggable game page.
+function makeCanvasElement(options: {
+    kind: "image" | "text";
+    activity?: string;
+}): HTMLElement {
+    const page = document.createElement("div");
+    page.className = "bloom-page";
+    if (options.activity) {
+        page.setAttribute("data-activity", options.activity);
+    }
+
+    const canvasElement = document.createElement("div");
+    canvasElement.className = "bloom-canvas-element";
+
+    if (options.kind === "image") {
+        const container = document.createElement("div");
+        container.className = "bloom-imageContainer";
+        container.appendChild(document.createElement("img"));
+        canvasElement.appendChild(container);
+    } else {
+        const editable = document.createElement("div");
+        editable.className = "bloom-editable normal-style";
+        canvasElement.appendChild(editable);
+    }
+
+    page.appendChild(canvasElement);
+    document.body.appendChild(page);
+    return canvasElement;
+}
+
+describe("canChooseAudioForElement", () => {
+    test("setup: the helper really does build the two element kinds we mean to test", () => {
+        // If inference ever stops recognizing these shapes, the assertions below would be
+        // testing the "none" fallback instead of images and text, and would pass for the
+        // wrong reason.
+        expect(
+            buildCanvasElementControlRegistryContext(
+                makeCanvasElement({ kind: "image" }),
+            ).elementType,
+        ).toBe("image");
+
+        const textCtx = buildCanvasElementControlRegistryContext(
+            makeCanvasElement({ kind: "text" }),
+        );
+        expect(textCtx.elementType).toBe("speech");
+        expect(textCtx.hasText).toBe(true);
+    });
+
+    test("offered for a picture on an ordinary page", () => {
+        // This is the case that regressed: no draggable game anywhere in sight.
+        const ctx = buildCanvasElementControlRegistryContext(
+            makeCanvasElement({ kind: "image" }),
+        );
+
+        expect(ctx.isInDraggableGame).toBe(false);
+        expect(ctx.canChooseAudioForElement).toBe(true);
+    });
+
+    test("still offered for a picture inside a draggable game", () => {
+        const ctx = buildCanvasElementControlRegistryContext(
+            makeCanvasElement({
+                kind: "image",
+                activity: "drag-letter-to-target",
+            }),
+        );
+
+        expect(ctx.isInDraggableGame).toBe(true);
+        expect(ctx.canChooseAudioForElement).toBe(true);
+    });
+
+    test("not offered for text on an ordinary page", () => {
+        // Text never had a click sound; its form of this menu item only points at the
+        // Talking Book tool, so broadening the image case must not drag text along.
+        const ctx = buildCanvasElementControlRegistryContext(
+            makeCanvasElement({ kind: "text" }),
+        );
+
+        expect(ctx.isInDraggableGame).toBe(false);
+        expect(ctx.canChooseAudioForElement).toBe(false);
+    });
+
+    test("still offered for text inside a draggable game", () => {
+        const ctx = buildCanvasElementControlRegistryContext(
+            makeCanvasElement({
+                kind: "text",
+                activity: "drag-letter-to-target",
+            }),
+        );
+
+        expect(ctx.isInDraggableGame).toBe(true);
+        expect(ctx.canChooseAudioForElement).toBe(true);
+    });
+});

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/buildCanvasElementControlRegistryContext.test.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/buildCanvasElementControlRegistryContext.test.ts
@@ -13,6 +13,7 @@ import { buildCanvasElementControlRegistryContext } from "./buildCanvasElementCo
 function makeCanvasElement(options: {
     kind: "image" | "text";
     activity?: string;
+    isBackgroundImage?: boolean;
 }): HTMLElement {
     const page = document.createElement("div");
     page.className = "bloom-page";
@@ -22,6 +23,9 @@ function makeCanvasElement(options: {
 
     const canvasElement = document.createElement("div");
     canvasElement.className = "bloom-canvas-element";
+    if (options.isBackgroundImage) {
+        canvasElement.classList.add("bloom-backgroundImage");
+    }
 
     if (options.kind === "image") {
         const container = document.createElement("div");
@@ -76,6 +80,20 @@ describe("canChooseAudioForElement", () => {
         );
 
         expect(ctx.isInDraggableGame).toBe(true);
+        expect(ctx.canChooseAudioForElement).toBe(true);
+    });
+
+    test("offered for a page's background picture too", () => {
+        // Gating on "has an image" reaches the page's background picture as well as
+        // pictures sitting on top of it. That was already true inside a draggable game
+        // (unlike draggability, which explicitly excludes the background image), so this
+        // pins the wider surface rather than leaving it untested. If we ever decide a
+        // background picture should not offer a click sound, this is the test to change.
+        const ctx = buildCanvasElementControlRegistryContext(
+            makeCanvasElement({ kind: "image", isBackgroundImage: true }),
+        );
+
+        expect(ctx.isBackgroundImage).toBe(true);
         expect(ctx.canChooseAudioForElement).toBe(true);
     });
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/buildCanvasElementControlRegistryContext.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/buildCanvasElementControlRegistryContext.ts
@@ -205,9 +205,18 @@ export const buildCanvasElementControlRegistryContext = (
             !!img &&
             !img.getAttribute("data-copyright"),
         isInDraggableGame,
+        // A click sound ("play when touched") is offered for any image, on any page, not
+        // just inside a draggable game: attaching a sound to a picture is ordinary book
+        // making, and the game-only gate was an unintended casualty of the move to this
+        // declarative registry -- it left no way at all to set one on a normal page
+        // (BL-16669 testing).
+        // Text is deliberately NOT broadened. There has never been a click sound for text;
+        // the text form of this menu item just points at the Talking Book tool, so it stays
+        // where it was.
         canChooseAudioForElement:
             elementType === "sound" ||
-            (isInDraggableGame && (hasImage || hasText)),
+            hasImage ||
+            (isInDraggableGame && hasText),
         hasCurrentImageSound,
         currentImageSoundLabel: hasCurrentImageSound
             ? dataSound.replace(/\.mp3$/, "")

--- a/src/BloomExe/Publish/BloomPub/BloomPubMaker.cs
+++ b/src/BloomExe/Publish/BloomPub/BloomPubMaker.cs
@@ -296,14 +296,10 @@ namespace Bloom.Publish.BloomPub
                             claimedFilenames
                         );
                         if (newFilename != null)
-                        {
-                            var oldEncoded = System.Web.HttpUtility.UrlPathEncode(filename);
-                            var newEncoded = System.Web.HttpUtility.UrlPathEncode(newFilename);
                             div.SetAttribute(
                                 "style",
-                                style.Replace(oldEncoded, newEncoded).Replace(filename, newFilename)
+                                ReplaceBackgroundImageFilename(style, newFilename)
                             );
-                        }
                     }
 
                     // After ConvertImagesToBackground, all content images (inside
@@ -470,18 +466,54 @@ namespace Bloom.Publish.BloomPub
                     .Cast<SafeXmlElement>()
             )
             {
-                preservedImages.Add(System.Web.HttpUtility.UrlDecode(img.GetAttribute("src")));
+                // An img @src is URL-encoded (see the encoding conventions in UrlPathString), and
+                // must be decoded the matching way; HttpUtility.UrlDecode would eat a literal '+'.
+                preservedImages.Add(
+                    UrlPathString.CreateFromUrlEncodedString(img.GetAttribute("src")).NotEncoded
+                );
             }
             return preservedImages;
         }
 
         private static string ExtractFilenameFromBackgroundImageStyleUrl(string style)
         {
-            var filename = style.Substring(
-                style.IndexOf(kBackgroundImage) + kBackgroundImage.Length
-            );
-            filename = filename.Substring(0, filename.IndexOf("'"));
-            return System.Web.HttpUtility.UrlDecode(filename);
+            // The url in the style is URL-encoded (HtmlDom.SetImageElementUrl wrote it with
+            // UrlPathString.UrlEncoded), so decode it the matching way. HttpUtility.UrlDecode is
+            // NOT the matching way: it would turn a '+' in a real file name into a space (BL-3259).
+            return UrlPathString
+                .CreateFromUrlEncodedString(ExtractEncodedUrlFromStyle(style, out _, out _))
+                .NotEncoded;
+        }
+
+        /// <summary>
+        /// Return the encoded url between the quotes of a "background-image:url('...')" style,
+        /// along with where in <paramref name="style"/> it starts and ends.
+        /// </summary>
+        private static string ExtractEncodedUrlFromStyle(string style, out int start, out int end)
+        {
+            start = style.IndexOf(kBackgroundImage) + kBackgroundImage.Length;
+            end = style.IndexOf("'", start);
+            return style.Substring(start, end - start);
+        }
+
+        /// <summary>
+        /// Point a "background-image:url('...')" style at a different file in the same folder,
+        /// leaving the rest of the style alone.
+        /// </summary>
+        /// <remarks>
+        /// This replaces the url outright rather than looking for the old name in the style and
+        /// substituting, because the search is what used to go wrong: it encoded the old and new
+        /// names with HttpUtility.UrlPathEncode, which encodes neither '%' nor '#' nor '&amp;', while
+        /// the style itself was written with UrlPathString.UrlEncoded, which encodes all three. So
+        /// for any such name nothing matched, the style went on naming the file that the resize
+        /// had just replaced, and the image vanished from the published book (BL-16669).
+        /// </remarks>
+        private static string ReplaceBackgroundImageFilename(string style, string newFilename)
+        {
+            ExtractEncodedUrlFromStyle(style, out var start, out var end);
+            return style.Substring(0, start)
+                + UrlPathString.CreateFromUnencodedString(newFilename).UrlEncoded
+                + style.Substring(end);
         }
 
         private static void CreateVersionFileWithSha(string bookFilePath, string outputDirectory)

--- a/src/BloomTests/Publish/BloomPub/CompressImagesTests.cs
+++ b/src/BloomTests/Publish/BloomPub/CompressImagesTests.cs
@@ -1,0 +1,155 @@
+using System.IO;
+using System.Linq;
+using Bloom;
+using Bloom.Book;
+using Bloom.Publish.BloomPub;
+using Bloom.SafeXml;
+using NUnit.Framework;
+using SIL.IO;
+using SIL.TestUtilities;
+
+namespace BloomTests.Publish.BloomPub
+{
+    /// <summary>
+    /// Tests for BloomPubMaker.CompressImages, which shrinks (and sometimes re-encodes and
+    /// makes transparent) each image in a book on its way into a BloomPub, and has to update
+    /// the page's reference to the file when doing so renames it.
+    /// </summary>
+    [TestFixture]
+    public class CompressImagesTests
+    {
+        private const string _pathToTestImages = "src/BloomTests/ImageProcessing/images";
+
+        /// <summary>
+        /// A file name that survives the resize rename unchanged is no test at all, so every
+        /// case here uses a photographic PNG and asks for a size smaller than it, which forces
+        /// both a resize and a jpg re-encoding, hence a new name.
+        /// </summary>
+        /// <remarks>
+        /// The awkward names are the ones Steve McConnel reported against 6.5.1322 in BL-16669
+        /// (a '%' or a '#' in the name), plus the neighbouring characters that the same
+        /// mismatched encoder gets wrong.
+        /// </remarks>
+        [TestCase("plain.png", TestName = "CompressImages_PlainName_ReferenceFollowsRename")]
+        [TestCase(
+            "Vacation 2010 410.png",
+            TestName = "CompressImages_Space_ReferenceFollowsRename"
+        )]
+        [TestCase(
+            "Restroom%41%42.png",
+            TestName = "CompressImages_PercentEscape_ReferenceFollowsRename"
+        )]
+        [TestCase(
+            "photo%20restroom.png",
+            TestName = "CompressImages_PercentTwenty_ReferenceFollowsRename"
+        )]
+        [TestCase("50% photo.png", TestName = "CompressImages_LonePercent_ReferenceFollowsRename")]
+        [TestCase(
+            "100%25 restroom.png",
+            TestName = "CompressImages_PercentTwentyFive_ReferenceFollowsRename"
+        )]
+        [TestCase("100_1242#Copy.png", TestName = "CompressImages_Hash_ReferenceFollowsRename")]
+        [TestCase("red & green.png", TestName = "CompressImages_Ampersand_ReferenceFollowsRename")]
+        [TestCase("one+one.png", TestName = "CompressImages_Plus_ReferenceFollowsRename")]
+        [TestCase("ብርሃን.png", TestName = "CompressImages_NonAscii_ReferenceFollowsRename")]
+        public void CompressImages_RenamedFile_PageStillPointsAtIt(string imageFileName)
+        {
+            using (var bookFolder = new TemporaryFolder("CompressImagesTests"))
+            {
+                var sourceImage = FileLocationUtilities.GetFileDistributedWithApplication(
+                    _pathToTestImages,
+                    "man.png"
+                );
+                RobustFile.Copy(sourceImage, Path.Combine(bookFolder.Path, imageFileName));
+
+                var dom = MakeDomWithBackgroundImage(imageFileName);
+                var styleBefore = GetBackgroundImageDiv(dom).GetAttribute("style");
+                // Sanity: the file we are about to publish really is on disk under the awkward
+                // name, and the page really does refer to it, so a failure below is about the
+                // rename and nothing else.
+                Assert.That(
+                    RobustFile.Exists(Path.Combine(bookFolder.Path, imageFileName)),
+                    Is.True,
+                    "setup: the image should be in the book folder under its original name"
+                );
+                Assert.That(
+                    FilenameFromStyle(styleBefore),
+                    Is.EqualTo(imageFileName),
+                    "setup: the page should refer to the original file name"
+                );
+
+                // A photo bigger than this must be resized, which is what triggers the rename.
+                BloomPubMaker.CompressImages(
+                    bookFolder.Path,
+                    new ImagePublishSettings { MaxWidth = 80, MaxHeight = 60 },
+                    dom
+                );
+
+                var filesInFolder = Directory
+                    .GetFiles(bookFolder.Path)
+                    .Select(Path.GetFileName)
+                    .ToList();
+                // Sanity: this case really did go through the rename path on disk. If it didn't,
+                // the assertion below would pass for the wrong reason.
+                Assert.That(
+                    filesInFolder,
+                    Has.None.EqualTo(imageFileName),
+                    "setup: the resize should have replaced the original file"
+                );
+
+                var referencedName = FilenameFromStyle(
+                    GetBackgroundImageDiv(dom).GetAttribute("style")
+                );
+                Assert.That(
+                    filesInFolder,
+                    Has.Member(referencedName),
+                    $"the page points at '{referencedName}', which is not in the book folder"
+                );
+            }
+        }
+
+        private static SafeXmlDocument MakeDomWithBackgroundImage(string imageFileName)
+        {
+            var dom = SafeXmlDocument.Create();
+            dom.LoadXml(
+                @"<html><body data-bffullscreenpicture=''>
+                    <div class='bloom-page'>
+                        <div class='bloom-canvas'>
+                            <div class='bloom-canvas-element bloom-backgroundImage'>
+                                <div class='bloom-imageContainer bloom-background-image-in-style-attr'></div>
+                            </div>
+                        </div>
+                    </div>
+                  </body></html>"
+            );
+            // Write the style the way production does, so the test is pinned to the real
+            // encoding convention rather than to a guess about it.
+            HtmlDom.SetImageElementUrl(
+                GetBackgroundImageDiv(dom),
+                UrlPathString.CreateFromUnencodedString(imageFileName)
+            );
+            return dom;
+        }
+
+        private static SafeXmlElement GetBackgroundImageDiv(SafeXmlDocument dom)
+        {
+            return dom.SafeSelectNodes(
+                    "//div[contains(@class,'bloom-background-image-in-style-attr')]"
+                )
+                .Cast<SafeXmlElement>()
+                .First();
+        }
+
+        /// <summary>
+        /// Pull the file name back out of a background-image style, undoing the URL encoding
+        /// that SetImageElementUrl applied.
+        /// </summary>
+        private static string FilenameFromStyle(string style)
+        {
+            const string prefix = "background-image:url('";
+            var start = style.IndexOf(prefix) + prefix.Length;
+            var encoded = style.Substring(start, style.IndexOf("'", start) - start);
+            return UrlPathString.CreateFromUrlEncodedString(encoded).NotEncoded;
+        }
+    }
+}


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
## Problem

Two unrelated faults, both found by Steve McConnel while testing the earlier percent-in-filename
fix in 6.5.1322.

**Pictures went missing from published books.** Publishing to BloomPUB silently dropped any
picture whose file name contained a `%`, `#`, `&` or `+` — a blank space where the picture should
be, in Bloom's own preview and in BloomPUB Viewer alike. The file in the published book had been
renamed to `Restroom%41%42_r.jpg` while the page still asked for `Restroom%2541%2542.jpg`.
Ordinary names, spaces included, came through fine, which made it look narrower than it was:
`red & green.jpg` and `one+one.jpg` were equally broken.

**A picture's click sound could not be set at all.** The menu item for the sound that plays when a
reader touches a picture had been reachable only on draggable-game pages since the canvas controls
were reworked in February, so on an ordinary page there was no way in.

## Cause

The first is an encoder mismatch. Publishing shrinks each image, which renames it, and then has to
point the page at the new file. It did that by searching the page's style for the old name and
substituting — encoding both names with a *different* encoder than the one that wrote the style.
`UrlPathString.UrlEncoded` (the writer) escapes `%`, `#`, `&` and `+`; `HttpUtility.UrlPathEncode`
(the searcher) escapes none of them. So nothing matched, and the page went on naming the file the
resize had just deleted.

The second was a one-condition oversight: `canChooseAudioForElement` was gated on the page being a
draggable game rather than on the selected thing being a picture.

## What this PR changes

- Publishing now **replaces the url outright** rather than hunting for the old name, so there is
  no old-name encoding left to get wrong. Anything else in the style is untouched.
- The two places in the same file that read a file name *out* of a page get the matching
  treatment; they used `HttpUtility.UrlDecode`, which turns a literal `+` into a space (BL-3259).
- **Any picture can take a click sound again**, on any page. Text is deliberately left alone: it
  never had a click sound, and its form of that menu item points at the Talking Book tool instead.
- Tests for both. The publish one puts a picture through ten awkward names and checks the page
  still points at a file that exists — seven of the ten fail without the fix. The menu one covers
  picture and text, on a game page and an ordinary one, plus the page's background picture.

Steve's third finding — a game sound with a `%` in its name staying silent when you *play* the
game, in the editor as well as in a published book — is bloom-player's, tracked as BL-16688, and
is deliberately not in this PR.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16669


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8221)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8221)
<!-- Reviewable:end -->

