### PR TITLE
Remove some Experimental Flags (BL-16731)

### DIFF
--- a/DistFiles/localization/en/BloomMediumPriority.xlf
+++ b/DistFiles/localization/en/BloomMediumPriority.xlf
@@ -38,11 +38,7 @@
         <source xml:lang="en">App Builder</source>
         <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.AppBuilder</note>
         <note>This checkbox enables the experimental publish-to-apps workflow.</note>
-      </trans-unit>
-      <trans-unit id="CollectionSettingsDialog.AdvancedTab.Experimental.EditWithAI" translate="no">
-        <source xml:lang="en">Edit Images with AI</source>
-        <note>ID: CollectionSettingsDialog.AdvancedTab.Experimental.EditWithAI</note>
-        <note>This checkbox enables the experimental "Edit with AI" image editor.</note>
+        <note>Obsolete as of Bloom 6.5</note>
       </trans-unit>
       <trans-unit id="Feature.AiImageEditing" translate="no">
         <source xml:lang="en">Edit Images with AI</source>

--- a/src/BloomBrowserUI/collection/AdvancedSettingsPanel.tsx
+++ b/src/BloomBrowserUI/collection/AdvancedSettingsPanel.tsx
@@ -19,8 +19,6 @@ interface IAdvancedSettings {
     autoUpdate?: boolean;
     showExperimentalBookSources?: boolean;
     allowTeamCollection?: boolean;
-    allowAppBuilder?: boolean;
-    allowAiImageEditing?: boolean;
     showQrCode?: boolean;
     qrcodeCaption?: string;
 }
@@ -61,14 +59,6 @@ export const AdvancedSettingsPanel: React.FunctionComponent = () => {
         "Team Collections",
         "TeamCollection.TeamCollections",
     );
-    const appBuilderLabel = useL10n(
-        "App Builder",
-        "CollectionSettingsDialog.AdvancedTab.Experimental.AppBuilder",
-    );
-    const aiImageEditingLabel = useL10n(
-        "Edit Images with AI",
-        "CollectionSettingsDialog.AdvancedTab.Experimental.EditWithAI",
-    );
     const qrCodesLabel = useL10n(
         "QR Codes",
         "CollectionSettingsDialog.AdvancedTab.QrCodes",
@@ -93,16 +83,6 @@ export const AdvancedSettingsPanel: React.FunctionComponent = () => {
     const featureStatus = useGetFeatureStatus("TeamCollection");
     const teamCollectionOptionEnabled =
         featureStatus === undefined ? true : featureStatus.enabled;
-    const appBuilderFeatureStatus = useGetFeatureStatus("AppBuilder");
-    const appBuilderOptionEnabled =
-        appBuilderFeatureStatus === undefined
-            ? false
-            : appBuilderFeatureStatus.enabled;
-    const aiImageEditingFeatureStatus = useGetFeatureStatus("AiImageEditing");
-    const aiImageEditingOptionEnabled =
-        aiImageEditingFeatureStatus === undefined
-            ? false
-            : aiImageEditingFeatureStatus.enabled;
     const canChangeTeamCollectionOption = allowTeamCollectionEnabled !== false;
 
     const normalizeConfigrSettings = React.useCallback(
@@ -242,62 +222,6 @@ export const AdvancedSettingsPanel: React.FunctionComponent = () => {
                                 >
                                     <BloomSubscriptionIndicatorIconAndText
                                         feature="TeamCollection"
-                                        className="bloom-subscriptionIndicator"
-                                    />
-                                </div>
-                            </div>
-                            <div
-                                css={css`
-                                    .Mui-disabled {
-                                        opacity: 1;
-                                    }
-                                `}
-                            >
-                                <ConfigrBoolean
-                                    label={appBuilderLabel}
-                                    path="allowAppBuilder"
-                                    disabled={!appBuilderOptionEnabled}
-                                />
-                                <div
-                                    css={css`
-                                        display: flex;
-                                        justify-content: flex-end;
-                                        .bloom-subscriptionIndicator {
-                                            font-size: 10pt;
-                                            font-weight: 700;
-                                        }
-                                    `}
-                                >
-                                    <BloomSubscriptionIndicatorIconAndText
-                                        feature="AppBuilder"
-                                        className="bloom-subscriptionIndicator"
-                                    />
-                                </div>
-                            </div>
-                            <div
-                                css={css`
-                                    .Mui-disabled {
-                                        opacity: 1;
-                                    }
-                                `}
-                            >
-                                <ConfigrBoolean
-                                    label={aiImageEditingLabel}
-                                    path="allowAiImageEditing"
-                                    disabled={!aiImageEditingOptionEnabled}
-                                />
-                                <div
-                                    css={css`
-                                        display: flex;
-                                        justify-content: flex-end;
-                                        .bloom-subscriptionIndicator {
-                                            font-size: 10pt;
-                                            font-weight: 700;
-                                        }
-                                    `}
-                                >
-                                    <BloomSubscriptionIndicatorIconAndText
-                                        feature="AiImageEditing"
                                         className="bloom-subscriptionIndicator"
                                     />
                                 </div>

--- a/src/BloomExe/Collection/CollectionSettingsDialog.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.cs
@@ -50,8 +50,6 @@ namespace Bloom.Collection
         internal bool ShowExperimentalBookSourcesOption = false;
 
         internal bool PendingAllowTeamCollection;
-        internal bool PendingAllowAppBuilder;
-        internal bool PendingAllowAiImageEditing;
         internal bool AllowTeamCollectionOptionEnabled = false;
 
         // "Internal" so CollectionSettingsApi can update these.
@@ -118,12 +116,6 @@ namespace Bloom.Collection
             );
             PendingAllowTeamCollection = ExperimentalFeatures.IsFeatureEnabled(
                 ExperimentalFeatures.kTeamCollections
-            );
-            PendingAllowAppBuilder = ExperimentalFeatures.IsFeatureEnabled(
-                ExperimentalFeatures.kAppBuilder
-            );
-            PendingAllowAiImageEditing = ExperimentalFeatures.IsFeatureEnabled(
-                ExperimentalFeatures.kAiImageEditing
             );
 
             if (
@@ -420,8 +412,6 @@ namespace Bloom.Collection
             Settings.Default.Save();
             UpdateExperimentalBookSources();
             UpdateTeamCollectionAllowed();
-            UpdateAppBuilderAllowed();
-            UpdateAiImageEditingAllowed();
 
             _collectionSettings.Country = _countryText.Text.Trim();
             _collectionSettings.Province = _provinceText.Text.Trim();
@@ -834,21 +824,6 @@ namespace Bloom.Collection
 
             if (wasTeamCollectionsEnabled != PendingAllowTeamCollection)
                 ChangeThatRequiresRestart();
-        }
-
-        private void UpdateAppBuilderAllowed()
-        {
-            // NB: This change does not require a restart.
-            ExperimentalFeatures.SetValue(ExperimentalFeatures.kAppBuilder, PendingAllowAppBuilder);
-        }
-
-        private void UpdateAiImageEditingAllowed()
-        {
-            // NB: This change does not require a restart.
-            ExperimentalFeatures.SetValue(
-                ExperimentalFeatures.kAiImageEditing,
-                PendingAllowAiImageEditing
-            );
         }
     }
 }

--- a/src/BloomExe/ExperimentalFeatures.cs
+++ b/src/BloomExe/ExperimentalFeatures.cs
@@ -10,8 +10,6 @@ namespace Bloom
     {
         public const string kExperimentalSourceBooks = "experimental-source-books";
         public const string kTeamCollections = "team-collections";
-        public const string kAppBuilder = "app-builder";
-        public const string kAiImageEditing = "ai-image-editing";
 
         public static string TokensOfEnabledFeatures =>
             Settings.Default.EnabledExperimentalFeatures;
@@ -26,8 +24,12 @@ namespace Bloom
                 SetValue(kExperimentalSourceBooks, true);
                 Settings.Default.ShowExperimentalFeatures = false;
             }
-            // remove obsolete experimental feature that has gone mainstream
+            // remove obsolete experimental features that have gone mainstream
             SetValue("webView2", false);
+            // App Building and AI image editing stopped being experimental in 6.5 (BL-16731);
+            // they are now gated only by the subscription tier.
+            SetValue("app-builder", false);
+            SetValue("ai-image-editing", false);
 
             // In June 2025, the only one of these sources was the Picture Dictionary,
             // and it had issues which had been introduced in an earlier version.

--- a/src/BloomExe/SubscriptionAndFeatures/FeatureRegistry.cs
+++ b/src/BloomExe/SubscriptionAndFeatures/FeatureRegistry.cs
@@ -193,13 +193,11 @@ namespace Bloom.SubscriptionAndFeatures
             {
                 Feature = FeatureName.AppBuilder,
                 SubscriptionTier = SubscriptionTier.Pro,
-                ExperimentalFeatureToken = Bloom.ExperimentalFeatures.kAppBuilder,
             },
             new FeatureInfo
             {
                 Feature = FeatureName.AiImageEditing,
                 SubscriptionTier = SubscriptionTier.Pro,
-                ExperimentalFeatureToken = Bloom.ExperimentalFeatures.kAiImageEditing,
             },
             // ----------------------------------------
             // Enterprise Tier Features

--- a/src/BloomExe/web/controllers/CollectionSettingsApi.cs
+++ b/src/BloomExe/web/controllers/CollectionSettingsApi.cs
@@ -394,12 +394,6 @@ namespace Bloom.web.controllers
                         ?? ExperimentalFeatures.IsFeatureEnabled(
                             ExperimentalFeatures.kTeamCollections
                         ),
-                    allowAppBuilder = dialog?.PendingAllowAppBuilder
-                        ?? ExperimentalFeatures.IsFeatureEnabled(ExperimentalFeatures.kAppBuilder),
-                    allowAiImageEditing = dialog?.PendingAllowAiImageEditing
-                        ?? ExperimentalFeatures.IsFeatureEnabled(
-                            ExperimentalFeatures.kAiImageEditing
-                        ),
                     showQrCode = dialog?.PendingShowQrCode
                         ?? _collectionSettings.ShowBlorgLanguageQrCode,
                     qrcodeCaption = dialog?.PendingBadgeQrCodeCaption
@@ -433,20 +427,6 @@ namespace Bloom.web.controllers
                 dialog.PendingAllowTeamCollection = allowTeamCollection;
                 if (allowTeamCollection != previousValue)
                     dialog.ChangeThatRequiresRestart();
-            }
-
-            var allowAppBuilderToken = data["allowAppBuilder"];
-            if (allowAppBuilderToken != null)
-            {
-                var allowAppBuilder = allowAppBuilderToken.Value<bool>();
-                dialog.PendingAllowAppBuilder = allowAppBuilder;
-            }
-
-            var allowAiImageEditingToken = data["allowAiImageEditing"];
-            if (allowAiImageEditingToken != null)
-            {
-                var allowAiImageEditing = allowAiImageEditingToken.Value<bool>();
-                dialog.PendingAllowAiImageEditing = allowAiImageEditing;
             }
 
             var showQrCodeToken = data["showQrCode"];

--- a/src/BloomTests/Subscription/FeatureStatusTests.cs
+++ b/src/BloomTests/Subscription/FeatureStatusTests.cs
@@ -97,21 +97,34 @@ namespace BloomTests.FeatureStatusTests
             StringAssert.Contains("\"visible\":true", json);
         }
 
+        // No feature in the registry is currently gated by an experimental token, so these two
+        // tests exercise the mechanism itself with a FeatureInfo made up here. The token is one
+        // no real feature uses, so flipping it cannot disturb any other test.
+        private const string kTestExperimentalToken = "test-only-experimental-feature";
+
+        private static FeatureInfo MakeExperimentalProFeature()
+        {
+            return new FeatureInfo
+            {
+                Feature = FeatureName.AppBuilder,
+                SubscriptionTier = SubscriptionTier.Pro,
+                ExperimentalFeatureToken = kTestExperimentalToken,
+            };
+        }
+
         [Test]
         public void GetFeatureStatus_ExperimentalFeatureHiddenUnlessEnabled()
         {
             var subscription = Subscription.CreateTempSubscriptionForTier(SubscriptionTier.Pro);
+            var feature = MakeExperimentalProFeature();
 
-            ExperimentalFeatures.SetValue(ExperimentalFeatures.kAppBuilder, false);
-            var hiddenStatus = FeatureStatus.GetFeatureStatus(subscription, FeatureName.AppBuilder);
+            ExperimentalFeatures.SetValue(kTestExperimentalToken, false);
+            var hiddenStatus = FeatureStatus.GetFeatureStatus(subscription, feature);
 
-            ExperimentalFeatures.SetValue(ExperimentalFeatures.kAppBuilder, true);
-            var visibleStatus = FeatureStatus.GetFeatureStatus(
-                subscription,
-                FeatureName.AppBuilder
-            );
+            ExperimentalFeatures.SetValue(kTestExperimentalToken, true);
+            var visibleStatus = FeatureStatus.GetFeatureStatus(subscription, feature);
 
-            ExperimentalFeatures.SetValue(ExperimentalFeatures.kAppBuilder, false);
+            ExperimentalFeatures.SetValue(kTestExperimentalToken, false);
 
             Assert.That(hiddenStatus.Visible, Is.False);
             Assert.That(hiddenStatus.Enabled, Is.True);
@@ -123,15 +136,34 @@ namespace BloomTests.FeatureStatusTests
         public void GetFeatureStatus_ExperimentalFeatureStillRequiresSubscription()
         {
             var subscription = Subscription.CreateTempSubscriptionForTier(SubscriptionTier.Basic);
-            ExperimentalFeatures.SetValue(ExperimentalFeatures.kAppBuilder, true);
+            ExperimentalFeatures.SetValue(kTestExperimentalToken, true);
 
-            var status = FeatureStatus.GetFeatureStatus(subscription, FeatureName.AppBuilder);
+            var status = FeatureStatus.GetFeatureStatus(subscription, MakeExperimentalProFeature());
 
-            ExperimentalFeatures.SetValue(ExperimentalFeatures.kAppBuilder, false);
+            ExperimentalFeatures.SetValue(kTestExperimentalToken, false);
 
             Assert.That(status.Visible, Is.True);
             Assert.That(status.Enabled, Is.False);
             Assert.That(status.SubscriptionTier, Is.EqualTo(SubscriptionTier.Pro));
+        }
+
+        [Test]
+        public void GetFeatureStatus_NonExperimentalFeatureIsAlwaysVisible()
+        {
+            var subscription = Subscription.CreateTempSubscriptionForTier(SubscriptionTier.Pro);
+
+            // AppBuilder and AiImageEditing stopped being experimental in 6.5 (BL-16731):
+            // they are visible to everyone and gated only by the subscription tier.
+            var appBuilder = FeatureStatus.GetFeatureStatus(subscription, FeatureName.AppBuilder);
+            var aiImageEditing = FeatureStatus.GetFeatureStatus(
+                subscription,
+                FeatureName.AiImageEditing
+            );
+
+            Assert.That(appBuilder.Visible, Is.True);
+            Assert.That(appBuilder.Enabled, Is.True);
+            Assert.That(aiImageEditing.Visible, Is.True);
+            Assert.That(aiImageEditing.Enabled, Is.True);
         }
 
         [Test]


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
## Problem

App Building and the AI image editor were each hidden behind an extra "Experimental Features"
checkbox in Collection Settings → Advanced. Both features are now considered ready, so that
second opt-in is just an obstacle: a Pro subscriber had to know to go find and tick a checkbox
before the Publish tab's **Apps** button or the image context menu's **Edit with AI…** command
would appear at all. The subscription tier was already doing the real gating.

## Fix

- `ExperimentalFeatures` no longer defines `app-builder` or `ai-image-editing`, and the startup
  migration clears those two tokens out of users' stored settings — the same treatment
  `webView2` got when it went mainstream.
- The two features' registry entries no longer carry an `ExperimentalFeatureToken`, so they are
  always visible and gated only by the Pro tier. The generic experimental-token mechanism stays
  in place for whatever is experimental next.
- The two checkboxes are gone from the Advanced settings panel, along with the pending-value
  plumbing that carried them between the WinForms dialog, the settings API, and the React panel.
- Their two English label strings get opposite treatment in the XLF, because only one of them
  will ever be translated. **App Builder** is marked `Obsolete as of Bloom 6.5` and kept: 6.4
  made that string translatable, so it goes to Crowdin, and removing the id from master would
  destroy those translations. **Edit Images with AI** does not exist on `Version6.4` at all, has
  always been `translate="no"`, and appears in no translated file, so it is simply deleted.
- The two tests that exercised the experimental-token mechanism were written against
  `kAppBuilder`; they now use a locally-constructed `FeatureInfo` with a token no real feature
  uses, so the mechanism stays covered. Added a test pinning that both features are now
  unconditionally visible.

**Net effect for users:** the two checkboxes disappear from Collection Settings; the Publish
tab's Apps button and the "Edit with AI…" image command show for everyone, with the existing
subscription overlays handling the Pro requirement.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16731


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8222)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8222)
<!-- Reviewable:end -->

