### PR TITLE
Consolidate the XLF/Crowdin localization rules into one home each

### DIFF
--- a/.github/prompts/bloom-l10.prompt.md
+++ b/.github/prompts/bloom-l10.prompt.md
@@ -4,7 +4,7 @@ description: make a string localizable
 
 This project uses the following methods to make strings localizable in react components:
 - use an l10n-aware component such as <BloomButton l10nKey="myKey">My Text</BloomButton>, <H1 l10nKey="myKey">My Text</H1>, etc.
-- useL10n("myKey", "My Text")
+- useL10n("My Text", "myKey")  — note the order: the English text first, then the id
 
 There should be a selected line with a string. If there is not, stop and tell me that I have to select a line with a string to be localized.
 
@@ -12,7 +12,7 @@ There should be a selected line with a string. If there is not, stop and tell me
 If the string is already wrapped in a l10n-aware component or useL10n, go on to the XLF portion of these instructions. Otherwise, wrap it in `useL10n2()`. Or `useL10n(english, id)`.
 ```tsx
 // somewhere in Foobar dialog
-<button>{Brighten everything}</button>
+<button>Brighten everything</button>
 ```
 to this:
 ```tsx
@@ -25,7 +25,7 @@ The `import` above will need the correct path relative to the current file. The 
 * Normally, don't fill in l10nComment parameter when using useL10n, that just clutters the code. We will put context in the xlf file instead. However if you want to use the later parameters, then you have to put something in that parameter.
 
 # Adding to XLF files
-For each string, we have to have a matching record in one of the xlf files in the /DistFiles/l10n/en folder. There are high (DistFiles/localization/en/Bloom.xlf), medium (DistFiles/localization/en/BloomMediumPriority.xlf), and low (DistFiles/localization/en/BloomLowPriority.xlf) priority options. Check all three xlf files for a matching record. If you find it, tell the me where it is. If you don't find it, stop and ask me which priority I want with numbers so I can respond 1 (high), 2 (medium), or 3 (low). Then create the record in the appropriate file, placing the record next to similar records. For example, here we would want to group the `FoobarDialog` records together.
+For each string, we have to have a matching record in one of the xlf files in the DistFiles/localization/en folder. There are high (DistFiles/localization/en/Bloom.xlf), medium (DistFiles/localization/en/BloomMediumPriority.xlf), and low (DistFiles/localization/en/BloomLowPriority.xlf) priority options. Check all three xlf files for a matching record. If you find it, tell me where it is. If you don't find it, stop and ask me which priority I want with numbers so I can respond 1 (high), 2 (medium), or 3 (low). Then create the record in the appropriate file, placing the record next to similar records. For example, here we would want to group the `FoobarDialog` records together.
 
 # Default to not ready for translation
 Add a `translate="no"` attribute to new records unless I tell that these strings are ready for translation.
@@ -36,8 +36,10 @@ The string ID may be used by translators as they try to understand context or tr
 ## Expose ID to translators
 Add a note like this: `<note>ID: LinkTargetChooser.URL.Paste.Tooltip</note>`
 
-## Legacy strings
-Our localization build system is such that if we are no longer using a string ID in the next version, we cannot remove the ID from the XLF file immediately. This is because if we release a new version of the previous release, we will still need that old localization ID. The fact that its code base still has it will not be sufficient. The actual Crowdin database will lose the string and translations when it sees the string ID removed from the master branch. Therefore when we stop using a string ID we just add a note like this: "<note>Obsolete as of 6.2</note>". You can figure out the current version from the `Version` property in `build/Bloom.proj`.
+## Anything beyond adding a string
+This prompt covers one job: making a selected string localizable. For everything else about XLF entries — changing one, retiring one, or reviewing a PR that touches them — follow `.github/skills/xlf-strings/SKILL.md`, and see `DistFiles/localization/README.md` for how Crowdin works and why those rules exist.
+
+In particular, **never delete a string ID that is no longer used.** Mark it obsolete instead; `.github/skills/xlf-strings/SKILL.md` has the note format. The reasoning is in the README's "Why we can't just delete a string".
 
 ## Add comments for translators
 Although we don't want to fill in l10nComment in useL10n, we do want to fill in the note field to give context to translators. They don't know where the string appears in the UI; they also might need some explanation of what it means. For example, for the above string, we might add a note like `<note>This is the text on a button in the Foobar dialog that brightens all images in the current book.</note>`

--- a/.github/skills/xlf-strings/SKILL.md
+++ b/.github/skills/xlf-strings/SKILL.md
@@ -5,6 +5,13 @@ description: Add or review localizable strings in Bloom XLF files
 
 Apply this skill whenever you add a new localizable string to the codebase, modify an existing one, or review XLF files as part of a task.
 
+This skill is the **how** — the procedure for each operation. The **why** — how Crowdin actually
+works and what each kind of edit does to existing translations — lives in one place,
+`DistFiles/localization/README.md`. Where a rule here has a reason, that reason is written there
+and cited from here rather than restated, so the two can't drift into telling you different
+things. Read its "Why we can't just delete a string" section before you conclude that any
+deletion or id change is harmless.
+
 ## Files
 
 Localizable strings live in `DistFiles/localization/en/`. Only ever add or change strings in the **English** subdirectory — never touch the other language folders.
@@ -59,14 +66,57 @@ Example with context note:
 
 - **Never change the ID** of an entry that is not new (i.e. not marked `translate="no"`). Changing an ID loses all existing translations.
 - **Never change the source text** of a translated entry unless you are certain it won't invalidate existing translations.
-- If you need to change the text or ID: mark the old entry with a `<note>` saying `obsolete as of <version>` and create a **new entry** with a new ID and the updated text. Find the current version in the `Version` property in `build/Bloom.proj`. Avoid this when possible.
+- If you need to change the text or ID: mark the old entry with a `<note>` saying `Obsolete as of <version>` and create a **new entry** with a new ID and the updated text. Find the current version in the `Version` property in `build/Bloom.proj`. Avoid this when possible.
 
 ## Marking an entry obsolete, and when it may be deleted
 
 BL-16686 found four entries marked obsolete that were all still in use, so be careful with both halves of this:
 
 - **Only add the obsolete note once nothing references the entry.** Search before you write it: code (`l10nKey`, `l10nId`, `useL10n`, `GetString`), shipped content under `src/content` — note that sample shells are `.htm`, not `.html` — and the XLF files themselves. Page label ids in particular are composed at runtime (`"TemplateBooks.PageLabel." + label`), so a page's visible label text is what to grep for, not just the id. A wrong note is actively harmful: it tells the next cleanup pass to delete a string we still use.
-- **Do not delete an obsolete entry unless the developer explicitly asks you to.** Deleting drops the translations, and an entry is only safe to remove once the version in which it became obsolete has been promoted to Release — otherwise a shipped update to that older version loses the string. Determining that is a human judgment, so an agent should mark and leave, never tidy up on its own. When you are explicitly asked to delete the entries for a given version, delete only from `DistFiles/localization/en/`; leaving the translated files intact means re-adding an id later recovers its translations.
+- **Do not delete an obsolete entry unless the developer explicitly asks you to.** Deleting an entry from the English file deletes its translations too, and judging when that has become safe is a human call — so mark and leave, never tidy up on your own initiative. `DistFiles/localization/README.md`, "Why we can't just delete a string", explains the route translations travel and why the obvious safety argument (*"but the release branch still has the entry"*) is false. When you **are** explicitly asked to delete the entries for a given version, delete only from `DistFiles/localization/en/`; leaving the translated files intact means re-adding an id later recovers its translations.
+
+### Establishing that a particular deletion loses nothing
+
+There is one case where deletion costs no translations: an entry that was **always**
+`translate="no"` was never handed to Crowdin, so no translation of it has ever existed
+(`DistFiles/localization/README.md`, "The exception: a string Crowdin never had"). Two commands
+establish it, and they are worth running before you either write an obsolete note or answer a
+developer asking whether an entry can go.
+
+```bash
+ID=CollectionSettingsDialog.AdvancedTab.Experimental.AppBuilder
+FILE=DistFiles/localization/en/BloomMediumPriority.xlf
+
+# 1. Was it ALWAYS translate="no"? Print the trans-unit line as it stood in every commit that
+#    ever touched it — on master AND on the release branch currently receiving updates,
+#    since an entry can be edited on one and not the other. You want translate="no" on every
+#    version of the line.
+#    Release branches are named origin/Version<major>.<minor>; fill in the one that is current
+#    (`git branch -r --list 'origin/Version*'` lists them). Left as-is this fails rather than
+#    quietly answering for the wrong branch.
+RELEASE=origin/VersionX.Y
+for ref in HEAD "$RELEASE"; do
+  echo "--- $ref"
+  # -G, not -S: -S only lists commits where the NUMBER of occurrences of the id changed, so a
+  # commit that edited only the translate attribute on that line would be skipped silently.
+  for c in $(git log --format=%h -G "$ID" $ref -- "$FILE"); do
+    git show $c:"$FILE" | grep "trans-unit id=\"$ID\""
+  done
+done
+
+# 2. Does it appear in any translated file? The en/ hit should be the only one.
+grep -rl "$ID" DistFiles/localization/
+```
+
+Clean on both means deletion is lossless. That still does **not** make it your call: report the
+findings and let the developer decide.
+
+When a deletion does go ahead on that basis, **put the evidence where the reviewer will meet
+it** — the commit message and the reply on the review thread, in as many words: always
+`translate="no"`, absent from every translated file. Review bots take their rules from
+`src/BloomBrowserUI/AGENTS.md` (Devin cites it by name, with `based_on_repo_rules: true`) and
+read the rule rather than your reasoning, so the deletion *will* be flagged. With the evidence
+attached, the next person sees a rule correctly applied; without it, they see a rule broken.
 
 ## Reviewing XLF changes in a PR
 
@@ -76,3 +126,4 @@ When reviewing a PR that touches XLF files:
 2. Check that new entries are in the right priority file (see table above).
 3. Check that every entry whose context isn't obvious from the string alone has a translator context note.
 4. Check that no existing translated entry has had its ID or source text changed without the obsolete/new-entry pattern.
+5. If entries were **deleted**, check the PR says why that was lossless — always `translate="no"`, absent from every translated file (see "Establishing that a particular deletion loses nothing"). Deletion without that evidence is the finding; deletion with it is fine.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,9 +201,11 @@ You have a complete set of faster, non-disruptive alternatives, so don't run the
 The full `pnpm build` exists to (re)populate the shared `output\browser` — `clean.js` plus content assets plus the bundle. It's slow, and it wrecks any running Vite dev server / `--watch` and the Bloom loading from it, so it's a developer/CI job, not something to spring on a live session. If you think you genuinely need it, ask the developer to run it (they can stop Bloom first) rather than running it yourself.
 
 # Localization
-Whenever you add, modify, or review localizable strings (XLF entries), follow `.github/skills/xlf-strings/SKILL.md`.
+Whenever you add, modify, or review localizable strings (XLF entries), follow `.github/skills/xlf-strings/SKILL.md`. For how Crowdin works and why those rules exist — including why a no-longer-used string is marked obsolete rather than deleted — see `DistFiles/localization/README.md`.
 
-The one rule that applies at all times even outside that skill: **only ever edit files under `DistFiles/localization/en/`** — never touch the other language subdirectories.
+Two rules apply at all times, even outside that skill:
+- **Only ever edit files under `DistFiles/localization/en/`** — never touch the other language subdirectories.
+- **Never delete a `<trans-unit>` on your own initiative**, even an obsolete one, and even when you are confident nothing uses it. Mark it obsolete and leave it.
 
 # Commenting
 All public methods should have a comment. So should most private ones!

--- a/DistFiles/localization/README.md
+++ b/DistFiles/localization/README.md
@@ -48,8 +48,11 @@ and it negates most of the value of using Crowdin to begin with.
   cleared.  (This appears to be a corner case in Crowdin's code that may or not be intentional.)
 
 - Adding, removing, or reordering *trans-unit* elements in the English xliff file without
-  changing them merely causes the corresponding addition, removal, or reordering in the
-  translation xliff file.
+  changing them causes the corresponding addition, removal, or reordering in the translation
+  xliff file.  Note what the "removal" half of that means in practice: **deleting a
+  *trans-unit* from the English file deletes its translations too.**  That is why we normally
+  mark a string obsolete rather than deleting it — see "Why we can't just delete a string"
+  below.
 
 - I (AP, May 2026) am pretty sure this is affected by the `update_option` option in crowdin.yml.
   - What I think is true today with `update_option: update_without_changes` on master: Editing the *source* element content does not affect the translation.
@@ -98,9 +101,55 @@ and it negates most of the value of using Crowdin to begin with.
   uploading it to Crowdin has no effect on what you see on Crowdin.
 
 
+## Why we can't just delete a string
+
+This is the reasoning behind the "mark it obsolete, don't delete it" convention. It is written
+down **here and nowhere else**; `src/BloomBrowserUI/AGENTS.md` and
+`.github/skills/xlf-strings/SKILL.md` state the resulting rules and point back at this section.
+If you are about to argue that some particular deletion is safe, read this first — the wrong
+argument for it is an easy one to reach.
+
+**Translations only ever travel one route, and every leg of it runs through master:**
+
+1. Crowdin takes its **source** strings from the English xliff files **on master**. Remove an id
+   from master and Crowdin stops knowing about that string.
+2. Finished translations come **back into master** as the periodic `l10n_master` pull request
+   (see "Merging Crowdin pull requests" below).
+3. A release branch gets those translations **only** by cherry-picking that merge — we do this
+   for beta, and it is conceivable though not usual for a release.
+
+So an id deleted from master is gone from Crowdin, therefore absent from every later
+`l10n_master` merge, therefore absent from anything picked into `Version6.x`. **The release
+branch still listing the entry in its own copy of the file saves nothing** — its translations
+were never going to come from that copy; they were going to come from master. This is the trap:
+"but the 6.4 branch still has the entry" feels like a safety argument and is not one.
+
+That is also why a deletion is only *eventually* safe. Once the version in which the string went
+obsolete has shipped and no longer receives updates, nothing will ever need to pick translations
+for it again, and the entry can go. Judging that is a human call.
+
+### The exception: a string Crowdin never had
+
+New entries are added with `translate="no"`, which is what keeps them out of Crowdin until we
+say they are ready. An entry that carried `translate="no"` from the day it was added until the
+day it became unused was therefore never offered to a translator, has no translations anywhere,
+and appears in none of the language subdirectories. Deleting it loses nothing, and an obsolete
+note on it protects nothing.
+
+Establishing that is mechanical — print the entry's line as it stood in every commit that ever
+touched it, on master and on the current release branch, and confirm `translate="no"` on all of
+them; then confirm the id appears only under `en/`. `.github/skills/xlf-strings/SKILL.md` has
+the exact commands. Deciding to act on it is still the developer's call, and the evidence
+belongs in the commit message and in the PR-review reply, because a reviewer — human or bot —
+reading only the rule will otherwise flag the deletion, quite correctly.
+
 ## Restrictions on xliff file changes
 
 - ***Never*** change the *original* attribute of the *file* element in a source xliff file.
+
+- **Do not delete a *trans-unit* from a source xliff file.**  Mark it obsolete instead.  See
+  "Why we can't just delete a string" above for the reasoning and for the one exception, and
+  `.github/skills/xlf-strings/SKILL.md` for the note format itself.
 
 - Change the *product-version* attribute of the *file* element in a source xliff file only when
   you think it is really needed.

--- a/src/BloomBrowserUI/AGENTS.md
+++ b/src/BloomBrowserUI/AGENTS.md
@@ -59,15 +59,39 @@ Usually if you get stuck, the best thing to do is to get the component showing i
 
 ## Localization
 
-Localizations are stored in xlf files. We put the "English" in the localization/en/Bloom*.xlf version, then people use Crowdin to create the translations that end up in the other xlf sets. There are three levels of priority `Bloom.xlf` is high priority, used for things that users will see every day. `BloomMediumPriority.xlf` is for strings that are less common or less vital. `BloomLowPriority.xlf` are for edge cases like rare error messages where people could look up the English translation if they had to. Use the askQuestions tool to find out which to use if the user doesn't tell you.
+Localizable strings live in xlf files under `DistFiles/localization/`. We write the English in
+`en/Bloom*.xlf`; translators work in Crowdin, and their work lands in the other language
+subdirectories.
 
-Do not ever touch existing translations.
-Unless `<trans-unit>` has `@translate="no"`, do not change the @id's of `<trans-unit>`s. If the user asks you to do this, refuse. If we ship an update to an older version of Bloom, it may cause us to lose localizations there.  Crowdin/Bloom handoff will causes a loss of translations on crowdin. If during review you notice that this has been done by the user, point it out. If a string is no longer used, do not remove it. Instead, add a note like this: <note>Obsolete as of 6.2</note>. You can get the current version number from the `Version` property of Bloom.proj.
+**Two documents own this subject; read the relevant one rather than working from memory.**
 
-Two things about that note, both of which we have gotten wrong:
+- **`.github/skills/xlf-strings/SKILL.md`** — how to add, change, review, or retire a string:
+  which priority file to use, the note conventions, and the checks each operation needs. Open it
+  whenever you touch an XLF entry.
+- **`DistFiles/localization/README.md`** — how Crowdin actually works, and *why* these rules
+  exist: what each kind of xliff edit does to existing translations, and (in "Why we can't just
+  delete a string") the route translations travel from Crowdin through master to a release
+  branch. Read it before concluding that any deletion or id change is harmless.
 
-- **Only mark an entry obsolete once nothing references it.** Check before you add the note — code (`l10nKey`/`l10nId`/`useL10n`/`GetString`), shipped content under `src/content` (remember sample shells are `.htm`, and page label ids are composed at runtime as `"TemplateBooks.PageLabel." + label`), and the rest of the XLF. A note claiming a live string is obsolete is worse than no note: it invites the next person to delete a string we are still using.
-- **Never delete an obsolete entry on your own initiative.** An entry can only safely go once the version in which it became obsolete has been promoted to Release — until then a shipped update to that older version still needs the string. An agent generally cannot tell when that has happened, so treat deletion as out of scope unless the developer explicitly asks you to delete the entries for a particular version.
+The rules themselves, which apply whether or not you have opened those:
+
+- **Only ever edit `DistFiles/localization/en/`.** Never touch the other language subdirectories,
+  and never touch an existing translation.
+- **Do not change the `@id` of a `<trans-unit>`** unless it is marked `@translate="no"`. Changing
+  an id loses its translations. If asked to do it anyway, refuse; if you notice it during a
+  review, point it out.
+- **Do not delete a `<trans-unit>` that is no longer used.** Mark it obsolete instead; the
+  skill has the exact note format and where to read the current version number.
+- **Only mark an entry obsolete once nothing references it.** Check first — code (`l10nKey` /
+  `l10nId` / `useL10n` / `GetString`), shipped content under `src/content` (sample shells are
+  `.htm`, and page label ids are composed at runtime as `"TemplateBooks.PageLabel." + label`),
+  and the rest of the XLF. A note claiming a live string is obsolete is worse than no note: it
+  invites the next person to delete a string we are still using.
+- **Never delete an entry on your own initiative**, even an obsolete one, and even when you are
+  confident it is safe. There is exactly one case where deletion loses nothing — a string that
+  was always `translate="no"` and so never reached Crowdin — and even then it is the developer's
+  decision, the evidence has to go in the commit message and the PR reply, and the skill has the
+  commands that establish it.
 
 ## Other notes
 


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
## Problem

The rules for editing Bloom's localizable strings (XLF entries) were stated in five documents,
each with its own partly-wrong account of *why* they exist, and none of them linking to the
others. `DistFiles/localization/README.md` is the only doc that describes the Crowdin mechanics
correctly, and nothing an agent normally loads pointed at it. The concrete cost: on BL-16731 an
agent reasoned from one of the incomplete copies and told a reviewer, wrongly, that deleting a
string from master was safe "because the Version6.4 branch keeps its own copy of the file."

## Cause

The five copies had drifted, and the one correct explanation was unreachable from always-loaded
context. In particular the widely-read `src/BloomBrowserUI/AGENTS.md` justified the
don't-delete rule with "until the version is promoted to Release" — a rule of thumb that does not
explain, and in fact contradicts, how translations actually reach a release branch.

## What this PR changes

Documentation only; no code. Each kind of content now has exactly one home, and the others cite
it rather than restating it.

- **`DistFiles/localization/README.md`** owns the reasoning. Its new "Why we can't just delete a
  string" section traces the one route translations travel — Crowdin reads its sources from
  master, translations return to master via the `l10n_master` PR, and a release branch gets them
  only by cherry-picking that merge — so an id deleted from master is gone from Crowdin and can
  never be picked into `Version6.x`. It names the trap explicitly: the release branch still
  listing the entry saves nothing. It also documents the one real exception (an entry that was
  always `translate="no"` never reached Crowdin, so has no translations to lose), and corrects
  the "Effects of English xliff file changes" bullet that described removal without saying it
  deletes translations.
- **`.github/skills/xlf-strings/SKILL.md`** owns the procedures. It gains the two commands that
  establish that exception — including the point that the evidence must go in the commit message
  and the review reply, because a reviewer reading only the rule will correctly flag the
  deletion — and a matching item in the PR-review checklist. It is also now the **only** place
  the obsolete-note text and the version source are written down.
- **`src/BloomBrowserUI/AGENTS.md`** owns the short normative rules: it drops its duplicated
  priority table and its incorrect "promoted to Release" reasoning, keeping the rules plus
  pointers to both docs above. It stays normative because review bots cite this file by name.
- **`AGENTS.md`** (root) links the README so it is reachable from always-loaded context — the
  omission that caused the original mistake — and states the two rules that hold even outside the
  skill. **`.github/prompts/bloom-l10.prompt.md`** is trimmed to its own job, making one selected
  string localizable.

Two details that would have reproduced the original failure by other routes are fixed rather than
documented: the always-`translate="no"` check uses `git log -G` (with `-S` it misses a commit that
edited only the `translate` attribute, and then looks clean), and it no longer names a release
branch that will go stale — an unfilled placeholder fails loudly instead. The prompt file also had
`useL10n`'s arguments in the wrong order, an invalid-JSX example, and a path to a folder that does
not exist.
<!-- preflight-narrative:end -->

Ref: BL-16731 (context in which the documentation gap was found; this PR is documentation cleanup, not a fix for that card)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8223)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8223)
<!-- Reviewable:end -->

