### PR TITLE
Fix unresponsive "Set up levels" after turning on the reader tool (BL-16732)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/readerSetup.ui.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/readerSetup.ui.ts
@@ -254,6 +254,13 @@ function requestWordsForSelectedStage(): void {
     const tr = <HTMLTableRowElement>(
         $("#stages-table").find("tbody tr.selected").get(0)
     );
+    // wordListChangedCallback() can reach us before the dialog has been given its data
+    // (the listener is hooked up on document.ready, but the stages table is not built
+    // and a row selected until the "Data" message arrives), and there is nothing to ask
+    // for until then. (BL-16732)
+    if (!tr) {
+        return;
+    }
 
     desiredGPCs = (<HTMLTableCellElement>tr.cells[1]).innerHTML.split(" ");
     previousGPCs = $.makeArray(

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/readerSetupDialog.spec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/readerSetupDialog.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { getTheOneReaderToolsModel } from "../readerToolsModel";
+import ReadersSynphonyWrapper from "../ReadersSynphonyWrapper";
+import { initializeReaderSetupDialog } from "./readerSetupDialog";
+
+// The setup dialog is populated by initializeReaderSetupDialog(), which the dialog's iframe
+// calls as soon as it loads. If the reader settings never made it into the model, that call
+// used to die on a bare "cannot read properties of undefined (reading 'source')", which told
+// nobody anything and left the dialog showing the wrong tab with empty fields -- what the user
+// experienced as "Set up Levels does nothing". (BL-16732)
+describe("initializeReaderSetupDialog", () => {
+    beforeEach(() => {
+        getTheOneReaderToolsModel().clearForTest();
+    });
+
+    it("reports that the settings were not loaded, rather than throwing a TypeError", () => {
+        // sanity check: this is the state we mean to test
+        expect(getTheOneReaderToolsModel().synphony).toBeUndefined();
+
+        expect(() => initializeReaderSetupDialog()).toThrowError(
+            "ReaderToolsModel was not loaded with settings",
+        );
+    });
+
+    it("sends the settings to the dialog frame once they are loaded", () => {
+        const synphony = new ReadersSynphonyWrapper();
+        synphony.loadSettings({
+            letters: "a b c",
+            moreWords: "cat sat",
+            stages: [{ letters: "a c", sightWords: "feline" }],
+            levels: [{ maxWordsPerPage: 6, thingsToRemember: [""] }],
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+        getTheOneReaderToolsModel().synphony = synphony;
+        // sanity check: the model now has something to send
+        expect(getTheOneReaderToolsModel().synphony?.source).toBeTruthy();
+
+        // The real settings frame is in the parent document; in this test window.parent is
+        // ourselves, so putting the iframe in our own document is enough for the lookup.
+        const settingsFrame = document.createElement("iframe");
+        settingsFrame.id = "settings_frame";
+        document.body.appendChild(settingsFrame);
+        const postMessage = vi.fn();
+        settingsFrame.contentWindow!.postMessage = postMessage;
+
+        initializeReaderSetupDialog();
+
+        const messages = postMessage.mock.calls.map((call) => call[0]);
+        expect(messages.some((m) => m.startsWith("Data\n"))).toBe(true);
+        expect(messages.some((m) => m.startsWith("Font\n"))).toBe(true);
+    });
+});

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/readerSetupDialog.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerSetup/readerSetupDialog.ts
@@ -10,6 +10,7 @@
 /// <reference path="../readerToolsModel.ts" />
 
 import { getTheOneReaderToolsModel } from "../readerToolsModel";
+import { beginLoadSynphonySettings } from "../readerTools";
 import theOneLocalizationManager from "../../../../lib/localizationManager/localizationManager";
 import { getWorkspaceBundleExports } from "../../../js/workspaceFrames";
 import { get, postBoolean } from "../../../../utils/bloomApi";
@@ -43,6 +44,24 @@ function settingsFrameWindow() {
 let setupDialogElement: JQuery;
 
 export function showSetupDialog(showWhat) {
+    // The dialog is useless without the collection's reader settings: as soon as its
+    // iframe loads, initializeReaderSetupDialog() posts them in, and the dialog uses
+    // them to pick the tab to show and to fill it in. The tool that owns this button
+    // normally loads them when it is activated, but we have no guarantee that has
+    // happened (or has survived) by the time the button is clicked, and if it hasn't,
+    // clicking the button appears to do nothing at all. So make sure they are loaded
+    // before we show anything. This is cheap when they already are. (BL-16732)
+    //
+    // The setTimeout builds the dialog outside the promise chain: a jQuery promise turns
+    // anything thrown in a .then() callback into a rejection nobody is listening for, so a
+    // failure in here would be swallowed and once again show up as a button that does
+    // nothing. Outside the chain, it reaches our usual error reporting.
+    beginLoadSynphonySettings().always(() =>
+        window.setTimeout(() => beginShowSetupDialog(showWhat), 0),
+    );
+}
+
+function beginShowSetupDialog(showWhat) {
     //var toolbox = window;
     theOneLocalizationManager.loadStrings(
         getSettingsDialogLocalizedStrings(),
@@ -176,14 +195,19 @@ function getSettingsDialogLocalizedStrings() {
  * Used by the settings_frame to initialize the setup dialog
  */
 export function initializeReaderSetupDialog() {
+    // Note that synphony itself is undefined until the settings load, so we have to check
+    // it before reaching for source; otherwise the intended error below is pre-empted by a
+    // bare "cannot read properties of undefined" that says nothing about what went wrong.
+    // (BL-16732)
+    const synphony = getTheOneReaderToolsModel().synphony;
     if (
-        typeof getTheOneReaderToolsModel().synphony.source === "undefined" ||
-        getTheOneReaderToolsModel().synphony.source === null
+        !synphony ||
+        synphony.source === undefined ||
+        synphony.source === null
     ) {
         throw new Error("ReaderToolsModel was not loaded with settings");
     }
-    const sourceMsg =
-        "Data\n" + JSON.stringify(getTheOneReaderToolsModel().synphony.source);
+    const sourceMsg = "Data\n" + JSON.stringify(synphony.source);
     const fontMsg = "Font\n" + getTheOneReaderToolsModel().fontName;
     const window = settingsFrameWindow();
     if (window) {

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerTools.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerTools.ts
@@ -82,15 +82,7 @@ function loadReaderSettingsWithRetry(
     onLoaded: (settings: ReaderSettings) => void,
     onFailed: () => void,
 ): void {
-    get("readers/io/readerToolSettings", (settingsFileContent) => {
-        const normalizedSettings = tryNormalizeReaderSettings(
-            settingsFileContent.data,
-        );
-        if (normalizedSettings) {
-            onLoaded(normalizedSettings);
-            return;
-        }
-
+    const retryOrFail = () => {
         if (attemptsRemaining > 1) {
             window.setTimeout(() => {
                 loadReaderSettingsWithRetry(
@@ -103,7 +95,35 @@ function loadReaderSettingsWithRetry(
         }
 
         onFailed();
-    });
+    };
+
+    get(
+        "readers/io/readerToolSettings",
+        (settingsFileContent) => {
+            const normalizedSettings = tryNormalizeReaderSettings(
+                settingsFileContent.data,
+            );
+            // Act on the reply outside the request's promise chain. bloomApi.get() hangs
+            // our error callback on a .catch() *after* this handler, so anything thrown in
+            // here -- a genuine bug in onLoaded, not a failed request -- would otherwise be
+            // caught, retried, and finally reported as a load failure, hiding it. Out here
+            // it fails fast and gets reported, which is what this repo wants. (BL-16732)
+            window.setTimeout(() => {
+                if (normalizedSettings) {
+                    onLoaded(normalizedSettings);
+                    return;
+                }
+
+                retryOrFail();
+            }, 0);
+        },
+        // A request that outright fails has to count as a failed attempt too. Without this
+        // error callback, bloomApi.get() reports the error and never calls anyone back, so
+        // neither onLoaded nor onFailed ever runs -- and every caller waiting on us waits
+        // forever. Callers act on that by doing nothing at all, which is invisible.
+        // (BL-16732)
+        retryOrFail,
+    );
 }
 
 function getSetupDialogWindow(): Window | null {
@@ -216,16 +236,34 @@ export function beginLoadSynphonySettings(): JQueryPromise<void> {
             maxReaderSettingsLoadAttempts,
             (normalizedSettings) => {
                 const newSettingsContent = JSON.stringify(normalizedSettings);
+                // readerToolsInitialized and lastReaderToolSettingsContent are module state
+                // in whichever frame loaded this module, but the ReaderToolsModel they
+                // describe lives in a holder on the top window which
+                // getTheOneReaderToolsModel() deliberately *replaces* when the frame that
+                // created it is reloaded. So our memory of having loaded the settings can
+                // outlive the model that holds them, and then "the settings are unchanged"
+                // is no reason to skip the work: the model in front of us has never seen
+                // them. Refreshing is what gets them into it. Without this, synphony stays
+                // undefined and every reader-tool feature needing it is silently dead
+                // (e.g. Set Up Levels/Stages) until Bloom is restarted. (BL-16732)
                 const shouldRefresh =
-                    newSettingsContent !== lastReaderToolSettingsContent;
+                    newSettingsContent !== lastReaderToolSettingsContent ||
+                    !getTheOneReaderToolsModel().synphony;
                 if (!shouldRefresh) {
                     result.resolve();
                     return;
                 }
-                beginRefreshEverything(normalizedSettings).then(() => {
-                    lastReaderToolSettingsContent = newSettingsContent;
-                    result.resolve();
-                });
+                beginRefreshEverything(normalizedSettings).then(
+                    () => {
+                        lastReaderToolSettingsContent = newSettingsContent;
+                        result.resolve();
+                    },
+                    // Refreshing fetches the sample-texts list, and if that request fails we
+                    // have no settings worth remembering -- but our callers still have to be
+                    // released. A caller left waiting forever is precisely what the user
+                    // experiences as a button that does nothing. (BL-16732)
+                    () => result.resolve(),
+                );
             },
             () => {
                 readerToolsInitialized = false;

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsSettingsLoadFailure.spec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsSettingsLoadFailure.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from "vitest";
+
+// A caller that waits forever is indistinguishable, to the user, from a button that does
+// nothing -- which is the whole complaint behind BL-16732. bloomApi.get() reports a failed
+// request and then calls nobody back, so loadReaderSettingsWithRetry() has to treat an
+// outright failure as a failed attempt itself; otherwise the promise every caller of
+// beginLoadSynphonySettings() is waiting on never settles. This lives in its own file
+// because readerTools.ts keeps its "already loaded" state in module scope, and these tests
+// are about what that module does on a cold start.
+
+let settingsRequests = 0;
+
+vi.mock("axios", () => ({
+    default: {
+        get: () => Promise.resolve({ data: "" }),
+        post: () => Promise.resolve({ data: "" }),
+        all: (promises: Promise<unknown>[]) => Promise.all(promises),
+        spread: (fn: (...args: unknown[]) => unknown) => (args: unknown[]) =>
+            fn(...args),
+    },
+}));
+
+vi.mock("../../../utils/bloomApi", () => ({
+    // Fail the reader settings request the way bloomApi.get() does when the server errors
+    // and the caller passed an error callback: the success handler is never called.
+    get: (
+        endpoint: string,
+        successCallback?: (result: { data: unknown }) => void,
+        errorCallback?: (error: unknown) => void,
+    ) => {
+        if (endpoint.split("?")[0] === "readers/io/readerToolSettings") {
+            settingsRequests++;
+            errorCallback?.(new Error("simulated 500 from the server"));
+            return;
+        }
+        successCallback?.({ data: "" });
+    },
+    getWithConfig: () => undefined,
+    post: () => undefined,
+    postData: () => undefined,
+    postString: () => undefined,
+    postBoolean: () => undefined,
+    postJson: () => undefined,
+}));
+
+import { beginLoadSynphonySettings } from "./readerTools";
+import { getTheOneReaderToolsModel } from "./readerToolsModel";
+
+describe("beginLoadSynphonySettings when the settings request fails", () => {
+    it("settles instead of leaving its caller waiting forever", async () => {
+        vi.useFakeTimers();
+        try {
+            // sanity check: the mock hasn't been asked for anything yet
+            expect(settingsRequests).toBe(0);
+
+            let settled = false;
+            const promise = beginLoadSynphonySettings().always(() => {
+                settled = true;
+            });
+
+            // The retries are on 150ms timers; run them all out.
+            await vi.runAllTimersAsync();
+            await promise;
+
+            expect(settled).toBe(true);
+            // sanity check: it really did retry rather than giving up on the first failure
+            expect(settingsRequests).toBeGreaterThan(1);
+            // Nothing to load, so the model is left without settings -- callers that need
+            // them report that clearly rather than hanging (see readerSetupDialog).
+            expect(getTheOneReaderToolsModel().synphony).toBeUndefined();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsSettingsLoading.spec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsSettingsLoading.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// beginLoadSynphonySettings() remembers, in module state, that it has already loaded the
+// collection's reader settings. But the ReaderToolsModel those settings live in is held on
+// the top window and gets *replaced* whenever the frame that created it is reloaded, so the
+// "already loaded" memory can outlive the data. When that happened, this function used to
+// resolve without loading anything, leaving synphony undefined for the rest of the session --
+// which is why "Set Up Levels" did nothing until Bloom was restarted. (BL-16732)
+
+// Loading the settings starts a watcher on the Sample Texts folder, which really polls the
+// server; there is nothing for it to talk to here, so stub it out.
+vi.mock("./directoryWatcher", () => ({
+    DirectoryWatcher: class {
+        public onChanged(): void {
+            // nothing to watch in this test
+        }
+        public start(): void {
+            // nothing to watch in this test
+        }
+        public stop(): void {
+            // nothing to watch in this test
+        }
+    },
+}));
+
+// The reload path fetches the sample-texts list through axios directly rather than bloomApi.
+vi.mock("axios", () => ({
+    default: {
+        get: () => Promise.resolve({ data: "" }),
+        post: () => Promise.resolve({ data: "" }),
+        all: (promises: Promise<unknown>[]) => Promise.all(promises),
+        spread: (fn: (...args: unknown[]) => unknown) => (args: unknown[]) =>
+            fn(...args),
+    },
+}));
+
+vi.mock("../../../utils/bloomApi", () => {
+    // Defined in here rather than at file scope because vi.mock() is hoisted above it.
+    const answers: { [endpoint: string]: unknown } = {
+        "readers/io/readerToolSettings": {
+            letters: "a b c",
+            moreWords: "cat sat",
+            stages: [{ letters: "a c", sightWords: "feline" }],
+            levels: [
+                { maxWordsPerPage: 6, thingsToRemember: [""] },
+                { maxWordsPerPage: 10, thingsToRemember: [""] },
+            ],
+        },
+        "collection/defaultFont": "Andika",
+        "readers/ui/sampleTextsList": "",
+    };
+    return {
+        get: (
+            endpoint: string,
+            handler?: (result: { data: unknown }) => void,
+        ) => {
+            const key = endpoint.split("?")[0];
+            if (handler && key in answers) {
+                handler({ data: answers[key] });
+            }
+        },
+        getWithConfig: () => undefined,
+        post: () => undefined,
+        postData: () => undefined,
+        postString: () => undefined,
+        postBoolean: () => undefined,
+        postJson: () => undefined,
+    };
+});
+
+import { beginLoadSynphonySettings } from "./readerTools";
+import { getTheOneReaderToolsModel } from "./readerToolsModel";
+
+describe("beginLoadSynphonySettings", () => {
+    beforeEach(() => {
+        getTheOneReaderToolsModel().clearForTest();
+    });
+
+    it("loads the settings again when the model it loaded them into has been replaced", async () => {
+        // sanity check: nothing loaded yet
+        expect(getTheOneReaderToolsModel().synphony).toBeUndefined();
+
+        await beginLoadSynphonySettings();
+
+        // sanity check: the first load is what sets up the "already loaded" module state
+        // that the second call has to see past.
+        expect(getTheOneReaderToolsModel().synphony).toBeDefined();
+        expect(getTheOneReaderToolsModel().getNumberOfLevels()).toBe(2);
+
+        // Stand in for the model having been thrown away and remade: the model in front of
+        // us no longer has the settings, but this module still thinks it loaded them.
+        getTheOneReaderToolsModel().synphony = undefined;
+
+        await beginLoadSynphonySettings();
+
+        expect(getTheOneReaderToolsModel().synphony).toBeDefined();
+        expect(getTheOneReaderToolsModel().getNumberOfLevels()).toBe(2);
+    });
+});


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
## Problem

**Set Up Levels** in the Leveled Reader tool did nothing at all — no dialog, no message — and
stayed that way until Bloom was restarted. **Set Up Stages** in the Decodable Reader tool had the
same fault. Timing-dependent, so not reproducible on demand.

## Cause

The reader tools remember in module state that they have loaded the collection's reader settings,
but the `ReaderToolsModel` holding those settings is replaced when the frame that created it
reloads. The memory then outlives the data: `beginLoadSynphonySettings()` saw its flags set, found
the settings unchanged, and skipped the work, leaving `synphony` undefined for the rest of the
session. The dialog opened but died on an unguarded `synphony.source` before it could be filled
in, so nothing the user would recognize as a dialog appeared.

## Fix

- Refresh when the model we're holding has no `synphony`, instead of trusting the flags. Root
  cause; goes through the existing refresh path, so no stale word cache and no leaked folder
  watcher.
- `showSetupDialog()` loads the settings itself rather than assuming the tool did.
- Release callers in the three places that could wait forever: a failed settings request, a failed
  sample-texts fetch during refresh, and a throw while building the dialog.
- Guard the `synphony` deref so "the settings were not loaded" is what gets reported.
- `requestWordsForSelectedStage()` tolerates being called before the dialog has its data.
- Tests for the reload into a replaced model, the failed request settling, and the error.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16732


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8224)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8224)
<!-- Reviewable:end -->


