### PR TITLE
Clean up English XLF files: note typos, stale ID notes, {lang} guidance

### DIFF
--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -5647,6 +5647,9 @@ is mostly status, which shows on the Collection Tab -->
       </trans-unit>
       <!--
 // Don't want these actually translated until things stabilize. Will need re-ordering.
+// NOTE: before uncommenting this section, verify the strings against the current code:
+// each string must match the English the code actually uses, any strings the feature now
+// uses must be added if missing here, and any entries the code no longer uses must be removed.
       <trans-unit id="TeamCollection.DropboxSettingsAcknowledgement" sil:dynamic="true">
         <source xml:lang="en">I will ensure that all team members have properly configured [Critical Dropbox Settings](https://docs.bloomlibrary.org/critical-dropbox-settings/).</source>
         <note>ID: TeamCollection.DropboxSettingsAcknowledgement</note>
@@ -5712,8 +5715,8 @@ is mostly status, which shows on the Collection Tab -->
         <note>ID: TeamCollection.ConflictingEdit</note>
       </trans-unit>
       <trans-unit id="TeamCollection.CheckoutRequired" sil:dynamic="true">
-        <source xml:lang="en">CheckoutRequired</source>
-        <note>ID: TeamCollection.ConflictingEdit</note>
+        <source xml:lang="en">Checkout Required</source>
+        <note>ID: TeamCollection.CheckoutRequired</note>
       </trans-unit>
       <trans-unit id="TeamCollection.CreateTeamCollection" sil:dynamic="true">
         <source xml:lang="en">Create a Team Collection</source>
@@ -5792,7 +5795,7 @@ is mostly status, which shows on the Collection Tab -->
         <note>{0} is the path to the book's folder</note>
         <note>{1} is the error message from the system</note>
       </trans-unit>
-      <trans-unit id="TeamCollection.ErrorCreating>
+      <trans-unit id="TeamCollection.ErrorCreating">
         <source xml:lang="en">Error creating team collection {0}: {1}</source>
         <note>ID: TeamCollection.ErrorCreating</note>
         <note>{0} is the path to the collection folder</note>
@@ -5809,7 +5812,7 @@ is mostly status, which shows on the Collection Tab -->
       </trans-unit>
       <trans-unit id="TeamCollection.CheckoutRequiredExplanation" sil:dynamic="true">
         <source xml:lang="en">Please check out this book from the Team Collection before publishing it.</source>
-        <note>ID: TeamCollection.ConflictingEdit</note>
+        <note>ID: TeamCollection.CheckoutRequiredExplanation</note>
       </trans-unit>
 -->
       <trans-unit id="TemplateBooks.BookName.Activity" sil:dynamic="true">

--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -1792,7 +1792,7 @@
       <trans-unit id="EditTab.FrontMatter.BookTitlePrompt" sil:dynamic="true">
         <source xml:lang="en">Book title in {lang}</source>
         <note>ID: EditTab.FrontMatter.BookTitlePrompt</note>
-        <note>Put {lang} in your translation, so it can be replaced by the language name.</note>
+        <note>Put {lang} in your translation, so it can be replaced by the language name. Do NOT translate "lang".</note>
       </trans-unit>
       <trans-unit id="EditTab.FrontMatter.CopyrightPrompt" sil:dynamic="true">
         <source xml:lang="en">Click to Edit Copyright &amp; License</source>
@@ -1801,7 +1801,7 @@
       <trans-unit id="EditTab.FrontMatter.CreditTranslator" sil:dynamic="true">
         <source xml:lang="en">Acknowledgments for this version, in {lang}. For example, give credit to the translator for this version.</source>
         <note>ID: EditTab.FrontMatter.CreditTranslator</note>
-        <note>Put {lang} in your translation, so it can be replaced by the language name.</note>
+        <note>Put {lang} in your translation, so it can be replaced by the language name. Do NOT translate "lang".</note>
       </trans-unit>
       <trans-unit id="EditTab.FrontMatter.EditOriginalTitleCaption" sil:dynamic="true">
         <source xml:lang="en">Edit Original Title</source>
@@ -1850,14 +1850,17 @@
       <trans-unit id="EditTab.FrontMatter.NameofTranslatorPrompt" sil:dynamic="true">
         <source xml:lang="en">Name of Translator, in {lang}</source>
         <note>ID: EditTab.FrontMatter.NameofTranslatorPrompt</note>
+        <note>Put {lang} in your translation, so it can be replaced by the language name. Do NOT translate "lang".</note>
       </trans-unit>
       <trans-unit id="EditTab.FrontMatter.OriginalAcknowledgmentsPrompt" sil:dynamic="true">
         <source xml:lang="en">Original (or Shell) Acknowledgments in {lang}</source>
         <note>ID: EditTab.FrontMatter.OriginalAcknowledgmentsPrompt</note>
+        <note>Put {lang} in your translation, so it can be replaced by the language name. Do NOT translate "lang".</note>
       </trans-unit>
       <trans-unit id="EditTab.FrontMatter.OriginalContributorsPrompt" sil:dynamic="true">
         <source xml:lang="en">The contributions made by writers, illustrators, editors, etc., in {lang}</source>
         <note>ID: EditTab.FrontMatter.OriginalContributorsPrompt</note>
+        <note>Put {lang} in your translation, so it can be replaced by the language name. Do NOT translate "lang".</note>
       </trans-unit>
       <trans-unit id="EditTab.FrontMatter.OriginalCopyrightSentence">
         <source xml:lang="en">This book is an adaptation of the original, {0}.</source>
@@ -1903,6 +1906,7 @@
       <trans-unit id="EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt" sil:dynamic="true">
         <source xml:lang="en">Acknowledgments for translated version, in {lang}</source>
         <note>ID: EditTab.FrontMatter.TranslatedAcknowledgmentsPrompt</note>
+        <note>Put {lang} in your translation, so it can be replaced by the language name. Do NOT translate "lang".</note>
       </trans-unit>
       <trans-unit id="EditTab.HowToUseHyperlink">
         <source xml:lang="en">To use this hyperlink, go to the page where you are making a Table of Contents. Next, select some text and then click on the image of chain link. This will turn the selected text into a hyperlink to this page.</source>

--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="AboutDialog.AboutBloom">
         <source xml:lang="en">About {0}</source>
-        <note>ID: AboutDialog.WindowTitle</note>
+        <note>ID: AboutDialog.AboutBloom</note>
         <note>{0} is the application name</note>
       </trans-unit>
       <trans-unit id="AboutDialog.BuiltOnDate">
@@ -1830,7 +1830,7 @@
       </trans-unit>
       <trans-unit id="EditTab.FrontMatter.ImageCreditMissing">
         <source xml:lang="en"> {0} (page {1})</source>
-        <note>ID: EditTab.FrontMatter.MissingCredit</note>
+        <note>ID: EditTab.FrontMatter.ImageCreditMissing</note>
         <note>The {0} is replaced by the filename of an image.  The {1} is replaced by a reference to the first page in the book where that image occurs.</note>
       </trans-unit>
       <trans-unit id="EditTab.FrontMatter.InsideFrontCoverTextPrompt" sil:dynamic="true">
@@ -2222,7 +2222,7 @@
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.ComicTool.Handle.Fill" sil:dynamic="true">
         <source xml:lang="en">Fill the space</source>
-        <note>ID: EditTab.Toolbox.ComicTool.Handle.Fit</note>
+        <note>ID: EditTab.Toolbox.ComicTool.Handle.Fill</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.ComicTool.Handle.Resize" sil:dynamic="true">
         <source xml:lang="en">Resize</source>
@@ -2995,7 +2995,7 @@
       </trans-unit>
       <trans-unit id="Errors.CopyImageMetadata">
         <source xml:lang="en">Bloom was not able to copy the metadata to {0} image(s): {1}. The files may be corrupted. Please try other images, or try with Bloom 6.0 or newer.</source>
-        <note>ID: Errors.BookProblem</note>
+        <note>ID: Errors.CopyImageMetadata</note>
         <note>The placeholder {0} will get a number that is the count of how many image files had a problem.</note>
         <note>The placeholder {1} will get a list of the names of image files that had a problem.</note>
       </trans-unit>
@@ -3745,7 +3745,7 @@
       </trans-unit>
       <trans-unit id="PublishTab.Android.WiFi.Hint" sil:dynamic="true">
         <source xml:lang="en">There are several ways to start a temporary one.</source>
-        <note>ID: </note>
+        <note>ID: PublishTab.Android.WiFi.Hint</note>
         <note>This is preceded by a heading that says 'No Wi-Fi Network'. 'one' here refers to 'Wi Fi' network.</note>
       </trans-unit>
       <trans-unit id="PublishTab.Android.AboutMotionBooks" sil:dynamic="true">
@@ -3755,7 +3755,7 @@
       </trans-unit>
       <trans-unit id="PublishTab.Android.Bookshelf" sil:dynamic="true">
         <source xml:lang="en">Bloom Reader Bookshelf</source>
-        <note>ID: PublishTab.Android.BookShelf</note>
+        <note>ID: PublishTab.Android.Bookshelf</note>
         <note>A heading in the Publish to Android screen.</note>
       </trans-unit>
       <trans-unit id="PublishTab.Android.CantGetLicenseInfo" sil:dynamic="true">
@@ -4018,7 +4018,7 @@
       </trans-unit>
       <trans-unit id="PublishTab.BloomPUB.BannerDescription.v2">
         <source xml:lang="en">BloomPUBs are a kind of eBook. Your book will look exactly like it does here in Bloom. It will have all the same features. This makes BloomPUBs better than ePUBs.</source>
-        <note>ID: PublishTab.BloomPUB.BannerDescription</note>
+        <note>ID: PublishTab.BloomPUB.BannerDescription.v2</note>
         <note>Task description at the top of the BloomPUB Publishing page</note>
       </trans-unit>
       <trans-unit id="PublishTab.BloomPUB.BannerTitle">
@@ -4033,12 +4033,12 @@
       </trans-unit>
       <trans-unit id="PublishTab.BulkBloomPub.Explanation" sil:dynamic="true">
         <source xml:lang="en">This file will cause these books to be grouped under a single bookshelf in Bloom Reader. This collection's bookshelf is set to "{0}".</source>
-        <note>ID: Publish.BulkBloomPub.Explanation</note>
+        <note>ID: PublishTab.BulkBloomPub.Explanation</note>
         <note>{0} will be replaced with the name of the bookshelf. Make sure to place the {0} at the appropriate place in the translation. The double quotes ("") around it can be replaced with whatever kind of quotation marks are appropriate in the language you are translating to.</note>
       </trans-unit>
       <trans-unit id="PublishTab.BulkBloomPub.Make" sil:dynamic="true">
         <source xml:lang="en">Make</source>
-        <note>ID: Publish.BulkBloomPub.Make</note>
+        <note>ID: PublishTab.BulkBloomPub.Make</note>
         <note>"Make" is the label of a button that will make the selected file</note>
       </trans-unit>
       <trans-unit id="PublishTab.BulkBloomPub.MakeAllBloomPubs" sil:dynamic="true">
@@ -4048,13 +4048,13 @@
       </trans-unit>
       <trans-unit id="PublishTab.BulkBloomPub.MakeBloomBundle" sil:dynamic="true">
         <source xml:lang="en">Compress into a single .bloombundle file</source>
-        <note>ID: Publish.BulkBloomPub.MakeBloomBundle</note>
+        <note>ID: PublishTab.BulkBloomPub.MakeBloomBundle</note>
         <note>"Compress" means to take multiple things and turn them into a single combined file. (The result is smaller than the sum of the parts.)</note>
         <note>.bloombundle is the file extension. It is in lowercase. It will be the same extension regardless of the user's language settings.</note>
       </trans-unit>
       <trans-unit id="PublishTab.BulkBloomPub.ProduceBloomShelf" sil:dynamic="true">
         <source xml:lang="en">Produce a .bloomshelf file</source>
-        <note>ID: Publish.BulkBloomPub.ProduceBloomShelf</note>
+        <note>ID: PublishTab.BulkBloomPub.ProduceBloomShelf</note>
       </trans-unit>
       <trans-unit id="Publish.RemovingDisallowedPages" sil:dynamic="true">
         <source xml:lang="en">Removing one or more pages which require a higher subscription tier</source>
@@ -5265,7 +5265,7 @@ Do you want to go ahead?</note>
       </trans-unit>
       <trans-unit id="ReaderSetup.SentenceMaxWords2" sil:dynamic="true">
         <source xml:lang="en">Per **Sentence**</source>
-        <note>ID: ReaderSetup.SentenceMaxWords</note>
+        <note>ID: ReaderSetup.SentenceMaxWords2</note>
         <note>follows headings "maximum" and "words" to convey "maximum words per sentence". Surround text that should be bold in double asterisks.</note>
       </trans-unit>
       <trans-unit id="ReaderSetup.SentencePunctuation.Header" sil:dynamic="true">

--- a/DistFiles/localization/en/Bloom.xlf
+++ b/DistFiles/localization/en/Bloom.xlf
@@ -875,7 +875,7 @@
       <trans-unit id="CollectionTab.UnableToCheckForUpdate">
         <source xml:lang="en">Could not connect to the server to check for an update. Are you connected to the internet?</source>
         <note>ID: CollectionTab.UnableToCheckForUpdate</note>
-        <note>Shown when Bloom tries to check for an update but can't, for example because it can't connect to the internet, or a problems with our server, etc.</note>
+        <note>Shown when Bloom tries to check for an update but can't, for example because it can't connect to the internet, or a problem with our server, etc.</note>
       </trans-unit>
       <trans-unit id="CollectionTab.UpToDate">
         <source xml:lang="en">Your Bloom is up to date.</source>
@@ -946,7 +946,7 @@
       <trans-unit id="Common.BloomSubscriptionFeature">
         <source xml:lang="en">Bloom Subscription Feature</source>
         <note>ID: Common.BloomSubscriptionFeature</note>
-        <note>This tooltip shows over the Bloom Subcription icon.</note>
+        <note>This tooltip shows over the Bloom Subscription icon.</note>
       </trans-unit>
       <trans-unit id="Common.Cancel">
         <source xml:lang="en">Cancel</source>
@@ -958,7 +958,7 @@
         <note>This is identical to Common.Cancel. The duplication was introduced by a mistake.</note>
         <note>This is shown at the bottom of a dialog box. It is paired with an action button like "OK" and it means "do not do the action".</note>
         <!-- The ampersand is used to indicate a mnemonic in C# WinForms. Ugh, I'm not happy that we expose it to the translators -->
-        <note>If you include "&amp;" (which represents an ampersand) in your translation, it will not be visible in Bloom. Instead, the letter following it will be a keyboard shortcut (e.g., &amp;Cancel means that alt-C can be used to activate the Cancel button.) The letter marked with ampersand is usually the first one but does not have to be. It is important not to mark the same letter in two different controls in the same dialog. If you are not sure, just don't include the "amp;"; the only consequence is that this control cannot be activated using an alt-key shortcut.</note>
+        <note>If you include "&amp;" (which represents an ampersand) in your translation, it will not be visible in Bloom. Instead, the letter following it will be a keyboard shortcut (e.g., &amp;Cancel means that alt-C can be used to activate the Cancel button.) The letter marked with ampersand is usually the first one but does not have to be. It is important not to mark the same letter in two different controls in the same dialog. If you are not sure, just don't include the "&amp;"; the only consequence is that this control cannot be activated using an alt-key shortcut.</note>
         <note>ID: Common.CancelButton</note>
       </trans-unit>
       <trans-unit id="Common.Close">
@@ -1535,7 +1535,7 @@
       <trans-unit id="EditTab.SubscriptionEnabled" sil:dynamic="true">
         <source xml:lang="en">Your subscription includes this feature.</source>
         <note>ID: EditTab.SubscriptionEnabled</note>
-        <note>Appears in a tooltip on the Subscription button when the user DOES have a subcription (cf EditTab.RequiresSubscription).</note>
+        <note>Appears in a tooltip on the Subscription button when the user DOES have a subscription (cf EditTab.RequiresSubscription).</note>
         <note>Obsolete as of Bloom 6.2</note>
       </trans-unit>
       <trans-unit id="EditTab.SubscriptionSettingsButton" sil:dynamic="true">
@@ -2032,7 +2032,7 @@
       <trans-unit id="EditTab.NewBookName">
         <source xml:lang="en">Book</source>
         <note>ID: EditTab.NewBookName</note>
-        <note>Default file and folder name when you make a new book, but haven't give it a title yet.</note>
+        <note>Default file and folder name when you make a new book, but haven't given it a title yet.</note>
       </trans-unit>
       <trans-unit id="EditTab.NoImageFoundOnClipboard">
         <source xml:lang="en">Before you can paste an image, copy one onto your 'clipboard', from another program.</source>
@@ -2045,7 +2045,7 @@
       <trans-unit id="EditTab.NoOtherLayouts">
         <source xml:lang="en">There are no other options for this template.</source>
         <note>ID: EditTab.NoOtherLayouts</note>
-        <note>Show in the size/orientation chooser dropdown of the edit tab, if there was only a single choice</note>
+        <note>Shown in the size/orientation chooser dropdown of the edit tab, if there was only a single choice</note>
       </trans-unit>
       <trans-unit id="EditTab.Overflow" sil:dynamic="true">
         <source xml:lang="en">This box has more text than will fit</source>
@@ -2095,7 +2095,7 @@
       <trans-unit id="EditTab.Snap.MatchImageAspect" sil:dynamic="true">
         <source xml:lang="en">Fit image</source>
         <note>ID: EditTab.Snap.MatchImageAspect</note>
-        <note>Explains why a splitter has snapped to a particular position. This position matches the proportion of the image so that it fits snuggly in the box.</note>
+        <note>Explains why a splitter has snapped to a particular position. This position matches the proportion of the image so that it fits snugly in the box.</note>
       </trans-unit>
       <trans-unit id="EditTab.Snap.MatchPreviousPage" sil:dynamic="true">
         <source xml:lang="en">Matches previous page</source>
@@ -2931,7 +2931,7 @@
       <trans-unit id="EditTab.Toolbox.TalkingBookTool.SplitError">
         <source xml:lang="en">Something went wrong while splitting the recording.</source>
         <note>ID: EditTab.Toolbox.TalkingBookTool.SplitError</note>
-        <note>This text appears if an error occurs while perfoming automatic splitting of audio (an audio file corresponding to an entire text box will be split into multiple sections, one section per sentence).</note>
+        <note>This text appears if an error occurs while performing automatic splitting of audio (an audio file corresponding to an entire text box will be split into multiple sections, one section per sentence).</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.TalkingBookTool.SplitLabel">
         <source xml:lang="en">Split</source>
@@ -3884,7 +3884,7 @@
       <trans-unit id="PublishTab.Android.Usb.Progress.Connected" sil:dynamic="true">
         <source xml:lang="en">Connected to {0} via USB...</source>
         <note>ID: PublishTab.Android.Usb.Progress.Connected</note>
-        <note>{0} is a the name of the device Bloom connected to</note>
+        <note>{0} is the name of the device Bloom connected to</note>
       </trans-unit>
       <trans-unit id="PublishTab.Android.Usb.Progress.DeviceOutOfMemory" sil:dynamic="true">
         <source xml:lang="en">The device reported that it does not have enough space for this book. The book is {0} MB.</source>
@@ -4096,7 +4096,7 @@
       <trans-unit id="PublishTab.Epub.Accessibility">
         <source xml:lang="en">Accessibility</source>
         <note>ID: PublishTab.Epub.Accessibility</note>
-        <note>Here, the English 'Accessibility' is a common way of refering to technologies that are usable by people with disabilities. With computers, this usually means people with visual impairments. It includes botht he blind and people who might need text to be larger, or who are colorblind, etc.</note>
+        <note>Here, the English 'Accessibility' is a common way of referring to technologies that are usable by people with disabilities. With computers, this usually means people with visual impairments. It includes both the blind and people who might need text to be larger, or who are colorblind, etc.</note>
       </trans-unit>
       <trans-unit id="PublishTab.Epub.BannerDescription">
         <source xml:lang="en">Make an electronic book that can be read in EPUB readers on all devices.</source>
@@ -4218,7 +4218,7 @@
       <trans-unit id="PublishTab.OnePagePerPaperRadio">
         <source xml:lang="en">Simple</source>
         <note>ID: PublishTab.OnePagePerPaperRadio</note>
-        <note>Instead of making a booklet, just make normal pages. (This is no longer a radio button, but keeping the name for backwards compatiblity with translations.)</note>
+        <note>Instead of making a booklet, just make normal pages. (This is no longer a radio button, but keeping the name for backwards compatibility with translations.)</note>
       </trans-unit>
       <trans-unit id="PublishTab.OnePagePerPaper-description" sil:dynamic="true">
         <source xml:lang="en">A simple PDF instead of a booklet.</source>
@@ -4719,7 +4719,7 @@
       <trans-unit id="PublishTab.Upload.EnterpriseShelfRequiredTooltip">
         <source xml:lang="en">This feature requires an Enterprise subscription and a destination shelf selected in Collection Settings.</source>
         <note>ID: PublishTab.Upload.EnterpriseShelfRequiredTooltip</note>
-        <note>Leaving this one as "enterprise" instead of "Subscription" becuase it really does require the Enterprise Tier.</note>
+        <note>Leaving this one as "enterprise" instead of "Subscription" because it really does require the Enterprise Tier.</note>
       </trans-unit>
       <trans-unit id="PublishTab.Upload.ErrorUploading">
         <source xml:lang="en">Sorry, there was a problem uploading {0}. Some details follow. You may need technical help.</source>
@@ -5005,7 +5005,7 @@ Do you want to go ahead?</note>
         </source>
         <note>ID: PublishTab.UploadCollisionDialog.Radio.SameBookCancel.Commentary</note>
         <note>This is explanatory commentary on a radio button. Don't translate the email in brackets ([librarian@bloomlibrary.org]). It will be replaced by a link to send an email.</note>
-        <note>Leaving this one as "enterprise" instead of "Subscription" becuase it really does require the Enterprise Tier.</note>
+        <note>Leaving this one as "enterprise" instead of "Subscription" because it really does require the Enterprise Tier.</note>
       </trans-unit>
       <trans-unit id="PublishTab.UploadCollisionDialog.SameBook">
         <source xml:lang="en">Is this an update of your existing book?</source>
@@ -5061,7 +5061,7 @@ Do you want to go ahead?</note>
       <trans-unit id="ReaderSetup.BookMaxWords2" sil:dynamic="true">
         <source xml:lang="en">Per **Book**</source>
         <note>ID: ReaderSetup.BookMaxWords2</note>
-        <note>follows headings "maximum" and "words" to convey "maximum words per book. Surround text that should be bold in double asterisks.</note>
+        <note>follows headings "maximum" and "words" to convey "maximum words per book". Surround text that should be bold in double asterisks.</note>
       </trans-unit>
       <trans-unit id="ReaderSetup.ChooseAllowedWordsFile" sil:dynamic="true">
         <source xml:lang="en">Choose...</source>
@@ -5131,7 +5131,7 @@ Do you want to go ahead?</note>
       <trans-unit id="ReaderSetup.LevelLabelMax" sil:dynamic="true">
         <source xml:lang="en">Level {0} Maximums</source>
         <note>ID: ReaderSetup.LevelLabelMax</note>
-        <note xml:lang="en">{0} is a number. A heading for several items each of which specfies a maximum for a different quantity for a reader of the level specified by the number.</note>
+        <note xml:lang="en">{0} is a number. A heading for several items each of which specifies a maximum for a different quantity for a reader of the level specified by the number.</note>
       </trans-unit>
       <trans-unit id="ReaderSetup.Levels" sil:dynamic="true">
         <source xml:lang="en">Reader Levels</source>
@@ -5150,7 +5150,7 @@ Do you want to go ahead?</note>
         <source xml:lang="en">Average per **Sentence** in **Book**</source>
         <note>ID: ReaderSetup.MaxAverageWords</note>
         <note>Prior to 4.9, was "Maximum Average Length of Sentences in Book"</note>
-        <note>follows headings like "Level 1 Maximum" and "Words". Should combine with those to convey "Maximum averate sentence length in book". Surround text that should be bold in double asterisks.</note>
+        <note>follows headings like "Level 1 Maximum" and "Words". Should combine with those to convey "Maximum average sentence length in book". Surround text that should be bold in double asterisks.</note>
       </trans-unit>
       <trans-unit id="ReaderSetup.MaxAverageWordsPerPage" sil:dynamic="true">
         <source xml:lang="en">Average per **Page**</source>
@@ -5439,7 +5439,7 @@ Do you want to go ahead?</note>
       <trans-unit id="ReportProblemDialog.FatalTitle">
         <source xml:lang="en">Bloom encountered an error and needs to quit</source>
         <note>ID: ReportProblemDialog.FatalTitle</note>
-        <note>The title of the dialog after a Fatal error will cause Bloom to close.</note>
+        <note>The title of the dialog after a Fatal error that will cause Bloom to close.</note>
       </trans-unit>
       <trans-unit id="ReportProblemDialog.FirstTime">
         <source xml:lang="en">First Time</source>
@@ -5563,12 +5563,12 @@ is mostly status, which shows on the Collection Tab -->
       <trans-unit id="Subscription.RequiredTierForFeatureSentence">
         <source xml:lang="en">This feature requires a Bloom subscription tier of at least "{0}".</source>
         <note>ID: Subscription.RequiredTierForFeatureSentence</note>
-        <note>{0} is will be filled in with name of the tier. e.g "Pro" or "Enterprise"</note>
+        <note>{0} will be filled in with the name of the tier, e.g. "Pro" or "Enterprise"</note>
       </trans-unit>
       <trans-unit id="Subscription.FeatureIsIncludedSentence">
         <source xml:lang="en">This feature is included in your {0} subscription.</source>
         <note>ID: Subscription.FeatureIsIncludedSentence</note>
-        <note>{0} is will be filled in with name of the tier. e.g "Pro" or "Enterprise"</note>
+        <note>{0} will be filled in with the name of the tier, e.g. "Pro" or "Enterprise"</note>
       </trans-unit>
       <trans-unit id="Subscription.Pro.EmailMismatch">
         <source xml:lang="en">Your Pro subscription for {0} does not match this BloomLibrary.org account: {1}.</source>

--- a/DistFiles/localization/en/BloomLowPriority.xlf
+++ b/DistFiles/localization/en/BloomLowPriority.xlf
@@ -15,7 +15,7 @@
       <trans-unit id="Errors.CorruptImageFile">
         <source xml:lang="en">The image file {0} is corrupt and needs to be replaced. ({1})</source>
         <note>ID: Errors.CorruptImageFile</note>
-        <note>The placeholder {0} represents the name of the corrupt file. The placeholder {0} represents a message describing the problem with the file.</note>
+        <note>The placeholder {0} represents the name of the corrupt file. The placeholder {1} represents a message describing the problem with the file.</note>
       </trans-unit>
       <trans-unit id="CollectionSettingsDialog.BookMakingTab.NoBookshelvesFromServer" sil:dynamic="true">
         <source xml:lang="en">Bloom could not reach the server to get the list of bookshelves.</source>
@@ -24,7 +24,7 @@
       <trans-unit id="EditTab.Toolbox.TalkingBookTool.ESpeakPreview.ConversionFileUsed">
         <source xml:lang="en">Conversion file used:</source>
         <note>ID: EditTab.Toolbox.TalkingBookTool.ESpeakPreview.ConversionFileUsed</note>
-        <note>After this text, the program will display the path to the conversion file (the location of the file on this computer). The conversion file specificies a mapping which is used to convert the script for one language into the script for another.</note>
+        <note>After this text, the program will display the path to the conversion file (the location of the file on this computer). The conversion file specifies a mapping which is used to convert the script for one language into the script for another.</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.TalkingBookTool.ESpeakPreview.Error">
         <source xml:lang="en">eSpeak failed.</source>
@@ -237,12 +237,12 @@
       <trans-unit id="Feature.Canvas">
         <source xml:lang="en">Canvas</source>
         <note>ID: Feature.Canvas</note>
-        <note>This is the name of a feature in BLoom</note>
+        <note>This is the name of a feature in Bloom</note>
       </trans-unit>
       <trans-unit id="Feature.Spreadsheet">
         <source xml:lang="en">Spreadsheet Import/Export</source>
         <note>ID: Feature.Spreadsheet</note>
-        <note>This is the name of a feature in BLoom</note>
+        <note>This is the name of a feature in Bloom</note>
       </trans-unit>
       <!-- TODO: add other features -->
 

--- a/DistFiles/localization/en/BloomMediumPriority.xlf
+++ b/DistFiles/localization/en/BloomMediumPriority.xlf
@@ -30,7 +30,7 @@
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.DragActivity.ChooseSoundFile">
         <source xml:lang="en">Choose Sound File</source>
-        <note>ID: EditTab.Toolbox.DragActivity.ChooseSound</note>
+        <note>ID: EditTab.Toolbox.DragActivity.ChooseSoundFile</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.DragActivity.Correct">
         <source xml:lang="en">Correct</source>
@@ -184,11 +184,11 @@
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.DragActivity.CorrectSound">
         <source xml:lang="en">Correct Sound</source>
-        <note>ID: EditTab.Toolbox.DragActivity.WhenCorrect</note>
+        <note>ID: EditTab.Toolbox.DragActivity.CorrectSound</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.DragActivity.WrongSound">
         <source xml:lang="en">Wrong Sound</source>
-        <note>ID: EditTab.Toolbox.DragActivity.WhenWrong</note>
+        <note>ID: EditTab.Toolbox.DragActivity.WrongSound</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.DragActivity.Word">
         <source xml:lang="en">Word</source>
@@ -282,7 +282,7 @@
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.Games.Placeholder.OrderWordsInstructions">
         <source>Drag the words where they go</source>
-        <note>ID: EditTab.Toolbox.Games.Placeholder.OrderInstructions</note>
+        <note>ID: EditTab.Toolbox.Games.Placeholder.OrderWordsInstructions</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.Games.Placeholder.CustomGameInstructions">
         <source>Put instructions here</source>
@@ -404,7 +404,7 @@
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.TalkingBookTool.InsertSegmentMarkerTipAddition" sil:dynamic="true">
         <source xml:lang="en">Bloom will hide these when you publish.</source>
-        <note>ID: EditTab.Toolbox.TalkingBookTool.InsertSegmentMarkerTip</note>
+        <note>ID: EditTab.Toolbox.TalkingBookTool.InsertSegmentMarkerTipAddition</note>
         <note>This will be appended to the end of EditTab.Toolbox.TalkingBookTool.InsertSegmentMarkerTip. "these" refers to the "|" characters that mark audio segments, described in EditTab.Toolbox.TalkingBookTool.InsertSegmentMarkerTip</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.TalkingBookTool.NeedCursorInRecordableThingDisabledTip" sil:dynamic="true">
@@ -414,7 +414,7 @@
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.TalkingBookTool.RecordingModeDisabledBecauseHasAudioTip" sil:dynamic="true">
         <source xml:lang="en">If you want to change this mode, first use the "Clear" button to remove your recording.</source>
-        <note>ID: EditTab.Toolbox.TalkingBookTool.EditTab.Toolbox.TalkingBookTool.RecordingModeDisabledBecauseHasAudioTip</note>
+        <note>ID: EditTab.Toolbox.TalkingBookTool.RecordingModeDisabledBecauseHasAudioTip</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.TalkingBookTool.RecordingModeSentenceTip" sil:dynamic="true">
         <source xml:lang="en">Record one sentence at a time. You can break up sentences using the `|` character.</source>
@@ -482,7 +482,7 @@
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.CanvasTool.DragInstructions" sil:dynamic="true">
         <source xml:lang="en">Drag any of these onto a canvas:</source>
-        <note>ID: EditTab.Toolbox.CanvasTool.DragInstructions2</note>
+        <note>ID: EditTab.Toolbox.CanvasTool.DragInstructions</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.CanvasTool.ImageFit" sil:dynamic="true">
         <source xml:lang="en">Image Fit</source>
@@ -510,7 +510,7 @@
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.CanvasTool.NavButtons" sil:dynamic="true">
         <source xml:lang="en">A button that jumps you to a page or book in your app</source>
-        <note>ID: EditTab.Toolbox.OverlayTool.NavButtons</note>
+        <note>ID: EditTab.Toolbox.CanvasTool.NavButtons</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.CanvasTool.Navigation" sil:dynamic="true">
         <source xml:lang="en">Navigation</source>
@@ -524,7 +524,7 @@
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.CanvasTool.SetDest" sil:dynamic="true">
         <source xml:lang="en">Set Destination</source>
-        <note>ID: EditTab.Toolbox.OverlayTool.SetDest</note>
+        <note>ID: EditTab.Toolbox.CanvasTool.SetDest</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.OverlayTool.KeyHints.Drag" sil:dynamic="true">
         <source xml:lang="en">drag</source>
@@ -610,7 +610,7 @@
       </trans-unit>
       <trans-unit id="PublishTab.Feature.Motion.Possible">
         <source xml:lang="en">Select this if you want to show motion when the book is read in landscape mode.</source>
-        <note>ID: PublishTab.Feature.Motion.None</note>
+        <note>ID: PublishTab.Feature.Motion.Possible</note>
         <note>This is a tooltip.</note>
       </trans-unit>
       <trans-unit id="PublishTab.Feature.Music">
@@ -934,7 +934,7 @@
       </trans-unit>
       <trans-unit id="Common.BackgroundColor" sil:dynamic="true">
         <source xml:lang="en">Background Color</source>
-        <note>Common.CoverBackgroundColor</note>
+        <note>Common.BackgroundColor</note>
       </trans-unit>
       <trans-unit id="BookSettings.WhatToShowOnCover" sil:dynamic="true">
         <source xml:lang="en">Front Cover</source>
@@ -977,7 +977,7 @@
       </trans-unit>
       <trans-unit id="BookSettings.PageNumbers.Left" sil:dynamic="true">
         <source xml:lang="en">Left</source>
-        <note>BookSettings.PageNumbers.TopLeft</note>
+        <note>BookSettings.PageNumbers.Left</note>
         <note>Indicates page number should be positioned on the left side of the page</note>
       </trans-unit>
       <trans-unit id="BookSettings.PageNumbers.Center" sil:dynamic="true">

--- a/DistFiles/localization/en/BloomMediumPriority.xlf
+++ b/DistFiles/localization/en/BloomMediumPriority.xlf
@@ -136,10 +136,16 @@
         <source xml:lang="en">This item comes with a “target” to which it must be dragged. If you want to have more items than targets, turn this off for some of them.</source>
         <note>ID: EditTab.Toolbox.DragActivity.PartOfRightAnswerMore.v2</note>
       </trans-unit>
-      <!--trans-unit id="EditTab.Toolbox.DragActivity.PartOfRightAnswerDisabled">
+      <!-- This string is not currently used. It was added (commit 472b7f6f6, July 2024) as a
+           tooltip for the disabled "part of the right answer" button, but three days later
+           commit 3b195aad0 changed that control to be hidden when not relevant instead of
+           disabled, so the string was commented out. Kept in case a disabled state returns;
+           if uncommenting, verify the wording against the code first.
+      <trans-unit id="EditTab.Toolbox.DragActivity.PartOfRightAnswerDisabled">
         <source xml:lang="en">Nothing that can be part of the right answer is selected</source>
         <note>ID: EditTab.Toolbox.DragActivity.PartOfRightAnswerDisabled</note>
-      </trans-unit-->
+      </trans-unit>
+      -->
       <trans-unit id="EditTab.Toolbox.DragActivity.Play">
         <source xml:lang="en">Play</source>
         <note>ID: EditTab.Toolbox.DragActivity.Play</note>

--- a/DistFiles/localization/en/BloomMediumPriority.xlf
+++ b/DistFiles/localization/en/BloomMediumPriority.xlf
@@ -137,7 +137,7 @@
         <note>ID: EditTab.Toolbox.DragActivity.PartOfRightAnswerMore.v2</note>
       </trans-unit>
       <!-- This string is not currently used. It was added (commit 472b7f6f6, July 2024) as a
-           tooltip for the disabled "part of the right answer" button, but three days later
+           tooltip for the disabled "part of the right answer" button, but days later
            commit 3b195aad0 changed that control to be hidden when not relevant instead of
            disabled, so the string was commented out. Kept in case a disabled state returns;
            if uncommenting, verify the wording against the code first.

--- a/DistFiles/localization/en/BloomMediumPriority.xlf
+++ b/DistFiles/localization/en/BloomMediumPriority.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="EditTab.Toolbox.DragActivity.Correct">
         <source xml:lang="en">Correct</source>
         <note>ID: EditTab.Toolbox.DragActivity.Correct</note>
-        <note>Label of a button that puts the Bloom Game tool into its the mode for adding elements that should show when the reader gets the answer right.</note>
+        <note>Label of a button that puts the Bloom Game tool into the mode for adding elements that should show when the reader gets the answer right.</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.DragActivity.CorrectInstructions">
         <source xml:lang="en">Add items that will show when the learner gets the correct answer. For example, you might add a text that says “Correct!” with a GIF of a dancing chicken.</source>
@@ -143,7 +143,7 @@
       <trans-unit id="EditTab.Toolbox.DragActivity.Play">
         <source xml:lang="en">Play</source>
         <note>ID: EditTab.Toolbox.DragActivity.Play</note>
-        <note>Label of a button that puts the Bloom Game tool into its the mode for playing (testing) the game.</note>
+        <note>Label of a button that puts the Bloom Game tool into the mode for playing (testing) the game.</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.DragActivity.TargetsSameSize">
         <source xml:lang="en">Keep all targets the same size so students can't use size as a clue.</source>
@@ -202,7 +202,7 @@
       <trans-unit id="EditTab.Toolbox.DragActivity.Wrong">
         <source xml:lang="en">Wrong</source>
         <note>ID: EditTab.Toolbox.DragActivity.Wrong</note>
-        <note>Label of a button that puts the Bloom Game tool into its the mode for adding elements that should show when the reader gets the answer wrong.</note>
+        <note>Label of a button that puts the Bloom Game tool into the mode for adding elements that should show when the reader gets the answer wrong.</note>
       </trans-unit>
       <trans-unit id="EditTab.Toolbox.DragActivity.WrongInstructions">
         <source xml:lang="en">Add items that will show when the learner gets the wrong answer. For example, you might add a text that says “Try Again!”.\nIt is OK to have no correct or wrong answers. Just give the same positive reinforcement, like “Looks Nice!”.</source>
@@ -868,7 +868,7 @@
       <trans-unit id="BookSettings.eBook.Image.MaxResolution.4K" sil:dynamic="true">
         <source xml:lang="en">4K</source>
         <note>BookSettings.eBook.Image.MaxResolution.4K</note>
-        <note>abbreviation for Ultra High Definition, also known as "4K" (3480 x 2160)</note>
+        <note>abbreviation for Ultra High Definition, also known as "4K" (3840 x 2160)</note>
       </trans-unit>
       <trans-unit id="BookSettings.eBook.Image.MaxResolution.Directions" sil:dynamic="true">
         <source xml:lang="en">Bloom reduces images to a maximum size to make books easier to view over poor internet connections and take up less space on phones.</source>


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
**Problem:** An audit of the XLF localization files found a scatter of long-standing defects in the English files that translators work from: misspellings and broken grammar in the developer notes translators rely on, two dozen boilerplate `ID:` notes still naming an entry's *old* id after a rename (one was empty, one had its prefix doubled), missing "don't translate `{lang}`" guidance that had already led four languages to translate the placeholder itself (leaving raw braces in the UI), and errors lurking in a commented-out section (a malformed `id` attribute missing its closing quote, stale notes, a placeholder source) that would bite whoever uncomments it.

**Fix:** This PR cleans up the English XLF files only — no `<source>`/`<target>` text that ships to users is changed, so no translations are disturbed:
- Fixes 27 note lines with typos, grammar errors, and wrong facts (e.g. the note describing `{0}` twice where the second should be `{1}`, 4K given as 3480x2160, a note showing translators a broken `amp;` where it meant `&`).
- Rewrites all 24 stale/broken `ID:` notes to match their trans-unit ids.
- Adds an explicit 'Do NOT translate "lang".' note to all six strings containing the `{lang}` placeholder.
- Repairs the commented-out TeamCollection section (quote, stale notes, placeholder source), adds a warning that uncommenting requires re-verifying the strings against the code, and documents why the commented-out `PartOfRightAnswerDisabled` unit exists.
<!-- preflight-narrative:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8226)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8226)
<!-- Reviewable:end -->

