### PR TITLE
Rotate and flip an image (BL-16741)

### DIFF
--- a/DistFiles/localization/en/BloomMediumPriority.xlf
+++ b/DistFiles/localization/en/BloomMediumPriority.xlf
@@ -49,6 +49,31 @@
         <note>ID: Feature.AiImageEditing</note>
         <note>Name of the AI image editing feature, used in subscription messages.</note>
       </trans-unit>
+      <trans-unit id="EditTab.Image.RotateRight" translate="no">
+        <source xml:lang="en">Rotate right</source>
+        <note>ID: EditTab.Image.RotateRight</note>
+        <note>Command on the menu for a picture in the Edit tab. It turns the picture a quarter turn clockwise. Its keyboard shortcut is Ctrl+R.</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Image.Flip" translate="no">
+        <source xml:lang="en">Flip</source>
+        <note>ID: EditTab.Image.Flip</note>
+        <note>Command on the menu for a picture in the Edit tab. It opens a submenu with the two items "Flip horizontal" and "Flip vertical". "Flip" here means to mirror the picture, as a mirror reverses what it shows.</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Image.FlipHorizontal" translate="no">
+        <source xml:lang="en">Flip horizontal</source>
+        <note>ID: EditTab.Image.FlipHorizontal</note>
+        <note>Item on the "Flip" submenu for a picture in the Edit tab. It mirrors the picture from side to side, so that the left of the picture becomes the right.</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Image.FlipVertical" translate="no">
+        <source xml:lang="en">Flip vertical</source>
+        <note>ID: EditTab.Image.FlipVertical</note>
+        <note>Item on the "Flip" submenu for a picture in the Edit tab. It mirrors the picture from top to bottom, so that the top of the picture becomes the bottom.</note>
+      </trans-unit>
+      <trans-unit id="EditTab.Toolbox.ComicTool.Handle.Rotate" translate="no">
+        <source xml:lang="en">Rotate</source>
+        <note>ID: EditTab.Toolbox.ComicTool.Handle.Rotate</note>
+        <note>Tooltip on the small handle above a selected item on a page in the Edit tab. Dragging that handle around the item turns the item to any angle.</note>
+      </trans-unit>
       <trans-unit id="EditTab.Image.EditWithAI">
         <source xml:lang="en">Edit with AI...</source>
         <note>ID: EditTab.Image.EditWithAI</note>

--- a/DistFiles/localization/en/BloomMediumPriority.xlf
+++ b/DistFiles/localization/en/BloomMediumPriority.xlf
@@ -52,7 +52,7 @@
       <trans-unit id="EditTab.Image.RotateRight" translate="no">
         <source xml:lang="en">Rotate right</source>
         <note>ID: EditTab.Image.RotateRight</note>
-        <note>Command on the menu for a picture in the Edit tab. It turns the picture a quarter turn clockwise. Its keyboard shortcut is Ctrl+R.</note>
+        <note>Command on the menu for a picture in the Edit tab. It turns the picture a quarter turn clockwise.</note>
       </trans-unit>
       <trans-unit id="EditTab.Image.Flip" translate="no">
         <source xml:lang="en">Flip</source>

--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -1747,6 +1747,10 @@ canvas.moving {
         padding: 0.2em;
         z-index: 2;
         text-wrap-mode: nowrap;
+        // The control frame turns with the element, so this text would lie at the angle
+        // of the element. Turn it back by the same angle to keep it level and readable.
+        // The frame sets the angle; a frame with no angle set gets zero and stays put.
+        transform: rotate(calc(-1 * var(--canvas-element-rotation, 0deg)));
     }
     // the tooltip may not be visible outside the frame, so
     // on the south and east sides we move it to the other side.

--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -1687,6 +1687,20 @@ canvas.moving {
         display: block;
     }
 
+    // Once the element is turned far enough, its top edge points down the screen, and a
+    // lollipop hanging from that edge lands behind the panel of controls that sits below the
+    // element. For those angles we hang the lollipop from the element's bottom
+    // edge, which is then the upper edge on screen. The stem goes with it, so it now rises
+    // from the pill to the edge below. alignControlFrameWithActiveElement adds this class.
+    &.rotate-handle-on-bottom-edge .bloom-ui-canvas-element-rotate-handle {
+        top: auto;
+        bottom: -(@rotateHandleDiameter + @rotateHandleStemLength);
+        &:before {
+            top: auto;
+            bottom: 100%;
+        }
+    }
+
     &.bloom-ui-canvas-element-show-move-crop-handle
         .bloom-ui-canvas-element-move-crop-handle {
         display: block;
@@ -1840,9 +1854,17 @@ svg.bloom-videoControl {
     }
 }
 
+// The browser gives a turned canvas element no :hover, because the comicaljs canvas covers it
+// and takes the pointer. So everywhere these rules ask for :hover on a video, they also accept
+// bloom-pointer-inside, which CanvasElementPointerInteractions puts on the turned element the
+// pointer is really inside. See kPointerInsideClass in canvasElementRotation.ts (BL-16741).
+@pointerInsideTurnedElement: ~".bloom-canvas-element.bloom-pointer-inside";
+
 // Show pause and replay when playing and hovered
 // (except for when we put bloom-ui-no-controls on draggable videos in Play Mode because there they can't be paused)
-.bloom-videoContainer.playing:hover:not(:has(video.bloom-ui-no-controls)) {
+.bloom-videoContainer.playing:hover:not(:has(video.bloom-ui-no-controls)),
+@{pointerInsideTurnedElement}
+    .bloom-videoContainer.playing:not(:has(video.bloom-ui-no-controls)) {
     .bloom-videoControlContainer {
         &.bloom-videoPauseIcon,
         &.bloom-videoReplayIcon {
@@ -1852,7 +1874,8 @@ svg.bloom-videoControl {
 }
 
 // Show play, centered, when hovering a video that is not paused or playing
-.bloom-videoContainer:not(.paused):not(.playing):hover {
+.bloom-videoContainer:not(.paused):not(.playing):hover,
+@{pointerInsideTurnedElement} .bloom-videoContainer:not(.paused):not(.playing) {
     .bloom-videoPlayIcon {
         display: flex;
         left: calc(50% - @videoIconSize / 2);
@@ -1867,7 +1890,10 @@ svg.bloom-videoControl {
 // (This rule would be more at home in Games.less, but we don't need any other Game-specific
 // rules about the video controls, so I think it's more helpful to keep it with the rules
 // it modifies.)
-.drag-activity-play .bloom-videoContainer:not(.paused):not(.playing):hover {
+.drag-activity-play .bloom-videoContainer:not(.paused):not(.playing):hover,
+.drag-activity-play
+    @{pointerInsideTurnedElement}
+    .bloom-videoContainer:not(.paused):not(.playing) {
     .bloom-videoPlayIcon {
         display: none;
     }

--- a/src/BloomBrowserUI/bookEdit/css/editMode.less
+++ b/src/BloomBrowserUI/bookEdit/css/editMode.less
@@ -1490,6 +1490,11 @@ canvas.moving {
 @resizeHandleRadius: 8px;
 @sideHandleRadius: 4px;
 @sideHandleCenter: 6px;
+// The rotate handle is a small pill on the end of a short stem, above the middle of the top
+// edge of the control frame. We put it outside the frame because the middle of every side
+// inside the frame is already a crop handle.
+@rotateHandleDiameter: 18px;
+@rotateHandleStemLength: 20px;
 // We place this frame over each canvas element to support resizing and cropping.
 // The frame itself is invisible (and ignores pointer events), but it provides a container
 // for the resize and crop handles and the toolbox below.
@@ -1524,7 +1529,8 @@ canvas.moving {
     // (except for the resize or crop control we are operating).
     &.moving {
         .bloom-ui-canvas-element-resize-handle,
-        .bloom-ui-canvas-element-side-handle {
+        .bloom-ui-canvas-element-side-handle,
+        .bloom-ui-canvas-element-rotate-handle {
             display: none;
             &.active-control {
                 display: block;
@@ -1626,6 +1632,59 @@ canvas.moving {
         left: calc(50% - @resizeHandleRadius);
         display: none;
         cursor: move;
+    }
+
+    // The rotate handle. It is only shown for the canvas elements we can turn: an element
+    // whose bubble outline is drawn by comicaljs cannot turn, because that drawing stays
+    // upright, and neither can a background image, which fills its bloom-canvas.
+    // The frame carries the same rotation as its element, so the handle orbits with it and
+    // always shows which way is up for the element.
+    .bloom-ui-canvas-element-rotate-handle {
+        display: none;
+        position: absolute;
+        width: @rotateHandleDiameter;
+        height: @rotateHandleDiameter;
+        top: -(@rotateHandleDiameter + @rotateHandleStemLength);
+        left: calc(50% - @rotateHandleDiameter / 2);
+        border-radius: 50%;
+        background-color: white;
+        border: 1px solid var(--canvas-element-control-color);
+        box-sizing: border-box;
+        pointer-events: all;
+        cursor: grab;
+        &.active-control {
+            cursor: grabbing;
+        }
+        &.active-control,
+        &:hover {
+            background-color: var(--canvas-element-control-color);
+        }
+        // the icon in the knob, which tells the user what the knob does. The mouse events
+        // belong to the knob, so the icon must not take any of them.
+        svg {
+            display: block;
+            width: 100%;
+            height: 100%;
+            fill: var(--canvas-element-control-color);
+            pointer-events: none;
+        }
+        &.active-control svg,
+        &:hover svg {
+            fill: white;
+        }
+        // the stem, joining the pill to the top edge of the frame
+        &:before {
+            content: "";
+            position: absolute;
+            left: calc(50% - 0.5px);
+            top: 100%;
+            width: 1px;
+            height: @rotateHandleStemLength;
+            background-color: var(--canvas-element-control-color);
+        }
+    }
+    &.can-rotate:not(.moving) .bloom-ui-canvas-element-rotate-handle {
+        display: block;
     }
 
     &.bloom-ui-canvas-element-show-move-crop-handle

--- a/src/BloomBrowserUI/bookEdit/js/ImageUndoManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/ImageUndoManager.ts
@@ -16,6 +16,15 @@ export interface IImageCropInfo {
     top: string;
 }
 
+// The inline size and place of a canvas element box, as written, so that an undo can put back
+// exactly what was there, including nothing at all.
+export interface IElementGeometry {
+    width: string;
+    height: string;
+    left: string;
+    top: string;
+}
+
 type ImageOperationUndoItem =
     | {
           kind: "restoreImage";
@@ -24,9 +33,11 @@ type ImageOperationUndoItem =
           cropInfo: IImageCropInfo;
       }
     // Rotate right, Flip, and a drag of the rotation handle. The picture keeps its file and
-    // its metadata, so the only things to put back are the rotation of the canvas element
-    // box, the turn and mirror of the picture, and the crop, which a turn of the picture
-    // removes. There is no img when the rotation handle turns a text box or a video.
+    // its metadata, so the things to put back are the rotation of the canvas element box, the
+    // turn and mirror of the picture, the crop, and the size and place of the box itself: a
+    // turn of a page background picture changes the shape of its box, because the box takes the
+    // shape of the picture. There is no img when the rotation handle turns a text box or a
+    // video.
     | {
           kind: "restoreImageTransform";
           canvasElement: HTMLElement;
@@ -34,6 +45,7 @@ type ImageOperationUndoItem =
           elementRotation: number;
           imageTransform: string;
           cropInfo: IImageCropInfo;
+          elementGeometry: IElementGeometry;
       };
 // | {
 //       kind: "removeElement";
@@ -122,6 +134,12 @@ export class ImageUndoManager {
                 height: img?.style.height ?? "",
                 left: img?.style.left ?? "",
                 top: img?.style.top ?? "",
+            },
+            elementGeometry: {
+                width: canvasElement.style.width,
+                height: canvasElement.style.height,
+                left: canvasElement.style.left,
+                top: canvasElement.style.top,
             },
         });
     }
@@ -219,6 +237,13 @@ export class ImageUndoManager {
                     undoItem.img.style.left = undoItem.cropInfo.left;
                     undoItem.img.style.top = undoItem.cropInfo.top;
                 }
+                undoItem.canvasElement.style.width =
+                    undoItem.elementGeometry.width;
+                undoItem.canvasElement.style.height =
+                    undoItem.elementGeometry.height;
+                undoItem.canvasElement.style.left =
+                    undoItem.elementGeometry.left;
+                undoItem.canvasElement.style.top = undoItem.elementGeometry.top;
                 // This also tells the tool panel about the change.
                 this.host.updateCanvasElementAfterTransformChange(
                     undoItem.canvasElement,

--- a/src/BloomBrowserUI/bookEdit/js/ImageUndoManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/ImageUndoManager.ts
@@ -4,6 +4,10 @@ import {
     notifyToolOfChangedImage,
 } from "./bloomEditing";
 import { normalizeCoverImageDesignation } from "./bloomImages";
+import {
+    getCanvasElementRotation,
+    setCanvasElementRotation,
+} from "./canvasElementManager/canvasElementRotation";
 
 export interface IImageCropInfo {
     width: string;
@@ -12,12 +16,24 @@ export interface IImageCropInfo {
     top: string;
 }
 
-type ImageOperationUndoItem = {
-    kind: "restoreImage";
-    element: HTMLElement;
-    imageInfo: IImageInfo;
-    cropInfo: IImageCropInfo;
-};
+type ImageOperationUndoItem =
+    | {
+          kind: "restoreImage";
+          element: HTMLElement;
+          imageInfo: IImageInfo;
+          cropInfo: IImageCropInfo;
+      }
+    // Rotate right and Flip. The picture keeps its file and its metadata, so the only things
+    // to put back are the rotation of the canvas element box, the turn and mirror of the
+    // picture, and the crop, which a turn of the picture removes.
+    | {
+          kind: "restoreImageTransform";
+          canvasElement: HTMLElement;
+          img: HTMLImageElement;
+          elementRotation: number;
+          imageTransform: string;
+          cropInfo: IImageCropInfo;
+      };
 // | {
 //       kind: "removeElement";
 //       element: HTMLElement;
@@ -27,6 +43,12 @@ export interface ImageUndoManagerHost {
     updateCanvasElementForChangedImage(
         imgOrImageContainer: HTMLElement,
         cropInfo?: IImageCropInfo,
+    ): void;
+    // Put the frame, the game target and the tool panel back in step after an undo that only
+    // changed a rotation, a mirror or a crop.
+    updateCanvasElementAfterTransformChange(
+        canvasElement: HTMLElement,
+        img: HTMLImageElement,
     ): void;
     getActiveElement(): HTMLElement | undefined;
     setActiveElement(element: HTMLElement | undefined): void;
@@ -53,6 +75,32 @@ export class ImageUndoManager {
             imageInfo: this.getCurrentImageInfo(imageOrContainer),
             cropInfo: this.getCurrentImageCropInfo(imageOrContainer),
         };
+    }
+
+    /**
+     * Record what Rotate right or Flip is about to change, so that Undo can put it back. This
+     * is one phase, not two: the command cannot fail or be canceled, so there is nothing to
+     * wait for before we keep the record.
+     */
+    public pushUndoForImageTransform(canvasElement: HTMLElement): void {
+        this.clearImageOperationUndoOnPageChange();
+        const img = this.getImageElement(canvasElement);
+        if (!img) {
+            return;
+        }
+        this.imageOperationUndoStack.push({
+            kind: "restoreImageTransform",
+            canvasElement,
+            img,
+            elementRotation: getCanvasElementRotation(canvasElement),
+            imageTransform: img.style.transform,
+            cropInfo: {
+                width: img.style.width,
+                height: img.style.height,
+                left: img.style.left,
+                top: img.style.top,
+            },
+        });
     }
 
     /** Clear all pending/recorded image operation undo state. */
@@ -122,6 +170,23 @@ export class ImageUndoManager {
                 }
                 const img = this.getImageElement(undoItem.element);
                 notifyToolOfChangedImage(img);
+                return true;
+            }
+            case "restoreImageTransform": {
+                setCanvasElementRotation(
+                    undoItem.canvasElement,
+                    undoItem.elementRotation,
+                );
+                undoItem.img.style.transform = undoItem.imageTransform;
+                undoItem.img.style.width = undoItem.cropInfo.width;
+                undoItem.img.style.height = undoItem.cropInfo.height;
+                undoItem.img.style.left = undoItem.cropInfo.left;
+                undoItem.img.style.top = undoItem.cropInfo.top;
+                // This also tells the tool panel about the change.
+                this.host.updateCanvasElementAfterTransformChange(
+                    undoItem.canvasElement,
+                    undoItem.img,
+                );
                 return true;
             }
             // case "removeElement": {
@@ -214,6 +279,10 @@ export function prepareUndoForImageOperation(
     imageOrContainer: HTMLElement,
 ): void {
     getImageUndoManager().prepareUndoForImageOperation(imageOrContainer);
+}
+
+export function pushUndoForImageTransform(canvasElement: HTMLElement): void {
+    getImageUndoManager().pushUndoForImageTransform(canvasElement);
 }
 
 export function clearImageOperationUndoState(): void {

--- a/src/BloomBrowserUI/bookEdit/js/ImageUndoManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/ImageUndoManager.ts
@@ -23,13 +23,14 @@ type ImageOperationUndoItem =
           imageInfo: IImageInfo;
           cropInfo: IImageCropInfo;
       }
-    // Rotate right and Flip. The picture keeps its file and its metadata, so the only things
-    // to put back are the rotation of the canvas element box, the turn and mirror of the
-    // picture, and the crop, which a turn of the picture removes.
+    // Rotate right, Flip, and a drag of the rotation handle. The picture keeps its file and
+    // its metadata, so the only things to put back are the rotation of the canvas element
+    // box, the turn and mirror of the picture, and the crop, which a turn of the picture
+    // removes. There is no img when the rotation handle turns a text box or a video.
     | {
           kind: "restoreImageTransform";
           canvasElement: HTMLElement;
-          img: HTMLImageElement;
+          img: HTMLImageElement | undefined;
           elementRotation: number;
           imageTransform: string;
           cropInfo: IImageCropInfo;
@@ -48,7 +49,7 @@ export interface ImageUndoManagerHost {
     // changed a rotation, a mirror or a crop.
     updateCanvasElementAfterTransformChange(
         canvasElement: HTMLElement,
-        img: HTMLImageElement,
+        img: HTMLImageElement | undefined,
     ): void;
     getActiveElement(): HTMLElement | undefined;
     setActiveElement(element: HTMLElement | undefined): void;
@@ -83,22 +84,44 @@ export class ImageUndoManager {
      * wait for before we keep the record.
      */
     public pushUndoForImageTransform(canvasElement: HTMLElement): void {
+        this.pushTransformUndo(
+            canvasElement,
+            getCanvasElementRotation(canvasElement),
+        );
+    }
+
+    /**
+     * Record a drag of the rotation handle, so that Undo can put the angle back. The caller
+     * gives the angle the element had when the drag started, because by the time the drag
+     * ends the element is already turned. It calls this only when the angle really changed,
+     * so a click on the handle leaves nothing for Undo to do.
+     */
+    public pushUndoForCanvasElementRotation(
+        canvasElement: HTMLElement,
+        rotationBeforeDrag: number,
+    ): void {
+        this.pushTransformUndo(canvasElement, rotationBeforeDrag);
+    }
+
+    private pushTransformUndo(
+        canvasElement: HTMLElement,
+        elementRotation: number,
+    ): void {
         this.clearImageOperationUndoOnPageChange();
+        // A rotation handle turns text boxes and videos as well, so there is not always a
+        // picture. The turn and the crop of the picture are only in the record when there is.
         const img = this.getImageElement(canvasElement);
-        if (!img) {
-            return;
-        }
         this.imageOperationUndoStack.push({
             kind: "restoreImageTransform",
             canvasElement,
             img,
-            elementRotation: getCanvasElementRotation(canvasElement),
-            imageTransform: img.style.transform,
+            elementRotation,
+            imageTransform: img?.style.transform ?? "",
             cropInfo: {
-                width: img.style.width,
-                height: img.style.height,
-                left: img.style.left,
-                top: img.style.top,
+                width: img?.style.width ?? "",
+                height: img?.style.height ?? "",
+                left: img?.style.left ?? "",
+                top: img?.style.top ?? "",
             },
         });
     }
@@ -137,6 +160,18 @@ export class ImageUndoManager {
     public canUndoImageOperation(): boolean {
         this.clearImageOperationUndoOnPageChange();
         const activeElement = this.host.getActiveElement();
+        const topOfStack =
+            this.imageOperationUndoStack[
+                this.imageOperationUndoStack.length - 1
+            ];
+        if (topOfStack?.kind === "restoreImageTransform") {
+            // The rotation handle turns text boxes and videos too, so this record does not
+            // need a picture. We ask instead that the element it belongs to is the selected
+            // one, which is the same idea as one undo stack for each text box.
+            return (
+                !!activeElement && activeElement === topOfStack.canvasElement
+            );
+        }
         let onImageContainer = false;
         if (activeElement) {
             onImageContainer =
@@ -177,11 +212,13 @@ export class ImageUndoManager {
                     undoItem.canvasElement,
                     undoItem.elementRotation,
                 );
-                undoItem.img.style.transform = undoItem.imageTransform;
-                undoItem.img.style.width = undoItem.cropInfo.width;
-                undoItem.img.style.height = undoItem.cropInfo.height;
-                undoItem.img.style.left = undoItem.cropInfo.left;
-                undoItem.img.style.top = undoItem.cropInfo.top;
+                if (undoItem.img) {
+                    undoItem.img.style.transform = undoItem.imageTransform;
+                    undoItem.img.style.width = undoItem.cropInfo.width;
+                    undoItem.img.style.height = undoItem.cropInfo.height;
+                    undoItem.img.style.left = undoItem.cropInfo.left;
+                    undoItem.img.style.top = undoItem.cropInfo.top;
+                }
                 // This also tells the tool panel about the change.
                 this.host.updateCanvasElementAfterTransformChange(
                     undoItem.canvasElement,
@@ -283,6 +320,16 @@ export function prepareUndoForImageOperation(
 
 export function pushUndoForImageTransform(canvasElement: HTMLElement): void {
     getImageUndoManager().pushUndoForImageTransform(canvasElement);
+}
+
+export function pushUndoForCanvasElementRotation(
+    canvasElement: HTMLElement,
+    rotationBeforeDrag: number,
+): void {
+    getImageUndoManager().pushUndoForCanvasElementRotation(
+        canvasElement,
+        rotationBeforeDrag,
+    );
 }
 
 export function clearImageOperationUndoState(): void {

--- a/src/BloomBrowserUI/bookEdit/js/ImageUndoManagerSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/ImageUndoManagerSpec.ts
@@ -4,6 +4,7 @@ import {
     ImageUndoManager,
     ImageUndoManagerHost,
 } from "./ImageUndoManager";
+import { setCanvasElementRotation } from "./canvasElementManager/canvasElementRotation";
 
 describe("ImageUndoManager crop preservation", () => {
     let manager: ImageUndoManager;
@@ -148,7 +149,7 @@ describe("ImageUndoManager rotate and flip", () => {
     let manager: ImageUndoManager;
     let updateAfterTransform: (
         canvasElement: HTMLElement,
-        img: HTMLImageElement,
+        img: HTMLImageElement | undefined,
     ) => void;
     let canvasElement: HTMLElement;
     let imgElement: HTMLImageElement;
@@ -255,5 +256,78 @@ describe("ImageUndoManager rotate and flip", () => {
 
         expect(manager.undoImageOperation()).toBe(true);
         expect(manager.undoImageOperation()).toBe(false);
+    });
+});
+
+describe("ImageUndoManager rotation handle drag", () => {
+    let manager: ImageUndoManager;
+    let updateAfterTransform: (
+        canvasElement: HTMLElement,
+        img: HTMLImageElement | undefined,
+    ) => void;
+    let activeElement: HTMLElement | undefined;
+    let page: HTMLElement;
+
+    // A drag of the rotation handle records the angle the element had before the drag, so
+    // the tests set the new angle first and then push the old one, as the drag does.
+    beforeEach(() => {
+        updateAfterTransform = vi.fn();
+        activeElement = undefined;
+        const hostMock: Partial<ImageUndoManagerHost> = {
+            getCurrentPage: () =>
+                document.querySelector<HTMLElement>(".bloom-page") || undefined,
+            updateCanvasElementAfterTransformChange: updateAfterTransform,
+            getActiveElement: () => activeElement,
+            setActiveElement: vi.fn(),
+            removeDetachedTargets: vi.fn(),
+            updateCanvasElementClass: vi.fn(),
+        };
+        manager = new ImageUndoManager(hostMock as ImageUndoManagerHost);
+
+        document.body.innerHTML = "";
+        page = document.createElement("div");
+        page.className = "bloom-page";
+        page.setAttribute("data-page-id", "drag-test-page");
+        document.body.appendChild(page);
+    });
+
+    function makeTextCanvasElement(): HTMLElement {
+        const element = document.createElement("div");
+        element.className = "bloom-canvas-element";
+        const editable = document.createElement("div");
+        editable.className = "bloom-editable";
+        editable.textContent = "some words";
+        element.appendChild(editable);
+        page.appendChild(element);
+        return element;
+    }
+
+    it("undo puts back the angle a text box had before the drag", () => {
+        const textBox = makeTextCanvasElement();
+        setCanvasElementRotation(textBox, 10);
+        expect(textBox.style.transform).toBe("rotate(10deg)");
+
+        // The drag turns the box, then records where it started.
+        setCanvasElementRotation(textBox, 75);
+        manager.pushUndoForCanvasElementRotation(textBox, 10);
+        expect(textBox.style.transform).toBe("rotate(75deg)");
+
+        expect(manager.undoImageOperation()).toBe(true);
+        expect(textBox.style.transform).toBe("rotate(10deg)");
+        expect(updateAfterTransform).toHaveBeenCalledWith(textBox, undefined);
+    });
+
+    it("a rotated text box is undoable while it is the selected element", () => {
+        const textBox = makeTextCanvasElement();
+        const otherBox = makeTextCanvasElement();
+        setCanvasElementRotation(textBox, 45);
+        manager.pushUndoForCanvasElementRotation(textBox, 0);
+
+        activeElement = textBox;
+        expect(manager.canUndoImageOperation()).toBe(true);
+
+        // Another element is selected, so this undo belongs to nothing the user is looking at.
+        activeElement = otherBox;
+        expect(manager.canUndoImageOperation()).toBe(false);
     });
 });

--- a/src/BloomBrowserUI/bookEdit/js/ImageUndoManagerSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/ImageUndoManagerSpec.ts
@@ -143,3 +143,117 @@ describe("ImageUndoManager crop preservation", () => {
         expect(imgElement.style.left).toBe("");
     });
 });
+
+describe("ImageUndoManager rotate and flip", () => {
+    let manager: ImageUndoManager;
+    let updateAfterTransform: (
+        canvasElement: HTMLElement,
+        img: HTMLImageElement,
+    ) => void;
+    let canvasElement: HTMLElement;
+    let imgElement: HTMLImageElement;
+
+    beforeEach(() => {
+        updateAfterTransform = vi.fn();
+        const hostMock: Partial<ImageUndoManagerHost> = {
+            getCurrentPage: () =>
+                document.querySelector<HTMLElement>(".bloom-page") || undefined,
+            updateCanvasElementAfterTransformChange: updateAfterTransform,
+            getActiveElement: vi.fn(() => undefined),
+            setActiveElement: vi.fn(),
+            removeDetachedTargets: vi.fn(),
+            updateCanvasElementClass: vi.fn(),
+        };
+        manager = new ImageUndoManager(hostMock as ImageUndoManagerHost);
+
+        document.body.innerHTML = "";
+        const page = document.createElement("div");
+        page.className = "bloom-page";
+        page.setAttribute("data-page-id", "rotate-test-page");
+        document.body.appendChild(page);
+
+        canvasElement = document.createElement("div");
+        canvasElement.className = "bloom-canvas-element";
+        page.appendChild(canvasElement);
+
+        const container = document.createElement("div");
+        container.className = "bloom-imageContainer";
+        canvasElement.appendChild(container);
+
+        imgElement = document.createElement("img");
+        imgElement.src = "test-image.png";
+        container.appendChild(imgElement);
+    });
+
+    it("undo puts back the rotation of the canvas element box", () => {
+        canvasElement.style.transform = "rotate(30deg)";
+        canvasElement.classList.add("bloom-rotated");
+
+        manager.pushUndoForImageTransform(canvasElement);
+
+        // Rotate right turns the box by another quarter turn.
+        canvasElement.style.transform = "rotate(120deg)";
+        expect(canvasElement.style.transform).toBe("rotate(120deg)");
+
+        expect(manager.undoImageOperation()).toBe(true);
+        expect(canvasElement.style.transform).toBe("rotate(30deg)");
+        expect(canvasElement.classList.contains("bloom-rotated")).toBe(true);
+        expect(updateAfterTransform).toHaveBeenCalledWith(
+            canvasElement,
+            imgElement,
+        );
+    });
+
+    it("undo of a rotation back to upright leaves no transform behind", () => {
+        manager.pushUndoForImageTransform(canvasElement);
+        canvasElement.style.transform = "rotate(90deg)";
+        canvasElement.classList.add("bloom-rotated");
+
+        expect(manager.undoImageOperation()).toBe(true);
+        expect(canvasElement.style.transform).toBe("");
+        expect(canvasElement.classList.contains("bloom-rotated")).toBe(false);
+    });
+
+    it("undo puts back the turn of the picture and the crop that the turn removed", () => {
+        imgElement.style.width = "150px";
+        imgElement.style.height = "120px";
+        imgElement.style.left = "-25px";
+        imgElement.style.top = "-30px";
+
+        manager.pushUndoForImageTransform(canvasElement);
+
+        // Rotate right on a background image turns the picture and drops the crop.
+        imgElement.style.transform = "rotate(90deg) scale(0.667, 0.667)";
+        imgElement.style.width = "";
+        imgElement.style.height = "";
+        imgElement.style.left = "";
+        imgElement.style.top = "";
+
+        expect(manager.undoImageOperation()).toBe(true);
+        expect(imgElement.style.transform).toBe("");
+        expect(imgElement.style.width).toBe("150px");
+        expect(imgElement.style.height).toBe("120px");
+        expect(imgElement.style.left).toBe("-25px");
+        expect(imgElement.style.top).toBe("-30px");
+    });
+
+    it("undo puts back the mirror of the picture", () => {
+        imgElement.style.transform = "scale(-1, 1)";
+
+        manager.pushUndoForImageTransform(canvasElement);
+
+        // Flip horizontal on a picture that is already mirrored puts it back.
+        imgElement.style.transform = "";
+
+        expect(manager.undoImageOperation()).toBe(true);
+        expect(imgElement.style.transform).toBe("scale(-1, 1)");
+    });
+
+    it("a second undo does nothing, because there is only one record", () => {
+        manager.pushUndoForImageTransform(canvasElement);
+        canvasElement.style.transform = "rotate(90deg)";
+
+        expect(manager.undoImageOperation()).toBe(true);
+        expect(manager.undoImageOperation()).toBe(false);
+    });
+});

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -327,6 +327,29 @@ function AddEditKeyHandlers(container) {
             hideInvisibles(e);
         });
 
+    addDocumentKeyHandlers();
+
+    // Note, CTRL+N is also caught, but up on the Shell where it is turned into an event,
+    // so that it can be caught even when the focus isn't on the browser
+}
+
+// Add the key handlers that listen on the whole document rather than on one element.
+// AddEditKeyHandlers runs again every time a canvas element is added, because SetupElements
+// does, so a handler bound here without this guard would be bound once more each time and
+// would then run several times for one key press. That did no harm while every command here
+// was one that gives the same result however often it runs, but Rotate right is not such a
+// command: it would turn the picture a quarter turn for each copy and leave that many steps
+// on the undo stack. The mark goes on the document object, not in the page, so a page the
+// user moves to gets its own handlers and nothing is written into the book.
+function addDocumentKeyHandlers(): void {
+    const documentWithMark = document as Document & {
+        bloomDocumentKeyHandlersAdded?: boolean;
+    };
+    if (documentWithMark.bloomDocumentKeyHandlersAdded) {
+        return;
+    }
+    documentWithMark.bloomDocumentKeyHandlersAdded = true;
+
     // Ctrl+Space: "clear formatting" on the current selection. We route this through the CKEditor
     // instance that currently has focus (rather than the browser's document.execCommand) so that
     // (a) it uses our removeFormat configuration/filter, which strips exactly the inline formatting
@@ -375,9 +398,6 @@ function AddEditKeyHandlers(container) {
             return;
         }
     });
-
-    // Note, CTRL+N is also caught, but up on the Shell where it is turned into an event,
-    // so that it can be caught even when the focus isn't on the browser
 }
 
 // Add little language tags. (At one point we limited this to visible .bloom-editable divs,

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -13,6 +13,7 @@ import {
     SetupMetadataButton,
     SetupResizableElement,
     SetupImagesInContainer,
+    kImageContainerClass,
 } from "./bloomImages";
 import {
     removeTransientVideoTimestampParams,
@@ -197,6 +198,41 @@ function SetupDeletable(containerDiv) {
     return $(containerDiv);
 }
 
+// True if the user is typing somewhere, so a shortcut must not take a key away from them.
+function isTypingInText(): boolean {
+    const target = document.activeElement as HTMLElement | null;
+    if (!target) {
+        return false;
+    }
+    return (
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable
+    );
+}
+
+// Carry out the Rotate Right command on the selected canvas element, if it holds a picture
+// the user is allowed to change. Answers whether it did anything, so the caller can fall
+// back to another meaning for the same shortcut.
+function rotateSelectedImageRight(): boolean {
+    if (!theOneCanvasElementManager?.isCanvasElementEditingOn) {
+        return false;
+    }
+    const activeElement = theOneCanvasElementManager.getActiveElement();
+    if (!activeElement) {
+        return false;
+    }
+    const imageContainer =
+        activeElement.getElementsByClassName(kImageContainerClass)[0];
+    if (
+        !imageContainer ||
+        imageContainer.classList.contains("bloom-unmodifiable-image")
+    ) {
+        return false;
+    }
+    return theOneCanvasElementManager.rotateActiveImageRight();
+}
+
 // Add various editing key handlers
 function AddEditKeyHandlers(container) {
     //Make F6 apply a superscript style (later we'll change to ctrl+shift+plus, as word does. But capturing those in js by hand is a pain.
@@ -300,9 +336,15 @@ function AddEditKeyHandlers(container) {
     });
 
     $(document).on("keydown", (e) => {
-        // Ctrl+R: right justify
+        // Ctrl+R: rotate the selected image a quarter turn clockwise, or, when no image is
+        // selected, right justify. The two commands share the shortcut because they can
+        // never apply at once: right justify needs the caret in text, and the rotate
+        // command needs a selected canvas element that holds a picture.
         if (e.ctrlKey && !e.altKey && !e.shiftKey && e.key === "r") {
             e.preventDefault();
+            if (!isTypingInText() && rotateSelectedImageRight()) {
+                return;
+            }
             document.execCommand("justifyright", false);
             return;
         }

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -32,6 +32,7 @@ import {
     initializeCanvasElementManager,
     theOneCanvasElementManager,
 } from "./canvasElementManager/CanvasElementManager";
+import { kPointerInsideClass } from "./canvasElementManager/canvasElementRotation";
 import { getCanvasElementManager } from "../toolbox/canvas/canvasElementPageBridge";
 import {
     canUndoImageOperation,
@@ -149,6 +150,9 @@ function Cleanup() {
         $(this).removeClass("ui-resizable");
         // obsolete, but we'll keep the cleanup for a while
         $(this).removeClass("hoverUp");
+        // Marks the turned canvas element the pointer is inside, so it means nothing once the
+        // page is saved. See kPointerInsideClass in canvasElementRotation.ts.
+        $(this).removeClass(kPointerInsideClass);
     });
     $("span").each(function () {
         $(this).removeClass("ui-disableHighlight");

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -13,8 +13,6 @@ import {
     SetupMetadataButton,
     SetupResizableElement,
     SetupImagesInContainer,
-    isPlaceHolderImage,
-    kImageContainerClass,
 } from "./bloomImages";
 import {
     removeTransientVideoTimestampParams,
@@ -199,48 +197,6 @@ function SetupDeletable(containerDiv) {
     return $(containerDiv);
 }
 
-// True if the user is typing somewhere, so a shortcut must not take a key away from them.
-function isTypingInText(): boolean {
-    const target = document.activeElement as HTMLElement | null;
-    if (!target) {
-        return false;
-    }
-    return (
-        target.tagName === "INPUT" ||
-        target.tagName === "TEXTAREA" ||
-        target.isContentEditable
-    );
-}
-
-// Carry out the Rotate Right command on the selected canvas element, if it holds a picture
-// the user is allowed to change. Answers whether it did anything, so the caller can fall
-// back to another meaning for the same shortcut.
-function rotateSelectedImageRight(): boolean {
-    if (!theOneCanvasElementManager?.isCanvasElementEditingOn) {
-        return false;
-    }
-    const activeElement = theOneCanvasElementManager.getActiveElement();
-    if (!activeElement) {
-        return false;
-    }
-    const imageContainer =
-        activeElement.getElementsByClassName(kImageContainerClass)[0];
-    if (
-        !imageContainer ||
-        imageContainer.classList.contains("bloom-unmodifiable-image")
-    ) {
-        return false;
-    }
-    // The Rotate Right menu item is offered only for a real picture, so the shortcut must
-    // ask for one too. Without this, Ctrl+R turns a box that still holds the grey
-    // placeholder and puts a step on the undo stack for it.
-    const img = imageContainer.getElementsByTagName("img")[0];
-    if (!img || isPlaceHolderImage(img.getAttribute("src"))) {
-        return false;
-    }
-    return theOneCanvasElementManager.rotateActiveImageRight();
-}
-
 // Add various editing key handlers
 function AddEditKeyHandlers(container) {
     //Make F6 apply a superscript style (later we'll change to ctrl+shift+plus, as word does. But capturing those in js by hand is a pain.
@@ -336,11 +292,11 @@ function AddEditKeyHandlers(container) {
 // Add the key handlers that listen on the whole document rather than on one element.
 // AddEditKeyHandlers runs again every time a canvas element is added, because SetupElements
 // does, so a handler bound here without this guard would be bound once more each time and
-// would then run several times for one key press. That did no harm while every command here
-// was one that gives the same result however often it runs, but Rotate right is not such a
-// command: it would turn the picture a quarter turn for each copy and leave that many steps
-// on the undo stack. The mark goes on the document object, not in the page, so a page the
-// user moves to gets its own handlers and nothing is written into the book.
+// would then run several times for one key press. Every command here gives the same result
+// however often it runs, so the copies did no visible harm, but a command that counts its
+// calls, such as one that puts a step on the undo stack, would be wrong for each extra copy.
+// The mark goes on the document object, not in the page, so a page the user moves to gets its
+// own handlers and nothing is written into the book.
 function addDocumentKeyHandlers(): void {
     const documentWithMark = document as Document & {
         bloomDocumentKeyHandlersAdded?: boolean;
@@ -367,15 +323,9 @@ function addDocumentKeyHandlers(): void {
     });
 
     $(document).on("keydown", (e) => {
-        // Ctrl+R: rotate the selected image a quarter turn clockwise, or, when no image is
-        // selected, right justify. The two commands share the shortcut because they can
-        // never apply at once: right justify needs the caret in text, and the rotate
-        // command needs a selected canvas element that holds a picture.
+        // Ctrl+R: right justify
         if (e.ctrlKey && !e.altKey && !e.shiftKey && e.key === "r") {
             e.preventDefault();
-            if (!isTypingInText() && rotateSelectedImageRight()) {
-                return;
-            }
             document.execCommand("justifyright", false);
             return;
         }

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -13,6 +13,7 @@ import {
     SetupMetadataButton,
     SetupResizableElement,
     SetupImagesInContainer,
+    isPlaceHolderImage,
     kImageContainerClass,
 } from "./bloomImages";
 import {
@@ -228,6 +229,13 @@ function rotateSelectedImageRight(): boolean {
         !imageContainer ||
         imageContainer.classList.contains("bloom-unmodifiable-image")
     ) {
+        return false;
+    }
+    // The Rotate Right menu item is offered only for a real picture, so the shortcut must
+    // ask for one too. Without this, Ctrl+R turns a box that still holds the grey
+    // placeholder and puts a step on the undo stack for it.
+    const img = imageContainer.getElementsByTagName("img")[0];
+    if (!img || isPlaceHolderImage(img.getAttribute("src"))) {
         return false;
     }
     return theOneCanvasElementManager.rotateActiveImageRight();

--- a/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
@@ -626,6 +626,23 @@ function isNearWhite(color: string): boolean {
 // Returns true when `color` is a non-empty, non-transparent, non-near-white CSS color string
 // — i.e., when a page with this background color needs image transparency applied.
 // Matches the behavior of the C# ImageUtils.ShouldMakeTransparentForPageBackground.
+/**
+ * Put the image's transparency back to "Auto": no explicit choice by the user, so the
+ * transparent parameter follows the page's own background color. The Transparency submenu's
+ * "Auto" item and the Reset Image command both use this.
+ */
+export function setImageTransparencyToAuto(img: HTMLElement): void {
+    img.classList.remove("bloom-transparent", "bloom-opaque");
+    const backgroundColor = getOwningPageBackgroundColor(img);
+    setImgTransparentParam(
+        img,
+        getImageTransparencyMode(
+            img,
+            pageBackgroundNeedsTransparency(backgroundColor),
+        ),
+    );
+}
+
 export function pageBackgroundNeedsTransparency(color: string): boolean {
     if (!color) return false;
     const normalized = normalizeCssColorToHexOrEmpty(color);

--- a/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
@@ -626,6 +626,13 @@ function isNearWhite(color: string): boolean {
 // Returns true when `color` is a non-empty, non-transparent, non-near-white CSS color string
 // — i.e., when a page with this background color needs image transparency applied.
 // Matches the behavior of the C# ImageUtils.ShouldMakeTransparentForPageBackground.
+export function pageBackgroundNeedsTransparency(color: string): boolean {
+    if (!color) return false;
+    const normalized = normalizeCssColorToHexOrEmpty(color);
+    if (!normalized) return false; // transparent / zero-alpha / no background
+    return !isNearWhite(normalized);
+}
+
 /**
  * Put the image's transparency back to "Auto": no explicit choice by the user, so the
  * transparent parameter follows the page's own background color. The Transparency submenu's
@@ -641,13 +648,6 @@ export function setImageTransparencyToAuto(img: HTMLElement): void {
             pageBackgroundNeedsTransparency(backgroundColor),
         ),
     );
-}
-
-export function pageBackgroundNeedsTransparency(color: string): boolean {
-    if (!color) return false;
-    const normalized = normalizeCssColorToHexOrEmpty(color);
-    if (!normalized) return false; // transparent / zero-alpha / no background
-    return !isNearWhite(normalized);
 }
 
 export function handleMouseEnterBloomCanvas(bloomCanvas: HTMLElement): void {

--- a/src/BloomBrowserUI/bookEdit/js/bloomVideo.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomVideo.ts
@@ -376,10 +376,25 @@ let currentVideoElement: HTMLVideoElement | null = null;
 // (This is also called by code in CanvasElementManager, when it determines that mouse activity
 // on the button SHOULD be considered a click, not a drag of the canvas element. The event is
 // then actually from the mouseup, and forcePlay is true.)
-export function handlePlayClick(ev: MouseEvent, forcePlay?: boolean) {
-    const video = (ev.target as HTMLElement)
+// The video one of the three buttons belongs to. Callers pass the button when the event's own
+// target is not it, which happens inside a turned canvas element: the comicaljs canvas covers
+// the buttons and is the target instead. See kPointerInsideClass in canvasElementRotation.ts
+// (BL-16741).
+function videoForButtonClick(
+    ev: MouseEvent,
+    button?: HTMLElement,
+): HTMLVideoElement | undefined {
+    return (button ?? (ev.target as HTMLElement))
         ?.closest(".bloom-videoContainer")
         ?.getElementsByTagName("video")[0];
+}
+
+export function handlePlayClick(
+    ev: MouseEvent,
+    forcePlay?: boolean,
+    button?: HTMLElement,
+) {
+    const video = videoForButtonClick(ev, button);
     if (!video) {
         return; // should not happen
     }
@@ -403,12 +418,10 @@ export function handlePlayClick(ev: MouseEvent, forcePlay?: boolean) {
     play(video);
 }
 
-function handleReplayClick(ev: MouseEvent) {
+export function handleReplayClick(ev: MouseEvent, button?: HTMLElement) {
     ev.stopPropagation();
     ev.preventDefault();
-    const video = (ev.target as HTMLElement)
-        ?.closest(".bloom-videoContainer")
-        ?.getElementsByTagName("video")[0];
+    const video = videoForButtonClick(ev, button);
     if (!video) {
         return; // should not happen
     }
@@ -422,12 +435,10 @@ function play(video: HTMLVideoElement) {
 
 // This is called when the user clicks the pause button on a video.
 // Unlike when pause is done from the control bar, we add a class that shows some buttons.
-function handlePauseClick(ev: MouseEvent) {
+export function handlePauseClick(ev: MouseEvent, button?: HTMLElement) {
     ev.stopPropagation();
     ev.preventDefault();
-    const video = (ev.target as HTMLElement)
-        ?.closest(".bloom-videoContainer")
-        ?.getElementsByTagName("video")[0];
+    const video = videoForButtonClick(ev, button);
     if (!video) return;
     // just possibly, the one we paused is not the one we most recently started playing.
     currentVideoElement = video;

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementHandleDragInteractions.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementHandleDragInteractions.ts
@@ -18,6 +18,7 @@ import {
     setCanvasElementRotation,
     unrotateVector,
 } from "./canvasElementRotation";
+import { pushUndoForCanvasElementRotation } from "../ImageUndoManager";
 
 export interface ICanvasElementHandleDragInteractionsHost {
     getActiveElement: () => HTMLElement | undefined;
@@ -228,6 +229,16 @@ export class CanvasElementHandleDragInteractions {
         this.host.stopMoving();
         const activeElement = this.host.getActiveElement();
         if (activeElement) {
+            // One record for the whole drag, and none at all if the element came back to the
+            // angle it started at, so that Undo always has something to put back.
+            if (
+                getCanvasElementRotation(activeElement) !== this.startRotation
+            ) {
+                pushUndoForCanvasElementRotation(
+                    activeElement,
+                    this.startRotation,
+                );
+            }
             this.host.adjustTarget(activeElement);
         }
         this.host.alignControlFrameWithActiveElement();

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementHandleDragInteractions.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementHandleDragInteractions.ts
@@ -48,14 +48,34 @@ export interface ICanvasElementHandleDragInteractionsHost {
     stopMoving: () => void;
 }
 
-// Which sides of a picture are cropped, in the coordinates of the canvas element that holds
-// it, so that the marks go on the right handles.
+// Where a picture lands inside the canvas element that holds it, in the element's own
+// coordinates.
 //
 // The picture's own box may be turned inside the element, by the Rotate Right command on a page
 // background. A CSS transform turns the box about its own centre and leaves the layout alone, so
 // what the element shows is a rectangle the size of the box with its two dimensions swapped for
-// an odd number of quarter turns, centred where the box's centre is. Comparing the box itself
-// against the element, as we may for an untuned picture, would mark every side of a turned one.
+// an odd number of quarter turns, centred where the layout put the box's centre. Every crop
+// measurement has to use this rectangle. The box itself, which the picture's `left`, `top` and
+// `width` describe, is the right answer only for a picture that is not turned.
+export function getShownContentRectangle(
+    boxLeft: number,
+    boxTop: number,
+    boxWidth: number,
+    boxHeight: number,
+    quarterTurns: number,
+): { left: number; top: number; width: number; height: number } {
+    const isQuarterTurn = quarterTurns % 2 === 1;
+    const width = isQuarterTurn ? boxHeight : boxWidth;
+    const height = isQuarterTurn ? boxWidth : boxHeight;
+    return {
+        left: boxLeft + boxWidth / 2 - width / 2,
+        top: boxTop + boxHeight / 2 - height / 2,
+        width,
+        height,
+    };
+}
+
+// Which sides of a picture are cropped, so that the marks go on the right handles.
 export function getCroppedSides(
     elementWidth: number,
     elementHeight: number,
@@ -67,16 +87,58 @@ export function getCroppedSides(
     // Client values are whole pixels, and rounding easily produces a spurious difference of one.
     slop = 1,
 ): { n: boolean; e: boolean; s: boolean; w: boolean } {
-    const isQuarterTurn = quarterTurns % 2 === 1;
-    const shownWidth = isQuarterTurn ? boxHeight : boxWidth;
-    const shownHeight = isQuarterTurn ? boxWidth : boxHeight;
-    const centreX = boxLeft + boxWidth / 2;
-    const centreY = boxTop + boxHeight / 2;
+    const shown = getShownContentRectangle(
+        boxLeft,
+        boxTop,
+        boxWidth,
+        boxHeight,
+        quarterTurns,
+    );
     return {
-        n: centreY - shownHeight / 2 < -slop,
-        e: centreX + shownWidth / 2 > elementWidth + slop,
-        s: centreY + shownHeight / 2 > elementHeight + slop,
-        w: centreX - shownWidth / 2 < -slop,
+        n: shown.top < -slop,
+        e: shown.left + shown.width > elementWidth + slop,
+        s: shown.top + shown.height > elementHeight + slop,
+        w: shown.left < -slop,
+    };
+}
+
+// Where to put a picture's box so that the picture keeps covering its canvas element while the
+// author drags it about inside the crop. The wanted position is what the pointer asks for; the
+// result is that position pulled back far enough that no blank band appears at an edge.
+//
+// The box is what we write, but the element shows the turned rectangle, so the limits belong to
+// that rectangle. On a picture whose two dimensions differ, and which is turned, the two frames
+// disagree by half the difference, which is enough to hold the picture still through a whole
+// drag.
+export function clampCropPosition(
+    elementWidth: number,
+    elementHeight: number,
+    wantedBoxLeft: number,
+    wantedBoxTop: number,
+    boxWidth: number,
+    boxHeight: number,
+    quarterTurns: number,
+): { left: number; top: number } {
+    const shown = getShownContentRectangle(
+        wantedBoxLeft,
+        wantedBoxTop,
+        boxWidth,
+        boxHeight,
+        quarterTurns,
+    );
+    const clampedShownLeft = Math.max(
+        Math.min(shown.left, 0),
+        elementWidth - shown.width,
+    );
+    const clampedShownTop = Math.max(
+        Math.min(shown.top, 0),
+        elementHeight - shown.height,
+    );
+    // The turn moves the box and the rectangle it shows by the same amount, so one difference
+    // carries the clamp back into the box's own frame.
+    return {
+        left: wantedBoxLeft + clampedShownLeft - shown.left,
+        top: wantedBoxTop + clampedShownTop - shown.top,
     };
 }
 
@@ -95,6 +157,7 @@ export class CanvasElementHandleDragInteractions {
     private oldTop: number;
     // The original size and position of the main img inside a canvas element being resized or cropped
     private oldImageWidth: number;
+    private oldImageHeight: number;
     private oldImageLeft: number;
     private oldImageTop: number;
     // during a resize drag, keeps track of which corner we're dragging
@@ -341,17 +404,14 @@ export class CanvasElementHandleDragInteractions {
         event.preventDefault();
         event.stopPropagation();
         const imgStyle = img.style;
-        const newLeft = Math.max(
-            Math.min(this.oldImageLeft + deltaX, 0),
-            activeElement.clientLeft +
-                activeElement.clientWidth -
-                img.clientWidth,
-        );
-        const newTop = Math.max(
-            Math.min(this.oldImageTop + deltaY, 0),
-            activeElement.clientTop +
-                activeElement.clientHeight -
-                img.clientHeight,
+        const { left: newLeft, top: newTop } = clampCropPosition(
+            activeElement.clientWidth,
+            activeElement.clientHeight,
+            this.oldImageLeft + deltaX,
+            this.oldImageTop + deltaY,
+            img.clientWidth,
+            img.clientHeight,
+            getImageContentTransform(img).quarterTurns,
         );
         imgStyle.left = newLeft + "px";
         imgStyle.top = newTop + "px";
@@ -648,6 +708,9 @@ export class CanvasElementHandleDragInteractions {
         if (img) {
             this.oldImageLeft = img.offsetLeft;
             this.oldImageTop = img.offsetTop;
+            // A side drag never writes the picture's own size, so these hold for the whole drag.
+            this.oldImageWidth = img.offsetWidth;
+            this.oldImageHeight = img.offsetHeight;
 
             if (this.lastCropControl !== event.currentTarget) {
                 this.initialCropImageWidth = img.offsetWidth;
@@ -851,6 +914,27 @@ export class CanvasElementHandleDragInteractions {
         const minWidth = this.host.getMinWidth();
         const minHeight = this.host.getMinHeight();
 
+        // How far each edge can travel is a property of the rectangle the element shows, not of
+        // the picture's own box, and the two differ on a turned picture. The n and w handles move
+        // the picture as well as the edge, so they measure from where the picture was when this
+        // drag began; the s and e handles leave the picture alone, so they measure from where it
+        // was when this handle was first taken hold of.
+        const quarterTurns = getImageContentTransform(img).quarterTurns;
+        const shownNow = getShownContentRectangle(
+            this.oldImageLeft,
+            this.oldImageTop,
+            this.oldImageWidth,
+            this.oldImageHeight,
+            quarterTurns,
+        );
+        const shownAtFirst = getShownContentRectangle(
+            this.initialCropImageLeft,
+            this.initialCropImageTop,
+            this.initialCropImageWidth,
+            this.initialCropImageHeight,
+            quarterTurns,
+        );
+
         switch (this.currentDragSide) {
             case "n":
                 deltaY = this.adjustDeltaForSnap(
@@ -859,8 +943,8 @@ export class CanvasElementHandleDragInteractions {
                     backgroundSnapDelta,
                     "n",
                 );
-                if (this.oldImageTop - deltaY > 0) {
-                    deltaY = this.oldImageTop;
+                if (shownNow.top - deltaY > 0) {
+                    deltaY = shownNow.top;
                 }
                 newCanvasElementHeight = Math.max(
                     this.oldHeight - deltaY,
@@ -879,13 +963,11 @@ export class CanvasElementHandleDragInteractions {
                     "s",
                 );
                 if (
-                    this.initialCropImageTop + this.initialCropImageHeight <
+                    shownAtFirst.top + shownAtFirst.height <
                     this.oldHeight + deltaY
                 ) {
                     deltaY =
-                        this.initialCropImageTop +
-                        this.initialCropImageHeight -
-                        this.oldHeight;
+                        shownAtFirst.top + shownAtFirst.height - this.oldHeight;
                 }
                 newCanvasElementHeight = Math.max(
                     this.oldHeight + deltaY,
@@ -902,13 +984,11 @@ export class CanvasElementHandleDragInteractions {
                     "e",
                 );
                 if (
-                    this.initialCropImageLeft + this.initialCropImageWidth <
+                    shownAtFirst.left + shownAtFirst.width <
                     this.oldWidth + deltaX
                 ) {
                     deltaX =
-                        this.initialCropImageLeft +
-                        this.initialCropImageWidth -
-                        this.oldWidth;
+                        shownAtFirst.left + shownAtFirst.width - this.oldWidth;
                 }
                 newCanvasElementWidth = Math.max(
                     this.oldWidth + deltaX,
@@ -924,8 +1004,8 @@ export class CanvasElementHandleDragInteractions {
                     backgroundSnapDelta,
                     "w",
                 );
-                if (this.oldImageLeft > deltaX) {
-                    deltaX = this.oldImageLeft;
+                if (shownNow.left > deltaX) {
+                    deltaX = shownNow.left;
                 }
                 newCanvasElementWidth = Math.max(
                     this.oldWidth - deltaX,

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementHandleDragInteractions.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementHandleDragInteractions.ts
@@ -19,6 +19,7 @@ import {
     unrotateVector,
 } from "./canvasElementRotation";
 import { pushUndoForCanvasElementRotation } from "../ImageUndoManager";
+import { getImageContentTransform } from "../imageContentTransform";
 
 export interface ICanvasElementHandleDragInteractionsHost {
     getActiveElement: () => HTMLElement | undefined;
@@ -45,6 +46,38 @@ export interface ICanvasElementHandleDragInteractionsHost {
 
     startMoving: () => void;
     stopMoving: () => void;
+}
+
+// Which sides of a picture are cropped, in the coordinates of the canvas element that holds
+// it, so that the marks go on the right handles.
+//
+// The picture's own box may be turned inside the element, by the Rotate Right command on a page
+// background. A CSS transform turns the box about its own centre and leaves the layout alone, so
+// what the element shows is a rectangle the size of the box with its two dimensions swapped for
+// an odd number of quarter turns, centred where the box's centre is. Comparing the box itself
+// against the element, as we may for an untuned picture, would mark every side of a turned one.
+export function getCroppedSides(
+    elementWidth: number,
+    elementHeight: number,
+    boxLeft: number,
+    boxTop: number,
+    boxWidth: number,
+    boxHeight: number,
+    quarterTurns: number,
+    // Client values are whole pixels, and rounding easily produces a spurious difference of one.
+    slop = 1,
+): { n: boolean; e: boolean; s: boolean; w: boolean } {
+    const isQuarterTurn = quarterTurns % 2 === 1;
+    const shownWidth = isQuarterTurn ? boxHeight : boxWidth;
+    const shownHeight = isQuarterTurn ? boxWidth : boxHeight;
+    const centreX = boxLeft + boxWidth / 2;
+    const centreY = boxTop + boxHeight / 2;
+    return {
+        n: centreY - shownHeight / 2 < -slop,
+        e: centreX + shownWidth / 2 > elementWidth + slop,
+        s: centreY + shownHeight / 2 > elementHeight + slop,
+        w: centreX - shownWidth / 2 < -slop,
+    };
 }
 
 export class CanvasElementHandleDragInteractions {
@@ -973,13 +1006,15 @@ export class CanvasElementHandleDragInteractions {
             imgLeft += e.offsetLeft;
             imgTop += e.offsetTop;
         }
-        const slop = 1;
-        const cropped = {
-            n: imgTop < -slop,
-            e: imgLeft + img.offsetWidth > activeElement.clientWidth + slop,
-            s: imgTop + img.offsetHeight > activeElement.clientHeight + slop,
-            w: imgLeft < -slop,
-        };
+        const cropped = getCroppedSides(
+            activeElement.clientWidth,
+            activeElement.clientHeight,
+            imgLeft,
+            imgTop,
+            img.offsetWidth,
+            img.offsetHeight,
+            getImageContentTransform(img).quarterTurns,
+        );
         sideHandles.forEach((handle) => {
             const longClass = Array.from(handle.classList).find((c) =>
                 c.startsWith("bloom-ui-canvas-element-side-handle-"),

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementHandleDragInteractions.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementHandleDragInteractions.ts
@@ -958,14 +958,27 @@ export class CanvasElementHandleDragInteractions {
             });
             return;
         }
-        const imgRect = img.getBoundingClientRect();
-        const canvasElementRect = activeElement.getBoundingClientRect();
+        // Compare the laid-out positions and sizes rather than the on-screen rectangles.
+        // getBoundingClientRect reports the upright box around a turned element, which is
+        // larger than the element itself, so on a turned element it puts the mark on sides
+        // that are not cropped. The image and the element are inside the same rotation, so
+        // their own offsets, widths and heights compare directly.
+        let imgLeft = 0;
+        let imgTop = 0;
+        for (
+            let e: HTMLElement | null = img;
+            e && e !== activeElement;
+            e = e.offsetParent as HTMLElement | null
+        ) {
+            imgLeft += e.offsetLeft;
+            imgTop += e.offsetTop;
+        }
         const slop = 1;
         const cropped = {
-            n: imgRect.top + slop < canvasElementRect.top,
-            e: imgRect.right > canvasElementRect.right + slop,
-            s: imgRect.bottom > canvasElementRect.bottom + slop,
-            w: imgRect.left + slop < canvasElementRect.left,
+            n: imgTop < -slop,
+            e: imgLeft + img.offsetWidth > activeElement.clientWidth + slop,
+            s: imgTop + img.offsetHeight > activeElement.clientHeight + slop,
+            w: imgLeft < -slop,
         };
         sideHandles.forEach((handle) => {
             const longClass = Array.from(handle.classList).find((c) =>

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementHandleDragInteractions.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementHandleDragInteractions.ts
@@ -12,6 +12,12 @@ import { renderCanvasElementContextControls } from "./CanvasElementContextContro
 import { CanvasGuideProvider } from "./CanvasGuideProvider";
 import { CanvasSnapProvider } from "./CanvasSnapProvider";
 import { getHandleTitlesAsync } from "./CanvasElementSelectionUi";
+import {
+    getCanvasElementRotation,
+    rotateVector,
+    setCanvasElementRotation,
+    unrotateVector,
+} from "./canvasElementRotation";
 
 export interface ICanvasElementHandleDragInteractionsHost {
     getActiveElement: () => HTMLElement | undefined;
@@ -82,6 +88,13 @@ export class CanvasElementHandleDragInteractions {
     private currentDragSide: string | undefined;
     private currentDragControl: HTMLElement | undefined;
 
+    // The centre of the element being rotated, in viewport coordinates, and the two angles
+    // we measure the drag against.
+    private rotateCenterX: number;
+    private rotateCenterY: number;
+    private startRotatePointerAngle: number;
+    private startRotation: number;
+
     public constructor(
         host: ICanvasElementHandleDragInteractionsHost,
         snapProvider: CanvasSnapProvider,
@@ -95,6 +108,130 @@ export class CanvasElementHandleDragInteractions {
     public resetCropBasis(): void {
         this.lastCropControl = undefined;
     }
+
+    // Convert a movement of the mouse, which is measured on the screen, into the element's
+    // own un-rotated coordinates. All the resize and crop arithmetic below works in those
+    // coordinates, so without this a rotated element grows along the wrong axis.
+    private getUnrotatedDelta(
+        activeElement: HTMLElement,
+        screenDeltaX: number,
+        screenDeltaY: number,
+    ): { x: number; y: number } {
+        return unrotateVector(
+            screenDeltaX,
+            screenDeltaY,
+            getCanvasElementRotation(activeElement),
+        );
+    }
+
+    // A rotated element turns about its own centre, so changing the size of the box moves
+    // what the user sees at both ends of it: the edge or corner opposite the one being
+    // dragged drifts away. This shifts the element to put that opposite edge back where it
+    // was on screen.
+    //
+    // Writing it as a correction applied after the ordinary arithmetic keeps the rotation out
+    // of that arithmetic. It is safe to run on every mouse move because the resize and crop
+    // code always recomputes the position from the values recorded at mouse-down, so the
+    // correction never accumulates.
+    private compensateForRotationDuringResize(
+        activeElement: HTMLElement,
+    ): void {
+        const rotation = getCanvasElementRotation(activeElement);
+        if (rotation === 0) {
+            return;
+        }
+        // How far the centre of the box has moved, in un-rotated coordinates.
+        const centerShiftX =
+            activeElement.offsetLeft +
+            activeElement.clientWidth / 2 -
+            (this.oldLeft + this.oldWidth / 2);
+        const centerShiftY =
+            activeElement.offsetTop +
+            activeElement.clientHeight / 2 -
+            (this.oldTop + this.oldHeight / 2);
+        // On screen that shift appears turned by the element's angle. The difference between
+        // where it appears and where the arithmetic put it is what we must undo.
+        const onScreen = rotateVector(centerShiftX, centerShiftY, rotation);
+        activeElement.style.left = `${
+            activeElement.offsetLeft + onScreen.x - centerShiftX
+        }px`;
+        activeElement.style.top = `${
+            activeElement.offsetTop + onScreen.y - centerShiftY
+        }px`;
+    }
+
+    // Start dragging the rotate handle (the "lollipop" above the top of the control frame).
+    // We turn the element by however far the pointer travels around its centre, so the point
+    // the user grabbed stays under the pointer.
+    public startRotateDrag = (event: MouseEvent) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const activeElement = this.host.getActiveElement();
+        if (!activeElement) return;
+        this.currentDragControl = event.currentTarget as HTMLElement;
+        this.currentDragControl.classList.add("active-control");
+        // Turning about the centre leaves the centre of the bounding rectangle where it was,
+        // so this is the centre of rotation whether or not the element is already turned.
+        const bounds = activeElement.getBoundingClientRect();
+        this.rotateCenterX = bounds.left + bounds.width / 2;
+        this.rotateCenterY = bounds.top + bounds.height / 2;
+        this.startRotation = getCanvasElementRotation(activeElement);
+        this.startRotatePointerAngle = this.getPointerAngle(event);
+        document.addEventListener("mousemove", this.continueRotateDrag, {
+            capture: true,
+        });
+        document.addEventListener("mouseup", this.endRotateDrag, {
+            capture: true,
+        });
+        this.host.startMoving();
+    };
+
+    // The angle from the centre of the element to the pointer, in degrees.
+    private getPointerAngle(event: MouseEvent): number {
+        return (
+            (Math.atan2(
+                event.clientY - this.rotateCenterY,
+                event.clientX - this.rotateCenterX,
+            ) *
+                180) /
+            Math.PI
+        );
+    }
+
+    private continueRotateDrag = (event: MouseEvent) => {
+        const activeElement = this.host.getActiveElement();
+        if (event.buttons !== 1 || !activeElement) {
+            this.endRotateDrag();
+            return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        const pointerTravel =
+            this.getPointerAngle(event) - this.startRotatePointerAngle;
+        // Snapping puts the common angles within easy reach; holding CTRL turns it off.
+        const newRotation = this.snapProvider.getSnappedRotation(
+            this.startRotation + pointerTravel,
+            event,
+        );
+        setCanvasElementRotation(activeElement, newRotation);
+        this.host.alignControlFrameWithActiveElement();
+    };
+
+    private endRotateDrag = () => {
+        document.removeEventListener("mousemove", this.continueRotateDrag, {
+            capture: true,
+        });
+        document.removeEventListener("mouseup", this.endRotateDrag, {
+            capture: true,
+        });
+        this.currentDragControl?.classList.remove("active-control");
+        this.host.stopMoving();
+        const activeElement = this.host.getActiveElement();
+        if (activeElement) {
+            this.host.adjustTarget(activeElement);
+        }
+        this.host.alignControlFrameWithActiveElement();
+    };
 
     public startMoveCrop = (event: MouseEvent) => {
         event.preventDefault();
@@ -148,8 +285,11 @@ export class CanvasElementHandleDragInteractions {
         if (event.buttons !== 1 || !activeElement) {
             return;
         }
-        const deltaX = event.clientX - this.startMoveCropX;
-        const deltaY = event.clientY - this.startMoveCropY;
+        const { x: deltaX, y: deltaY } = this.getUnrotatedDelta(
+            activeElement,
+            event.clientX - this.startMoveCropX,
+            event.clientY - this.startMoveCropY,
+        );
         const imgC =
             activeElement.getElementsByClassName(kImageContainerClass)[0];
         const img = imgC?.getElementsByTagName("img")[0];
@@ -270,8 +410,11 @@ export class CanvasElementHandleDragInteractions {
         this.lastCropControl = undefined;
 
         if (!this.resizeDragCorner) return;
-        const deltaX = event.clientX - this.startResizeDragX;
-        const deltaY = event.clientY - this.startResizeDragY;
+        const { x: deltaX, y: deltaY } = this.getUnrotatedDelta(
+            activeElement,
+            event.clientX - this.startResizeDragX,
+            event.clientY - this.startResizeDragY,
+        );
         const style = activeElement.style;
         const imgOrVideo = this.getImageOrVideo(activeElement);
         let slope = imgOrVideo ? this.oldHeight / this.oldWidth : 0;
@@ -423,6 +566,7 @@ export class CanvasElementHandleDragInteractions {
         style.height = newHeight + "px";
         style.top = newTop + "px";
         style.left = newLeft + "px";
+        this.compensateForRotationDuringResize(activeElement);
         if (imgOrVideo?.style.width) {
             const scale = newWidth / this.oldWidth;
             imgOrVideo.style.width = this.oldImageWidth * scale + "px";
@@ -519,8 +663,13 @@ export class CanvasElementHandleDragInteractions {
     private continueTextBoxResize(event: MouseEvent, editable: HTMLElement) {
         const activeElement = this.host.getActiveElement();
         if (!activeElement) return;
-        let deltaX = event.clientX - this.startSideDragX;
-        let deltaY = event.clientY - this.startSideDragY;
+        const unrotatedDelta = this.getUnrotatedDelta(
+            activeElement,
+            event.clientX - this.startSideDragX,
+            event.clientY - this.startSideDragY,
+        );
+        let deltaX = unrotatedDelta.x;
+        let deltaY = unrotatedDelta.y;
         let newCanvasElementWidth = this.oldWidth;
         let newCanvasElementHeight = this.oldHeight;
         console.assert(
@@ -566,6 +715,7 @@ export class CanvasElementHandleDragInteractions {
                 activeElement.style.height = `${newCanvasElementHeight}px`;
         }
         this.host.adjustCanvasElementHeightToContentOrMarkOverflow(editable);
+        this.compensateForRotationDuringResize(activeElement);
         this.host.adjustTarget(activeElement);
         this.host.alignControlFrameWithActiveElement();
         this.guideProvider.duringDrag(activeElement);
@@ -595,8 +745,13 @@ export class CanvasElementHandleDragInteractions {
         }
         event.preventDefault();
         event.stopPropagation();
-        let deltaX = event.clientX - this.startSideDragX;
-        let deltaY = event.clientY - this.startSideDragY;
+        const unrotatedDelta = this.getUnrotatedDelta(
+            activeElement,
+            event.clientX - this.startSideDragX,
+            event.clientY - this.startSideDragY,
+        );
+        let deltaX = unrotatedDelta.x;
+        let deltaY = unrotatedDelta.y;
         if (event.movementX === 0 && event.movementY === 0) return;
 
         let newCanvasElementWidth = this.oldWidth;
@@ -738,6 +893,7 @@ export class CanvasElementHandleDragInteractions {
                 img.style.left = `${this.oldImageLeft - deltaX}px`;
                 break;
         }
+        this.compensateForRotationDuringResize(activeElement);
         this.host.adjustStuffRelatedToImage(activeElement, img);
         CanvasElementHandleDragInteractions.updateCurrentlyCropped(
             activeElement,

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementHandleDragInteractions.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementHandleDragInteractions.ts
@@ -227,11 +227,18 @@ export class CanvasElementHandleDragInteractions {
     // was on screen.
     //
     // Writing it as a correction applied after the ordinary arithmetic keeps the rotation out
-    // of that arithmetic. It is safe to run on every mouse move because the resize and crop
-    // code always recomputes the position from the values recorded at mouse-down, so the
-    // correction never accumulates.
+    // of that arithmetic.
+    //
+    // The caller passes the position the ordinary arithmetic wants, rather than letting this
+    // method read the position out of the element. That matters because the correction writes
+    // both left and top, while a drag of one edge recomputes only one of them from the
+    // mouse-down values: the other still holds the correction of the previous mouse move.
+    // Reading it back therefore fed each correction into the next one, and the element crept
+    // across the page for as long as the drag went on (BL-16741).
     private compensateForRotationDuringResize(
         activeElement: HTMLElement,
+        newLeft: number,
+        newTop: number,
     ): void {
         const rotation = getCanvasElementRotation(activeElement);
         if (rotation === 0) {
@@ -239,22 +246,18 @@ export class CanvasElementHandleDragInteractions {
         }
         // How far the centre of the box has moved, in un-rotated coordinates.
         const centerShiftX =
-            activeElement.offsetLeft +
+            newLeft +
             activeElement.clientWidth / 2 -
             (this.oldLeft + this.oldWidth / 2);
         const centerShiftY =
-            activeElement.offsetTop +
+            newTop +
             activeElement.clientHeight / 2 -
             (this.oldTop + this.oldHeight / 2);
         // On screen that shift appears turned by the element's angle. The difference between
         // where it appears and where the arithmetic put it is what we must undo.
         const onScreen = rotateVector(centerShiftX, centerShiftY, rotation);
-        activeElement.style.left = `${
-            activeElement.offsetLeft + onScreen.x - centerShiftX
-        }px`;
-        activeElement.style.top = `${
-            activeElement.offsetTop + onScreen.y - centerShiftY
-        }px`;
+        activeElement.style.left = `${newLeft + onScreen.x - centerShiftX}px`;
+        activeElement.style.top = `${newTop + onScreen.y - centerShiftY}px`;
     }
 
     // Start dragging the rotate handle (the "lollipop" above the top of the control frame).
@@ -670,7 +673,7 @@ export class CanvasElementHandleDragInteractions {
         style.height = newHeight + "px";
         style.top = newTop + "px";
         style.left = newLeft + "px";
-        this.compensateForRotationDuringResize(activeElement);
+        this.compensateForRotationDuringResize(activeElement, newLeft, newTop);
         if (imgOrVideo?.style.width) {
             const scale = newWidth / this.oldWidth;
             imgOrVideo.style.width = this.oldImageWidth * scale + "px";
@@ -779,6 +782,9 @@ export class CanvasElementHandleDragInteractions {
         let deltaY = unrotatedDelta.y;
         let newCanvasElementWidth = this.oldWidth;
         let newCanvasElementHeight = this.oldHeight;
+        // Where this drag puts the box. Only the w handle moves it, but the rotation
+        // correction needs both numbers; see compensateForRotationDuringResize.
+        let newLeft = this.oldLeft;
         console.assert(
             this.currentDragSide === "e" ||
                 this.currentDragSide === "w" ||
@@ -807,8 +813,9 @@ export class CanvasElementHandleDragInteractions {
                     minWidth,
                 );
                 deltaX = this.oldWidth - newCanvasElementWidth;
+                newLeft = this.oldLeft + deltaX;
                 activeElement.style.width = `${newCanvasElementWidth}px`;
-                activeElement.style.left = `${this.oldLeft + deltaX}px`;
+                activeElement.style.left = `${newLeft}px`;
                 break;
             case "s":
                 newCanvasElementHeight = Math.max(
@@ -822,7 +829,11 @@ export class CanvasElementHandleDragInteractions {
                 activeElement.style.height = `${newCanvasElementHeight}px`;
         }
         this.host.adjustCanvasElementHeightToContentOrMarkOverflow(editable);
-        this.compensateForRotationDuringResize(activeElement);
+        this.compensateForRotationDuringResize(
+            activeElement,
+            newLeft,
+            this.oldTop,
+        );
         this.host.adjustTarget(activeElement);
         this.host.alignControlFrameWithActiveElement();
         this.guideProvider.duringDrag(activeElement);
@@ -863,6 +874,10 @@ export class CanvasElementHandleDragInteractions {
 
         let newCanvasElementWidth = this.oldWidth;
         let newCanvasElementHeight = this.oldHeight;
+        // Where this drag puts the box. Only the n and w handles move it, but the rotation
+        // correction needs both numbers; see compensateForRotationDuringResize.
+        let newLeft = this.oldLeft;
+        let newTop = this.oldTop;
         let shouldSnapForBackground = "";
         let backgroundSnapDelta = 0;
         if (
@@ -951,8 +966,9 @@ export class CanvasElementHandleDragInteractions {
                     minHeight,
                 );
                 deltaY = this.oldHeight - newCanvasElementHeight;
+                newTop = this.oldTop + deltaY;
                 activeElement.style.height = `${newCanvasElementHeight}px`;
-                activeElement.style.top = `${this.oldTop + deltaY}px`;
+                activeElement.style.top = `${newTop}px`;
                 img.style.top = `${this.oldImageTop - deltaY}px`;
                 break;
             case "s":
@@ -1012,12 +1028,13 @@ export class CanvasElementHandleDragInteractions {
                     minWidth,
                 );
                 deltaX = this.oldWidth - newCanvasElementWidth;
+                newLeft = this.oldLeft + deltaX;
                 activeElement.style.width = `${newCanvasElementWidth}px`;
-                activeElement.style.left = `${this.oldLeft + deltaX}px`;
+                activeElement.style.left = `${newLeft}px`;
                 img.style.left = `${this.oldImageLeft - deltaX}px`;
                 break;
         }
-        this.compensateForRotationDuringResize(activeElement);
+        this.compensateForRotationDuringResize(activeElement, newLeft, newTop);
         this.host.adjustStuffRelatedToImage(activeElement, img);
         CanvasElementHandleDragInteractions.updateCurrentlyCropped(
             activeElement,

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementHandleDragInteractionsSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementHandleDragInteractionsSpec.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { getCroppedSides } from "./CanvasElementHandleDragInteractions";
+import {
+    clampCropPosition,
+    getCroppedSides,
+    getShownContentRectangle,
+} from "./CanvasElementHandleDragInteractions";
 
 describe("getCroppedSides", () => {
     it("says no side is cropped when the picture just fills its element", () => {
@@ -49,5 +53,88 @@ describe("getCroppedSides", () => {
             s: false,
             w: false,
         });
+    });
+});
+
+describe("getShownContentRectangle", () => {
+    it("returns the box itself when the picture is not turned", () => {
+        expect(getShownContentRectangle(-300, 0, 1080, 720, 0)).toEqual({
+            left: -300,
+            top: 0,
+            width: 1080,
+            height: 720,
+        });
+    });
+
+    it("swaps the two dimensions about the centre for a quarter turn", () => {
+        // The layout Rotate Right leaves on a cropped page background: a box 720 by 480 at
+        // (-120, -80). The turn is about the box's own centre, at (240, 160), so the element
+        // shows 480 by 720 there, which starts at the element's left edge and reaches 200
+        // above its top.
+        expect(getShownContentRectangle(-120, -80, 720, 480, 1)).toEqual({
+            left: 0,
+            top: -200,
+            width: 480,
+            height: 720,
+        });
+    });
+
+    it("returns the box itself for a half turn, which swaps nothing", () => {
+        expect(getShownContentRectangle(-120, -80, 720, 480, 2)).toEqual({
+            left: -120,
+            top: -80,
+            width: 720,
+            height: 480,
+        });
+    });
+});
+
+describe("clampCropPosition", () => {
+    it("leaves a position that keeps the picture covering the element", () => {
+        expect(clampCropPosition(480, 720, -300, 0, 1080, 720, 0)).toEqual({
+            left: -300,
+            top: 0,
+        });
+    });
+
+    it("stops the picture before a blank band appears at the left or the top", () => {
+        // Asked for a position down and to the right of the element's own corner.
+        expect(clampCropPosition(480, 720, 40, 25, 1080, 720, 0)).toEqual({
+            left: 0,
+            top: 0,
+        });
+    });
+
+    it("stops the picture before a blank band appears at the right", () => {
+        // 480 - 1080 is as far left as the picture can go and still reach the right edge.
+        expect(clampCropPosition(480, 720, -900, 0, 1080, 720, 0)).toEqual({
+            left: -600,
+            top: 0,
+        });
+    });
+
+    it("uses the turned rectangle, not the box, for a turned picture", () => {
+        // Element 480 by 320, holding a box 720 by 480 given a quarter turn, so the element
+        // shows 480 by 720. The width matches the element exactly, so the only position that
+        // leaves no blank band puts the box at -120. Up and down, the box may sit anywhere
+        // from -280 to 120, and 200 is past that.
+        expect(clampCropPosition(480, 320, 0, 200, 720, 480, 1)).toEqual({
+            left: -120,
+            top: 120,
+        });
+        expect(clampCropPosition(480, 320, 0, -400, 720, 480, 1)).toEqual({
+            left: -120,
+            top: -280,
+        });
+    });
+
+    it("lets a turned picture move where the box's own numbers would pin it", () => {
+        // The bug this fixes: measuring the box rather than what the element shows made the
+        // limits cross each other, and the same position came back for every drag.
+        const high = clampCropPosition(480, 320, 0, -100, 720, 480, 1);
+        const low = clampCropPosition(480, 320, 0, 100, 720, 480, 1);
+        expect(high.top).toBe(-100);
+        expect(low.top).toBe(100);
+        expect(high.top).not.toBe(low.top);
     });
 });

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementHandleDragInteractionsSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementHandleDragInteractionsSpec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { getCroppedSides } from "./CanvasElementHandleDragInteractions";
+
+describe("getCroppedSides", () => {
+    it("says no side is cropped when the picture just fills its element", () => {
+        expect(getCroppedSides(480, 320, 0, 0, 480, 320, 0)).toEqual({
+            n: false,
+            e: false,
+            s: false,
+            w: false,
+        });
+    });
+
+    it("marks the two sides a crop of the width hides", () => {
+        // A picture 1080 wide in an element 480 wide, moved 300 to the left, so its left and
+        // right hang outside and its top and bottom line up.
+        expect(getCroppedSides(480, 720, -300, 0, 1080, 720, 0)).toEqual({
+            n: false,
+            e: true,
+            s: false,
+            w: true,
+        });
+    });
+
+    it("marks the sides the element really hides for a turned picture", () => {
+        // The same crop after a quarter turn, as Rotate Right leaves it: a box 720 by 480 at
+        // (-120, -80) in an element 480 by 320. The box hangs outside on all four sides in its
+        // own coordinates, but the turn shows a rectangle 480 by 720, which fits the element's
+        // width exactly and hangs out above and below.
+        expect(getCroppedSides(480, 320, -120, -80, 720, 480, 1)).toEqual({
+            n: true,
+            e: false,
+            s: true,
+            w: false,
+        });
+    });
+
+    it("treats a half turn like no turn, because it swaps nothing", () => {
+        const upright = getCroppedSides(480, 720, -300, 0, 1080, 720, 0);
+        const halfTurned = getCroppedSides(480, 720, -300, 0, 1080, 720, 2);
+        expect(halfTurned).toEqual(upright);
+    });
+
+    it("does not mark a side for a difference of less than a pixel", () => {
+        // Client values are whole pixels, so a fraction of a pixel is rounding, not a crop.
+        expect(getCroppedSides(480, 320, -0.4, 0, 480.8, 320, 0)).toEqual({
+            n: false,
+            e: false,
+            s: false,
+            w: false,
+        });
+    });
+});

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementManager.ts
@@ -2290,17 +2290,25 @@ export class CanvasElementManager {
             // and it probably isn't necessary.
             if (canvasElement.closest(".bloom-describedImage")) return;
 
-            // Careful. For older books, left and top might be percentages.
-            const canvasElementRect = canvasElement.getBoundingClientRect();
-            const parentRect = parentContainer.getBoundingClientRect();
-
+            // Read the element's own laid-out position, which is what
+            // adjustCanvasElementLocation compares against and writes back. Careful: for
+            // older books, left and top might be percentages, which offsetLeft and offsetTop
+            // resolve to pixels for us.
+            //
+            // A turned element is why this cannot use the on-screen rectangle.
+            // getBoundingClientRect reports the upright box around the turned element, and
+            // the corner of that box is not the corner of the element's own box: for a
+            // quarter turn the two differ by half the difference of the element's width and
+            // height. Reading the position from it therefore moved a turned element on every
+            // page load, up the page and to the right for a wide element, and down and to the
+            // left for a tall one, a little further each time (BL-16741).
             this.adjustCanvasElementLocation(
                 canvasElement,
                 parentContainer,
                 new Point(
-                    canvasElementRect.left - parentRect.left,
-                    canvasElementRect.top - parentRect.top,
-                    PointScaling.Scaled,
+                    canvasElement.offsetLeft,
+                    canvasElement.offsetTop,
+                    PointScaling.Unscaled,
                     "ensureCanvasElementsIntersectParent",
                 ),
             );

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementManager.ts
@@ -98,6 +98,7 @@ import {
     clearImageContentTransform,
     flipImageContent,
     FlipAxis,
+    getImageContentTransform,
     rotateImageContentRight,
 } from "../imageContentTransform";
 import {
@@ -1377,8 +1378,9 @@ export class CanvasElementManager {
     // Rotate whatever the Rotate Right command applies to for the active element: the
     // element itself where that is possible, otherwise the picture inside it. A background
     // image fills its bloom-canvas and cannot be turned as a box, so for it we turn the
-    // picture and shrink it to fit, which is what an author wants for a photograph that
-    // arrived on its side. Answers whether anything was rotated.
+    // picture inside the box and reshape the box to match, which gives what an author wants
+    // for a photograph that arrived on its side: the picture upright, and any crop kept.
+    // Answers whether anything was rotated.
     public rotateActiveImageRight(): boolean {
         if (!this.activeElement) {
             return false;
@@ -1510,6 +1512,9 @@ export class CanvasElementManager {
         const currentImgWidth = imgStyleWidth
             ? CanvasElementManager.pxToNumber(imgStyleWidth)
             : img.clientWidth;
+        if (getImageContentTransform(img).quarterTurns % 2 === 1) {
+            return this.getExpandedTurnedImageDimensions(img, bloomCanvas);
+        }
         // using <= here because client values are whole pixels and rounding easily
         // produces a spurious 1px difference.
         const canvasElementFillsCanvas =
@@ -1565,6 +1570,49 @@ export class CanvasElementManager {
             }
         }
         return null;
+    }
+
+    // The same as getExpandedImageDimensions, for a picture that has been turned a quarter
+    // turn. The picture's layout box lies across the page, so the box's width has to cover the
+    // page's height and the box's height has to cover the page's width, and both offsets have
+    // to move, because the box turns about its own centre.
+    private getExpandedTurnedImageDimensions(
+        img: HTMLImageElement,
+        bloomCanvas: HTMLElement,
+    ): {
+        imgWidth: number;
+        imgTop?: number;
+        imgLeft?: number;
+    } | null {
+        const pageWidth = bloomCanvas.clientWidth;
+        const pageHeight = bloomCanvas.clientHeight;
+        const imgWidth = Math.max(
+            pageHeight,
+            (pageWidth * img.naturalWidth) / img.naturalHeight,
+        );
+        const imgHeight = (imgWidth * img.naturalHeight) / img.naturalWidth;
+        const imgLeft = (pageWidth - imgWidth) / 2;
+        const imgTop = (pageHeight - imgHeight) / 2;
+        const currentWidth = img.style.width
+            ? CanvasElementManager.pxToNumber(img.style.width)
+            : img.clientWidth;
+        const alreadyDone =
+            Math.abs(currentWidth - imgWidth) < 1 &&
+            Math.abs(
+                CanvasElementManager.pxToNumber(img.style.left) - imgLeft,
+            ) < 1 &&
+            Math.abs(CanvasElementManager.pxToNumber(img.style.top) - imgTop) <
+                1 &&
+            Math.abs(
+                bloomCanvas.clientHeight - this.activeElement!.clientHeight,
+            ) <= 1 &&
+            Math.abs(
+                bloomCanvas.clientWidth - this.activeElement!.clientWidth,
+            ) <= 1;
+        if (alreadyDone) {
+            return null;
+        }
+        return { imgWidth, imgLeft, imgTop };
     }
 
     // If the background canvas element doesn't fill the container, we can expand the image to make it so.

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementManager.ts
@@ -31,6 +31,7 @@ import {
     getImageFromCanvasElement,
     kImageContainerClass,
     normalizeCoverImageDesignation,
+    setImageTransparencyToAuto,
     SetupMetadataButton,
     UpdateImageTooltipVisibility,
     HandleImageError,
@@ -88,6 +89,17 @@ import {
 } from "./CanvasElementSelectionUi";
 import { CanvasElementPointerInteractions } from "./CanvasElementPointerInteractions";
 import { CanvasElementHandleDragInteractions } from "./CanvasElementHandleDragInteractions";
+import {
+    canRotateCanvasElement,
+    getCanvasElementRotation,
+    setCanvasElementRotation,
+} from "./canvasElementRotation";
+import {
+    clearImageContentTransform,
+    flipImageContent,
+    FlipAxis,
+    rotateImageContentRight,
+} from "../imageContentTransform";
 import {
     adjustCanvasElementOrdering,
     adjustDraggableTarget,
@@ -1337,7 +1349,63 @@ export class CanvasElementManager {
             startSideControlDrag:
                 this.handleDragInteractions.startSideControlDrag,
             startMoveCrop: this.handleDragInteractions.startMoveCrop,
+            startRotateDrag: this.handleDragInteractions.startRotateDrag,
         });
+    }
+
+    // Turn the active canvas element a quarter turn clockwise. Used by the Rotate Right
+    // menu command and its Ctrl+R shortcut, for everything except a background image; see
+    // rotateActiveImageRight.
+    public rotateActiveElementRight(): void {
+        if (
+            !this.activeElement ||
+            !canRotateCanvasElement(this.activeElement)
+        ) {
+            return;
+        }
+        setCanvasElementRotation(
+            this.activeElement,
+            getCanvasElementRotation(this.activeElement) + 90,
+        );
+        this.adjustTarget(this.activeElement);
+        this.alignControlFrameWithActiveElement();
+    }
+
+    // Rotate whatever the Rotate Right command applies to for the active element: the
+    // element itself where that is possible, otherwise the picture inside it. A background
+    // image fills its bloom-canvas and cannot be turned as a box, so for it we turn the
+    // picture and shrink it to fit, which is what an author wants for a photograph that
+    // arrived on its side. Answers whether anything was rotated.
+    public rotateActiveImageRight(): boolean {
+        if (!this.activeElement) {
+            return false;
+        }
+        if (canRotateCanvasElement(this.activeElement)) {
+            this.rotateActiveElementRight();
+            return true;
+        }
+        const img = getImageFromCanvasElement(this.activeElement);
+        if (!img || isPlaceHolderImage(img.getAttribute("src"))) {
+            return false;
+        }
+        rotateImageContentRight(img);
+        this.adjustStuffRelatedToImage(this.activeElement, img);
+        return true;
+    }
+
+    // Mirror the picture in the active canvas element about the axis the user sees. This is
+    // always done to the picture rather than to the box, because mirroring a box would move
+    // it without changing how it looks.
+    public flipActiveImage(axis: FlipAxis): void {
+        if (!this.activeElement) {
+            return;
+        }
+        const img = getImageFromCanvasElement(this.activeElement);
+        if (!img) {
+            return;
+        }
+        flipImageContent(img, axis);
+        this.adjustStuffRelatedToImage(this.activeElement, img);
     }
 
     private minWidth = 30; // @MinTextBoxWidth in canvasTool.less
@@ -1364,6 +1432,22 @@ export class CanvasElementManager {
         this.alignControlFrameWithActiveElement();
         this.adjustTarget(this.activeElement);
         notifyToolOfChangedImage(img);
+    }
+
+    // The Reset Image command: put the picture back the way it arrived. That means the crop
+    // goes, and so do the quarter turns and the mirrors that Rotate right and Flip apply to
+    // the picture. The rotation of a canvas element box is left alone, because it belongs to
+    // the box, like its size and its position; the rotate handle and Undo are the way back
+    // from that. The transparency goes back to "Auto", which is the state of a picture that
+    // the user has not made a choice about.
+    public resetImage(): void {
+        if (!this.activeElement) return;
+        const img = getImageFromCanvasElement(this.activeElement);
+        if (!img) return;
+        clearImageContentTransform(img);
+        setImageTransparencyToAuto(img);
+        this.resetCropping();
+        this.adjustStuffRelatedToImage(this.activeElement, img);
     }
 
     public resetCropping(adjustContainer = true) {

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementManager.ts
@@ -1410,7 +1410,13 @@ export class CanvasElementManager {
             return;
         }
         pushUndoForImageTransform(this.activeElement);
-        flipImageContent(img, axis);
+        // The box may be turned as well, which moves the picture on screen, so the axis the
+        // user asked for is found from the two turns together; see flipImageContent.
+        flipImageContent(
+            img,
+            axis,
+            getCanvasElementRotation(this.activeElement),
+        );
         this.adjustStuffRelatedToImage(this.activeElement, img);
     }
 
@@ -1446,6 +1452,11 @@ export class CanvasElementManager {
     // the box, like its size and its position; the rotate handle and Undo are the way back
     // from that. The transparency goes back to "Auto", which is the state of a picture that
     // the user has not made a choice about.
+    //
+    // This command deliberately puts nothing on the undo stack, as the older reset-crop
+    // command did not either: a reset is itself a way back, so an undo of it would be a way
+    // back from a way back. Rotate right and Flip do record undo, because each of them is a
+    // step forward.
     public resetImage(): void {
         if (!this.activeElement) return;
         const img = getImageFromCanvasElement(this.activeElement);

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementManager.ts
@@ -119,6 +119,7 @@ import {
     IImageCropInfo,
     initializeImageUndoManager,
     prepareUndoForImageOperation,
+    pushUndoForImageTransform,
 } from "../ImageUndoManager";
 
 const kComicalGeneratedClass: string = "comical-generated";
@@ -180,6 +181,8 @@ export class CanvasElementManager {
                     | undefined,
             updateCanvasElementForChangedImage:
                 this.updateCanvasElementForChangedImage.bind(this),
+            updateCanvasElementAfterTransformChange:
+                this.adjustStuffRelatedToImage.bind(this),
             getActiveElement: this.getActiveElement.bind(this),
             setActiveElement: this.setActiveElement.bind(this),
             removeDetachedTargets: this.removeDetachedTargets.bind(this),
@@ -1381,6 +1384,7 @@ export class CanvasElementManager {
             return false;
         }
         if (canRotateCanvasElement(this.activeElement)) {
+            pushUndoForImageTransform(this.activeElement);
             this.rotateActiveElementRight();
             return true;
         }
@@ -1388,6 +1392,7 @@ export class CanvasElementManager {
         if (!img || isPlaceHolderImage(img.getAttribute("src"))) {
             return false;
         }
+        pushUndoForImageTransform(this.activeElement);
         rotateImageContentRight(img);
         this.adjustStuffRelatedToImage(this.activeElement, img);
         return true;
@@ -1404,6 +1409,7 @@ export class CanvasElementManager {
         if (!img) {
             return;
         }
+        pushUndoForImageTransform(this.activeElement);
         flipImageContent(img, axis);
         this.adjustStuffRelatedToImage(this.activeElement, img);
     }

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementManager.ts
@@ -1358,8 +1358,7 @@ export class CanvasElementManager {
     }
 
     // Turn the active canvas element a quarter turn clockwise. Used by the Rotate Right
-    // menu command and its Ctrl+R shortcut, for everything except a background image; see
-    // rotateActiveImageRight.
+    // menu command, for everything except a background image; see rotateActiveImageRight.
     public rotateActiveElementRight(): void {
         if (
             !this.activeElement ||

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementPointerInteractions.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementPointerInteractions.ts
@@ -5,11 +5,21 @@ import { handlePlayClick } from "../bloomVideo";
 import {
     kBackgroundImageClass,
     kBloomCanvasSelector,
+    kCanvasElementClass,
     kCanvasElementSelector,
 } from "../../toolbox/canvas/canvasElementConstants";
 import { CanvasGuideProvider } from "./CanvasGuideProvider";
 import { CanvasSnapProvider } from "./CanvasSnapProvider";
-import { convertPointFromViewportToElementFrame } from "./CanvasElementGeometry";
+import {
+    convertPointFromViewportToElementFrame,
+    getLeftAndTopBorderWidths,
+    getLeftAndTopPaddings,
+} from "./CanvasElementGeometry";
+import {
+    getCanvasElementRotation,
+    isPointInsideRotatedCanvasElement,
+    kRotatedClass,
+} from "./canvasElementRotation";
 import { inPlayMode } from "./CanvasElementPositioning";
 
 export interface ICanvasElementPointerInteractionsHost {
@@ -110,6 +120,116 @@ export class CanvasElementPointerInteractions {
         };
     }
 
+    // Which canvas element the user clicked on, given a point in the coordinates of the
+    // bloom-canvas.
+    //
+    // comicaljs tests each element against its un-rotated offset box, so it reports a miss
+    // for a point that is really inside an element the user has turned, and a hit for a point
+    // in the part of the box the element has turned away from. We therefore test the turned
+    // elements here and leave the rest to comicaljs, then take whichever hit is on top.
+    private getCanvasElementHit(
+        bloomCanvas: HTMLElement,
+        x: number,
+        y: number,
+    ): Bubble | undefined {
+        const unrotatedHit = Comical.getBubbleHit(
+            bloomCanvas,
+            x,
+            y,
+            true, // only consider canvas elements with pointer events allowed.
+            `.${kRotatedClass}`,
+        );
+        const rotatedHit = this.getRotatedCanvasElementHit(bloomCanvas, x, y);
+        if (!rotatedHit) {
+            return unrotatedHit;
+        }
+        if (!unrotatedHit) {
+            return rotatedHit;
+        }
+        // Level is comicaljs's stacking order; the higher one is in front.
+        const rotatedLevel =
+            Bubble.getBubbleSpec(rotatedHit.content).level ?? 0;
+        const unrotatedLevel =
+            Bubble.getBubbleSpec(unrotatedHit.content).level ?? 0;
+        return rotatedLevel >= unrotatedLevel ? rotatedHit : unrotatedHit;
+    }
+
+    private getRotatedCanvasElementHit(
+        bloomCanvas: HTMLElement,
+        x: number,
+        y: number,
+    ): Bubble | undefined {
+        let hit: HTMLElement | undefined;
+        let hitLevel = Number.NEGATIVE_INFINITY;
+        Array.from(bloomCanvas.getElementsByClassName(kRotatedClass)).forEach(
+            (element) => {
+                if (
+                    !(element instanceof HTMLElement) ||
+                    !element.classList.contains(kCanvasElementClass)
+                ) {
+                    return;
+                }
+                const styles = window.getComputedStyle(element);
+                // Match the two things comicaljs filters on: an invisible element is not there,
+                // and one that takes no pointer events cannot be clicked.
+                if (
+                    styles.display === "none" ||
+                    styles.pointerEvents === "none" ||
+                    !isPointInsideRotatedCanvasElement(element, x, y)
+                ) {
+                    return;
+                }
+                const level = Bubble.getBubbleSpec(element).level ?? 0;
+                if (level >= hitLevel) {
+                    hitLevel = level;
+                    hit = element;
+                }
+            },
+        );
+        return hit ? new Bubble(hit) : undefined;
+    }
+
+    // Where inside the canvas element the user took hold of it. The move code subtracts this
+    // from the pointer position to get the element's new position, so it must be measured
+    // against the element's own box.
+    //
+    // For an element the user has turned, getBoundingClientRect reports the box around the
+    // turned element instead, which would make the element jump as soon as the drag began. In
+    // that case we rebuild the same measurement from offsetLeft/offsetTop, which describe the
+    // element's own box whatever its angle. For an element that is not turned the two agree,
+    // so nothing changes for the ordinary case.
+    private getGrabOffsetPoint(
+        pointRelativeToViewport: Point,
+        canvasElement: HTMLElement,
+    ): Point {
+        if (getCanvasElementRotation(canvasElement) === 0) {
+            return convertPointFromViewportToElementFrame(
+                pointRelativeToViewport,
+                canvasElement,
+            );
+        }
+        const bloomCanvas = canvasElement.parentElement?.closest(
+            kBloomCanvasSelector,
+        ) as HTMLElement;
+        const pointInCanvas = convertPointFromViewportToElementFrame(
+            pointRelativeToViewport,
+            bloomCanvas,
+        );
+        const borderAndPadding = getLeftAndTopBorderWidths(canvasElement).add(
+            getLeftAndTopPaddings(canvasElement),
+        );
+        return new Point(
+            pointInCanvas.getUnscaledX() -
+                canvasElement.offsetLeft -
+                borderAndPadding.getUnscaledX(),
+            pointInCanvas.getUnscaledY() -
+                canvasElement.offsetTop -
+                borderAndPadding.getUnscaledY(),
+            PointScaling.Unscaled,
+            "Grab offset within a rotated canvas element",
+        );
+    }
+
     private moveInsertionPointAndFocusTo = (x, y): Range | undefined => {
         type DocumentWithCaret = Document & {
             caretPositionFromPoint?: (
@@ -179,11 +299,10 @@ export class CanvasElementPointerInteractions {
             return;
         }
 
-        const bubble = Comical.getBubbleHit(
+        const bubble = this.getCanvasElementHit(
             bloomCanvas,
             coordinates.getUnscaledX(),
             coordinates.getUnscaledY(),
-            true, // only consider canvas elements with pointer events allowed.
         );
         if (bubble && event.button === 2) {
             // Right mouse button
@@ -244,7 +363,7 @@ export class CanvasElementPointerInteractions {
                 PointScaling.Scaled,
                 "MouseEvent Client (Relative to viewport)",
             );
-            const relativePoint = convertPointFromViewportToElementFrame(
+            const relativePoint = this.getGrabOffsetPoint(
                 pointRelativeToViewport,
                 bubbleToStart.content,
             );

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementPointerInteractions.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementPointerInteractions.ts
@@ -1,7 +1,11 @@
 import { Bubble, Comical } from "comicaljs";
 import { Point, PointScaling } from "../point";
 import { renderCanvasElementContextControls } from "./CanvasElementContextControls";
-import { handlePlayClick } from "../bloomVideo";
+import {
+    handlePauseClick,
+    handlePlayClick,
+    handleReplayClick,
+} from "../bloomVideo";
 import {
     kBackgroundImageClass,
     kBloomCanvasSelector,
@@ -18,6 +22,7 @@ import {
 import {
     getCanvasElementRotation,
     isPointInsideRotatedCanvasElement,
+    kPointerInsideClass,
     kRotatedClass,
 } from "./canvasElementRotation";
 import { inPlayMode } from "./CanvasElementPositioning";
@@ -89,6 +94,12 @@ export class CanvasElementPointerInteractions {
         bloomCanvas.onmousedown = null;
         bloomCanvas.onmousemove = null;
         bloomCanvas.onmouseup = null;
+
+        // While the pointer is inside the bloom-canvas, onMouseMove keeps the mark on the turned
+        // element the pointer is inside. No move event tells us it has left, so clear the mark here.
+        // This must be the same function object every time, because this method runs again on every
+        // page load and addEventListener would otherwise stack up another listener each time.
+        bloomCanvas.addEventListener("mouseleave", this.onMouseLeave);
 
         // We use mousemove effects instead of drag due to concerns that drag effects would make the entire bloom-canvas appear to drag.
         // Instead, with mousemove, we can make only the specific canvas element move around
@@ -420,6 +431,13 @@ export class CanvasElementPointerInteractions {
 
     // MUST be defined this way, rather than as a member function, so that it can
     // be passed directly to addEventListener and still get the correct 'this'.
+    public onMouseLeave = (event: MouseEvent) => {
+        this.markTurnedElementUnderPointer(
+            event.currentTarget as HTMLElement,
+            undefined,
+        );
+    };
+
     public onMouseMove = (event: MouseEvent) => {
         if (inPlayMode(event.currentTarget as HTMLElement)) {
             return;
@@ -427,6 +445,12 @@ export class CanvasElementPointerInteractions {
         if (event.buttons === 0 && this.mouseIsDown) {
             this.onBubbleDragMouseUp(event);
             return;
+        }
+        if (event.buttons === 0) {
+            // Not a drag, so keep the mark on the turned element the pointer is inside. This has
+            // to come before the bubbleToDrag test, because a mouse-up on a video's play button
+            // returns while that field is still set, which would leave the mark behind.
+            this.updateTurnedElementUnderPointer(event);
         }
         if (!this.bubbleToDrag) {
             return;
@@ -448,6 +472,44 @@ export class CanvasElementPointerInteractions {
         const container = event.currentTarget as HTMLElement;
         this.handleMouseMoveDragCanvasElement(event, container);
     };
+
+    // Which turned canvas element the pointer is inside, so that the CSS can do what :hover
+    // cannot for a turned element; see kPointerInsideClass. An element the user has not turned
+    // gets a real :hover from the browser, so we only have to do this for the turned ones, which
+    // also keeps the work small: we walk the turned elements, not every element, and we do no
+    // comicaljs hit test.
+    private updateTurnedElementUnderPointer(event: MouseEvent) {
+        const bloomCanvas = event.currentTarget as HTMLElement;
+        if (bloomCanvas.getElementsByClassName(kRotatedClass).length === 0) {
+            return;
+        }
+        const coordinates = this.getPointRelativeToCanvas(event, bloomCanvas);
+        if (!coordinates) {
+            return;
+        }
+        const hit = this.getRotatedCanvasElementHit(
+            bloomCanvas,
+            coordinates.getUnscaledX(),
+            coordinates.getUnscaledY(),
+        );
+        this.markTurnedElementUnderPointer(bloomCanvas, hit?.content);
+    }
+
+    // Put the mark on one turned element and take it off the others. Pass undefined to clear it
+    // from all of them.
+    private markTurnedElementUnderPointer(
+        bloomCanvas: HTMLElement,
+        element: HTMLElement | undefined,
+    ) {
+        Array.from(bloomCanvas.getElementsByClassName(kRotatedClass)).forEach(
+            (turned) => {
+                turned.classList.toggle(
+                    kPointerInsideClass,
+                    turned === element,
+                );
+            },
+        );
+    }
 
     private handleMouseMoveDragCanvasElement(
         event: MouseEvent,
@@ -534,6 +596,38 @@ export class CanvasElementPointerInteractions {
         });
     }
 
+    // One of a video's three buttons, when the user has clicked it inside a turned canvas
+    // element. The obvious test, event.target, works only while the button is what the browser
+    // hit; inside a turned element the comicaljs canvas is on top and is the target instead, for
+    // the reason given at kPointerInsideClass. So we look through everything under the pointer
+    // rather than at the topmost thing alone.
+    //
+    // Two limits keep that from clicking a button the user cannot see. The button must belong to
+    // the element the user pressed on, which the ordinary hit test chose, so a button that
+    // another element covers is not clicked. And a button that is not displayed is not in the
+    // list at all, so a hidden video cannot be started.
+    private getVideoButtonInsideTurnedElement(
+        event: MouseEvent,
+    ): HTMLElement | undefined {
+        const pressed = this.bubbleToDrag?.content;
+        if (!pressed?.classList.contains(kRotatedClass)) {
+            return undefined;
+        }
+        const doc = pressed.ownerDocument;
+        for (const element of doc.elementsFromPoint(
+            event.clientX,
+            event.clientY,
+        )) {
+            const button = element.closest(
+                ".bloom-videoPlayIcon, .bloom-videoPauseIcon, .bloom-videoReplayIcon",
+            );
+            if (button instanceof HTMLElement && pressed.contains(button)) {
+                return button;
+            }
+        }
+        return undefined;
+    }
+
     private onBubbleDragMouseUp = (event: MouseEvent) => {
         this.mouseIsDown = false;
         this.snapProvider.endDrag();
@@ -550,6 +644,23 @@ export class CanvasElementPointerInteractions {
             (event.target as HTMLElement).closest(".bloom-videoPlayIcon")
         ) {
             handlePlayClick(event, true);
+            return;
+        }
+        // Inside a turned element the buttons never get the click themselves, so we deliver it.
+        // The pause and replay buttons need this as much as play does: isMouseEventAlreadyHandled
+        // leaves those two to their own listeners, which the comicaljs canvas stops from ever
+        // firing on a turned element.
+        const button = this.gotAMoveWhileMouseDown
+            ? undefined
+            : this.getVideoButtonInsideTurnedElement(event);
+        if (button) {
+            if (button.classList.contains("bloom-videoPlayIcon")) {
+                handlePlayClick(event, true, button);
+            } else if (button.classList.contains("bloom-videoPauseIcon")) {
+                handlePauseClick(event, button);
+            } else {
+                handleReplayClick(event, button);
+            }
             return;
         }
 

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementSelectionUi.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementSelectionUi.ts
@@ -13,6 +13,29 @@ import {
     kBloomCanvasSelector,
 } from "../../toolbox/canvas/canvasElementConstants";
 import { CanvasElementHandleDragInteractions } from "./CanvasElementHandleDragInteractions";
+import { canRotateCanvasElement } from "./canvasElementRotation";
+
+// The picture in the rotate knob: the Material UI "Refresh" icon, which shows a circling
+// arrow. We build the SVG here rather than rendering a React icon component, because the
+// control frame is plain DOM that this file creates and removes by hand. The path is the one
+// in @mui/icons-material/Refresh.
+const kRefreshIconPath =
+    "M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 " +
+    "6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 " +
+    "3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z";
+
+function makeRotateHandleIcon(
+    elementInTheRightDocument: HTMLElement,
+): SVGElement {
+    const doc = elementInTheRightDocument.ownerDocument;
+    const kSvgNamespace = "http://www.w3.org/2000/svg";
+    const svg = doc.createElementNS(kSvgNamespace, "svg");
+    svg.setAttribute("viewBox", "0 0 24 24");
+    const path = doc.createElementNS(kSvgNamespace, "path");
+    path.setAttribute("d", kRefreshIconPath);
+    svg.appendChild(path);
+    return svg;
+}
 
 export interface ICanvasElementSelectionUiCallbacks {
     getActiveElement: () => HTMLElement | undefined;
@@ -27,6 +50,7 @@ export interface ICanvasElementSelectionUiCallbacks {
     ) => void;
     startSideControlDrag: (event: MouseEvent, side: string) => void;
     startMoveCrop: (event: MouseEvent) => void;
+    startRotateDrag: (event: MouseEvent) => void;
 }
 
 let pendingRemoveControlFrameTimeout: number | undefined;
@@ -148,6 +172,22 @@ export function setupControlFrame(
             }
             callbacks.startMoveCrop(event);
         });
+        // The rotate handle is the "lollipop": a stem rising from the top edge of the frame
+        // with a knob on the end, which the user drags around the element to turn it. We put
+        // it outside the frame because every centre-of-a-side position inside the frame is
+        // already a crop handle. On an element right at the top of its bloom-canvas the
+        // lollipop is clipped, as the corner resize handles already are there.
+        const rotateHandle =
+            eltToPutControlsOn.ownerDocument.createElement("div");
+        rotateHandle.classList.add("bloom-ui-canvas-element-rotate-handle");
+        rotateHandle.appendChild(makeRotateHandleIcon(eltToPutControlsOn));
+        controlFrame?.appendChild(rotateHandle);
+        rotateHandle.addEventListener("mousedown", (event) => {
+            if (event.buttons !== 1 || !callbacks.getActiveElement()) {
+                return;
+            }
+            callbacks.startRotateDrag(event);
+        });
         const toolboxRoot =
             eltToPutControlsOn.ownerDocument.createElement("div");
         toolboxRoot.setAttribute("id", "canvas-element-context-controls");
@@ -172,6 +212,10 @@ export function setupControlFrame(
         },
         { className: "has-svg", enabled: hasSvg },
         { className: "has-text", enabled: hasText },
+        {
+            className: "can-rotate",
+            enabled: canRotateCanvasElement(eltToPutControlsOn),
+        },
     ];
     controlFrameClassStates.forEach((state) => {
         controlFrame.classList.toggle(state.className, !!state.enabled);
@@ -232,6 +276,17 @@ export function alignControlFrameWithActiveElement(
         "bloom-noAutoHeight",
         activeElement.classList.contains("bloom-noAutoHeight"),
     );
+    // The frame must lie over the element, so it turns with it. Both turn about their
+    // centres (the CSS default), and we give the frame the same size and position as the
+    // element below, so copying the transform is enough to keep them together.
+    controlFrame.style.transform = activeElement.style.transform;
+    // The user can change a text box's bubble style while it is selected, which can turn
+    // rotation on or off, so this has to be kept up to date here as well as when the frame
+    // is first set up.
+    controlFrame.classList.toggle(
+        "can-rotate",
+        canRotateCanvasElement(activeElement),
+    );
     // We want some special CSS rules for control frames on background images (e.g., no resize handles).
     // But we give the class a different name so the control frame won't accidentally be affected
     // by any CSS intended for the background image itself. That is, if the active element (the actual canvas
@@ -275,6 +330,11 @@ export function alignControlFrameWithActiveElement(
         controlFrame,
         "bloom-ui-canvas-element-move-crop-handle",
         "Shift",
+    );
+    void getHandleTitlesAsync(
+        controlFrame,
+        "bloom-ui-canvas-element-rotate-handle",
+        "Rotate",
     );
     // Text boxes get a little extra padding, making the control frame bigger than
     // the canvas element itself. The extra needed corresponds roughly to the (.less) @sideHandleRadius,
@@ -335,11 +395,16 @@ export function adjustMoveCropHandleVisibility(
     const img = imgC?.getElementsByTagName("img")[0];
     let wantMoveCropHandle = false;
     if (img) {
-        const imgRect = img.getBoundingClientRect();
-        const controlRect = controlFrame.getBoundingClientRect();
+        // Compare the laid-out sizes rather than the on-screen rectangles. For a rotated
+        // canvas element getBoundingClientRect reports the box around the turned element,
+        // which is bigger than the element itself and would make a picture that is not
+        // cropped look as if it were. The image and the element are both children of the
+        // same rotation, so their own widths and heights can be compared directly. (For an
+        // image the control frame is the same size as the element; the few extra pixels the
+        // frame gets are for text elements, which have no image.)
         wantMoveCropHandle =
-            imgRect.width > controlRect.width + 1 ||
-            imgRect.height > controlRect.height + 1;
+            img.offsetWidth > activeElement.clientWidth + 1 ||
+            img.offsetHeight > activeElement.clientHeight + 1;
         if (!wantMoveCropHandle && removeCropAttrsIfNotNeeded) {
             img.style.width = "";
             img.style.top = "";

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementSelectionUi.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementSelectionUi.ts
@@ -16,6 +16,7 @@ import { CanvasElementHandleDragInteractions } from "./CanvasElementHandleDragIn
 import {
     canRotateCanvasElement,
     getCanvasElementRotation,
+    getHandleCursorForRotation,
 } from "./canvasElementRotation";
 
 // The picture in the rotate knob: the Material UI "Refresh" icon, which shows a circling
@@ -260,47 +261,30 @@ export async function getHandleTitlesAsync(
     }
 }
 
-// The eight directions of the eight resize cursors, clockwise from the top.
-const kClockwiseDirections = ["n", "ne", "e", "se", "s", "sw", "w", "nw"];
-// The cursors for an axis, for the same eight directions taken two at a time: a vertical
-// axis, then the two diagonals with the horizontal axis between them.
-const kAxisCursors = ["ns-resize", "nwse-resize", "ew-resize", "nesw-resize"];
-
 /**
  * Give each resize handle and each crop handle the cursor for the direction it really moves
- * on screen. The handles turn with the element, but a cursor cannot turn, so on a turned
- * element each handle needs the cursor of another direction. There are only eight cursors,
- * so the angle is taken to the nearest eighth of a turn.
+ * on screen; see getHandleCursorForRotation.
  */
 function setHandleCursorsForRotation(
     controlFrame: HTMLElement,
     rotation: number,
 ): void {
-    const steps = ((Math.round(rotation / 45) % 8) + 8) % 8;
     const setCursor = (className: string, cursor: string) => {
         const handle = controlFrame.getElementsByClassName(className)[0] as
             | HTMLElement
             | undefined;
         if (handle) handle.style.cursor = cursor;
     };
-    // A corner moves along one of the eight directions, so its cursor is the direction the
-    // rotation takes it to.
-    ["nw", "ne", "se", "sw"].forEach((corner) => {
-        const direction =
-            kClockwiseDirections[
-                (kClockwiseDirections.indexOf(corner) + steps) % 8
-            ];
+    (["nw", "ne", "se", "sw"] as const).forEach((corner) => {
         setCursor(
             "bloom-ui-canvas-element-resize-handle-" + corner,
-            direction + "-resize",
+            getHandleCursorForRotation(corner, rotation),
         );
     });
-    // A side moves along an axis, and an axis turned half a turn is the same axis, so four
-    // cursors cover it.
-    ["n", "e", "s", "w"].forEach((side) => {
+    (["n", "e", "s", "w"] as const).forEach((side) => {
         setCursor(
             "bloom-ui-canvas-element-side-handle-" + side,
-            kAxisCursors[(kClockwiseDirections.indexOf(side) + steps) % 4],
+            getHandleCursorForRotation(side, rotation),
         );
     });
 }

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementSelectionUi.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementSelectionUi.ts
@@ -320,6 +320,29 @@ export function alignControlFrameWithActiveElement(
         rotation + "deg",
     );
     setHandleCursorsForRotation(controlFrame, rotation);
+    // The lollipop hangs from the element's top edge. Once the element is turned far enough,
+    // that edge points down the screen, and the lollipop lands behind the panel of controls
+    // that sits below the element. So for those angles we hang it from the element's bottom
+    // edge instead. We leave it alone during a drag: the lollipop is under the pointer, and
+    // moving it to the other end of the element part way through a turn would take it out
+    // from under the pointer.
+    //
+    // The switch waits for three eighths of a turn, not a quarter turn. At a quarter turn the
+    // handle points straight out to the side, where the panel does not reach it, so a switch
+    // there only moved the handle across the element for no gain, at the angle a user stops at
+    // most often (BL-16741). The rotation snap stops at every 45 degrees, so 135 is the first
+    // stop where the handle is on its way under the panel.
+    //
+    // Turning to 180 degrees still moves the handle on the mouse-up of the drag that got there,
+    // because endRotateDrag calls stopMoving before it aligns the frame. That is the angle where
+    // the panel really does cover the handle, so the move is what the user needs, but it does
+    // take the handle out from under the pointer at the end of the drag.
+    if (!controlFrame.classList.contains("moving")) {
+        controlFrame.classList.toggle(
+            "rotate-handle-on-bottom-edge",
+            rotation > 135 && rotation < 225,
+        );
+    }
     // The user can change a text box's bubble style while it is selected, which can turn
     // rotation on or off, so this has to be kept up to date here as well as when the frame
     // is first set up.

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementSelectionUi.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementSelectionUi.ts
@@ -13,7 +13,10 @@ import {
     kBloomCanvasSelector,
 } from "../../toolbox/canvas/canvasElementConstants";
 import { CanvasElementHandleDragInteractions } from "./CanvasElementHandleDragInteractions";
-import { canRotateCanvasElement } from "./canvasElementRotation";
+import {
+    canRotateCanvasElement,
+    getCanvasElementRotation,
+} from "./canvasElementRotation";
 
 // The picture in the rotate knob: the Material UI "Refresh" icon, which shows a circling
 // arrow. We build the SVG here rather than rendering a React icon component, because the
@@ -257,6 +260,51 @@ export async function getHandleTitlesAsync(
     }
 }
 
+// The eight directions of the eight resize cursors, clockwise from the top.
+const kClockwiseDirections = ["n", "ne", "e", "se", "s", "sw", "w", "nw"];
+// The cursors for an axis, for the same eight directions taken two at a time: a vertical
+// axis, then the two diagonals with the horizontal axis between them.
+const kAxisCursors = ["ns-resize", "nwse-resize", "ew-resize", "nesw-resize"];
+
+/**
+ * Give each resize handle and each crop handle the cursor for the direction it really moves
+ * on screen. The handles turn with the element, but a cursor cannot turn, so on a turned
+ * element each handle needs the cursor of another direction. There are only eight cursors,
+ * so the angle is taken to the nearest eighth of a turn.
+ */
+function setHandleCursorsForRotation(
+    controlFrame: HTMLElement,
+    rotation: number,
+): void {
+    const steps = ((Math.round(rotation / 45) % 8) + 8) % 8;
+    const setCursor = (className: string, cursor: string) => {
+        const handle = controlFrame.getElementsByClassName(className)[0] as
+            | HTMLElement
+            | undefined;
+        if (handle) handle.style.cursor = cursor;
+    };
+    // A corner moves along one of the eight directions, so its cursor is the direction the
+    // rotation takes it to.
+    ["nw", "ne", "se", "sw"].forEach((corner) => {
+        const direction =
+            kClockwiseDirections[
+                (kClockwiseDirections.indexOf(corner) + steps) % 8
+            ];
+        setCursor(
+            "bloom-ui-canvas-element-resize-handle-" + corner,
+            direction + "-resize",
+        );
+    });
+    // A side moves along an axis, and an axis turned half a turn is the same axis, so four
+    // cursors cover it.
+    ["n", "e", "s", "w"].forEach((side) => {
+        setCursor(
+            "bloom-ui-canvas-element-side-handle-" + side,
+            kAxisCursors[(kClockwiseDirections.indexOf(side) + steps) % 4],
+        );
+    });
+}
+
 // Align the control frame with the active canvas element.
 export function alignControlFrameWithActiveElement(
     activeElement: HTMLElement | undefined,
@@ -280,6 +328,14 @@ export function alignControlFrameWithActiveElement(
     // centres (the CSS default), and we give the frame the same size and position as the
     // element below, so copying the transform is enough to keep them together.
     controlFrame.style.transform = activeElement.style.transform;
+    // The frame turns everything inside it, including the tooltip of each handle, which the
+    // CSS then turns back so that the text stays level.
+    const rotation = getCanvasElementRotation(activeElement);
+    controlFrame.style.setProperty(
+        "--canvas-element-rotation",
+        rotation + "deg",
+    );
+    setHandleCursorsForRotation(controlFrame, rotation);
     // The user can change a text box's bubble style while it is selected, which can turn
     // rotation on or off, so this has to be kept up to date here as well as when the frame
     // is first set up.

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasSnapProvider.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasSnapProvider.ts
@@ -8,6 +8,14 @@ import { Point, PointScaling } from "../point";
 // The size of the grid cells for snapping.
 const gridSize = 10;
 
+// Rotation snaps to every multiple of this many degrees: 0, 45, 90 and so on.
+const rotationSnapInterval = 45;
+
+// How close to one of those angles the pointer must be before the rotation snaps to it.
+// Wide enough that the common angles are easy to hit, narrow enough that a third of each
+// 45 degree span is still free.
+const rotationSnapTolerance = 14;
+
 // Type definition for functions that modify a position based on snapping rules.
 type SnapPositionFunction = (
     event: MouseEvent | KeyboardEvent | undefined,
@@ -212,6 +220,29 @@ export class CanvasSnapProvider {
             return { x: this.dragContext.startX!, y };
         }
         // Note: The logic guarantees axis is either "horizontal" or "vertical" here if shift is pressed.
+    }
+
+    /**
+     * Snaps a rotation angle to the nearest multiple of 45 degrees, if it is within
+     * rotationSnapTolerance of one. As with position snapping, holding CTRL turns the
+     * snapping off and gives the exact angle the pointer asks for.
+     * @param degrees The angle the pointer asks for.
+     * @param event The mouse or keyboard event, used to check for the CTRL key.
+     * @returns The angle to use, in degrees.
+     */
+    public getSnappedRotation(
+        degrees: number,
+        event: MouseEvent | KeyboardEvent | undefined,
+    ): number {
+        if (event && event.ctrlKey) {
+            return degrees;
+        }
+        const nearestSnapAngle =
+            Math.round(degrees / rotationSnapInterval) * rotationSnapInterval;
+        if (Math.abs(degrees - nearestSnapAngle) <= rotationSnapTolerance) {
+            return nearestSnapAngle;
+        }
+        return degrees;
     }
 
     /**

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasSnapProviderSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasSnapProviderSpec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { CanvasSnapProvider } from "./CanvasSnapProvider";
+
+// The rotation handle asks for the snapped angle on every pointer move. The rule is: snap to
+// every 45 degrees when the pointer is within 14 degrees of one of them, unless CTRL is held.
+describe("CanvasSnapProvider.getSnappedRotation", () => {
+    const snapProvider = new CanvasSnapProvider();
+    const ctrlEvent = { ctrlKey: true } as unknown as MouseEvent;
+    const plainEvent = { ctrlKey: false } as unknown as MouseEvent;
+
+    it("snaps to an angle it is close to", () => {
+        expect(snapProvider.getSnappedRotation(43, plainEvent)).toBe(45);
+        expect(snapProvider.getSnappedRotation(88, plainEvent)).toBe(90);
+        expect(snapProvider.getSnappedRotation(4, plainEvent)).toBe(0);
+    });
+
+    it("leaves an angle that is not close to one of them", () => {
+        expect(snapProvider.getSnappedRotation(20, plainEvent)).toBe(20);
+        expect(snapProvider.getSnappedRotation(70, plainEvent)).toBe(70);
+    });
+
+    it("snaps at exactly the edge of the tolerance", () => {
+        expect(snapProvider.getSnappedRotation(31, plainEvent)).toBe(45);
+        expect(snapProvider.getSnappedRotation(59, plainEvent)).toBe(45);
+    });
+
+    it("does not snap just outside the tolerance", () => {
+        expect(snapProvider.getSnappedRotation(30.5, plainEvent)).toBe(30.5);
+        expect(snapProvider.getSnappedRotation(59.5, plainEvent)).toBe(59.5);
+    });
+
+    it("leaves the angle alone while CTRL is held", () => {
+        // Sanity check: this angle does snap without CTRL.
+        expect(snapProvider.getSnappedRotation(43, plainEvent)).toBe(45);
+
+        expect(snapProvider.getSnappedRotation(43, ctrlEvent)).toBe(43);
+    });
+
+    it("snaps when there is no event at all", () => {
+        expect(snapProvider.getSnappedRotation(43, undefined)).toBe(45);
+    });
+
+    it("snaps a negative angle", () => {
+        // toBeCloseTo, because rounding a negative angle to zero gives negative zero,
+        // which is zero everywhere it matters but is not Object.is equal to it.
+        expect(snapProvider.getSnappedRotation(-5, plainEvent)).toBeCloseTo(0);
+        expect(snapProvider.getSnappedRotation(-43, plainEvent)).toBe(-45);
+    });
+
+    it("snaps an angle near a whole turn to the whole turn", () => {
+        // 360 rather than 0: the caller brings the angle into range when it writes it.
+        expect(snapProvider.getSnappedRotation(359, plainEvent)).toBe(360);
+    });
+});

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/canvasElementRotation.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/canvasElementRotation.ts
@@ -22,6 +22,15 @@ import { kBackgroundImageClass } from "../../toolbox/canvas/canvasElementConstan
 // exists so that CSS and selectors can find the rotated elements cheaply.
 export const kRotatedClass = "bloom-rotated";
 
+// Marks the turned canvas element the pointer is inside. A turned element has a CSS transform,
+// which makes it a stacking context, so the high z-indexes its contents use to get above the
+// comicaljs canvas no longer reach past the element itself. The canvas therefore covers the
+// element and takes the pointer, and the browser never gives the element :hover. Anything shown
+// on hover, such as a video's play button, would never appear. CanvasElementPointerInteractions
+// puts this class on the element the pointer is really inside, using the same rotation-aware hit
+// test that click uses, and the CSS accepts it in place of :hover (BL-16741).
+export const kPointerInsideClass = "bloom-pointer-inside";
+
 const kRotatePattern = /rotate\(\s*(-?[0-9]*\.?[0-9]+)deg\s*\)/;
 
 // Reduce any angle to the [0, 360) range that we store and display.
@@ -56,6 +65,9 @@ export function setCanvasElementRotation(
     if (rounded === 0 || rounded === 360) {
         canvasElement.style.transform = "";
         canvasElement.classList.remove(kRotatedClass);
+        // The code that marks the element the pointer is inside only ever visits the turned
+        // elements, so it can neither find nor clear this once the element is upright again.
+        canvasElement.classList.remove(kPointerInsideClass);
     } else {
         canvasElement.style.transform = `rotate(${rounded}deg)`;
         canvasElement.classList.add(kRotatedClass);

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/canvasElementRotation.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/canvasElementRotation.ts
@@ -1,0 +1,128 @@
+// Rotation of a whole canvas element.
+//
+// The rotation lives in the element's own inline `transform`, in the canonical form
+// `rotate(<angle>deg)`. That inline style is part of the page HTML, so the rotation is
+// saved with the book and applies in the reader and in PDF output without any Bloom
+// JavaScript. The inline style is therefore the single source of truth; this module owns
+// the code that reads and writes it, so nothing else has to parse a transform string.
+//
+// The rotation is about the centre of the element (the CSS default transform-origin), which
+// keeps `style.left`/`style.top` and the element's centre point unchanged. Code that
+// positions an element can therefore ignore the rotation; code that converts between mouse
+// positions and element coordinates cannot, and uses `rotateVector` below.
+//
+// Not every canvas element can rotate. A speech bubble, thought bubble, caption, rectangle
+// or ellipse has its outline and tail drawn by comicaljs onto a shared SVG layer, from the
+// element's un-rotated offset box. A CSS rotation of the element does not turn that drawn
+// shape, so we do not offer rotation for those elements. See canRotateCanvasElement.
+import { Bubble } from "comicaljs";
+import { kBackgroundImageClass } from "../../toolbox/canvas/canvasElementConstants";
+
+// Marks a rotated canvas element. The angle itself is in the inline transform; this class
+// exists so that CSS and selectors can find the rotated elements cheaply.
+export const kRotatedClass = "bloom-rotated";
+
+const kRotatePattern = /rotate\(\s*(-?[0-9]*\.?[0-9]+)deg\s*\)/;
+
+// Reduce any angle to the [0, 360) range that we store and display.
+export function normalizeDegrees(degrees: number): number {
+    if (!Number.isFinite(degrees)) {
+        return 0;
+    }
+    const remainder = degrees % 360;
+    return remainder < 0 ? remainder + 360 : remainder;
+}
+
+// The angle, in degrees, that this canvas element is currently rotated by. Zero when it is
+// not rotated.
+export function getCanvasElementRotation(canvasElement: HTMLElement): number {
+    const match = kRotatePattern.exec(canvasElement.style.transform ?? "");
+    if (!match) {
+        return 0;
+    }
+    return normalizeDegrees(parseFloat(match[1]));
+}
+
+// Rotate this canvas element to the given angle. An angle of zero removes the transform, so
+// an element that was never rotated, and one the user rotated back to upright, save the same
+// way.
+export function setCanvasElementRotation(
+    canvasElement: HTMLElement,
+    degrees: number,
+): void {
+    const normalized = normalizeDegrees(degrees);
+    // Two decimal places is finer than the user can see and keeps the saved HTML short.
+    const rounded = Math.round(normalized * 100) / 100;
+    if (rounded === 0 || rounded === 360) {
+        canvasElement.style.transform = "";
+        canvasElement.classList.remove(kRotatedClass);
+    } else {
+        canvasElement.style.transform = `rotate(${rounded}deg)`;
+        canvasElement.classList.add(kRotatedClass);
+    }
+}
+
+// True if we offer rotation for this canvas element.
+export function canRotateCanvasElement(canvasElement: HTMLElement): boolean {
+    // The background image fills its bloom-canvas and cannot be moved or resized, so turning
+    // the box makes no sense. The Rotate Right command turns the picture inside the box
+    // instead; see rotateImageContentRight in imageContentTransform.ts.
+    if (canvasElement.classList.contains(kBackgroundImageClass)) {
+        return false;
+    }
+    // comicaljs draws these shapes axis-aligned; see the note at the top of this file.
+    const style = Bubble.getBubbleSpec(canvasElement).style;
+    return !style || style === "none";
+}
+
+// Rotate the vector (x, y) by the given angle, clockwise, which is the direction CSS
+// `rotate()` turns in a document whose y axis points down.
+export function rotateVector(
+    x: number,
+    y: number,
+    degrees: number,
+): { x: number; y: number } {
+    if (degrees === 0) {
+        return { x, y };
+    }
+    const radians = (degrees * Math.PI) / 180;
+    const cos = Math.cos(radians);
+    const sin = Math.sin(radians);
+    return {
+        x: x * cos - y * sin,
+        y: x * sin + y * cos,
+    };
+}
+
+// Convert a vector measured on the screen into the element's own un-rotated coordinates.
+// Drag code computes sizes and positions in un-rotated coordinates, so it must convert the
+// mouse movement first, or a rotated element grows in the wrong direction.
+export function unrotateVector(
+    x: number,
+    y: number,
+    degrees: number,
+): { x: number; y: number } {
+    return rotateVector(x, y, -degrees);
+}
+
+// True if the point (in the coordinate system of the element's offsetParent, which is what
+// offsetLeft/offsetTop are measured in) is inside this canvas element, taking its rotation
+// into account. comicaljs tests the un-rotated offset box, so the page code has to do this
+// itself for rotated elements.
+export function isPointInsideRotatedCanvasElement(
+    canvasElement: HTMLElement,
+    x: number,
+    y: number,
+): boolean {
+    const degrees = getCanvasElementRotation(canvasElement);
+    const left = canvasElement.offsetLeft;
+    const top = canvasElement.offsetTop;
+    const width = canvasElement.offsetWidth;
+    const height = canvasElement.offsetHeight;
+    const centerX = left + width / 2;
+    const centerY = top + height / 2;
+    // Turning the point back by the element's angle puts it in the same frame as the
+    // un-rotated box, where the test is a simple rectangle containment.
+    const local = unrotateVector(x - centerX, y - centerY, degrees);
+    return Math.abs(local.x) <= width / 2 && Math.abs(local.y) <= height / 2;
+}

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/canvasElementRotation.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/canvasElementRotation.ts
@@ -105,6 +105,32 @@ export function unrotateVector(
     return rotateVector(x, y, -degrees);
 }
 
+// The eight directions of the eight directional resize cursors, clockwise from the top.
+const kClockwiseDirections = ["n", "ne", "e", "se", "s", "sw", "w", "nw"];
+
+// The cursors for an axis, one for each 45 degrees of turn from the vertical. A vertical axis
+// turned 45 degrees clockwise runs from the bottom left to the top right, which is the
+// north-east to south-west diagonal, so that cursor comes second.
+const kAxisCursors = ["ns-resize", "nesw-resize", "ew-resize", "nwse-resize"];
+
+// The cursor for one handle of the control frame on an element turned by the given angle. The
+// handles turn with the element, but a cursor cannot turn, so a handle on a turned element
+// needs the cursor of another direction. There are only eight cursors, so the angle is taken
+// to the nearest eighth of a turn. A corner moves along one of the eight directions and takes
+// a directional cursor; a side moves along an axis, and an axis turned half a turn is the same
+// axis, so four cursors cover the sides.
+export function getHandleCursorForRotation(
+    handle: "n" | "e" | "s" | "w" | "nw" | "ne" | "se" | "sw",
+    degrees: number,
+): string {
+    const steps = ((Math.round(normalizeDegrees(degrees) / 45) % 8) + 8) % 8;
+    const index = kClockwiseDirections.indexOf(handle) + steps;
+    if (handle.length === 2) {
+        return kClockwiseDirections[index % 8] + "-resize";
+    }
+    return kAxisCursors[index % 4];
+}
+
 // True if the point (in the coordinate system of the element's offsetParent, which is what
 // offsetLeft/offsetTop are measured in) is inside this canvas element, taking its rotation
 // into account. comicaljs tests the un-rotated offset box, so the page code has to do this

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/canvasElementRotationSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/canvasElementRotationSpec.ts
@@ -16,6 +16,7 @@ vi.mock("comicaljs", () => ({
 import {
     canRotateCanvasElement,
     getCanvasElementRotation,
+    getHandleCursorForRotation,
     isPointInsideRotatedCanvasElement,
     kRotatedClass,
     normalizeDegrees,
@@ -226,5 +227,46 @@ describe("isPointInsideRotatedCanvasElement", () => {
         giveElementABox(element, 100, 100, 100, 20);
         setCanvasElementRotation(element, 37);
         expect(isPointInsideRotatedCanvasElement(element, 150, 110)).toBe(true);
+    });
+});
+
+describe("getHandleCursorForRotation", () => {
+    it("gives each handle its own cursor on an upright element", () => {
+        expect(getHandleCursorForRotation("n", 0)).toBe("ns-resize");
+        expect(getHandleCursorForRotation("s", 0)).toBe("ns-resize");
+        expect(getHandleCursorForRotation("e", 0)).toBe("ew-resize");
+        expect(getHandleCursorForRotation("w", 0)).toBe("ew-resize");
+        expect(getHandleCursorForRotation("nw", 0)).toBe("nw-resize");
+        expect(getHandleCursorForRotation("ne", 0)).toBe("ne-resize");
+        expect(getHandleCursorForRotation("se", 0)).toBe("se-resize");
+        expect(getHandleCursorForRotation("sw", 0)).toBe("sw-resize");
+    });
+
+    it("swaps the two axes of the sides at a quarter turn", () => {
+        expect(getHandleCursorForRotation("n", 90)).toBe("ew-resize");
+        expect(getHandleCursorForRotation("e", 90)).toBe("ns-resize");
+    });
+
+    it("gives a side the diagonal its axis really lies on at 45 degrees", () => {
+        // A vertical axis turned 45 degrees clockwise runs from the bottom left to the top
+        // right, so the north handle takes the north-east to south-west cursor.
+        expect(getHandleCursorForRotation("n", 45)).toBe("nesw-resize");
+        expect(getHandleCursorForRotation("e", 45)).toBe("nwse-resize");
+    });
+
+    it("moves a corner round to the direction the turn takes it to", () => {
+        expect(getHandleCursorForRotation("nw", 90)).toBe("ne-resize");
+        expect(getHandleCursorForRotation("nw", 45)).toBe("n-resize");
+        expect(getHandleCursorForRotation("se", 180)).toBe("nw-resize");
+    });
+
+    it("takes an angle to the nearest eighth of a turn", () => {
+        expect(getHandleCursorForRotation("n", 4)).toBe("ns-resize");
+        expect(getHandleCursorForRotation("n", 88)).toBe("ew-resize");
+    });
+
+    it("treats a whole turn as no turn", () => {
+        expect(getHandleCursorForRotation("nw", 360)).toBe("nw-resize");
+        expect(getHandleCursorForRotation("n", 720)).toBe("ns-resize");
     });
 });

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/canvasElementRotationSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/canvasElementRotationSpec.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi } from "vitest";
+
+// The real comicaljs Bubble reads the data-bubble attribute of the element and does a lot
+// else besides. canRotateCanvasElement wants only the bubble style, so supply that much,
+// from an attribute that the tests set.
+vi.mock("comicaljs", () => ({
+    Bubble: {
+        getBubbleSpec: (element: HTMLElement) => ({
+            style: element.getAttribute("data-test-bubble-style") ?? undefined,
+        }),
+    },
+}));
+
+// This import deliberately comes after the vi.mock call above, so that the module gets the
+// stubbed comicaljs.
+import {
+    canRotateCanvasElement,
+    getCanvasElementRotation,
+    isPointInsideRotatedCanvasElement,
+    kRotatedClass,
+    normalizeDegrees,
+    rotateVector,
+    setCanvasElementRotation,
+    unrotateVector,
+} from "./canvasElementRotation";
+
+function makeCanvasElement(): HTMLElement {
+    return document.createElement("div");
+}
+
+// jsdom lays nothing out, so offsetLeft and its friends are all zero. Give the element the
+// box that the test wants.
+function giveElementABox(
+    element: HTMLElement,
+    left: number,
+    top: number,
+    width: number,
+    height: number,
+): void {
+    Object.defineProperty(element, "offsetLeft", { value: left });
+    Object.defineProperty(element, "offsetTop", { value: top });
+    Object.defineProperty(element, "offsetWidth", { value: width });
+    Object.defineProperty(element, "offsetHeight", { value: height });
+}
+
+describe("normalizeDegrees", () => {
+    it("leaves an angle that is already in range", () => {
+        expect(normalizeDegrees(0)).toBe(0);
+        expect(normalizeDegrees(45)).toBe(45);
+        expect(normalizeDegrees(359)).toBe(359);
+    });
+
+    it("brings an angle of 360 or more into range", () => {
+        expect(normalizeDegrees(360)).toBe(0);
+        expect(normalizeDegrees(370)).toBe(10);
+        expect(normalizeDegrees(725)).toBe(5);
+    });
+
+    it("brings a negative angle into range", () => {
+        expect(normalizeDegrees(-90)).toBe(270);
+        // toBeCloseTo, because a remainder of zero from a negative number is negative
+        // zero, which is zero everywhere it matters but is not Object.is equal to it.
+        expect(normalizeDegrees(-360)).toBeCloseTo(0);
+        expect(normalizeDegrees(-450)).toBe(270);
+    });
+
+    it("gives zero for an angle that is not a number", () => {
+        expect(normalizeDegrees(NaN)).toBe(0);
+        expect(normalizeDegrees(Infinity)).toBe(0);
+    });
+});
+
+describe("getCanvasElementRotation", () => {
+    it("gives zero for an element with no transform", () => {
+        expect(getCanvasElementRotation(makeCanvasElement())).toBe(0);
+    });
+
+    it("gives zero for a transform that holds no rotation", () => {
+        const element = makeCanvasElement();
+        element.style.transform = "scale(2)";
+        expect(getCanvasElementRotation(element)).toBe(0);
+    });
+
+    it("reads the angle out of the transform", () => {
+        const element = makeCanvasElement();
+        element.style.transform = "rotate(45deg)";
+        expect(getCanvasElementRotation(element)).toBe(45);
+    });
+
+    it("reads the angle when another function comes first", () => {
+        const element = makeCanvasElement();
+        element.style.transform = "translate(5px, 5px) rotate(90deg)";
+        expect(getCanvasElementRotation(element)).toBe(90);
+    });
+
+    it("brings a negative saved angle into range", () => {
+        const element = makeCanvasElement();
+        element.style.transform = "rotate(-30deg)";
+        expect(getCanvasElementRotation(element)).toBe(330);
+    });
+});
+
+describe("setCanvasElementRotation", () => {
+    it("writes the angle and marks the element", () => {
+        const element = makeCanvasElement();
+        // Sanity check: nothing is set before the call.
+        expect(element.style.transform).toBe("");
+        expect(element.classList.contains(kRotatedClass)).toBe(false);
+
+        setCanvasElementRotation(element, 45);
+
+        expect(element.style.transform).toBe("rotate(45deg)");
+        expect(element.classList.contains(kRotatedClass)).toBe(true);
+        expect(getCanvasElementRotation(element)).toBe(45);
+    });
+
+    it("brings a negative angle into range", () => {
+        const element = makeCanvasElement();
+        setCanvasElementRotation(element, -30);
+        expect(element.style.transform).toBe("rotate(330deg)");
+    });
+
+    it("keeps two decimal places", () => {
+        const element = makeCanvasElement();
+        setCanvasElementRotation(element, 12.347);
+        expect(element.style.transform).toBe("rotate(12.35deg)");
+    });
+
+    it("removes the transform and the mark for an angle of zero", () => {
+        const element = makeCanvasElement();
+        setCanvasElementRotation(element, 90);
+        // Sanity check: the element really is rotated before we straighten it.
+        expect(element.classList.contains(kRotatedClass)).toBe(true);
+
+        setCanvasElementRotation(element, 0);
+
+        expect(element.style.transform).toBe("");
+        expect(element.classList.contains(kRotatedClass)).toBe(false);
+    });
+
+    it("treats a whole turn as no rotation at all", () => {
+        const element = makeCanvasElement();
+        setCanvasElementRotation(element, 360);
+        expect(element.style.transform).toBe("");
+        expect(element.classList.contains(kRotatedClass)).toBe(false);
+    });
+});
+
+describe("canRotateCanvasElement", () => {
+    it("allows a plain canvas element", () => {
+        expect(canRotateCanvasElement(makeCanvasElement())).toBe(true);
+    });
+
+    it("refuses the background image", () => {
+        const element = makeCanvasElement();
+        element.classList.add("bloom-backgroundImage");
+        expect(canRotateCanvasElement(element)).toBe(false);
+    });
+
+    it("refuses a shape that comicaljs draws", () => {
+        const element = makeCanvasElement();
+        element.setAttribute("data-test-bubble-style", "speech");
+        expect(canRotateCanvasElement(element)).toBe(false);
+    });
+
+    it("allows an element whose bubble style is none", () => {
+        const element = makeCanvasElement();
+        element.setAttribute("data-test-bubble-style", "none");
+        expect(canRotateCanvasElement(element)).toBe(true);
+    });
+});
+
+describe("rotateVector and unrotateVector", () => {
+    it("gives back the same vector for an angle of zero", () => {
+        expect(rotateVector(3, 4, 0)).toEqual({ x: 3, y: 4 });
+    });
+
+    it("turns clockwise, which is down the screen from the x axis", () => {
+        const turned = rotateVector(10, 0, 90);
+        expect(turned.x).toBeCloseTo(0);
+        expect(turned.y).toBeCloseTo(10);
+    });
+
+    it("turns half a turn", () => {
+        const turned = rotateVector(10, 5, 180);
+        expect(turned.x).toBeCloseTo(-10);
+        expect(turned.y).toBeCloseTo(-5);
+    });
+
+    it("undoes the turn", () => {
+        const turned = rotateVector(7, -3, 37);
+        // Sanity check: the turn really moved the vector.
+        expect(turned.x).not.toBeCloseTo(7);
+
+        const back = unrotateVector(turned.x, turned.y, 37);
+
+        expect(back.x).toBeCloseTo(7);
+        expect(back.y).toBeCloseTo(-3);
+    });
+});
+
+describe("isPointInsideRotatedCanvasElement", () => {
+    it("tests the box itself when the element is not rotated", () => {
+        const element = makeCanvasElement();
+        giveElementABox(element, 100, 100, 100, 20);
+        expect(isPointInsideRotatedCanvasElement(element, 195, 110)).toBe(true);
+        expect(isPointInsideRotatedCanvasElement(element, 150, 155)).toBe(
+            false,
+        );
+    });
+
+    it("tests the turned box when the element is rotated", () => {
+        const element = makeCanvasElement();
+        giveElementABox(element, 100, 100, 100, 20);
+        setCanvasElementRotation(element, 90);
+        // A quarter turn about the centre (150, 110) puts the long side up and down the
+        // screen, so a point above the centre is now inside and one beside it is not.
+        expect(isPointInsideRotatedCanvasElement(element, 150, 155)).toBe(true);
+        expect(isPointInsideRotatedCanvasElement(element, 195, 110)).toBe(
+            false,
+        );
+    });
+
+    it("takes the centre of the element as inside whatever the angle", () => {
+        const element = makeCanvasElement();
+        giveElementABox(element, 100, 100, 100, 20);
+        setCanvasElementRotation(element, 37);
+        expect(isPointInsideRotatedCanvasElement(element, 150, 110)).toBe(true);
+    });
+});

--- a/src/BloomBrowserUI/bookEdit/js/imageContentTransform.ts
+++ b/src/BloomBrowserUI/bookEdit/js/imageContentTransform.ts
@@ -1,0 +1,167 @@
+// Turning and mirroring the picture inside its container.
+//
+// This is separate from rotating a whole canvas element (canvasElementManager/
+// canvasElementRotation.ts). Here the container keeps its shape and only the picture inside
+// it changes: the Rotate Right command uses this for a background image, which fills its
+// bloom-canvas and so cannot itself turn, and the Flip commands use it for every image,
+// because mirroring the box would make no sense.
+//
+// State lives in the img's own inline `transform`, in the canonical form
+// `rotate(<angle>deg) scale(<sx>, <sy>)`. As with canvas element rotation, an inline style
+// is what makes the change appear in the reader and in PDF output, where no Bloom
+// JavaScript runs, so it is the single source of truth and this module owns the parsing.
+//
+// The three logical values we keep are:
+// - a number of quarter turns clockwise, 0 to 3, from the `rotate` part;
+// - whether the picture is mirrored along its own x axis, from the sign of sx;
+// - whether it is mirrored along its own y axis, from the sign of sy.
+//
+// The magnitude of the scale is not state: it is recomputed on every write, because a
+// quarter turn leaves the picture's layout box lying across its container and it has to be
+// shrunk to fit again.
+
+export type FlipAxis = "horizontal" | "vertical";
+
+interface ImageContentTransform {
+    // Quarter turns clockwise: 0, 1, 2 or 3.
+    quarterTurns: number;
+    // Mirrored along the picture's own x axis (before the turn is applied).
+    flipX: boolean;
+    // Mirrored along the picture's own y axis (before the turn is applied).
+    flipY: boolean;
+}
+
+const kRotatePattern = /rotate\(\s*(-?[0-9]*\.?[0-9]+)deg\s*\)/;
+const kScalePattern =
+    /scale\(\s*(-?[0-9]*\.?[0-9]+)\s*(?:,\s*(-?[0-9]*\.?[0-9]+)\s*)?\)/;
+
+// Read the current turn and mirror state of the picture.
+export function getImageContentTransform(
+    img: HTMLImageElement,
+): ImageContentTransform {
+    const transform = img.style.transform ?? "";
+
+    let quarterTurns = 0;
+    const rotateMatch = kRotatePattern.exec(transform);
+    if (rotateMatch) {
+        const degrees = parseFloat(rotateMatch[1]);
+        // Round to the nearest quarter turn. Only quarter turns can get here, because this
+        // is the only code that writes the value, but rounding keeps a hand-edited or
+        // future value from producing a fractional turn count.
+        quarterTurns = ((Math.round(degrees / 90) % 4) + 4) % 4;
+    }
+
+    let flipX = false;
+    let flipY = false;
+    const scaleMatch = kScalePattern.exec(transform);
+    if (scaleMatch) {
+        const sx = parseFloat(scaleMatch[1]);
+        // A one-argument scale() scales both axes by the same amount.
+        const sy = scaleMatch[2] === undefined ? sx : parseFloat(scaleMatch[2]);
+        flipX = sx < 0;
+        flipY = sy < 0;
+    }
+
+    return { quarterTurns, flipX, flipY };
+}
+
+// True if the picture has been turned or mirrored at all.
+export function imageContentIsTransformed(img: HTMLImageElement): boolean {
+    const state = getImageContentTransform(img);
+    return state.quarterTurns !== 0 || state.flipX || state.flipY;
+}
+
+// How much the picture must shrink so that, lying across its container after an odd number
+// of quarter turns, it still fits. Its layout box keeps the shape it had before the turn, so
+// the box's width has to fit the container's height and the box's height the container's
+// width.
+function getFitScaleForQuarterTurn(img: HTMLImageElement): number {
+    const width = img.clientWidth;
+    const height = img.clientHeight;
+    if (!width || !height) {
+        // We cannot measure the picture yet (it has not been laid out). Leaving the scale at
+        // 1 turns the picture without shrinking it; the container clips the overhang, which
+        // is better than dividing by zero.
+        return 1;
+    }
+    const container = img.parentElement;
+    const containerWidth = container?.clientWidth ?? width;
+    const containerHeight = container?.clientHeight ?? height;
+    return Math.min(containerHeight / width, containerWidth / height);
+}
+
+// Write the turn and mirror state back to the img's inline transform.
+function setImageContentTransform(
+    img: HTMLImageElement,
+    state: ImageContentTransform,
+): void {
+    const isQuarterTurn = state.quarterTurns % 2 === 1;
+    const fitScale = isQuarterTurn ? getFitScaleForQuarterTurn(img) : 1;
+    const sx = (state.flipX ? -1 : 1) * fitScale;
+    const sy = (state.flipY ? -1 : 1) * fitScale;
+
+    if (state.quarterTurns === 0 && sx === 1 && sy === 1) {
+        // Back to the original picture, so leave no transform behind at all.
+        img.style.transform = "";
+        return;
+    }
+
+    const parts: string[] = [];
+    if (state.quarterTurns !== 0) {
+        parts.push(`rotate(${state.quarterTurns * 90}deg)`);
+    }
+    if (sx !== 1 || sy !== 1) {
+        // Three decimal places keeps the fit scale accurate to well under a pixel at any
+        // page size we support, without filling the saved HTML with digits.
+        const round = (value: number) => Math.round(value * 1000) / 1000;
+        parts.push(`scale(${round(sx)}, ${round(sy)})`);
+    }
+    img.style.transform = parts.join(" ");
+}
+
+// Put the picture back the way it arrived: no turn and no mirror. The Reset Image command
+// uses this together with removing the crop. It does not touch the rotation of a canvas
+// element box, which is a property of the box rather than of the picture.
+export function clearImageContentTransform(img: HTMLImageElement): void {
+    img.style.transform = "";
+}
+
+// Cropping is stored as an explicit size and offset that makes the img bigger than its
+// container. Those numbers describe the picture as it was, so a quarter turn would leave the
+// crop showing a part of the picture the user never chose. We therefore drop the crop when
+// we turn the picture. Mirroring keeps the box the same shape, so it leaves the crop alone.
+function removeCropping(img: HTMLImageElement): void {
+    img.style.width = "";
+    img.style.height = "";
+    img.style.left = "";
+    img.style.top = "";
+}
+
+// Turn the picture a quarter turn clockwise inside its container, and shrink it so that it
+// still fits. Any cropping is removed; see removeCropping.
+export function rotateImageContentRight(img: HTMLImageElement): void {
+    const state = getImageContentTransform(img);
+    // Drop the crop first, so that the fit scale is measured against the layout box the
+    // picture will actually have. (clientWidth reports the layout box, which a transform
+    // does not change, so the old transform can stay in place while we measure.)
+    removeCropping(img);
+    setImageContentTransform(img, {
+        ...state,
+        quarterTurns: (state.quarterTurns + 1) % 4,
+    });
+}
+
+// Mirror the picture about the axis the user sees on screen. "Horizontal" means left and
+// right change places on screen, whichever way the picture has been turned. After an odd
+// number of quarter turns the picture's own x axis runs up and down the screen, so a
+// horizontal flip on screen is a flip of the picture's y axis.
+export function flipImageContent(img: HTMLImageElement, axis: FlipAxis): void {
+    const state = getImageContentTransform(img);
+    const isQuarterTurn = state.quarterTurns % 2 === 1;
+    const flipLocalX = axis === "horizontal" ? !isQuarterTurn : isQuarterTurn;
+    setImageContentTransform(img, {
+        ...state,
+        flipX: flipLocalX ? !state.flipX : state.flipX,
+        flipY: flipLocalX ? state.flipY : !state.flipY,
+    });
+}

--- a/src/BloomBrowserUI/bookEdit/js/imageContentTransform.ts
+++ b/src/BloomBrowserUI/bookEdit/js/imageContentTransform.ts
@@ -1,10 +1,11 @@
 // Turning and mirroring the picture inside its container.
 //
 // This is separate from rotating a whole canvas element (canvasElementManager/
-// canvasElementRotation.ts). Here the container keeps its shape and only the picture inside
-// it changes: the Rotate Right command uses this for a background image, which fills its
-// bloom-canvas and so cannot itself turn, and the Flip commands use it for every image,
-// because mirroring the box would make no sense.
+// canvasElementRotation.ts). There the box turns on the page and the picture rides round with
+// it. Here the picture turns inside the page's picture area: the Rotate Right command uses this
+// for a page background picture, whose box is the page's picture area itself and so cannot turn
+// on the page, and the Flip commands use it for every picture, because mirroring a box would
+// make no sense.
 //
 // State lives in the img's own inline `transform`, in the canonical form
 // `rotate(<angle>deg) scale(<sx>, <sy>)`. As with canvas element rotation, an inline style
@@ -16,9 +17,16 @@
 // - whether the picture is mirrored along its own x axis, from the sign of sx;
 // - whether it is mirrored along its own y axis, from the sign of sy.
 //
-// The magnitude of the scale is not state: it is recomputed on every write, because a
-// quarter turn leaves the picture's layout box lying across its container and it has to be
-// shrunk to fit again.
+// The scale carries the mirrors and nothing else: each factor is 1 or -1. A quarter turn
+// leaves the picture's layout box lying across its container, and we answer that by moving
+// the box and the box's own canvas element, not by shrinking the picture. See
+// computeTurnedBackgroundLayout.
+
+import {
+    kBackgroundImageClass,
+    kBloomCanvasSelector,
+    kCanvasElementSelector,
+} from "../toolbox/canvas/canvasElementConstants";
 
 export type FlipAxis = "horizontal" | "vertical";
 
@@ -71,34 +79,13 @@ export function imageContentIsTransformed(img: HTMLImageElement): boolean {
     return state.quarterTurns !== 0 || state.flipX || state.flipY;
 }
 
-// How much the picture must shrink so that, lying across its container after an odd number
-// of quarter turns, it still fits. Its layout box keeps the shape it had before the turn, so
-// the box's width has to fit the container's height and the box's height the container's
-// width.
-function getFitScaleForQuarterTurn(img: HTMLImageElement): number {
-    const width = img.clientWidth;
-    const height = img.clientHeight;
-    if (!width || !height) {
-        // We cannot measure the picture yet (it has not been laid out). Leaving the scale at
-        // 1 turns the picture without shrinking it; the container clips the overhang, which
-        // is better than dividing by zero.
-        return 1;
-    }
-    const container = img.parentElement;
-    const containerWidth = container?.clientWidth ?? width;
-    const containerHeight = container?.clientHeight ?? height;
-    return Math.min(containerHeight / width, containerWidth / height);
-}
-
 // Write the turn and mirror state back to the img's inline transform.
 function setImageContentTransform(
     img: HTMLImageElement,
     state: ImageContentTransform,
 ): void {
-    const isQuarterTurn = state.quarterTurns % 2 === 1;
-    const fitScale = isQuarterTurn ? getFitScaleForQuarterTurn(img) : 1;
-    const sx = (state.flipX ? -1 : 1) * fitScale;
-    const sy = (state.flipY ? -1 : 1) * fitScale;
+    const sx = state.flipX ? -1 : 1;
+    const sy = state.flipY ? -1 : 1;
 
     if (state.quarterTurns === 0 && sx === 1 && sy === 1) {
         // Back to the original picture, so leave no transform behind at all.
@@ -111,10 +98,7 @@ function setImageContentTransform(
         parts.push(`rotate(${state.quarterTurns * 90}deg)`);
     }
     if (sx !== 1 || sy !== 1) {
-        // Three decimal places keeps the fit scale accurate to well under a pixel at any
-        // page size we support, without filling the saved HTML with digits.
-        const round = (value: number) => Math.round(value * 1000) / 1000;
-        parts.push(`scale(${round(sx)}, ${round(sy)})`);
+        parts.push(`scale(${sx}, ${sy})`);
     }
     img.style.transform = parts.join(" ");
 }
@@ -126,25 +110,253 @@ export function clearImageContentTransform(img: HTMLImageElement): void {
     img.style.transform = "";
 }
 
-// Cropping is stored as an explicit size and offset that makes the img bigger than its
-// container. Those numbers describe the picture as it was, so a quarter turn would leave the
-// crop showing a part of the picture the user never chose. We therefore drop the crop when
-// we turn the picture. Mirroring keeps the box the same shape, so it leaves the crop alone.
-function removeCropping(img: HTMLImageElement): void {
-    img.style.width = "";
-    img.style.height = "";
-    img.style.left = "";
-    img.style.top = "";
+// The size and place of a background picture's canvas element and of the picture inside it.
+// All eight numbers are CSS pixels within the bloom-canvas (the page's picture area).
+export interface BackgroundPictureLayout {
+    elementWidth: number;
+    elementHeight: number;
+    elementLeft: number;
+    elementTop: number;
+    // The picture's layout box, which is what a transform then turns.
+    imageWidth: number;
+    imageHeight: number;
+    imageLeft: number;
+    imageTop: number;
 }
 
-// Turn the picture a quarter turn clockwise inside its container, and shrink it so that it
-// still fits. Any cropping is removed; see removeCropping.
+// Where a background picture and its canvas element must go after one more quarter turn.
+//
+// Bloom shows a background picture by giving its canvas element the shape of the picture and
+// centring that element in the page's picture area. A picture that is not the shape of the page
+// therefore leaves blank bands above and below (or left and right), and the Expand Image
+// command is there for an author who would rather fill the page. A quarter turn changes the
+// shape of the picture, so it has to change the shape of the element in the same way: what you
+// get by turning a picture is what you would have got if the picture had arrived already
+// turned.
+//
+// So we turn the whole content of the element, which swaps the element's two dimensions, and
+// then scale everything so that the swapped element fits the page again. Turning the content of
+// a container of width Cw and height Ch a quarter turn clockwise gives a container of width Ch
+// and height Cw, and carries the point (x, y) to (Ch - y, x). The picture's box turns about its
+// own centre, because that is what a CSS transform does, so the only thing we have to place is
+// that centre.
+//
+// The caller passes the picture's drawn rectangle, not its layout box. For a cropped picture the
+// two are the same, but an uncropped picture is drawn inside its box by object-fit, and it is
+// the drawn rectangle that has to land in the right place.
+export function computeTurnedBackgroundLayout(
+    // The bloom-canvas: the page's picture area.
+    pageWidth: number,
+    pageHeight: number,
+    // The background canvas element, which is also the size of the image container.
+    elementWidth: number,
+    elementHeight: number,
+    // The drawn picture, in the element's coordinates.
+    imageWidth: number,
+    imageHeight: number,
+    imageLeft: number,
+    imageTop: number,
+    // True for a picture the author has told to fill the page (the Expand Image command, which
+    // adds the class bloom-imageObjectFit-cover). Such a picture keeps the whole page and has
+    // its ends clipped, instead of fitting inside the page with blank bands.
+    fillsPage: boolean,
+): BackgroundPictureLayout {
+    // The turned element measures elementHeight by elementWidth. Scale it to the page.
+    const widthRatio = pageWidth / elementHeight;
+    const heightRatio = pageHeight / elementWidth;
+    const scale = fillsPage
+        ? Math.max(widthRatio, heightRatio)
+        : Math.min(widthRatio, heightRatio);
+
+    const newElementWidth = fillsPage ? pageWidth : scale * elementHeight;
+    const newElementHeight = fillsPage ? pageHeight : scale * elementWidth;
+
+    // Where the turned content sits inside the new element. When the element fits the page, the
+    // two are the same size and this is zero. When the element fills the page, the content is
+    // bigger than the element, and we centre it so that equal amounts are clipped from each end.
+    const shiftLeft = (newElementWidth - scale * elementHeight) / 2;
+    const shiftTop = (newElementHeight - scale * elementWidth) / 2;
+
+    // The centre of the picture's box, carried by the turn and then scaled.
+    const centreX =
+        scale * (elementHeight - imageTop - imageHeight / 2) + shiftLeft;
+    const centreY = scale * (imageLeft + imageWidth / 2) + shiftTop;
+
+    const newImageWidth = scale * imageWidth;
+    const newImageHeight = scale * imageHeight;
+    return {
+        elementWidth: newElementWidth,
+        elementHeight: newElementHeight,
+        elementLeft: (pageWidth - newElementWidth) / 2,
+        elementTop: (pageHeight - newElementHeight) / 2,
+        imageWidth: newImageWidth,
+        imageHeight: newImageHeight,
+        imageLeft: centreX - newImageWidth / 2,
+        imageTop: centreY - newImageHeight / 2,
+    };
+}
+
+// The class the Expand Image command puts on a background picture that must fill the page.
+const kFillsPageClass = "bloom-imageObjectFit-cover";
+
+// Read a length we wrote ourselves. Anything we did not write counts as zero.
+function pxOrZero(value: string): number {
+    const parsed = parseFloat(value);
+    return isNaN(parsed) ? 0 : parsed;
+}
+
+// Round to a hundredth of a pixel. That is finer than anyone can see, and it keeps the saved
+// HTML from filling up with digits.
+function roundPx(value: number): number {
+    return Math.round(value * 100) / 100;
+}
+
+// The picture's drawn rectangle inside its layout box, in the container's coordinates.
+//
+// A cropped picture has an explicit width, and then its box and its drawn rectangle are the
+// same thing. An uncropped picture has a box the size of its container and is drawn inside that
+// box by object-fit: contain, which fills the box only when the container is already the shape
+// of the picture. The container usually is, because Bloom shapes it that way, but we work the
+// drawn rectangle out rather than assume it.
+function getDrawnPictureRectangle(
+    img: HTMLImageElement,
+): { width: number; height: number; left: number; top: number } | undefined {
+    const boxWidth = img.clientWidth;
+    const boxHeight = img.clientHeight;
+    if (!boxWidth || !boxHeight) {
+        return undefined;
+    }
+    const left = pxOrZero(img.style.left);
+    const top = pxOrZero(img.style.top);
+    if (img.style.width) {
+        return { width: boxWidth, height: boxHeight, left, top };
+    }
+    const naturalWidth = img.naturalWidth;
+    const naturalHeight = img.naturalHeight;
+    if (!naturalWidth || !naturalHeight) {
+        return undefined;
+    }
+    const containScale = Math.min(
+        boxWidth / naturalWidth,
+        boxHeight / naturalHeight,
+    );
+    const width = containScale * naturalWidth;
+    const height = containScale * naturalHeight;
+    return {
+        width,
+        height,
+        left: left + (boxWidth - width) / 2,
+        top: top + (boxHeight - height) / 2,
+    };
+}
+
+// Move the picture's canvas element and the picture inside it for one more quarter turn, and say
+// whether it worked. It does not touch the transform; the caller does that.
+//
+// This is where a crop survives a turn. The four numbers that hold a crop say how big to draw
+// the whole picture and how far to move it up and to the left. They describe the picture as it
+// lies before the turn, and they stay true of it afterwards: all that changes is where that box
+// has to be for the turned picture to land on the page.
+//
+// There are two kinds of element to place the turned content in, and one formula covers both.
+// A background picture has to fit the page's picture area, so its element is scaled to that
+// area and centred in it. Any other element keeps the size it has, so the area is that element
+// with its own two dimensions swapped, the scale comes out as one, and the element turns about
+// its own centre and stays where the author put it. The Rotate Right command reaches an element
+// of the second kind when its box cannot turn on the page for some other reason, which is the
+// case for an element whose outline comicaljs draws.
+function setTurnedBackgroundLayout(img: HTMLImageElement): boolean {
+    const element = img.closest(kCanvasElementSelector) as HTMLElement | null;
+    const page = img.closest(kBloomCanvasSelector) as HTMLElement | null;
+    if (!element || !page) {
+        return false;
+    }
+    const isBackground = element.classList.contains(kBackgroundImageClass);
+    const elementWidth = element.clientWidth;
+    const elementHeight = element.clientHeight;
+    // The area the turned element has to land in.
+    const areaWidth = isBackground ? page.clientWidth : elementHeight;
+    const areaHeight = isBackground ? page.clientHeight : elementWidth;
+    const picture = getDrawnPictureRectangle(img);
+    if (
+        !areaWidth ||
+        !areaHeight ||
+        !elementWidth ||
+        !elementHeight ||
+        !picture
+    ) {
+        // Something has not been laid out yet, so we have nothing to measure and would write
+        // nonsense. The turn itself still happens, and the container clips any overhang.
+        return false;
+    }
+
+    const layout = computeTurnedBackgroundLayout(
+        areaWidth,
+        areaHeight,
+        elementWidth,
+        elementHeight,
+        picture.width,
+        picture.height,
+        picture.left,
+        picture.top,
+        img.classList.contains(kFillsPageClass),
+    );
+
+    element.style.width = `${roundPx(layout.elementWidth)}px`;
+    element.style.height = `${roundPx(layout.elementHeight)}px`;
+    if (isBackground) {
+        // Centred in the page's picture area, which is where Bloom keeps a background picture.
+        element.style.left = `${roundPx(layout.elementLeft)}px`;
+        element.style.top = `${roundPx(layout.elementTop)}px`;
+    } else {
+        // Turned about its own centre, so the element stays where the author put it.
+        element.style.left = `${roundPx(
+            pxOrZero(element.style.left) +
+                (elementWidth - layout.elementWidth) / 2,
+        )}px`;
+        element.style.top = `${roundPx(
+            pxOrZero(element.style.top) +
+                (elementHeight - layout.elementHeight) / 2,
+        )}px`;
+    }
+
+    // If the picture fills its element again, it needs no numbers of its own. Leaving them off
+    // matters: an explicit width is how the rest of Bloom recognizes a crop, so an uncropped
+    // picture must not acquire one just by being turned. The other direction matters as well.
+    // When the page changes size, adjustBackgroundImageSizeToFit keeps the element's own shape
+    // for a picture that has a width and goes back to the picture's natural shape for one that
+    // has none. A quarter turn always writes a width, so the turned shape survives a resize; a
+    // half turn writes none, and the natural shape is then the right one.
+    const fillsElementExactly =
+        Math.abs(layout.imageWidth - layout.elementWidth) < 1 &&
+        Math.abs(layout.imageHeight - layout.elementHeight) < 1 &&
+        Math.abs(layout.imageLeft) < 1 &&
+        Math.abs(layout.imageTop) < 1;
+    if (fillsElementExactly) {
+        img.style.width = "";
+        img.style.height = "";
+        img.style.left = "";
+        img.style.top = "";
+        return true;
+    }
+    img.style.width = `${roundPx(layout.imageWidth)}px`;
+    img.style.left = `${roundPx(layout.imageLeft)}px`;
+    img.style.top = `${roundPx(layout.imageTop)}px`;
+    // The height follows the width and the picture's own shape, and we must not write it: when
+    // the page changes size, Bloom scales a picture's width, left and top and leaves its height
+    // alone, so a height written here would stay behind and stretch the picture.
+    img.style.height = "";
+    return true;
+}
+
+// Turn the picture a quarter turn clockwise inside the page's picture area, keeping any crop the
+// author made. See setTurnedBackgroundLayout for how, and computeTurnedBackgroundLayout for why
+// the picture's own canvas element changes shape as well.
 export function rotateImageContentRight(img: HTMLImageElement): void {
     const state = getImageContentTransform(img);
-    // Drop the crop first, so that the fit scale is measured against the layout box the
-    // picture will actually have. (clientWidth reports the layout box, which a transform
-    // does not change, so the old transform can stay in place while we measure.)
-    removeCropping(img);
+    // Measure and move first: clientWidth reports the layout box, which a transform does not
+    // change, so the old transform can stay in place while we measure.
+    setTurnedBackgroundLayout(img);
     setImageContentTransform(img, {
         ...state,
         quarterTurns: (state.quarterTurns + 1) % 4,

--- a/src/BloomBrowserUI/bookEdit/js/imageContentTransform.ts
+++ b/src/BloomBrowserUI/bookEdit/js/imageContentTransform.ts
@@ -155,9 +155,21 @@ export function rotateImageContentRight(img: HTMLImageElement): void {
 // right change places on screen, whichever way the picture has been turned. After an odd
 // number of quarter turns the picture's own x axis runs up and down the screen, so a
 // horizontal flip on screen is a flip of the picture's y axis.
-export function flipImageContent(img: HTMLImageElement, axis: FlipAxis): void {
+//
+// The canvas element box can be turned as well, by the Rotate Right command or by the
+// rotation handle, and that turn moves the picture on screen just as a turn of the picture
+// itself does. The caller passes that angle as boxRotationDegrees. The handle turns to any
+// angle, and no mirror of the picture's own axes equals a mirror about the screen axis at,
+// say, 37 degrees, so we take the box angle to the nearest quarter turn and mirror about the
+// axis of the picture that lies nearest the one the user asked for.
+export function flipImageContent(
+    img: HTMLImageElement,
+    axis: FlipAxis,
+    boxRotationDegrees = 0,
+): void {
     const state = getImageContentTransform(img);
-    const isQuarterTurn = state.quarterTurns % 2 === 1;
+    const boxQuarterTurns = Math.round(boxRotationDegrees / 90);
+    const isQuarterTurn = (state.quarterTurns + boxQuarterTurns) % 2 !== 0;
     const flipLocalX = axis === "horizontal" ? !isQuarterTurn : isQuarterTurn;
     setImageContentTransform(img, {
         ...state,

--- a/src/BloomBrowserUI/bookEdit/js/imageContentTransformSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/imageContentTransformSpec.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect } from "vitest";
+import {
+    clearImageContentTransform,
+    flipImageContent,
+    getImageContentTransform,
+    imageContentIsTransformed,
+    rotateImageContentRight,
+} from "./imageContentTransform";
+
+// A picture inside a container, which is what the code expects. jsdom lays nothing out, so
+// the sizes are zero unless a test gives them, and a zero size makes the fit scale 1. That
+// keeps the transform easy to read in the tests that are about the turn and the mirror.
+function makeImage(): HTMLImageElement {
+    const container = document.createElement("div");
+    const img = document.createElement("img");
+    container.appendChild(img);
+    return img;
+}
+
+// Give the picture and its container a laid-out size, so that the fit scale can be measured.
+function giveSizes(
+    img: HTMLImageElement,
+    imgWidth: number,
+    imgHeight: number,
+    containerWidth: number,
+    containerHeight: number,
+): void {
+    Object.defineProperty(img, "clientWidth", { value: imgWidth });
+    Object.defineProperty(img, "clientHeight", { value: imgHeight });
+    Object.defineProperty(img.parentElement, "clientWidth", {
+        value: containerWidth,
+    });
+    Object.defineProperty(img.parentElement, "clientHeight", {
+        value: containerHeight,
+    });
+}
+
+// The number that both axes of the scale are multiplied by, or undefined when there is no
+// scale at all. The sign is dropped, because the sign is the mirror and this is the size.
+function getScaleMagnitude(img: HTMLImageElement): number | undefined {
+    const match = /scale\(\s*(-?[0-9.]+)/.exec(img.style.transform);
+    return match ? Math.abs(parseFloat(match[1])) : undefined;
+}
+
+describe("getImageContentTransform", () => {
+    it("reports nothing for a picture with no transform", () => {
+        expect(getImageContentTransform(makeImage())).toEqual({
+            quarterTurns: 0,
+            flipX: false,
+            flipY: false,
+        });
+    });
+
+    it("reads the number of quarter turns", () => {
+        const img = makeImage();
+        img.style.transform = "rotate(180deg)";
+        expect(getImageContentTransform(img).quarterTurns).toBe(2);
+    });
+
+    it("brings a turn of a whole circle or more back into range", () => {
+        const img = makeImage();
+        img.style.transform = "rotate(450deg)";
+        expect(getImageContentTransform(img).quarterTurns).toBe(1);
+    });
+
+    it("reads a mirror of one axis from the sign of the scale", () => {
+        const img = makeImage();
+        img.style.transform = "rotate(90deg) scale(-1, 1)";
+        expect(getImageContentTransform(img)).toEqual({
+            quarterTurns: 1,
+            flipX: true,
+            flipY: false,
+        });
+    });
+
+    it("takes a scale with one number as both axes", () => {
+        const img = makeImage();
+        img.style.transform = "scale(-0.5)";
+        expect(getImageContentTransform(img)).toEqual({
+            quarterTurns: 0,
+            flipX: true,
+            flipY: true,
+        });
+    });
+});
+
+describe("imageContentIsTransformed", () => {
+    it("is false for a picture with no transform", () => {
+        expect(imageContentIsTransformed(makeImage())).toBe(false);
+    });
+
+    it("is false for a picture that is only made smaller to fit", () => {
+        const img = makeImage();
+        img.style.transform = "scale(0.5, 0.5)";
+        expect(imageContentIsTransformed(img)).toBe(false);
+    });
+
+    it("is true for a turned picture", () => {
+        const img = makeImage();
+        img.style.transform = "rotate(90deg)";
+        expect(imageContentIsTransformed(img)).toBe(true);
+    });
+
+    it("is true for a mirrored picture", () => {
+        const img = makeImage();
+        img.style.transform = "scale(-1, 1)";
+        expect(imageContentIsTransformed(img)).toBe(true);
+    });
+});
+
+describe("rotateImageContentRight", () => {
+    it("adds a quarter turn each time, and four turns leave nothing behind", () => {
+        const img = makeImage();
+
+        rotateImageContentRight(img);
+        expect(getImageContentTransform(img).quarterTurns).toBe(1);
+        rotateImageContentRight(img);
+        expect(getImageContentTransform(img).quarterTurns).toBe(2);
+        rotateImageContentRight(img);
+        expect(getImageContentTransform(img).quarterTurns).toBe(3);
+        rotateImageContentRight(img);
+
+        expect(getImageContentTransform(img).quarterTurns).toBe(0);
+        expect(img.style.transform).toBe("");
+    });
+
+    it("keeps a mirror while it turns", () => {
+        const img = makeImage();
+        img.style.transform = "scale(-1, 1)";
+        rotateImageContentRight(img);
+        expect(getImageContentTransform(img)).toEqual({
+            quarterTurns: 1,
+            flipX: true,
+            flipY: false,
+        });
+    });
+
+    it("removes the crop, because the crop described the picture before the turn", () => {
+        const img = makeImage();
+        img.style.width = "300px";
+        img.style.height = "200px";
+        img.style.left = "-20px";
+        img.style.top = "-10px";
+        // Sanity check: the crop is really there before the turn.
+        expect(img.style.width).toBe("300px");
+
+        rotateImageContentRight(img);
+
+        expect(img.style.width).toBe("");
+        expect(img.style.height).toBe("");
+        expect(img.style.left).toBe("");
+        expect(img.style.top).toBe("");
+    });
+
+    it("shrinks the picture so that it still fits after an odd quarter turn", () => {
+        const img = makeImage();
+        // A wide picture in a wide container: lying across the container, its 200 of width
+        // has to fit into 100 of height, so it must come down to half its size.
+        giveSizes(img, 200, 100, 200, 100);
+
+        rotateImageContentRight(img);
+
+        expect(getScaleMagnitude(img)).toBeCloseTo(0.5);
+    });
+
+    it("uses the full size again after a half turn", () => {
+        const img = makeImage();
+        giveSizes(img, 200, 100, 200, 100);
+        rotateImageContentRight(img);
+        // Sanity check: the picture is smaller after the first turn.
+        expect(getScaleMagnitude(img)).toBeCloseTo(0.5);
+
+        rotateImageContentRight(img);
+
+        expect(getScaleMagnitude(img)).toBeUndefined();
+        expect(img.style.transform).toBe("rotate(180deg)");
+    });
+});
+
+describe("flipImageContent", () => {
+    it("mirrors the x axis of an upright picture from side to side", () => {
+        const img = makeImage();
+        flipImageContent(img, "horizontal");
+        expect(getImageContentTransform(img)).toEqual({
+            quarterTurns: 0,
+            flipX: true,
+            flipY: false,
+        });
+    });
+
+    it("mirrors the y axis of an upright picture from top to bottom", () => {
+        const img = makeImage();
+        flipImageContent(img, "vertical");
+        expect(getImageContentTransform(img)).toEqual({
+            quarterTurns: 0,
+            flipX: false,
+            flipY: true,
+        });
+    });
+
+    it("leaves nothing behind when the same mirror is used twice", () => {
+        const img = makeImage();
+        flipImageContent(img, "horizontal");
+        // Sanity check: the first mirror really was written.
+        expect(img.style.transform).not.toBe("");
+
+        flipImageContent(img, "horizontal");
+
+        expect(img.style.transform).toBe("");
+    });
+
+    it("mirrors the other axis of the picture after a quarter turn", () => {
+        const img = makeImage();
+        rotateImageContentRight(img);
+        // After a quarter turn the x axis of the picture runs up and down the screen, so a
+        // mirror from side to side on screen is a mirror of the y axis of the picture.
+        flipImageContent(img, "horizontal");
+        expect(getImageContentTransform(img)).toEqual({
+            quarterTurns: 1,
+            flipX: false,
+            flipY: true,
+        });
+    });
+
+    it("keeps the crop, because a mirror does not change the shape of the box", () => {
+        const img = makeImage();
+        img.style.width = "300px";
+        img.style.left = "-20px";
+
+        flipImageContent(img, "horizontal");
+
+        expect(img.style.width).toBe("300px");
+        expect(img.style.left).toBe("-20px");
+    });
+});
+
+describe("clearImageContentTransform", () => {
+    it("removes the turn and the mirror", () => {
+        const img = makeImage();
+        img.style.transform = "rotate(90deg) scale(-1, 1)";
+        // Sanity check: there is something to clear.
+        expect(imageContentIsTransformed(img)).toBe(true);
+
+        clearImageContentTransform(img);
+
+        expect(img.style.transform).toBe("");
+        expect(imageContentIsTransformed(img)).toBe(false);
+    });
+});

--- a/src/BloomBrowserUI/bookEdit/js/imageContentTransformSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/imageContentTransformSpec.ts
@@ -222,6 +222,47 @@ describe("flipImageContent", () => {
         });
     });
 
+    it("mirrors the other axis when the box is turned a quarter turn", () => {
+        const img = makeImage();
+        // The picture itself is not turned; the box around it is, which moves the picture on
+        // screen in the same way, so a mirror from side to side on screen is again a mirror
+        // of the y axis of the picture.
+        flipImageContent(img, "horizontal", 90);
+        expect(getImageContentTransform(img)).toEqual({
+            quarterTurns: 0,
+            flipX: false,
+            flipY: true,
+        });
+    });
+
+    it("mirrors the requested axis when the box is turned a half turn", () => {
+        const img = makeImage();
+        flipImageContent(img, "horizontal", 180);
+        expect(getImageContentTransform(img).flipX).toBe(true);
+    });
+
+    it("takes the two turns together", () => {
+        const img = makeImage();
+        rotateImageContentRight(img);
+        // A quarter turn of the picture and a quarter turn of the box make a half turn, which
+        // leaves the axes of the picture the way they started on screen.
+        flipImageContent(img, "horizontal", 90);
+        expect(getImageContentTransform(img)).toEqual({
+            quarterTurns: 1,
+            flipX: true,
+            flipY: false,
+        });
+    });
+
+    it("takes the angle of the box to the nearest quarter turn", () => {
+        const img = makeImage();
+        flipImageContent(img, "horizontal", 80);
+        expect(getImageContentTransform(img).flipY).toBe(true);
+        const other = makeImage();
+        flipImageContent(other, "horizontal", 10);
+        expect(getImageContentTransform(other).flipX).toBe(true);
+    });
+
     it("keeps the crop, because a mirror does not change the shape of the box", () => {
         const img = makeImage();
         img.style.width = "300px";

--- a/src/BloomBrowserUI/bookEdit/js/imageContentTransformSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/imageContentTransformSpec.ts
@@ -1,15 +1,17 @@
 import { describe, it, expect } from "vitest";
 import {
     clearImageContentTransform,
+    computeTurnedBackgroundLayout,
     flipImageContent,
     getImageContentTransform,
     imageContentIsTransformed,
     rotateImageContentRight,
 } from "./imageContentTransform";
 
-// A picture inside a container, which is what the code expects. jsdom lays nothing out, so
-// the sizes are zero unless a test gives them, and a zero size makes the fit scale 1. That
-// keeps the transform easy to read in the tests that are about the turn and the mirror.
+// A picture inside a container, which is what the code expects. There is no page and no canvas
+// element around it, so a turn of this picture changes only the transform. That keeps the
+// transform easy to read in the tests that are about the turn and the mirror; the tests about
+// where a background picture lands use makeBackgroundImage below.
 function makeImage(): HTMLImageElement {
     const container = document.createElement("div");
     const img = document.createElement("img");
@@ -17,7 +19,7 @@ function makeImage(): HTMLImageElement {
     return img;
 }
 
-// Give the picture and its container a laid-out size, so that the fit scale can be measured.
+// Give the picture and its container a laid-out size.
 function giveSizes(
     img: HTMLImageElement,
     imgWidth: number,
@@ -40,6 +42,91 @@ function giveSizes(
 function getScaleMagnitude(img: HTMLImageElement): number | undefined {
     const match = /scale\(\s*(-?[0-9.]+)/.exec(img.style.transform);
     return match ? Math.abs(parseFloat(match[1])) : undefined;
+}
+
+// A page background picture as Bloom builds it: the page's picture area (the bloom-canvas), the
+// background canvas element inside it, the image container, and the picture. jsdom lays nothing
+// out, so we answer the layout questions ourselves, from the styles the code writes. That is
+// what lets a test turn a picture several times and see where it really ends up.
+//
+// The rules here are the browser's rules for these elements. A picture with an explicit width
+// is that wide, and as tall as its own shape then makes it. A picture with no explicit width
+// fills its container.
+function makeBackgroundImage(
+    pageWidth: number,
+    pageHeight: number,
+    elementWidth: number,
+    elementHeight: number,
+    naturalWidth: number,
+    naturalHeight: number,
+    // False for an ordinary picture element, which keeps its own size and place rather than
+    // being fitted to the page's picture area.
+    isBackground = true,
+): HTMLImageElement {
+    const page = document.createElement("div");
+    page.classList.add("bloom-canvas");
+    const element = document.createElement("div");
+    element.classList.add("bloom-canvas-element");
+    if (isBackground) {
+        element.classList.add("bloom-backgroundImage");
+    }
+    const container = document.createElement("div");
+    container.classList.add("bloom-imageContainer");
+    const img = document.createElement("img");
+    page.appendChild(element);
+    element.appendChild(container);
+    container.appendChild(img);
+
+    Object.defineProperty(page, "clientWidth", { get: () => pageWidth });
+    Object.defineProperty(page, "clientHeight", { get: () => pageHeight });
+    Object.defineProperty(img, "naturalWidth", { get: () => naturalWidth });
+    Object.defineProperty(img, "naturalHeight", { get: () => naturalHeight });
+
+    const elementSize = (axis: "width" | "height") => {
+        const written = parseFloat(element.style[axis]);
+        if (!isNaN(written)) {
+            return written;
+        }
+        return axis === "width" ? elementWidth : elementHeight;
+    };
+    for (const box of [element, container]) {
+        Object.defineProperty(box, "clientWidth", {
+            get: () => elementSize("width"),
+        });
+        Object.defineProperty(box, "clientHeight", {
+            get: () => elementSize("height"),
+        });
+    }
+    Object.defineProperty(img, "clientWidth", {
+        get: () => {
+            const written = parseFloat(img.style.width);
+            return isNaN(written) ? elementSize("width") : written;
+        },
+    });
+    Object.defineProperty(img, "clientHeight", {
+        get: () => {
+            const writtenHeight = parseFloat(img.style.height);
+            if (!isNaN(writtenHeight)) {
+                return writtenHeight;
+            }
+            const writtenWidth = parseFloat(img.style.width);
+            if (!isNaN(writtenWidth)) {
+                return (writtenWidth * naturalHeight) / naturalWidth;
+            }
+            return elementSize("height");
+        },
+    });
+    return img;
+}
+
+// The canvas element a picture belongs to, so a test can read where the turn put it.
+function elementOf(img: HTMLImageElement): HTMLElement {
+    return img.closest(".bloom-canvas-element") as HTMLElement;
+}
+
+// A length the code wrote, as a number.
+function px(value: string): number {
+    return parseFloat(value);
 }
 
 describe("getImageContentTransform", () => {
@@ -89,7 +176,7 @@ describe("imageContentIsTransformed", () => {
         expect(imageContentIsTransformed(makeImage())).toBe(false);
     });
 
-    it("is false for a picture that is only made smaller to fit", () => {
+    it("is false for a scale that mirrors nothing", () => {
         const img = makeImage();
         img.style.transform = "scale(0.5, 0.5)";
         expect(imageContentIsTransformed(img)).toBe(false);
@@ -135,45 +222,293 @@ describe("rotateImageContentRight", () => {
         });
     });
 
-    it("removes the crop, because the crop described the picture before the turn", () => {
+    it("never shrinks the picture with the transform", () => {
+        // The transform carries the turn and the mirrors and nothing else. Where the picture
+        // goes is said by the picture's own size and place, and by its canvas element's.
         const img = makeImage();
-        img.style.width = "300px";
-        img.style.height = "200px";
-        img.style.left = "-20px";
-        img.style.top = "-10px";
-        // Sanity check: the crop is really there before the turn.
-        expect(img.style.width).toBe("300px");
+        giveSizes(img, 200, 100, 200, 100);
 
         rotateImageContentRight(img);
 
+        expect(img.style.transform).toBe("rotate(90deg)");
+        expect(getScaleMagnitude(img)).toBeUndefined();
+    });
+});
+
+describe("rotateImageContentRight, on a page background picture", () => {
+    // A photograph three units wide and two high, which the camera saved on its side, on a page
+    // whose picture area is 480 by 720. Bloom gives the picture's canvas element the shape of
+    // the picture, so before any turn that element is 480 by 320, centred in the page.
+    function makeSidewaysPhotograph(): HTMLImageElement {
+        return makeBackgroundImage(480, 720, 480, 320, 300, 200);
+    }
+
+    it("turns an uncropped picture to exactly where it would be if it had arrived turned", () => {
+        const img = makeSidewaysPhotograph();
+        // Sanity check: the picture has no numbers of its own before the turn.
         expect(img.style.width).toBe("");
+
+        rotateImageContentRight(img);
+
+        // The element now has the shape of the turned picture, which on this page is the shape
+        // of the page itself, so the picture fills the page. That is what an author would have
+        // had if they had turned the file before they chose it.
+        expect(px(elementOf(img).style.width)).toBeCloseTo(480);
+        expect(px(elementOf(img).style.height)).toBeCloseTo(720);
+        expect(px(elementOf(img).style.left)).toBeCloseTo(0);
+        expect(px(elementOf(img).style.top)).toBeCloseTo(0);
+        // The picture's box still lies the way the picture does, and the turn of the box about
+        // its own centre brings it upright over the element.
+        expect(px(img.style.width)).toBeCloseTo(720);
+        expect(px(img.style.left)).toBeCloseTo(-120);
+        expect(px(img.style.top)).toBeCloseTo(120);
+        expect(img.style.transform).toBe("rotate(90deg)");
+    });
+
+    it("leaves no height behind, which a change of page size would stretch", () => {
+        const img = makeSidewaysPhotograph();
+        rotateImageContentRight(img);
+        // Bloom scales a picture's width, left and top when the page changes size, and leaves
+        // its height alone, so a height written here would stay behind and stretch the picture.
         expect(img.style.height).toBe("");
+    });
+
+    it("brings an uncropped picture back to where it began after four turns", () => {
+        const img = makeSidewaysPhotograph();
+
+        for (let turn = 0; turn < 4; turn++) {
+            rotateImageContentRight(img);
+        }
+
+        expect(px(elementOf(img).style.width)).toBeCloseTo(480);
+        expect(px(elementOf(img).style.height)).toBeCloseTo(320);
+        expect(img.style.width).toBe("");
         expect(img.style.left).toBe("");
         expect(img.style.top).toBe("");
+        expect(img.style.transform).toBe("");
     });
 
-    it("shrinks the picture so that it still fits after an odd quarter turn", () => {
-        const img = makeImage();
-        // A wide picture in a wide container: lying across the container, its 200 of width
-        // has to fit into 100 of height, so it must come down to half its size.
-        giveSizes(img, 200, 100, 200, 100);
+    it("gives an uncropped picture no numbers of its own after a half turn", () => {
+        const img = makeSidewaysPhotograph();
+        rotateImageContentRight(img);
+        // Sanity check: the quarter turn does give it numbers.
+        expect(img.style.width).not.toBe("");
 
         rotateImageContentRight(img);
 
-        expect(getScaleMagnitude(img)).toBeCloseTo(0.5);
-    });
-
-    it("uses the full size again after a half turn", () => {
-        const img = makeImage();
-        giveSizes(img, 200, 100, 200, 100);
-        rotateImageContentRight(img);
-        // Sanity check: the picture is smaller after the first turn.
-        expect(getScaleMagnitude(img)).toBeCloseTo(0.5);
-
-        rotateImageContentRight(img);
-
-        expect(getScaleMagnitude(img)).toBeUndefined();
+        // An explicit width is how the rest of Bloom recognizes a crop, so a picture nobody
+        // cropped must not keep one.
+        expect(img.style.width).toBe("");
+        expect(px(elementOf(img).style.height)).toBeCloseTo(320);
         expect(img.style.transform).toBe("rotate(180deg)");
+    });
+
+    // The same photograph, cropped: the author magnified it to 1080 wide, which is three and
+    // three fifths of its own size, and centred it, so the crop fills a canvas element that
+    // covers the whole page.
+    function makeCroppedPhotograph(): HTMLImageElement {
+        const img = makeBackgroundImage(480, 720, 480, 720, 300, 200);
+        img.style.width = "1080px";
+        img.style.left = "-300px";
+        img.style.top = "0px";
+        return img;
+    }
+
+    it("keeps the crop", () => {
+        const img = makeCroppedPhotograph();
+        // Sanity check: the crop is really there before the turn.
+        expect(px(img.style.width)).toBeCloseTo(1080);
+
+        rotateImageContentRight(img);
+
+        expect(img.style.width).not.toBe("");
+        expect(px(img.style.width)).toBeGreaterThan(0);
+    });
+
+    it("shows the whole of the crop, and shortens the element rather than cut it", () => {
+        const img = makeCroppedPhotograph();
+
+        rotateImageContentRight(img);
+
+        // The crop had the shape of the page, so turned it has the page's shape lying down, and
+        // it cannot fill a page that has not changed. The element takes the turned crop's shape
+        // and keeps the page's width, which leaves 200 blank above it and 200 below.
+        expect(px(elementOf(img).style.width)).toBeCloseTo(480);
+        expect(px(elementOf(img).style.height)).toBeCloseTo(320);
+        expect(px(elementOf(img).style.top)).toBeCloseTo(200);
+        // The whole crop is there: its box is 720 by 480, its centre is the centre of the
+        // element, and turning it about that centre covers the element exactly.
+        expect(px(img.style.width)).toBeCloseTo(720);
+        expect(px(img.style.left)).toBeCloseTo(-120);
+        expect(px(img.style.top)).toBeCloseTo(-80);
+    });
+
+    it("keeps filling the page for a picture the author told to fill it", () => {
+        const img = makeCroppedPhotograph();
+        // The Expand Image command marks a picture this way.
+        img.classList.add("bloom-imageObjectFit-cover");
+
+        rotateImageContentRight(img);
+
+        // The element still covers the page, and the ends of the picture are clipped instead.
+        expect(px(elementOf(img).style.width)).toBeCloseTo(480);
+        expect(px(elementOf(img).style.height)).toBeCloseTo(720);
+        expect(px(img.style.width)).toBeCloseTo(1620);
+        expect(px(img.style.left)).toBeCloseTo(-570);
+        expect(px(img.style.top)).toBeCloseTo(-180);
+    });
+
+    it("turns the picture even when nothing has been laid out yet", () => {
+        // A page that has not been laid out gives no sizes to measure. We must still turn the
+        // picture, and we must write no numbers we cannot work out.
+        const img = makeBackgroundImage(0, 0, 0, 0, 300, 200);
+
+        rotateImageContentRight(img);
+
+        expect(img.style.transform).toBe("rotate(90deg)");
+        expect(img.style.width).toBe("");
+        expect(elementOf(img).style.width).toBe("");
+    });
+});
+
+describe("rotateImageContentRight, on an ordinary picture element", () => {
+    // The Rotate Right command turns the picture inside the box, rather than the box on the
+    // page, whenever the box itself cannot turn. That is true of a background picture, and also
+    // of an element whose outline comicaljs draws. Such an element is not the page's background,
+    // so it must keep the size and the place the author gave it.
+    function makeOrdinaryPicture(): HTMLImageElement {
+        return makeBackgroundImage(480, 720, 300, 200, 300, 200, false);
+    }
+
+    it("swaps the element's two dimensions about the element's own centre", () => {
+        const img = makeOrdinaryPicture();
+        elementOf(img).style.left = "100px";
+        elementOf(img).style.top = "50px";
+
+        rotateImageContentRight(img);
+
+        // The box is now as tall as it was wide, and its centre has not moved: it was at
+        // (250, 150) and it still is.
+        expect(px(elementOf(img).style.width)).toBeCloseTo(200);
+        expect(px(elementOf(img).style.height)).toBeCloseTo(300);
+        expect(px(elementOf(img).style.left)).toBeCloseTo(150);
+        expect(px(elementOf(img).style.top)).toBeCloseTo(0);
+    });
+
+    it("does not stretch the element to the page's picture area", () => {
+        const img = makeOrdinaryPicture();
+
+        rotateImageContentRight(img);
+
+        // The page's picture area is 480 by 720. A background picture would have been fitted to
+        // it; this one must not be.
+        expect(px(elementOf(img).style.width)).toBeLessThan(480);
+        expect(px(elementOf(img).style.height)).toBeLessThan(720);
+    });
+
+    it("keeps the picture the size it was, turned to fill the swapped element", () => {
+        const img = makeOrdinaryPicture();
+
+        rotateImageContentRight(img);
+
+        // The picture's box still lies the way the picture does, at its old size, and the turn
+        // about its own centre brings it upright over the element.
+        expect(px(img.style.width)).toBeCloseTo(300);
+        expect(px(img.style.left)).toBeCloseTo(-50);
+        expect(px(img.style.top)).toBeCloseTo(50);
+        expect(img.style.transform).toBe("rotate(90deg)");
+    });
+});
+
+describe("computeTurnedBackgroundLayout", () => {
+    it("swaps the two dimensions of the element and fits it to the page", () => {
+        // A landscape element, 480 by 320, on a page 480 by 720.
+        const layout = computeTurnedBackgroundLayout(
+            480,
+            720,
+            480,
+            320,
+            480,
+            320,
+            0,
+            0,
+            false,
+        );
+
+        expect(layout.elementWidth).toBeCloseTo(480);
+        expect(layout.elementHeight).toBeCloseTo(720);
+    });
+
+    it("centres the element in the page", () => {
+        // A square element on a tall page: it fills the width and leaves equal bands.
+        const layout = computeTurnedBackgroundLayout(
+            480,
+            720,
+            480,
+            480,
+            480,
+            480,
+            0,
+            0,
+            false,
+        );
+
+        expect(layout.elementWidth).toBeCloseTo(480);
+        expect(layout.elementHeight).toBeCloseTo(480);
+        expect(layout.elementLeft).toBeCloseTo(0);
+        expect(layout.elementTop).toBeCloseTo(120);
+    });
+
+    it("puts the centre of the picture at the centre of the element", () => {
+        const layout = computeTurnedBackgroundLayout(
+            480,
+            720,
+            480,
+            320,
+            480,
+            320,
+            0,
+            0,
+            false,
+        );
+
+        expect(layout.imageLeft + layout.imageWidth / 2).toBeCloseTo(
+            layout.elementWidth / 2,
+        );
+        expect(layout.imageTop + layout.imageHeight / 2).toBeCloseTo(
+            layout.elementHeight / 2,
+        );
+    });
+
+    it("magnifies instead of shrinking for a picture that must fill the page", () => {
+        const fitted = computeTurnedBackgroundLayout(
+            480,
+            720,
+            480,
+            720,
+            1080,
+            720,
+            -300,
+            0,
+            false,
+        );
+        const filling = computeTurnedBackgroundLayout(
+            480,
+            720,
+            480,
+            720,
+            1080,
+            720,
+            -300,
+            0,
+            true,
+        );
+
+        // Sanity check: the fitted one really is smaller than the page.
+        expect(fitted.elementHeight).toBeLessThan(720);
+        expect(filling.elementWidth).toBeCloseTo(480);
+        expect(filling.elementHeight).toBeCloseTo(720);
+        expect(filling.imageWidth).toBeGreaterThan(fitted.imageWidth);
     });
 });
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/buildCanvasElementControlRegistryContext.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/buildCanvasElementControlRegistryContext.ts
@@ -20,6 +20,7 @@ import { canvasElementControlRegistry } from "./canvasElementControlRegistry";
 import { CanvasElementType } from "./canvasElementTypes";
 import { IControlContext } from "./canvasControlTypes";
 import { isAiEditableImageSrc } from "../../aiImageEditor/aiEditorImageFormats";
+import { imageContentIsTransformed } from "../../js/imageContentTransform";
 
 const hasRealImage = (img: HTMLImageElement | undefined): boolean => {
     if (!img) {
@@ -187,6 +188,11 @@ export const buildCanvasElementControlRegistryContext = (
         rectangleHasBackground:
             rectangle?.classList.contains("bloom-theme-background") ?? false,
         isCropped: !!img?.style?.width,
+        isImageContentTransformed: img ? imageContentIsTransformed(img) : false,
+        hasChosenTransparency:
+            !!img &&
+            (img.classList.contains("bloom-transparent") ||
+                img.classList.contains("bloom-opaque")),
         isNavigationButton: elementType.startsWith("navigation-"),
         isButton,
         isBackgroundImage,

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlAvailabilityRules.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlAvailabilityRules.ts
@@ -29,7 +29,22 @@ export const imageAvailabilityRules: AvailabilityRulesMap = {
     },
     resetImage: {
         visible: (ctx) => ctx.hasImage,
-        enabled: (ctx) => ctx.isCropped,
+        // Reset Image puts the picture back the way it arrived, so it applies to a crop, to a
+        // turn or a mirror, and to a transparency the user chose by hand. It does not
+        // straighten a rotated canvas element box; that rotation belongs to the box, like its
+        // size and its position.
+        enabled: (ctx) =>
+            ctx.isCropped ||
+            ctx.isImageContentTransformed ||
+            ctx.hasChosenTransparency,
+    },
+    rotateRight: {
+        visible: (ctx) => ctx.hasImage,
+        enabled: (ctx) => ctx.hasRealImage && ctx.canModifyImage,
+    },
+    flipImage: {
+        visible: (ctx) => ctx.hasImage,
+        enabled: (ctx) => ctx.hasRealImage && ctx.canModifyImage,
     },
     editWithAi: {
         // Only offered when the AI Image Editing experimental feature is turned on.

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlRegistry.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlRegistry.ts
@@ -510,17 +510,14 @@ export const controlRegistry: Record<TopLevelControlId, IControlDefinition> = {
     // - An ordinary image canvas element turns as a whole, using the same rotation the
     //   rotate handle on the control frame sets, so the two commands cannot disagree.
     // - A background image fills its bloom-canvas and cannot be turned as a box, so the
-    //   picture inside turns and is shrunk to fit. Any cropping is dropped, because the
-    //   cropped region described the picture the way it was before the turn.
+    //   picture inside turns and its own box is reshaped to match. Any cropping is kept: the
+    //   cropped region turns with the picture and is scaled to fit the page.
     rotateRight: {
         kind: "command",
         id: "rotateRight",
         l10nId: "EditTab.Image.RotateRight",
         englishLabel: "Rotate right",
         icon: RotateRightIcon,
-        menu: {
-            shortcutDisplay: "Ctrl+R",
-        },
         action: () => {
             getCanvasElementManager()?.rotateActiveImageRight();
         },

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlRegistry.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlRegistry.ts
@@ -37,6 +37,8 @@ import { default as CopyIcon } from "@mui/icons-material/ContentCopy";
 import { default as PasteIcon } from "@mui/icons-material/ContentPaste";
 import { default as CopyrightIcon } from "@mui/icons-material/Copyright";
 import { default as DeleteIcon } from "@mui/icons-material/DeleteOutline";
+import { default as FlipIcon } from "@mui/icons-material/Flip";
+import { default as RotateRightIcon } from "@mui/icons-material/RotateRight";
 import { default as SearchIcon } from "@mui/icons-material/Search";
 import { default as VolumeUpIcon } from "@mui/icons-material/VolumeUp";
 import { getWorkspaceBundleExports } from "../../js/workspaceFrames";
@@ -51,6 +53,7 @@ import {
     isPlaceHolderImage,
     kImageContainerClass,
     pageBackgroundNeedsTransparency,
+    setImageTransparencyToAuto,
     setImgTransparentParam,
 } from "../../js/bloomImages";
 import { doVideoCommand } from "../../js/bloomVideo";
@@ -496,14 +499,77 @@ export const controlRegistry: Record<TopLevelControlId, IControlDefinition> = {
         id: "resetImage",
         l10nId: "EditTab.Image.Reset",
         englishLabel: "Reset Image",
-        iconScale: 0.9,
-        icon: React.createElement("img", {
-            src: "/bloom/images/reset image black.svg",
-            alt: "",
-            className: "canvas-context-menu-monochrome-icon",
-        }),
+        // No icon: the row reads better without one, and the command is the odd one out in
+        // its group, because it undoes the commands above it.
         action: () => {
-            getCanvasElementManager()?.resetCropping();
+            getCanvasElementManager()?.resetImage();
+        },
+    },
+    // "Rotate right" — a quarter turn clockwise. What turns depends on what the image is
+    // part of, because the two cases want different things:
+    // - An ordinary image canvas element turns as a whole, using the same rotation the
+    //   rotate handle on the control frame sets, so the two commands cannot disagree.
+    // - A background image fills its bloom-canvas and cannot be turned as a box, so the
+    //   picture inside turns and is shrunk to fit. Any cropping is dropped, because the
+    //   cropped region described the picture the way it was before the turn.
+    rotateRight: {
+        kind: "command",
+        id: "rotateRight",
+        l10nId: "EditTab.Image.RotateRight",
+        englishLabel: "Rotate right",
+        icon: RotateRightIcon,
+        menu: {
+            shortcutDisplay: "Ctrl+R",
+        },
+        action: () => {
+            getCanvasElementManager()?.rotateActiveImageRight();
+        },
+    },
+    // "Flip" — mirror the picture. This always applies to the picture rather than to the
+    // canvas element, because mirroring a box moves it without changing how it looks.
+    // The axes are the ones the user sees on screen, whatever way the picture is turned.
+    flipImage: {
+        kind: "command",
+        id: "flipImage",
+        l10nId: "EditTab.Image.Flip",
+        englishLabel: "Flip",
+        icon: FlipIcon,
+        action: () => {},
+        menu: {
+            buildMenuItem: () => {
+                return {
+                    id: "flipImage",
+                    l10nId: "EditTab.Image.Flip",
+                    englishLabel: "Flip",
+                    onSelect: () => {},
+                    subMenuItems: [
+                        {
+                            l10nId: "EditTab.Image.FlipHorizontal",
+                            englishLabel: "Flip horizontal",
+                            icon: React.createElement(FlipIcon, null),
+                            onSelect: () => {
+                                getCanvasElementManager()?.flipActiveImage(
+                                    "horizontal",
+                                );
+                            },
+                        },
+                        {
+                            l10nId: "EditTab.Image.FlipVertical",
+                            englishLabel: "Flip vertical",
+                            // The same icon turned a quarter turn, so that the pair reads as
+                            // one idea about two axes. MUI has no vertical flip icon.
+                            icon: React.createElement(FlipIcon, {
+                                style: { transform: "rotate(90deg)" },
+                            }),
+                            onSelect: () => {
+                                getCanvasElementManager()?.flipActiveImage(
+                                    "vertical",
+                                );
+                            },
+                        },
+                    ],
+                };
+            },
         },
     },
     // "Edit with AI…" — the entry point for the AI Image Editor integration. This command
@@ -770,11 +836,7 @@ export const controlRegistry: Record<TopLevelControlId, IControlDefinition> = {
                                 : undefined,
                             onSelect: () => {
                                 if (!img) return;
-                                img.classList.remove(
-                                    "bloom-transparent",
-                                    "bloom-opaque",
-                                );
-                                applyTransparencyParam();
+                                setImageTransparencyToAuto(img);
                             },
                         },
                         {
@@ -1245,21 +1307,32 @@ export const controlSections: Record<SectionId, IControlSection> = {
             menu: ["format"],
         },
     },
+    // The image commands come in three menu sections, so that the menu shows a line between
+    // them. The first section is about which picture is in the box, the second about how the
+    // picture sits in the box, and the third about the other things we can do to it. Reset
+    // image is last in its section because it undoes the commands above it.
     image: {
         id: "image",
         controlsBySurface: {
+            menu: ["missingMetadata", "chooseImage", "copyImage", "pasteImage"],
+        },
+    },
+    imageArrangement: {
+        id: "imageArrangement",
+        controlsBySurface: {
             menu: [
-                "missingMetadata",
-                "chooseImage",
-                "copyImage",
-                "pasteImage",
-                "resetImage",
                 "expandToFillSpace",
-                "becomeBackground",
-                "imageFieldType",
+                "rotateRight",
+                "flipImage",
                 "imageBackground",
-                "editWithAi",
+                "resetImage",
             ],
+        },
+    },
+    imageSettings: {
+        id: "imageSettings",
+        controlsBySurface: {
+            menu: ["becomeBackground", "imageFieldType", "editWithAi"],
         },
     },
     imagePanel: {

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlTypes.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlTypes.ts
@@ -46,6 +46,8 @@ export type ControlId =
     | "missingMetadata"
     | "editWithAi"
     | "resetImage"
+    | "rotateRight"
+    | "flipImage"
     | "expandToFillSpace"
     | "imageFieldType"
     | "becomeBackground"
@@ -100,6 +102,8 @@ export type SectionId =
     | "gameDraggable"
     | "formatTarget"
     | "image"
+    | "imageArrangement"
+    | "imageSettings"
     | "imagePanel"
     | "video"
     | "audio"
@@ -124,6 +128,10 @@ export interface IControlContext {
     isRectangle: boolean;
     rectangleHasBackground: boolean;
     isCropped: boolean;
+    // The picture inside the box has been turned or mirrored by Rotate right or Flip.
+    isImageContentTransformed: boolean;
+    // The user chose Transparent or Opaque for the picture, instead of leaving it on Auto.
+    hasChosenTransparency: boolean;
     isNavigationButton: boolean;
     isButton: boolean;
     isBackgroundImage: boolean;

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasElementControlRegistry.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasElementControlRegistry.ts
@@ -44,7 +44,14 @@ export const imageCanvasElementControls: ICanvasElementControlConfiguration = {
     // also as game pieces created from the Game tool.
     // `gameDraggable` is intentionally listed here so game pages can surface
     // draggable commands; availability rules/context keep it hidden on non-game pages.
-    menuSections: ["image", "audio", "gameDraggable", "wholeElement"],
+    menuSections: [
+        "image",
+        "imageArrangement",
+        "imageSettings",
+        "audio",
+        "gameDraggable",
+        "wholeElement",
+    ],
     toolbar: [
         "missingMetadata",
         "chooseImage",
@@ -162,7 +169,13 @@ export const bookLinkGridControls: ICanvasElementControlConfiguration = {
 export const navigationImageButtonControls: ICanvasElementControlConfiguration =
     {
         type: "navigation-image-button",
-        menuSections: ["url", "image", "wholeElement"],
+        menuSections: [
+            "url",
+            "image",
+            "imageArrangement",
+            "imageSettings",
+            "wholeElement",
+        ],
         toolbar: [
             "setDestination",
             "chooseImage",
@@ -209,7 +222,14 @@ export const navigationImageButtonControls: ICanvasElementControlConfiguration =
 export const navigationImageWithLabelButtonControls: ICanvasElementControlConfiguration =
     {
         type: "navigation-image-with-label-button",
-        menuSections: ["url", "image", "text", "wholeElement"],
+        menuSections: [
+            "url",
+            "image",
+            "imageArrangement",
+            "imageSettings",
+            "text",
+            "wholeElement",
+        ],
         toolbar: [
             "setDestination",
             "chooseImage",


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
## Problem

A picture that arrives on its side stays on its side. Bloom could crop a picture and move it,
but it could not turn it, mirror it, or set an item on a page at an angle. An author whose
camera saved a photograph sideways had to leave Bloom, turn the file in another program, and
put it back.

## Fix

- **Rotate right** on the picture menu turns the picture a quarter turn clockwise. An ordinary
  picture turns as a box; a background picture, which fills its page area and cannot turn as a
  box, has the picture inside it turned and its area reshaped to match. The result is what the
  author would have had if the picture had arrived already turned: upright, at the same framing,
  with any crop kept. A picture told to fill the page still fills it, ends clipped rather than
  blank bands. Neither path acts on an empty placeholder.
- **Flip horizontal** and **Flip vertical** mirror the picture about the axes the user sees,
  whichever way the picture and its box have been turned.
- A **rotation handle** turns a selected item to any angle: a knob on a short stem above its top
  edge, snapping to every 45 degrees within 14 degrees of one, with CTRL to turn snapping off.
  Past 135 degrees the knob hangs from the item's other edge, because the top edge then points
  down the screen and the knob would sit behind the panel of controls; it does not move mid-drag.
  An item whose outline comicaljs draws (a speech bubble, caption, rectangle or ellipse) gets no
  handle, because that outline stays upright.
- **Dragging, resizing and cropping work on a turned item.** Mouse movement is converted into the
  item's own coordinates, and the item is shifted once so that the edge opposite the dragged one
  stays where it looks. A turned item also stays put across page loads and through a whole crop
  drag, because every check now reads the item's own laid-out box rather than the upright box the
  browser reports around it. A click picks the right item, which comicaljs alone cannot do. The
  control frame turns with the item: each handle shows the cursor for the direction it really
  moves, each tooltip stays level, and the crop marks count both turns, so they mark the two
  sides that are really hidden.
- **A turned item's contents stay reachable.** A CSS transform makes the item a stacking context,
  so the z-index its contents use to clear the comicaljs canvas no longer reaches past the item.
  The canvas then covers it and takes the pointer, and the browser gives it no `:hover`, which is
  why a turned video lost its play button. Bloom now marks the turned item the pointer is really
  inside, using the same rotation-aware hit test a click uses, and the CSS accepts that mark in
  place of `:hover`. A click on the play, pause or replay button is found among everything under
  the pointer, limited to the item pressed on, so a covered button is never clicked. The mark goes
  when the item is upright again, and before the page is saved.
- **Undo** puts back a Rotate right, a Flip, and a drag of the handle, one step each. **Reset
  Image** now clears the crop, the picture's turn and mirror, and a transparency chosen by hand.
  It does not straighten a turned box, because that angle belongs to the box as its size and
  position do; the handle and Undo are the way back. The picture menu is now three groups: which
  picture is in the box, how it sits in the box, and the rest.

Every angle and mirror lives in the item's own inline `transform`, saved in the book HTML, so it
appears in BloomPlayer and in PDF output, where no Bloom JavaScript runs.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16741


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8227)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8227)
<!-- Reviewable:end -->






