### PR TITLE
Analytics for the features new in 6.5 (BL-16716)

### DIFF
--- a/build/check-csharp-analytics.sh
+++ b/build/check-csharp-analytics.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# This script is run by the pre-commit hook in src/BloomBrowserUI/.vite-hooks/pre-commit. We need to get to
+# the root of the git repository, which is one level up from where this script lives.
+cd $(dirname $0)/..
+
+missing_dependencies=
+for dependency in git awk tr; do
+  if ! command -v "$dependency" >/dev/null 2>&1; then
+    missing_dependencies="$missing_dependencies $dependency"
+  fi
+done
+
+if [ -n "$missing_dependencies" ]; then
+  echo "Missing required commands for build/check-csharp-analytics.sh:$missing_dependencies"
+  echo "This hook runs in a POSIX shell environment and requires Git plus common Unix tools."
+  echo "If you are committing from Windows, make sure the hook is running under Git Bash or equivalent."
+  exit 1
+fi
+
+echo Checking that analytics events go through BloomAnalytics.
+# Why: DesktopAnalytics decides whether to send an event INSIDE Analytics.Track, and in a DEBUG
+# build it decides not to (Program.InitializeAnalytics passes allowTracking:false). An event that
+# calls it directly is therefore impossible to observe on a developer machine -- it neither sends
+# nor says it didn't. BloomAnalytics.Track logs every event before handing it on, which is the only
+# way to see one without shipping to alpha. That log is only worth reading if it is complete, so a
+# call that bypasses it stops the commit: a missing line has to mean "did not happen" rather than
+# "somebody used the other API".
+#
+# 1) Get the list of C# files that have been staged for commit (added or modified).
+# 2) Skip the wrapper itself, which necessarily calls DesktopAnalytics.
+# 3) Look for Analytics.Track / Analytics.ReportException that are NOT BloomAnalytics.<method>.
+#    The [^A-Za-z0-9_] guard is what distinguishes them: it rejects "BloomAnalytics.Track(" (the
+#    preceding character is a letter) while catching both "Analytics.Track(" and the fully
+#    qualified "DesktopAnalytics.Analytics.Track(".
+# 4) If anything is found, stop everything and complain.
+filesToCheck=filesToCheck.lst
+git diff --cached --name-only --diff-filter=AM -z -- '*.cs' | tr '\0' '\n' >$filesToCheck
+status=1
+if [ -s $filesToCheck ]; then
+  while IFS= read -r file; do
+    case "$file" in
+      src/BloomExe/BloomAnalytics.cs) continue;;
+    esac
+    if awk '
+      # A commented-out call is not a call, and this repo has explanatory comments that name the
+      # very API this script bans -- flagging those would block a commit for no reason.
+      /^[[:space:]]*(\/\/|\*|\/\*)/ { next }
+      /(^|[^A-Za-z0-9_])Analytics\.(Track|ReportException)[[:space:]]*\(/ {
+        print FILENAME ":" FNR ": " $0;
+        found = 1;
+      }
+      END {
+        exit found ? 0 : 1;
+      }
+    ' "$file"; then
+      echo "Use BloomAnalytics.Track / BloomAnalytics.ReportException instead, so the event is"
+      echo "logged and can be seen in a build where tracking is off. See src/BloomExe/BloomAnalytics.cs."
+      status=0
+      break
+    fi
+  done < $filesToCheck
+fi
+rm $filesToCheck
+# if we found instances of the unwrapped API, then stop the commit.
+[ $status -eq 0 ] && exit 1 || exit 0

--- a/src/BloomBrowserUI/.vite-hooks/pre-commit
+++ b/src/BloomBrowserUI/.vite-hooks/pre-commit
@@ -187,4 +187,5 @@ fi
 build/check-csharp-robustfile.sh || exit 1
 build/check-csharp-xmlclasses.sh || exit 1
 build/check-csharp-ApplicationExit.sh || exit 1
+build/check-csharp-analytics.sh || exit 1
 build/run-csharpier.sh || exit 1

--- a/src/BloomBrowserUI/bookEdit/aiImageEditor/aiEditorOverlay.test.ts
+++ b/src/BloomBrowserUI/bookEdit/aiImageEditor/aiEditorOverlay.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 // Tests for the top-window half of the AI Image Editor integration: the overlay and its
-// conversation with the editor's iframe.
+// conversation with the AI Image Editor's iframe.
 //
 // Two things this half is responsible for, both of which used to be tangled up with the
 // live page and are pinned here:
@@ -43,7 +43,7 @@ const kPageId = "page1";
 const kImageFile = "old.png";
 
 // Opens the overlay as C# does, and answers the launch request as C# would. Returns the
-// handles a test needs, with the overlay up and the editor about to be sent its `init`.
+// handles a test needs, with the overlay up and the AI Image Editor about to be sent its `init`.
 const openAgainstABookWithOneImage = (
     target = { pageId: kPageId, imageFileName: kImageFile },
     bookImages: Array<{ id: string; src: string; isPlaceholder?: boolean }> = [
@@ -76,7 +76,7 @@ const openAgainstABookWithOneImage = (
     const iframe = overlay.querySelector("iframe") as HTMLIFrameElement;
     const closeButton = overlay.querySelector("button") as HTMLButtonElement;
 
-    // Deliver a message as if it came from the editor's iframe. The overlay ignores
+    // Deliver a message as if it came from the AI Image Editor's iframe. The overlay ignores
     // messages from anywhere else, so the source has to be the iframe's window.
     const postFromEditor = (data: unknown) => {
         window.dispatchEvent(
@@ -90,7 +90,7 @@ const openAgainstABookWithOneImage = (
     return { closeButton, iframe, postFromEditor };
 };
 
-// Answers the editor's `ready` and returns the `init` the overlay posts back into its
+// Answers the AI Image Editor's `ready` and returns the `init` the overlay posts back into its
 // iframe — which is where the edit target ("Image to Edit") is named.
 const getInitPayloadSentToEditor = (
     iframe: HTMLIFrameElement,
@@ -166,7 +166,7 @@ beforeEach(() => {
 });
 
 describe("aiEditorOverlay: the edit target", () => {
-    test("the image C# names becomes the editor's edit target", () => {
+    test("the image C# names becomes the AI Image Editor's edit target", () => {
         const { iframe, postFromEditor } = openAgainstABookWithOneImage();
 
         const payload = getInitPayloadSentToEditor(iframe, postFromEditor);
@@ -273,7 +273,7 @@ describe("aiEditorOverlay: saving the live page after a commit", () => {
         expect(postThatMightNavigate).not.toHaveBeenCalled();
     });
 
-    test("a failed swap's reason reaches the editor, not just the count", () => {
+    test("a failed swap's reason reaches the AI Image Editor, not just the count", () => {
         // The page frame reports a throw as a return value, so the overlay has to append
         // its reason itself or the user only ever sees "Only 1 of 2 …".
         applyAiImageEditorReplacements.mockReturnValue({
@@ -404,7 +404,7 @@ describe("aiEditorOverlay: analytics", () => {
             },
         });
 
-        // Sanity: the editor's own event was passed through, under our name for it.
+        // Sanity: the AI Image Editor's own event was passed through, under our name for it.
         expect(trackEvent).toHaveBeenCalledWith("AI Image Editor Generate", {
             model: "some-model",
             result: "success",
@@ -441,10 +441,10 @@ describe("aiEditorOverlay: analytics", () => {
         expect(abandonedEvents()).toHaveLength(1);
     });
 
-    test("the properties of a known event are passed on as the ai-editor sent them", () => {
+    test("the properties of a known event are passed on as the AI Image Editor sent them", () => {
         // Deliberately not filtered: we control both ends of this channel. If a property ever must
-        // not be forwarded, it is stopped in the ai-editor or removed by name here -- not by an
-        // allow-list that only guards us against ourselves.
+        // not be forwarded, it is stopped in the AI Image Editor or removed by name here -- not
+        // by an allow-list that only guards us against ourselves.
         const { postFromEditor } = openAgainstABookWithOneImage();
 
         postFromEditor({
@@ -509,7 +509,7 @@ describe("aiEditorOverlay: analytics", () => {
         });
 
         expect(abandonedEvents()).toHaveLength(0);
-        // And the swap that landed on the page is still saved. Answering an ai-editor that has
+        // And the swap that landed on the page is still saved. Answering an AI Image Editor that has
         // gone away used to throw from inside postMessage, which skipped everything after it
         // in the finally block -- including this save, losing the user's picture.
         expect(postThatMightNavigate).toHaveBeenCalledWith(
@@ -542,8 +542,9 @@ describe("aiEditorOverlay: analytics", () => {
     });
 
     test("two overlapping commits: closing is not a cancel while either is outstanding", () => {
-        // The ai-editor is free to send a second commit before the first is answered. With a flag
-        // rather than a count, the first reply cleared it while the second was still in the air, so
+        // The AI Image Editor is free to send a second commit before the first is answered. With
+        // a flag rather than a count, the first reply cleared it while the second was still in the
+        // air, so
         // closing then reported the session as thrown away with a commit still running.
         applyAiImageEditorReplacements.mockReturnValue({
             applied: 0,
@@ -679,10 +680,10 @@ describe("aiEditorOverlay: analytics", () => {
         expect(closedEvents()[0][1]).toMatchObject({ appliedCount: 1 });
         expect(abandonedEvents()).toHaveLength(0);
     });
-    test("a commit answered after the ai-editor was reopened leaves the new overlay alone", () => {
+    test("a commit answered after the AI Image Editor was reopened leaves the new overlay alone", () => {
         // The old session's success path calls its own cleanup, which tears down "the" overlay by
         // id and deletes the cleanup hook on the window -- both of which belong to the NEW session
-        // by then. Without an idempotence guard the editor the user is looking at disappears.
+        // by then. Without an idempotence guard the AI Image Editor the user is looking at disappears.
         const first = openAgainstABookWithOneImage();
 
         first.postFromEditor({
@@ -861,7 +862,7 @@ describe("aiEditorOverlay: reporting what a commit achieved", () => {
         expect(trackChangePicture).toHaveBeenCalledWith("ai-editor");
     });
 
-    test("generated and reused come from what the editor sent", () => {
+    test("generated and reused come from what the AI Image Editor sent", () => {
         applyAiImageEditorReplacements.mockReturnValue({
             applied: 1,
             expected: 1,
@@ -871,7 +872,7 @@ describe("aiEditorOverlay: reporting what a commit achieved", () => {
         commitAndReply(
             postFromEditor,
             [
-                // A newly generated image: the editor gives it a result id.
+                // A newly generated image: the AI Image Editor gives it a result id.
                 { incomingId: `${kPageId}:0`, resultId: "result1" },
                 // One the user reused from an image already in the book.
                 {
@@ -970,7 +971,8 @@ describe("aiEditorOverlay: reporting what a commit achieved", () => {
 
         const onError = postJson.mock.calls[0][3] as () => void;
         onError();
-        // The request failed, so the ai-editor is still up; the session ends when the user closes.
+        // The request failed, so the AI Image Editor is still up; the session ends when the user
+        // closes it.
         closeButton.click();
 
         // The attempt survives as a replacementCount with nothing applied, which is the

--- a/src/BloomBrowserUI/bookEdit/aiImageEditor/aiEditorOverlay.test.ts
+++ b/src/BloomBrowserUI/bookEdit/aiImageEditor/aiEditorOverlay.test.ts
@@ -17,6 +17,8 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 const post = vi.fn();
 const postJson = vi.fn();
 const postThatMightNavigate = vi.fn();
+const trackEvent = vi.fn();
+const trackChangePicture = vi.fn();
 const applyAiImageEditorReplacements = vi.fn();
 const getEditablePageBundleExports = vi.fn();
 
@@ -25,6 +27,8 @@ vi.mock("../../utils/bloomApi", () => ({
     postJson: (...args: unknown[]) => postJson(...args),
     postThatMightNavigate: (...args: unknown[]) =>
         postThatMightNavigate(...args),
+    trackEvent: (...args: unknown[]) => trackEvent(...args),
+    trackChangePicture: (...args: unknown[]) => trackChangePicture(...args),
 }));
 
 vi.mock("../js/workspaceFrames", () => ({
@@ -146,6 +150,8 @@ beforeEach(() => {
     post.mockClear();
     postJson.mockClear();
     postThatMightNavigate.mockClear();
+    trackEvent.mockClear();
+    trackChangePicture.mockClear();
     applyAiImageEditorReplacements.mockClear();
     applyAiImageEditorReplacements.mockReturnValue({
         applied: 1,
@@ -370,5 +376,610 @@ describe("aiEditorOverlay: saving the live page after a commit", () => {
         // Nothing landed, so nothing to save.
         expect(postThatMightNavigate).not.toHaveBeenCalled();
         postMessageToEditor.mockRestore();
+    });
+});
+
+describe("aiEditorOverlay: analytics", () => {
+    // One "AI Image Editor Closed" event per session, sent when the session settles. An
+    // appliedCount of zero is what makes it the abandoned case: it says how much AI work was
+    // thrown away, so it must be zero when a session ends without committing, and must NOT be
+    // zero when the session ended because the work was accepted.
+    const closedEvents = () =>
+        trackEvent.mock.calls.filter(
+            (call) => call[0] === "AI Image Editor Closed",
+        );
+    const abandonedEvents = () =>
+        closedEvents().filter(
+            (call) => (call[1] as { appliedCount: number }).appliedCount === 0,
+        );
+
+    test("closing without committing reports a cancel, with what was generated", () => {
+        const { closeButton, postFromEditor } = openAgainstABookWithOneImage();
+        postFromEditor({
+            channel: "bloom-ai-image-tools",
+            type: "analytics",
+            payload: {
+                event: "AI Editor Generate",
+                properties: { model: "some-model", result: "success" },
+            },
+        });
+
+        // Sanity: the editor's own event was passed through, under our name for it.
+        expect(trackEvent).toHaveBeenCalledWith("AI Image Editor Generate", {
+            model: "some-model",
+            result: "success",
+        });
+        expect(abandonedEvents()).toHaveLength(0);
+
+        closeButton.click();
+
+        expect(abandonedEvents()).toHaveLength(1);
+        expect(abandonedEvents()[0][1]).toMatchObject({
+            generatedThisSession: 1,
+        });
+    });
+
+    test("an event name we do not know is ignored, and does not break the session", () => {
+        const { closeButton, postFromEditor } = openAgainstABookWithOneImage();
+
+        // "toString" is the interesting case rather than a random word: with an object literal
+        // instead of a Map, `"toString" in list` answers true, so the name would be treated as one
+        // we know and would go on to create a junk event type in our data.
+        postFromEditor({
+            channel: "bloom-ai-image-tools",
+            type: "analytics",
+            payload: {
+                event: "toString",
+                properties: { prompt: "leaked book text" },
+            },
+        });
+
+        expect(trackEvent).not.toHaveBeenCalled();
+
+        // The session must still be alive: closing still reports the cancel.
+        closeButton.click();
+        expect(abandonedEvents()).toHaveLength(1);
+    });
+
+    test("the properties of a known event are passed on as the ai-editor sent them", () => {
+        // Deliberately not filtered: we control both ends of this channel. If a property ever must
+        // not be forwarded, it is stopped in the ai-editor or removed by name here -- not by an
+        // allow-list that only guards us against ourselves.
+        const { postFromEditor } = openAgainstABookWithOneImage();
+
+        postFromEditor({
+            channel: "bloom-ai-image-tools",
+            type: "analytics",
+            payload: {
+                event: "AI Editor Generate",
+                properties: {
+                    model: "some-model",
+                    costUSD: 0.0733,
+                    spentCredits: true,
+                },
+            },
+        });
+
+        expect(trackEvent).toHaveBeenCalledWith("AI Image Editor Generate", {
+            model: "some-model",
+            costUSD: 0.0733,
+            spentCredits: true,
+        });
+    });
+
+    test("closing while a commit is in flight does not report a cancel as well", () => {
+        // The overlay goes away the moment the user clicks the close box, but the pictures may be
+        // saved a moment later. Reporting a cancel here would count one session as both thrown
+        // away and committed, inflating the number the cancel event exists to provide.
+        const { closeButton, postFromEditor } = openAgainstABookWithOneImage();
+
+        postFromEditor({
+            channel: "bloom-ai-image-tools",
+            type: "commit",
+            requestId: "req1",
+            payload: {
+                replacements: [
+                    { incomingId: `${kPageId}:0`, resultId: "result1" },
+                ],
+            },
+        });
+        expect(postJson).toHaveBeenCalledTimes(1);
+
+        closeButton.click();
+        // Sanity: nothing reported yet -- the outcome is still unknown.
+        expect(abandonedEvents()).toHaveLength(0);
+
+        const onSuccess = postJson.mock.calls[0][2] as (r: {
+            data: unknown;
+        }) => void;
+        onSuccess({
+            data: {
+                ok: true,
+                appliedCount: 1,
+                results: [
+                    {
+                        incomingId: `${kPageId}:0`,
+                        ok: true,
+                        isCurrentPage: true,
+                        oldSrc: kImageFile,
+                        newSrc: "ai-image1.png",
+                    },
+                ],
+            },
+        });
+
+        expect(abandonedEvents()).toHaveLength(0);
+        // And the swap that landed on the page is still saved. Answering an ai-editor that has
+        // gone away used to throw from inside postMessage, which skipped everything after it
+        // in the finally block -- including this save, losing the user's picture.
+        expect(postThatMightNavigate).toHaveBeenCalledWith(
+            "common/saveChangesAndRethinkPageEvent",
+        );
+    });
+
+    test("closing while a commit is in flight DOES report a cancel if the commit then fails", () => {
+        // The other half: the session really did end with nothing kept, so it must still be
+        // counted -- just later, once the answer is known.
+        const { closeButton, postFromEditor } = openAgainstABookWithOneImage();
+
+        postFromEditor({
+            channel: "bloom-ai-image-tools",
+            type: "commit",
+            requestId: "req1",
+            payload: {
+                replacements: [
+                    { incomingId: `${kPageId}:0`, resultId: "result1" },
+                ],
+            },
+        });
+        closeButton.click();
+        expect(abandonedEvents()).toHaveLength(0);
+
+        const onError = postJson.mock.calls[0][3] as () => void;
+        onError();
+
+        expect(abandonedEvents()).toHaveLength(1);
+    });
+
+    test("two overlapping commits: closing is not a cancel while either is outstanding", () => {
+        // The ai-editor is free to send a second commit before the first is answered. With a flag
+        // rather than a count, the first reply cleared it while the second was still in the air, so
+        // closing then reported the session as thrown away with a commit still running.
+        applyAiImageEditorReplacements.mockReturnValue({
+            applied: 0,
+            expected: 0,
+        });
+        const { closeButton, postFromEditor } = openAgainstABookWithOneImage();
+
+        const sendCommit = (requestId: string, slot: string) =>
+            postFromEditor({
+                channel: "bloom-ai-image-tools",
+                type: "commit",
+                requestId,
+                payload: {
+                    replacements: [
+                        { incomingId: slot, resultId: "r" + requestId },
+                    ],
+                },
+            });
+
+        sendCommit("req1", "page2:0");
+        sendCommit("req2", "page3:0");
+        expect(postJson).toHaveBeenCalledTimes(2);
+
+        // The FIRST one comes back, failing, while the second is still outstanding.
+        (postJson.mock.calls[0][3] as () => void)();
+
+        closeButton.click();
+        expect(abandonedEvents()).toHaveLength(0);
+
+        // Once the second is answered too -- also with nothing applied -- the cancel is due.
+        (postJson.mock.calls[1][3] as () => void)();
+        expect(abandonedEvents()).toHaveLength(1);
+    });
+
+    test("a reply path that throws does not report the session twice", () => {
+        // postJson chains .then(success).catch(error), so a throw inside the success callback runs
+        // the error callback for the SAME request -- which is why both are exercised here. Two
+        // things must survive that. The outstanding-commit count must not be decremented by both,
+        // or it would sit at -1 and "no commit outstanding" would never be true again. And the
+        // session must not be reported a second time by the error path.
+        applyAiImageEditorReplacements.mockReturnValue({
+            applied: 0,
+            expected: 0,
+        });
+        const { closeButton, postFromEditor } = openAgainstABookWithOneImage();
+
+        postFromEditor({
+            channel: "bloom-ai-image-tools",
+            type: "commit",
+            requestId: "req1",
+            payload: {
+                replacements: [{ incomingId: "page2:0", resultId: "r1" }],
+            },
+        });
+        // Closed with the commit still in flight, so the reply is what will report -- which is
+        // what puts the send inside the success callback, where it can throw.
+        closeButton.click();
+        expect(closedEvents()).toHaveLength(0);
+
+        trackEvent.mockImplementationOnce(() => {
+            throw new Error("analytics blew up");
+        });
+        const onSuccess = postJson.mock.calls[0][2] as (r: {
+            data: unknown;
+        }) => void;
+        expect(() =>
+            onSuccess({
+                data: {
+                    ok: false,
+                    results: [
+                        {
+                            incomingId: "page2:0",
+                            ok: false,
+                            isCurrentPage: false,
+                        },
+                    ],
+                },
+            }),
+        ).toThrow();
+        // ...so the error callback runs for the same request, as postJson would do.
+        (postJson.mock.calls[0][3] as () => void)();
+
+        // Attempted exactly once: the throw was on the way out of the send, not before it.
+        expect(abandonedEvents()).toHaveLength(1);
+    });
+
+    test("of two overlapping commits, one failing and one succeeding is not also a cancel", () => {
+        // The other ordering from the test above, and the one that was wrong: the user closes with
+        // both commits outstanding, the FIRST comes back a failure, and the second then succeeds.
+        // Reporting the cancel when the failure arrived would put one session in both the cancel
+        // and the commit figures.
+        applyAiImageEditorReplacements.mockReturnValue({
+            applied: 0,
+            expected: 0,
+        });
+        const { closeButton, postFromEditor } = openAgainstABookWithOneImage();
+
+        const sendCommit = (requestId: string, slot: string) =>
+            postFromEditor({
+                channel: "bloom-ai-image-tools",
+                type: "commit",
+                requestId,
+                payload: {
+                    replacements: [
+                        { incomingId: slot, resultId: "r" + requestId },
+                    ],
+                },
+            });
+
+        sendCommit("req1", "page2:0");
+        sendCommit("req2", "page3:0");
+        closeButton.click();
+
+        // The first fails...
+        (postJson.mock.calls[0][3] as () => void)();
+        expect(abandonedEvents()).toHaveLength(0);
+
+        // ...and the second puts its picture in the book.
+        const onSuccess = postJson.mock.calls[1][2] as (r: {
+            data: unknown;
+        }) => void;
+        onSuccess({
+            data: {
+                ok: true,
+                results: [
+                    { incomingId: "page3:0", ok: true, isCurrentPage: false },
+                ],
+            },
+        });
+
+        // Sanity: the session really was reported as putting a picture in the book.
+        expect(closedEvents()).toHaveLength(1);
+        expect(closedEvents()[0][1]).toMatchObject({ appliedCount: 1 });
+        expect(abandonedEvents()).toHaveLength(0);
+    });
+    test("a commit answered after the ai-editor was reopened leaves the new overlay alone", () => {
+        // The old session's success path calls its own cleanup, which tears down "the" overlay by
+        // id and deletes the cleanup hook on the window -- both of which belong to the NEW session
+        // by then. Without an idempotence guard the editor the user is looking at disappears.
+        const first = openAgainstABookWithOneImage();
+
+        first.postFromEditor({
+            channel: "bloom-ai-image-tools",
+            type: "commit",
+            requestId: "req1",
+            payload: {
+                replacements: [
+                    { incomingId: `${kPageId}:0`, resultId: "result1" },
+                ],
+            },
+        });
+        const onSuccess = postJson.mock.calls[0][2] as (r: {
+            data: unknown;
+        }) => void;
+
+        first.closeButton.click();
+        // The helper expects a fresh launch, and this is the second in one test.
+        post.mockClear();
+        openAgainstABookWithOneImage();
+        // Sanity: the new session is up and is the one the window would tear down.
+        expect(document.getElementById("ai-editor-overlay")).not.toBeNull();
+
+        onSuccess({
+            data: {
+                ok: true,
+                appliedCount: 1,
+                results: [
+                    {
+                        incomingId: `${kPageId}:0`,
+                        ok: true,
+                        isCurrentPage: true,
+                        oldSrc: kImageFile,
+                        newSrc: "ai-image1.png",
+                    },
+                ],
+            },
+        });
+
+        expect(document.getElementById("ai-editor-overlay")).not.toBeNull();
+        expect(
+            (window as Window & { __bloomAiImageEditorCleanup?: () => void })
+                .__bloomAiImageEditorCleanup,
+        ).toBeTypeOf("function");
+    });
+    test("a cancel is reported at most once", () => {
+        const { closeButton } = openAgainstABookWithOneImage();
+
+        closeButton.click();
+        expect(abandonedEvents()).toHaveLength(1);
+
+        // The close box is gone with the overlay, but the cleanup hook survives on the window
+        // for a relaunch to call; calling it again must not report a second cancel.
+        (
+            window as Window & { __bloomAiImageEditorCleanup?: () => void }
+        ).__bloomAiImageEditorCleanup?.();
+
+        expect(abandonedEvents()).toHaveLength(1);
+    });
+    test("a successful commit is not reported as a cancel", () => {
+        const { postFromEditor } = openAgainstABookWithOneImage();
+
+        commitAndReplyFromHost(postFromEditor, true);
+
+        // Sanity: the commit really did close the overlay, so this is not just a session
+        // that never ended.
+        expect(document.getElementById("ai-editor-overlay")).toBeNull();
+        expect(abandonedEvents()).toHaveLength(0);
+    });
+});
+
+// "AI Image Editor Closed" and the per-picture "Change Picture" events are reported from the
+// overlay rather than from C#, because C# cannot know whether a picture on the page being edited
+// actually got swapped in -- it only stages those. These tests are what makes that worth having:
+// they pin that a swap the page frame failed to make is NOT counted as a picture that reached the
+// book.
+//
+// The counts arrive when the SESSION settles, not when a commit is answered, so a test whose
+// commit leaves the overlay up has to close it before there is anything to assert on.
+describe("aiEditorOverlay: reporting what a commit achieved", () => {
+    const closedEvents = () =>
+        trackEvent.mock.calls.filter(
+            (call) => call[0] === "AI Image Editor Closed",
+        );
+
+    // Sends a commit for the given replacements and answers it with C#'s reply.
+    const commitAndReply = (
+        postFromEditor: (data: unknown) => void,
+        replacements: Array<{
+            incomingId: string;
+            resultId?: string;
+            sourceUrl?: string;
+        }>,
+        results: Array<Record<string, unknown>>,
+    ) => {
+        postFromEditor({
+            channel: "bloom-ai-image-tools",
+            type: "commit",
+            requestId: "req1",
+            payload: { replacements },
+        });
+        expect(postJson).toHaveBeenCalledTimes(1);
+        const onSuccess = postJson.mock.calls[0][2] as (r: {
+            data: unknown;
+        }) => void;
+        onSuccess({ data: { ok: true, results } });
+    };
+
+    const currentPageResult = (ordinal: number) => ({
+        incomingId: `${kPageId}:${ordinal}`,
+        ok: true,
+        isCurrentPage: true,
+        oldSrc: kImageFile,
+        newSrc: `ai-image${ordinal}.png`,
+    });
+
+    test("a picture the page frame could not swap in is not counted as applied", () => {
+        // The case the move exists for. C# staged this replacement and would have called it
+        // applied; the live page is where it actually failed.
+        applyAiImageEditorReplacements.mockReturnValue({
+            applied: 0,
+            expected: 1,
+        });
+        const { closeButton, postFromEditor } = openAgainstABookWithOneImage();
+
+        commitAndReply(
+            postFromEditor,
+            [{ incomingId: `${kPageId}:0`, resultId: "result1" }],
+            [currentPageResult(0)],
+        );
+
+        // The commit failed on the live page, so the overlay stays up and the session is not over.
+        expect(closedEvents()).toHaveLength(0);
+        closeButton.click();
+
+        expect(closedEvents()).toHaveLength(1);
+        expect(closedEvents()[0][1]).toMatchObject({
+            replacementCount: 1,
+            appliedCount: 0,
+            failedCount: 1,
+        });
+        // And no picture is added to the where-do-pictures-come-from breakdown.
+        expect(trackChangePicture).not.toHaveBeenCalled();
+    });
+
+    test("applied adds up C#'s off-page successes and what the page frame landed", () => {
+        applyAiImageEditorReplacements.mockReturnValue({
+            applied: 1,
+            expected: 1,
+        });
+        const { postFromEditor } = openAgainstABookWithOneImage();
+
+        commitAndReply(
+            postFromEditor,
+            [
+                { incomingId: `${kPageId}:0`, resultId: "result1" },
+                { incomingId: "page2:0", resultId: "result2" },
+                { incomingId: "page3:0", resultId: "result3" },
+            ],
+            [
+                currentPageResult(0),
+                // C# applied and saved this one itself.
+                { incomingId: "page2:0", ok: true, isCurrentPage: false },
+                // And could not do this one at all.
+                { incomingId: "page3:0", ok: false, isCurrentPage: false },
+            ],
+        );
+
+        expect(closedEvents()[0][1]).toMatchObject({
+            replacementCount: 3,
+            appliedCount: 2,
+            failedCount: 1,
+        });
+        // One per picture that reached the book, in the same vocabulary as the other routes.
+        expect(trackChangePicture).toHaveBeenCalledTimes(2);
+        expect(trackChangePicture).toHaveBeenCalledWith("ai-editor");
+    });
+
+    test("generated and reused come from what the editor sent", () => {
+        applyAiImageEditorReplacements.mockReturnValue({
+            applied: 1,
+            expected: 1,
+        });
+        const { postFromEditor } = openAgainstABookWithOneImage();
+
+        commitAndReply(
+            postFromEditor,
+            [
+                // A newly generated image: the editor gives it a result id.
+                { incomingId: `${kPageId}:0`, resultId: "result1" },
+                // One the user reused from an image already in the book.
+                {
+                    incomingId: "page2:0",
+                    sourceUrl: "http://host/book/existing.png",
+                },
+            ],
+            [
+                currentPageResult(0),
+                { incomingId: "page2:0", ok: true, isCurrentPage: false },
+            ],
+        );
+
+        expect(closedEvents()[0][1]).toMatchObject({
+            generatedCount: 1,
+            reusedCount: 1,
+        });
+    });
+
+    test("a commit is reported at most once, even if the reply path also errors", () => {
+        // postJson chains .then(success).catch(error), so anything escaping the success callback
+        // runs the error callback too -- which reports as well. One commit must not be counted
+        // twice, nor its pictures added twice to the picture-source breakdown.
+        applyAiImageEditorReplacements.mockReturnValue({
+            applied: 1,
+            expected: 1,
+        });
+        const { postFromEditor } = openAgainstABookWithOneImage();
+
+        commitAndReply(
+            postFromEditor,
+            [{ incomingId: `${kPageId}:0`, resultId: "result1" }],
+            [currentPageResult(0)],
+        );
+        expect(closedEvents()).toHaveLength(1);
+        expect(trackChangePicture).toHaveBeenCalledTimes(1);
+
+        // Now the error callback runs as well, as it would if anything threw on the way out.
+        const onError = postJson.mock.calls[0][3] as () => void;
+        onError();
+
+        expect(closedEvents()).toHaveLength(1);
+        expect(trackChangePicture).toHaveBeenCalledTimes(1);
+    });
+    test("a session that got some pictures into the book is not also counted as thrown away", () => {
+        // A commit can succeed for one picture and fail for another. The overlay stays open, and
+        // the user closes it -- but their AI work was not thrown away, so an appliedCount of zero
+        // here would file a session that did save a picture as one that discarded everything.
+        applyAiImageEditorReplacements.mockReturnValue({
+            applied: 0,
+            expected: 1,
+        });
+        const { closeButton, postFromEditor } = openAgainstABookWithOneImage();
+
+        commitAndReply(
+            postFromEditor,
+            [
+                { incomingId: `${kPageId}:0`, resultId: "result1" },
+                { incomingId: "page2:0", resultId: "result2" },
+            ],
+            [
+                // The page frame could not swap this one in...
+                currentPageResult(0),
+                // ...but C# applied and saved this one itself.
+                { incomingId: "page2:0", ok: true, isCurrentPage: false },
+            ],
+        );
+        // Sanity: the overlay is still up, so nothing has been reported yet.
+        expect(document.getElementById("ai-editor-overlay")).not.toBeNull();
+        expect(closedEvents()).toHaveLength(0);
+
+        closeButton.click();
+
+        // One event, and it says a picture landed -- not a session that threw everything away.
+        expect(closedEvents()).toHaveLength(1);
+        expect(closedEvents()[0][1]).toMatchObject({
+            appliedCount: 1,
+            failedCount: 1,
+        });
+    });
+    test("a commit whose request fails reports that nothing landed", () => {
+        const { closeButton, postFromEditor } = openAgainstABookWithOneImage();
+
+        postFromEditor({
+            channel: "bloom-ai-image-tools",
+            type: "commit",
+            requestId: "req1",
+            payload: {
+                replacements: [
+                    { incomingId: `${kPageId}:0`, resultId: "result1" },
+                ],
+            },
+        });
+        // Sanity: nothing reported until the request is answered one way or the other.
+        expect(closedEvents()).toHaveLength(0);
+
+        const onError = postJson.mock.calls[0][3] as () => void;
+        onError();
+        // The request failed, so the ai-editor is still up; the session ends when the user closes.
+        closeButton.click();
+
+        // The attempt survives as a replacementCount with nothing applied, which is the
+        // BL-16702 shape: a commit that reached nobody.
+        expect(closedEvents()[0][1]).toMatchObject({
+            replacementCount: 1,
+            appliedCount: 0,
+            failedCount: 1,
+        });
+        expect(trackChangePicture).not.toHaveBeenCalled();
     });
 });

--- a/src/BloomBrowserUI/bookEdit/aiImageEditor/aiEditorOverlay.ts
+++ b/src/BloomBrowserUI/bookEdit/aiImageEditor/aiEditorOverlay.ts
@@ -303,14 +303,31 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
                       payload?: {
                           level?: string;
                           message?: string;
-                          // We relay this array to C# as-is, so every field the
-                          // ai-editor sends is declared here even though this side
-                          // reads only resultId and sourceUrl (to say how many pictures
-                          // were generated rather than reused — see noteCommitResult).
-                          // Rebuilding the array field by field instead of passing it
-                          // through would silently drop `credits`, and the result would
-                          // lose its credits — the bug this whole feature exists to
-                          // prevent.
+                          // Note that this whole block is a type assertion on the
+                          // message that arrived -- it describes the wire, and builds
+                          // nothing. The `commit` case below forwards `replacements` to
+                          // C# by reference, unchanged, which has two consequences worth
+                          // knowing before touching either place:
+                          //
+                          //  - a field the ai-editor sends arrives at C# intact whether
+                          //    or not it is declared here, so this list being incomplete
+                          //    would break nothing today;
+                          //  - it is nevertheless kept complete on purpose, because the
+                          //    obvious-looking refactor -- rebuild the array field by
+                          //    field on the way to C# -- can only carry the fields
+                          //    someone thought to name, and would silently drop any this
+                          //    type had not caught up with.
+                          //
+                          // This side itself reads only resultId and sourceUrl, to say
+                          // how many pictures were generated rather than reused (see
+                          // noteCommitResult).
+                          //
+                          // "credits" below means the picture's ATTRIBUTION -- copyright
+                          // notice, creator, license. It has nothing to do with the
+                          // OpenRouter credits that costUSD and spentCredits report, in
+                          // this same message type. Attribution being lost when a picture
+                          // went through the ai-editor was BL-16603; that is why these
+                          // fields exist and why they have to survive the trip.
                           replacements?: Array<{
                               incomingId?: string;
                               resultId?: string;

--- a/src/BloomBrowserUI/bookEdit/aiImageEditor/aiEditorOverlay.ts
+++ b/src/BloomBrowserUI/bookEdit/aiImageEditor/aiEditorOverlay.ts
@@ -190,7 +190,6 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
         let picturesGenerated = 0;
         let picturesReused = 0;
         let closedReported = false;
-        let commitSucceeded = false;
         // How many commits we have sent and not yet had an answer to. Reporting the session while
         // any is outstanding must not happen: the pictures may be moments from being saved. A count
         // rather than a flag, because the ai-editor is free to send a second commit before the
@@ -545,7 +544,6 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
                                     currentPageApplied,
                                 );
                                 if (finalOk) {
-                                    commitSucceeded = true;
                                     cleanup();
                                 }
                                 // Unconditionally, and after cleanup rather than instead of it.

--- a/src/BloomBrowserUI/bookEdit/aiImageEditor/aiEditorOverlay.ts
+++ b/src/BloomBrowserUI/bookEdit/aiImageEditor/aiEditorOverlay.ts
@@ -437,6 +437,13 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
                         const applied = offPageApplied + currentPageApplied;
                         replacementsAttempted += replacements.length;
                         picturesApplied += applied;
+                        // Deliberately counted over every replacement the ai-editor sent, not only
+                        // the ones that landed -- so generatedCount and reusedCount are NOT
+                        // comparable with appliedCount, and do not sum to it when a swap fails.
+                        // They answer a different question: what the user chose, and therefore what
+                        // they paid OpenRouter for, which is true whether or not the picture then
+                        // made it into the book. appliedCount and failedCount are the pair that
+                        // says what landed.
                         picturesGenerated += replacements.filter(
                             (r) => !!r?.resultId,
                         ).length;

--- a/src/BloomBrowserUI/bookEdit/aiImageEditor/aiEditorOverlay.ts
+++ b/src/BloomBrowserUI/bookEdit/aiImageEditor/aiEditorOverlay.ts
@@ -8,28 +8,34 @@
 // frame through getEditablePageBundleExports() (see aiEditorPageCommands.ts).
 //
 // The C# half is AiImageEditorApi.cs (read that file's header for the full picture). The
-// AI image editor is a SEPARATE web app (the `bloom-ai-image-tools` package); we do not
+// ai-editor is a SEPARATE web app (the `bloom-ai-image-tools` package); we do not
 // import it — we load it into an <iframe> overlay. The flow:
 //   0. The menu command (aiEditorPageCommands.launchAiImageEditor, in the page frame)
 //      POSTs aiImageEditor/saveThenLaunch. C# saves the page being edited — which the
 //      whole-book image list below depends on, and which reloads the page frame — and then
 //      calls openAiImageEditor() here. See HandleSaveThenLaunch.
 //   1. POST aiImageEditor/launch -> C# mints a session, makes the per-book
-//      .ai-image-editor folder, and returns the AI image editor URL + the whole-book image
+//      .ai-image-editor folder, and returns the ai-editor URL + the whole-book image
 //      list + enumerated history + httpBase/sessionToken.
 //   2. Build a fixed overlay <div id="ai-editor-overlay"> holding an <iframe> at
 //      that URL with ?mode=bloom-iframe.
 //   3. Handshake over window.postMessage on channel "bloom-ai-image-tools": the
-//      AI image editor posts `ready`; we post `init` (the launch reply + the right-clicked
+//      ai-editor posts `ready`; we post `init` (the launch reply + the right-clicked
 //      image as selectedBookImageId). Image bytes never ride postMessage — they go
-//      over HTTP via aiImageEditor/file; the AI image editor references results by id.
+//      over HTTP via aiImageEditor/file; the ai-editor references results by id.
 //   4. On `commit` we POST aiImageEditor/commit; C# applies replacements to all
 //      non-current pages and returns {oldSrc,newSrc,copyright,creator,license} for any on
 //      the live page, which the page frame applies for us. `cancel`/close just tear the
 //      overlay down. (There is intentionally no C#->iframe message channel; init flows from
 //      here, because only the browser can postMessage to the iframe.)
 
-import { post, postJson, postThatMightNavigate } from "../../utils/bloomApi";
+import {
+    post,
+    postJson,
+    postThatMightNavigate,
+    trackChangePicture,
+    trackEvent,
+} from "../../utils/bloomApi";
 import { getEditablePageBundleExports } from "../js/workspaceFrames";
 import {
     fileNameOf,
@@ -38,6 +44,28 @@ import {
     IAiImageEditorTarget,
     isCurrentPageSwap,
 } from "./aiEditorShared";
+
+// The analytics events the ai-editor may ask us to send, mapping the name IT uses to the name we
+// record. Bloom is what actually posts to Segment, and a name it does not recognize would create a
+// new event type in our data rather than land in an existing one, so the vocabulary is pinned on
+// this side.
+//
+// The rename is why this is a map and not just a list: our events say "AI Image Editor" because
+// one day there may be an AI editor for text, or video, or games, and "AI Editor Generate" would
+// then be ambiguous. Doing the translation here rather than in the ai-editor means Bloom's
+// vocabulary is Bloom's business, and a package release is not needed to change it.
+//
+// Their PROPERTIES are not filtered. We control both ends of this channel, so an allow-list of
+// property names would only be guarding against ourselves; if something specific ever must not be
+// forwarded, the place to stop it is in the ai-editor, or by removing that one property here.
+// Today it sends nothing but ids, enums, numbers and booleans -- no free-form text of any kind.
+//
+// A Map, not an object literal: with an object, `event in obj` is also true for inherited members,
+// so an event named "toString" or "constructor" would be treated as permitted. Map.get() only sees
+// real entries.
+const kAnalyticsEventsTheAiEditorMaySend = new Map<string, string>([
+    ["AI Editor Generate", "AI Image Editor Generate"],
+]);
 
 // Hand the commit's current-page swaps to the page frame, which owns the live page. Only call
 // this when there is such a swap (see isCurrentPageSwap): the frame is briefly unreachable while
@@ -82,16 +110,16 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
                 name?: string;
             }>;
             // Enumerated by C# from the per-book history folder; rides through
-            // the `...launchData` spread into the AI image editor's init payload.
+            // the `...launchData` spread into the ai-editor's init payload.
             history?: Array<{
                 id: string;
                 url: string;
                 metadata?: Record<string, unknown> | null;
             }>;
             apiKey?: string | null;
-            // Playground/demo context: the AI image editor must disable its
+            // Playground/demo context: the ai-editor must disable its
             // "set OpenRouter API key" UI. Rides through the `...launchData`
-            // spread below into the AI image editor's init payload.
+            // spread below into the ai-editor's init payload.
             demoOnly?: boolean;
         };
         const hostWindow = window as Window & {
@@ -105,11 +133,11 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
         iframeUrl.searchParams.set("mode", "bloom-iframe");
         // Bloom (C#) enumerates every user-changeable image in the whole book
         // and supplies them as `launchData.bookImages`, each with a stable
-        // "{pageId}:{ordinal}" id the AI image editor echoes back on commit. The host
+        // "{pageId}:{ordinal}" id the ai-editor echoes back on commit. The host
         // applies replacements book-wide in C#, so there is no per-image DOM
         // id wrangling here anymore.
 
-        // Identify the image the user right-clicked so the AI image editor can open with it
+        // Identify the image the user right-clicked so the ai-editor can open with it
         // already in the "Image to Edit" slot. We match by page + filename rather than DOM
         // ordinal, because the live page has extra injected UI images that would throw
         // positional indices off.
@@ -137,7 +165,88 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
 
         hostWindow.__bloomAiImageEditorCleanup?.();
 
+        // ----- Analytics for this ai-editor session (BL-16716) -----
+        // Generation happens inside the ai-editor app, which reports each attempt to us over the
+        // bridge (the "analytics" message below); we count those so that a session the user
+        // abandons can say how much AI work was thrown away. That is the clearest signal we
+        // have that the output was not good enough -- much better than a count of generations,
+        // which goes up whether people liked what they got or not.
+        //
+        // ONE event per session, "AI Image Editor Closed", sent when the session settles. It says
+        // what the session achieved, and an appliedCount of zero IS the cancel -- which is why
+        // there is no separate cancel event to keep in step with this one.
+        //
+        // "Settles" means the overlay has gone AND no commit is still outstanding, which is why
+        // the counts below accumulate rather than being reported as each reply arrives. Reporting
+        // per reply would be wrong in both directions: a session with two commits, one that fails
+        // and one that succeeds, would be recorded by whichever answered first -- so a session
+        // whose pictures did land could be filed as one that threw everything away. Waiting costs
+        // us a session that is never closed at all (Bloom quit with the overlay still up), which
+        // is the rarer and less misleading loss.
+        let generationsThisSession = 0;
+        // What every commit in this session added up to. failedCount is derived from the first two.
+        let replacementsAttempted = 0;
+        let picturesApplied = 0;
+        let picturesGenerated = 0;
+        let picturesReused = 0;
+        let closedReported = false;
+        let commitSucceeded = false;
+        // How many commits we have sent and not yet had an answer to. Reporting the session while
+        // any is outstanding must not happen: the pictures may be moments from being saved. A count
+        // rather than a flag, because the ai-editor is free to send a second commit before the
+        // first is answered, and the first reply would then clear a flag while the second was still
+        // in the air.
+        let commitsInFlight = 0;
+        // Set by cleanup. Asking the DOM whether the overlay is still there would not do: a
+        // relaunch tears this session down and immediately puts up a new overlay with the same id.
+        let sessionEnded = false;
+
+        // Report how this session turned out. Safe -- and expected -- to call from anywhere that
+        // might have settled the last thing we were waiting for: it does nothing until both
+        // conditions hold, and nothing ever again once it has reported.
+        //
+        // Both conditions are tested HERE rather than at the call sites, because every caller
+        // needs them and one of them is easy to get wrong: a reply arriving for commit A must not
+        // report while commit B is still in the air. Each reply decrements the count before calling
+        // us, so whichever settles last is the one that reports.
+        const reportClosed = () => {
+            if (closedReported || !sessionEnded || commitsInFlight > 0) return;
+            closedReported = true;
+            // Did anything actually reach the book? A non-zero failedCount is exactly the class of
+            // bug BL-16702 was: a commit that silently did nothing. Generated versus reused says
+            // whether people are paying for new pictures or re-using ones they already have. And
+            // generatedThisSession against a zero appliedCount is how much AI work was thrown away
+            // -- the clearest signal we have that the output was not good enough, and much better
+            // than a count of generations, which goes up whether people liked what they got or not.
+            trackEvent("AI Image Editor Closed", {
+                replacementCount: replacementsAttempted,
+                appliedCount: picturesApplied,
+                failedCount: replacementsAttempted - picturesApplied,
+                generatedCount: picturesGenerated,
+                reusedCount: picturesReused,
+                generatedThisSession: generationsThisSession,
+                historyCount: (launchData.history ?? []).length,
+            });
+        };
+
         const cleanup = () => {
+            // Every way of ending the session without committing lands here: the ai-editor's own
+            // Cancel button, our close box, and a relaunch superseding this session.
+            //
+            // Except one: closing while a commit is still in flight. The overlay goes away
+            // immediately, but the pictures may well be saved a moment later, so this is not yet
+            // the moment to say what the session achieved. reportClosed declines while a commit is
+            // outstanding; the last reply to arrive is what reports.
+            //
+            // Idempotent, and it has to be: a commit sent by THIS session can be answered after the
+            // user has closed it and opened the ai-editor again, and its success path calls us. The
+            // overlay we would then tear down -- looked up by id, and the cleanup hook on the
+            // window -- belong to the new session, so a second run would make the ai-editor the user
+            // is looking at vanish, unclosably. (Pre-existing; deferring the outcome to the commit
+            // reply made it easier to reach.)
+            if (sessionEnded) return;
+            sessionEnded = true;
+            reportClosed();
             hostWindow.removeEventListener("message", handleMessage);
             hostDocument.getElementById("ai-editor-overlay")?.remove();
             delete hostWindow.__bloomAiImageEditorCleanup;
@@ -195,12 +304,14 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
                       payload?: {
                           level?: string;
                           message?: string;
-                          // We relay this array to C# as-is, so every field the AI
-                          // image editor sends is declared here even though nothing
-                          // on this side reads them. Rebuilding the array field by
-                          // field instead of passing it through would silently drop
-                          // `credits`, and the result would lose its credits — the
-                          // bug this whole feature exists to prevent.
+                          // We relay this array to C# as-is, so every field the
+                          // ai-editor sends is declared here even though this side
+                          // reads only resultId and sourceUrl (to say how many pictures
+                          // were generated rather than reused — see noteCommitResult).
+                          // Rebuilding the array field by field instead of passing it
+                          // through would silently drop `credits`, and the result would
+                          // lose its credits — the bug this whole feature exists to
+                          // prevent.
                           replacements?: Array<{
                               incomingId?: string;
                               resultId?: string;
@@ -220,6 +331,14 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
                               } | null;
                           }>;
                           apiKey?: string | null;
+                          // For the "analytics" message: an event the ai-editor wants recorded.
+                          // Its own code guarantees no prompt text or other user content is in
+                          // here -- see IBloomHostControl.trackEvent in bloom-ai-image-tools.
+                          event?: string;
+                          properties?: Record<
+                              string,
+                              string | number | boolean
+                          >;
                       };
                   }
                 | undefined;
@@ -252,16 +371,30 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
                     // via Bloom's own changeImageByElement().
                     const requestId = data.requestId;
                     const ackEditor = (ok: boolean, error?: string) => {
-                        iframe.contentWindow?.postMessage(
-                            {
-                                channel: "bloom-ai-image-tools",
-                                type: "ack",
-                                requestId,
-                                ok,
-                                error,
-                            },
-                            iframeUrl.origin,
-                        );
+                        // The ai-editor can be gone by the time we answer: the user is free to close
+                        // the overlay while a commit is in flight, which detaches this iframe.
+                        // Telling a window that no longer exists must not throw, because the work
+                        // that follows this call still has to happen -- saving the page the swaps
+                        // landed on, and deciding whether the session ended with nothing kept.
+                        // (Browsers null contentWindow on a detached frame, so the optional chain
+                        // usually covers it; jsdom leaves it non-null and throws from inside
+                        // postMessage, and that is a difference we should not be relying on.)
+                        try {
+                            iframe.contentWindow?.postMessage(
+                                {
+                                    channel: "bloom-ai-image-tools",
+                                    type: "ack",
+                                    requestId,
+                                    ok,
+                                    error,
+                                },
+                                iframeUrl.origin,
+                            );
+                        } catch (e) {
+                            console.warn(
+                                `[AI Image Editor] could not acknowledge commit ${requestId}: ${e}`,
+                            );
+                        }
                     };
 
                     const replacements = data.payload?.replacements ?? [];
@@ -270,6 +403,58 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
                         break;
                     }
 
+                    // Reported from here rather than from C# (AiImageEditorApi.HandleCommit, which
+                    // has the matching comment) because this is the only side that ever learns
+                    // whether the pictures on the page being edited really got swapped in. C# can
+                    // only stage those and hand them back, so counting a staged one as applied
+                    // overstated success in exactly the case the event exists to catch -- and in the
+                    // ordinary case at that, since the picture the user right-clicked to open the
+                    // ai-editor is by definition on the page they have open.
+                    //
+                    // offPageApplied comes from C#, which did those itself and knows;
+                    // currentPageApplied is what the page frame says it managed.
+                    // Both of these exist because postJson chains .then(success).catch(error): if
+                    // anything escapes the success callback, the error callback runs for the SAME
+                    // request, and everything either of them does would otherwise happen twice.
+                    // Counting twice would put one commit's pictures into the session totals and
+                    // into the picture-source breakdown twice over; decrementing twice would leave
+                    // commitsInFlight at -1, after which "no commit outstanding" is never true
+                    // again and the session could never be reported at all.
+                    let commitCounted = false;
+                    let commitSettled = false;
+                    const noteCommitSettled = () => {
+                        if (commitSettled) return;
+                        commitSettled = true;
+                        commitsInFlight--;
+                    };
+                    // Add what this commit achieved to the session totals. It does not send
+                    // anything: reportClosed sends one event for the whole session (see there).
+                    const noteCommitResult = (
+                        offPageApplied: number,
+                        currentPageApplied: number,
+                    ) => {
+                        if (commitCounted) return;
+                        commitCounted = true;
+                        const applied = offPageApplied + currentPageApplied;
+                        replacementsAttempted += replacements.length;
+                        picturesApplied += applied;
+                        picturesGenerated += replacements.filter(
+                            (r) => !!r?.resultId,
+                        ).length;
+                        picturesReused += replacements.filter(
+                            (r) => !r?.resultId && !!r?.sourceUrl,
+                        ).length;
+                        // Count each picture that reached the book the same way a pasted or
+                        // chooser-chosen one is counted, so the source breakdown covers every route
+                        // a picture can enter a book by. One per picture, as those routes do, and
+                        // reported as it happens rather than at session end because these are
+                        // per-picture facts and nothing about them is still pending.
+                        for (let i = 0; i < applied; i++) {
+                            trackChangePicture("ai-editor");
+                        }
+                    };
+
+                    commitsInFlight++;
                     postJson(
                         "aiImageEditor/commit?session=" +
                             encodeURIComponent(launchData.sessionToken),
@@ -284,7 +469,7 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
                                 | undefined;
                             // The server reports whether it staged every replacement; for
                             // current-page slots only the live DOM knows whether the edit
-                            // actually landed. Combine both so the AI image editor's ack
+                            // actually landed. Combine both so the ai-editor's ack
                             // reflects the true outcome, and always ack (even when the
                             // apply fails) so its overlay can't hang.
                             let finalOk = false;
@@ -349,15 +534,71 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
                                         "common/saveChangesAndRethinkPageEvent",
                                     );
                                 }
+                                noteCommitSettled();
+                                // Now, and only now, is the applied count a fact. Counted from
+                                // C#'s own results for the other pages, plus what the page frame
+                                // reported for this one (0 if we never got that far).
+                                noteCommitResult(
+                                    (result?.results ?? []).filter(
+                                        (r) => r?.ok && !r.isCurrentPage,
+                                    ).length,
+                                    currentPageApplied,
+                                );
                                 if (finalOk) {
+                                    commitSucceeded = true;
                                     cleanup();
                                 }
+                                // Unconditionally, and after cleanup rather than instead of it.
+                                // cleanup() reports when IT is what ends the session, but it
+                                // short-circuits when the session has already ended -- which is
+                                // exactly the case where this reply is the last thing anyone was
+                                // waiting for, so leaving the report to cleanup would lose a
+                                // session whose pictures did land. A partial failure, meanwhile,
+                                // leaves the overlay up, and this correctly does nothing until the
+                                // user closes it.
+                                reportClosed();
                             }
                         },
                         () => {
+                            noteCommitSettled();
+                            // The request failed, so we know nothing landed as far as anyone can
+                            // tell -- which is also what the ai-editor is about to tell the user.
+                            // Counting the attempt matters more than the small chance that C#
+                            // did the work and only the reply went missing: a commit that reaches
+                            // nobody is the failure this event was added to make visible, and it
+                            // shows up as replacementCount without appliedCount.
+                            noteCommitResult(0, 0);
                             ackEditor(false, "Failed to apply replacements.");
+                            reportClosed();
                         },
                     );
+                    break;
+                }
+                case "analytics": {
+                    // The ai-editor has no analytics service of its own; it hands events to
+                    // whatever host it is running in. C# adds BookId; branding is already on every
+                    // event as "BrandingProjectName" (see AnalyticsApi).
+                    //
+                    // Known event names only, so an unrecognized one cannot invent a new event type
+                    // in our data, and each is recorded under Bloom's own name for it. Their
+                    // properties are passed through as sent -- see the comment on
+                    // kAnalyticsEventsTheAiEditorMaySend.
+                    const event = data.payload?.event;
+                    const ourNameForIt = event
+                        ? kAnalyticsEventsTheAiEditorMaySend.get(event)
+                        : undefined;
+                    if (!ourNameForIt) {
+                        if (event) {
+                            console.warn(
+                                `[AI Image Editor] not forwarding unrecognized analytics event "${event}"`,
+                            );
+                        }
+                        break;
+                    }
+                    if (event === "AI Editor Generate") {
+                        generationsThisSession++;
+                    }
+                    trackEvent(ourNameForIt, data.payload?.properties);
                     break;
                 }
                 case "log":
@@ -369,8 +610,8 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
                     );
                     break;
                 case "saveCredentials":
-                    // Bloom owns the OpenRouter API key. A key the user pastes into the AI
-                    // image editor is handed up here so Bloom persists it per-user (and
+                    // Bloom owns the OpenRouter API key. A key the user pastes into the
+                    // ai-editor is handed up here so Bloom persists it per-user (and
                     // supplies it on the next launch). A null apiKey clears the stored key.
                     postJson(
                         "aiImageEditor/saveCredentials?session=" +

--- a/src/BloomBrowserUI/bookEdit/aiImageEditor/aiEditorOverlay.ts
+++ b/src/BloomBrowserUI/bookEdit/aiImageEditor/aiEditorOverlay.ts
@@ -8,21 +8,21 @@
 // frame through getEditablePageBundleExports() (see aiEditorPageCommands.ts).
 //
 // The C# half is AiImageEditorApi.cs (read that file's header for the full picture). The
-// ai-editor is a SEPARATE web app (the `bloom-ai-image-tools` package); we do not
+// AI Image Editor is a SEPARATE web app (the `bloom-ai-image-tools` package); we do not
 // import it — we load it into an <iframe> overlay. The flow:
 //   0. The menu command (aiEditorPageCommands.launchAiImageEditor, in the page frame)
 //      POSTs aiImageEditor/saveThenLaunch. C# saves the page being edited — which the
 //      whole-book image list below depends on, and which reloads the page frame — and then
 //      calls openAiImageEditor() here. See HandleSaveThenLaunch.
 //   1. POST aiImageEditor/launch -> C# mints a session, makes the per-book
-//      .ai-image-editor folder, and returns the ai-editor URL + the whole-book image
+//      .ai-image-editor folder, and returns the AI Image Editor URL + the whole-book image
 //      list + enumerated history + httpBase/sessionToken.
 //   2. Build a fixed overlay <div id="ai-editor-overlay"> holding an <iframe> at
 //      that URL with ?mode=bloom-iframe.
 //   3. Handshake over window.postMessage on channel "bloom-ai-image-tools": the
-//      ai-editor posts `ready`; we post `init` (the launch reply + the right-clicked
+//      AI Image Editor posts `ready`; we post `init` (the launch reply + the right-clicked
 //      image as selectedBookImageId). Image bytes never ride postMessage — they go
-//      over HTTP via aiImageEditor/file; the ai-editor references results by id.
+//      over HTTP via aiImageEditor/file; the AI Image Editor references results by id.
 //   4. On `commit` we POST aiImageEditor/commit; C# applies replacements to all
 //      non-current pages and returns {oldSrc,newSrc,copyright,creator,license} for any on
 //      the live page, which the page frame applies for us. `cancel`/close just tear the
@@ -45,19 +45,20 @@ import {
     isCurrentPageSwap,
 } from "./aiEditorShared";
 
-// The analytics events the ai-editor may ask us to send, mapping the name IT uses to the name we
-// record. Bloom is what actually posts to Segment, and a name it does not recognize would create a
+// The analytics events the AI Image Editor may ask us to send, mapping the name IT uses to the
+// name we record. Bloom is what actually posts to Segment, and a name it does not recognize
+// would create a
 // new event type in our data rather than land in an existing one, so the vocabulary is pinned on
 // this side.
 //
 // The rename is why this is a map and not just a list: our events say "AI Image Editor" because
 // one day there may be an AI editor for text, or video, or games, and "AI Editor Generate" would
-// then be ambiguous. Doing the translation here rather than in the ai-editor means Bloom's
+// then be ambiguous. Doing the translation here rather than in the AI Image Editor means Bloom's
 // vocabulary is Bloom's business, and a package release is not needed to change it.
 //
 // Their PROPERTIES are not filtered. We control both ends of this channel, so an allow-list of
 // property names would only be guarding against ourselves; if something specific ever must not be
-// forwarded, the place to stop it is in the ai-editor, or by removing that one property here.
+// forwarded, the place to stop it is in the AI Image Editor, or by removing that one property here.
 // Today it sends nothing but ids, enums, numbers and booleans -- no free-form text of any kind.
 //
 // A Map, not an object literal: with an object, `event in obj` is also true for inherited members,
@@ -110,16 +111,16 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
                 name?: string;
             }>;
             // Enumerated by C# from the per-book history folder; rides through
-            // the `...launchData` spread into the ai-editor's init payload.
+            // the `...launchData` spread into the AI Image Editor's init payload.
             history?: Array<{
                 id: string;
                 url: string;
                 metadata?: Record<string, unknown> | null;
             }>;
             apiKey?: string | null;
-            // Playground/demo context: the ai-editor must disable its
+            // Playground/demo context: the AI Image Editor must disable its
             // "set OpenRouter API key" UI. Rides through the `...launchData`
-            // spread below into the ai-editor's init payload.
+            // spread below into the AI Image Editor's init payload.
             demoOnly?: boolean;
         };
         const hostWindow = window as Window & {
@@ -133,11 +134,11 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
         iframeUrl.searchParams.set("mode", "bloom-iframe");
         // Bloom (C#) enumerates every user-changeable image in the whole book
         // and supplies them as `launchData.bookImages`, each with a stable
-        // "{pageId}:{ordinal}" id the ai-editor echoes back on commit. The host
+        // "{pageId}:{ordinal}" id the AI Image Editor echoes back on commit. The host
         // applies replacements book-wide in C#, so there is no per-image DOM
         // id wrangling here anymore.
 
-        // Identify the image the user right-clicked so the ai-editor can open with it
+        // Identify the image the user right-clicked so the AI Image Editor can open with it
         // already in the "Image to Edit" slot. We match by page + filename rather than DOM
         // ordinal, because the live page has extra injected UI images that would throw
         // positional indices off.
@@ -165,9 +166,9 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
 
         hostWindow.__bloomAiImageEditorCleanup?.();
 
-        // ----- Analytics for this ai-editor session (BL-16716) -----
-        // Generation happens inside the ai-editor app, which reports each attempt to us over the
-        // bridge (the "analytics" message below); we count those so that a session the user
+        // ----- Analytics for this AI Image Editor session (BL-16716) -----
+        // Generation happens inside the AI Image Editor app, which reports each attempt to us
+        // over the bridge (the "analytics" message below); we count those so that a session the user
         // abandons can say how much AI work was thrown away. That is the clearest signal we
         // have that the output was not good enough -- much better than a count of generations,
         // which goes up whether people liked what they got or not.
@@ -192,7 +193,7 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
         let closedReported = false;
         // How many commits we have sent and not yet had an answer to. Reporting the session while
         // any is outstanding must not happen: the pictures may be moments from being saved. A count
-        // rather than a flag, because the ai-editor is free to send a second commit before the
+        // rather than a flag, because the AI Image Editor is free to send a second commit before the
         // first is answered, and the first reply would then clear a flag while the second was still
         // in the air.
         let commitsInFlight = 0;
@@ -229,8 +230,8 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
         };
 
         const cleanup = () => {
-            // Every way of ending the session without committing lands here: the ai-editor's own
-            // Cancel button, our close box, and a relaunch superseding this session.
+            // Every way of ending the session without committing lands here: the AI Image
+            // Editor's own Cancel button, our close box, and a relaunch superseding this session.
             //
             // Except one: closing while a commit is still in flight. The overlay goes away
             // immediately, but the pictures may well be saved a moment later, so this is not yet
@@ -238,10 +239,11 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
             // outstanding; the last reply to arrive is what reports.
             //
             // Idempotent, and it has to be: a commit sent by THIS session can be answered after the
-            // user has closed it and opened the ai-editor again, and its success path calls us. The
-            // overlay we would then tear down -- looked up by id, and the cleanup hook on the
-            // window -- belong to the new session, so a second run would make the ai-editor the user
-            // is looking at vanish, unclosably. (Pre-existing; deferring the outcome to the commit
+            // user has closed it and opened the AI Image Editor again, and its success path calls
+            // us. The overlay we would then tear down -- looked up by id, and the cleanup hook on
+            // the window -- belong to the new session, so a second run would make the AI Image
+            // Editor the user is looking at vanish, unclosably. (Pre-existing; deferring the
+            // outcome to the commit
             // reply made it easier to reach.)
             if (sessionEnded) return;
             sessionEnded = true;
@@ -309,7 +311,7 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
                           // C# by reference, unchanged, which has two consequences worth
                           // knowing before touching either place:
                           //
-                          //  - a field the ai-editor sends arrives at C# intact whether
+                          //  - a field the AI Image Editor sends arrives at C# intact whether
                           //    or not it is declared here, so this list being incomplete
                           //    would break nothing today;
                           //  - it is nevertheless kept complete on purpose, because the
@@ -326,7 +328,7 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
                           // notice, creator, license. It has nothing to do with the
                           // OpenRouter credits that costUSD and spentCredits report, in
                           // this same message type. Attribution being lost when a picture
-                          // went through the ai-editor was BL-16603; that is why these
+                          // went through the AI Image Editor was BL-16603; that is why these
                           // fields exist and why they have to survive the trip.
                           replacements?: Array<{
                               incomingId?: string;
@@ -347,8 +349,9 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
                               } | null;
                           }>;
                           apiKey?: string | null;
-                          // For the "analytics" message: an event the ai-editor wants recorded.
-                          // Its own code guarantees no prompt text or other user content is in
+                          // For the "analytics" message: an event the AI Image Editor wants
+                          // recorded. Its own code guarantees no prompt text or other user
+                          // content is in
                           // here -- see IBloomHostControl.trackEvent in bloom-ai-image-tools.
                           event?: string;
                           properties?: Record<
@@ -387,8 +390,9 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
                     // via Bloom's own changeImageByElement().
                     const requestId = data.requestId;
                     const ackEditor = (ok: boolean, error?: string) => {
-                        // The ai-editor can be gone by the time we answer: the user is free to close
-                        // the overlay while a commit is in flight, which detaches this iframe.
+                        // The AI Image Editor can be gone by the time we answer: the user is free
+                        // to close the overlay while a commit is in flight, which detaches this
+                        // iframe.
                         // Telling a window that no longer exists must not throw, because the work
                         // that follows this call still has to happen -- saving the page the swaps
                         // landed on, and deciding whether the session ended with nothing kept.
@@ -425,7 +429,7 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
                     // only stage those and hand them back, so counting a staged one as applied
                     // overstated success in exactly the case the event exists to catch -- and in the
                     // ordinary case at that, since the picture the user right-clicked to open the
-                    // ai-editor is by definition on the page they have open.
+                    // AI Image Editor is by definition on the page they have open.
                     //
                     // offPageApplied comes from C#, which did those itself and knows;
                     // currentPageApplied is what the page frame says it managed.
@@ -454,8 +458,8 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
                         const applied = offPageApplied + currentPageApplied;
                         replacementsAttempted += replacements.length;
                         picturesApplied += applied;
-                        // Deliberately counted over every replacement the ai-editor sent, not only
-                        // the ones that landed -- so generatedCount and reusedCount are NOT
+                        // Deliberately counted over every replacement the AI Image Editor sent,
+                        // not only the ones that landed -- so generatedCount and reusedCount are NOT
                         // comparable with appliedCount, and do not sum to it when a swap fails.
                         // They answer a different question: what the user chose, and therefore what
                         // they paid OpenRouter for, which is true whether or not the picture then
@@ -492,7 +496,7 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
                                 | undefined;
                             // The server reports whether it staged every replacement; for
                             // current-page slots only the live DOM knows whether the edit
-                            // actually landed. Combine both so the ai-editor's ack
+                            // actually landed. Combine both so the AI Image Editor's ack
                             // reflects the true outcome, and always ack (even when the
                             // apply fails) so its overlay can't hang.
                             let finalOk = false;
@@ -584,8 +588,8 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
                         () => {
                             noteCommitSettled();
                             // The request failed, so we know nothing landed as far as anyone can
-                            // tell -- which is also what the ai-editor is about to tell the user.
-                            // Counting the attempt matters more than the small chance that C#
+                            // tell -- which is also what the AI Image Editor is about to tell the
+                            // user. Counting the attempt matters more than the small chance that C#
                             // did the work and only the reply went missing: a commit that reaches
                             // nobody is the failure this event was added to make visible, and it
                             // shows up as replacementCount without appliedCount.
@@ -597,7 +601,7 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
                     break;
                 }
                 case "analytics": {
-                    // The ai-editor has no analytics service of its own; it hands events to
+                    // The AI Image Editor has no analytics service of its own; it hands events to
                     // whatever host it is running in. C# adds BookId; branding is already on every
                     // event as "BrandingProjectName" (see AnalyticsApi).
                     //
@@ -633,7 +637,7 @@ export function openAiImageEditor(target: IAiImageEditorTarget): void {
                     break;
                 case "saveCredentials":
                     // Bloom owns the OpenRouter API key. A key the user pastes into the
-                    // ai-editor is handed up here so Bloom persists it per-user (and
+                    // AI Image Editor is handed up here so Bloom persists it per-user (and
                     // supplies it on the next launch). A null apiKey clears the stored key.
                     postJson(
                         "aiImageEditor/saveCredentials?session=" +

--- a/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
@@ -422,6 +422,12 @@ async function doChangeGifImage(
             "imageGallery/imageGalleryResult",
             {
                 localPath: filePath,
+                // Say where this came from, or the endpoint records it as an image-chooser pick
+                // from an "unknown" provider (see ImageGalleryApi.TrackPictureChosenFromGallery).
+                // A GIF change never opens the chooser at all: it goes straight to the native file
+                // picker, so it belongs with the other pictures the user took off their own disk.
+                // "local-disk" is the id the chooser uses for that route too.
+                provider: "local-disk",
             },
         );
         const result = changeResponse!.data as {

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlRegistry.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlRegistry.ts
@@ -143,7 +143,7 @@ function imageFileOf(img: HTMLImageElement): string {
 //
 //  - the raw src, because setImgTransparentParam adds and removes a "?transparent=yes"
 //    parameter, so each choice would be filed under a different key from the one before it and
-//    the path would restart on the very first change;
+//    the sequence would restart on the very first change;
 //  - the file alone, because a page image's src is just its bare name relative to the book
 //    folder ("placeholder.png", "aor_AOR_ABC.png"). This map is module-level and lives for the
 //    whole run of Bloom, so two books -- or two pages -- using the same file would append to
@@ -155,7 +155,7 @@ function imageHistoryKeyOf(img: HTMLImageElement): string {
     return `${pageId}/${imageFileOf(img)}`;
 }
 
-// Append this choice to the image's sequence and return the whole path, e.g.
+// Append this choice to the image's sequence and return the whole of it, e.g.
 // "auto > transparent > opaque".
 function recordTransparencyChoice(
     img: HTMLImageElement,
@@ -826,7 +826,7 @@ export const controlRegistry: Record<TopLevelControlId, IControlDefinition> = {
                     if (!img) return;
                     const from = transparencyModeOf(img);
                     if (from === to) return; // re-picking what is already ticked says nothing
-                    const path = recordTransparencyChoice(img, from, to);
+                    const choices = recordTransparencyChoice(img, from, to);
                     trackEvent("Image Transparency Set", {
                         from,
                         to,
@@ -841,7 +841,7 @@ export const controlRegistry: Record<TopLevelControlId, IControlDefinition> = {
                         // (built by recordTransparencyChoice above). A long one may mean the three
                         // labels did not predict the result and the user was guessing, though it
                         // could as easily be someone just exploring the options.
-                        path,
+                        choices,
                     });
                 }
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlRegistry.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlRegistry.ts
@@ -836,11 +836,11 @@ export const controlRegistry: Record<TopLevelControlId, IControlDefinition> = {
                                 getOwningPageBackgroundColor(img),
                             ),
                         imageFormat: imageFormatOf(img),
-                        // The whole sequence of choices made on this image, so we can see the
-                        // person who cycled through the options -- someone who did not like what
-                        // they saw and was guessing. A lot of those means the three labels do not
-                        // predict the result well enough, which is a UI problem rather than an
-                        // algorithm one.
+                        // Every transparency choice made on this image so far, joined with " > "
+                        // -- so a picture switched twice reads "auto > transparent > opaque"
+                        // (built by recordTransparencyChoice above). A long one may mean the three
+                        // labels did not predict the result and the user was guessing, though it
+                        // could as easily be someone just exploring the options.
                         path,
                     });
                 }

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlRegistry.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlRegistry.ts
@@ -76,6 +76,7 @@ import {
 import { showTalkingBookTool } from "../talkingBook/showTalkingBookTool";
 import { showLinkTargetChooserDialog } from "../../../react_components/LinkTargetChooser/LinkTargetChooserDialogLauncher";
 import { kBloomBlue } from "../../../bloomMaterialUITheme";
+import { trackEvent } from "../../../utils/bloomApi";
 import {
     IControlContext,
     IControlDefinition,
@@ -126,6 +127,64 @@ const getImage = (ctx: IControlContext): HTMLImageElement | undefined => {
     }
     return getImageFromContainer(imageContainer) ?? undefined;
 };
+
+// Analytics support for the Transparency menu (BL-16716). Keyed by image FILE rather than by
+// element, because saving the page rebuilds the DOM and we want the whole sequence of choices
+// the user made on one picture, not one entry per surviving element. Session-scoped on purpose:
+// what we are after is the person still guessing a minute later, not a history across runs.
+const transparencyChoicesByImage = new Map<string, string[]>();
+
+// The image file, with any query string removed.
+function imageFileOf(img: HTMLImageElement): string {
+    return (img.getAttribute("src") ?? "").split("?")[0];
+}
+
+// The key the choice history is filed under. Two things it must NOT be:
+//
+//  - the raw src, because setImgTransparentParam adds and removes a "?transparent=yes"
+//    parameter, so each choice would be filed under a different key from the one before it and
+//    the path would restart on the very first change;
+//  - the file alone, because a page image's src is just its bare name relative to the book
+//    folder ("placeholder.png", "aor_AOR_ABC.png"). This map is module-level and lives for the
+//    whole run of Bloom, so two books -- or two pages -- using the same file would append to
+//    one another's history and produce a sequence no single picture ever went through.
+//
+// Page id and file together, then: unique across books, since page ids are GUIDs.
+function imageHistoryKeyOf(img: HTMLImageElement): string {
+    const pageId = img.closest(".bloom-page")?.getAttribute("id") ?? "";
+    return `${pageId}/${imageFileOf(img)}`;
+}
+
+// Append this choice to the image's sequence and return the whole path, e.g.
+// "auto > transparent > opaque".
+function recordTransparencyChoice(
+    img: HTMLImageElement,
+    from: string,
+    to: string,
+): string {
+    const key = imageHistoryKeyOf(img);
+    const choices = transparencyChoicesByImage.get(key) ?? [from];
+    choices.push(to);
+    transparencyChoicesByImage.set(key, choices);
+    return choices.join(" > ");
+}
+
+// The current transparency mode of an image, read from its classes. Read at click time rather
+// than captured when the menu was built, so that two choices from one open submenu still
+// report the mode each was actually made from.
+function transparencyModeOf(img: HTMLImageElement): string {
+    if (img.classList.contains("bloom-transparent")) return "transparent";
+    if (img.classList.contains("bloom-opaque")) return "opaque";
+    return "auto";
+}
+
+// The image's file type, lower case and without the dot ("png", "jpg", ...). Tells us whether
+// the detection failures cluster on photos or on line art.
+function imageFormatOf(img: HTMLImageElement): string {
+    const src = imageFileOf(img);
+    const dot = src.lastIndexOf(".");
+    return dot < 0 ? "" : src.substring(dot + 1).toLowerCase();
+}
 
 const getVideoContainer = (ctx: IControlContext): HTMLElement | undefined => {
     return ctx.canvasElement.getElementsByClassName(
@@ -756,6 +815,36 @@ export const controlRegistry: Record<TopLevelControlId, IControlDefinition> = {
                     );
                 }
 
+                // Every explicit choice here is a user telling us our line-art detection got
+                // it wrong -- and which way. Opaque means Auto fired when it should not have
+                // and Bloom was eating parts of their picture (forcing transparency "can also
+                // erase very light-colored parts of an image"); Transparent means the detector
+                // failed to recognise line art that plainly is line art. There is no other way
+                // to evaluate that heuristic in the field, and this gives us a continuous read
+                // on it. Call this BEFORE mutating the classes, so "from" is the mode we chose.
+                function reportTransparencyChoice(to: string) {
+                    if (!img) return;
+                    const from = transparencyModeOf(img);
+                    if (from === to) return; // re-picking what is already ticked says nothing
+                    const path = recordTransparencyChoice(img, from, to);
+                    trackEvent("Image Transparency Set", {
+                        from,
+                        to,
+                        // What gates Auto in the first place, so failures can be read against it.
+                        pageBackgroundIsColored:
+                            pageBackgroundNeedsTransparency(
+                                getOwningPageBackgroundColor(img),
+                            ),
+                        imageFormat: imageFormatOf(img),
+                        // The whole sequence of choices made on this image, so we can see the
+                        // person who cycled through the options -- someone who did not like what
+                        // they saw and was guessing. A lot of those means the three labels do not
+                        // predict the result well enough, which is a UI problem rather than an
+                        // algorithm one.
+                        path,
+                    });
+                }
+
                 return {
                     id: "imageBackground",
                     l10nId: "EditTab.Image.Transparency",
@@ -770,6 +859,7 @@ export const controlRegistry: Record<TopLevelControlId, IControlDefinition> = {
                                 : undefined,
                             onSelect: () => {
                                 if (!img) return;
+                                reportTransparencyChoice("auto");
                                 img.classList.remove(
                                     "bloom-transparent",
                                     "bloom-opaque",
@@ -785,6 +875,7 @@ export const controlRegistry: Record<TopLevelControlId, IControlDefinition> = {
                                 : undefined,
                             onSelect: () => {
                                 if (!img) return;
+                                reportTransparencyChoice("transparent");
                                 img.classList.add("bloom-transparent");
                                 img.classList.remove("bloom-opaque");
                                 applyTransparencyParam();
@@ -798,6 +889,7 @@ export const controlRegistry: Record<TopLevelControlId, IControlDefinition> = {
                                 : undefined,
                             onSelect: () => {
                                 if (!img) return;
+                                reportTransparencyChoice("opaque");
                                 img.classList.add("bloom-opaque");
                                 img.classList.remove("bloom-transparent");
                                 // bloom-opaque always means "none" regardless of page background.

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/customXmatterPage.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/customXmatterPage.tsx
@@ -496,7 +496,9 @@ export function setupPageLayoutMenu(): void {
     if (usingLegacyTheme && page.classList.contains("bloom-customLayout")) {
         // A legacy theme can't show a custom layout, so force this page back to standard,
         // keeping the custom layout data in case the user switches to a newer theme.
-        setCustomPageLayout(page.getAttribute("id")!, "standard", true);
+        // userInitiated false: this is Bloom forcing the page back as it opens, not a choice
+        // anyone made.
+        setCustomPageLayout(page.getAttribute("id")!, "standard", true, false);
         return;
     }
 
@@ -510,16 +512,23 @@ export function setupPageLayoutMenu(): void {
 
 // Ask the server to put this page into the given layout. This says what it means: asking for the
 // layout the page is already in is a no-op on the server, rather than flipping to the other one.
+//
+// userInitiated distinguishes a choice the user made from the revert Bloom performs for itself
+// when a legacy theme cannot support a custom layout. Only the former is a decision, and only
+// the former is reported to analytics -- otherwise the figures count switches nobody made, and
+// over-count "standard" precisely on the books where custom was wanted.
 function setCustomPageLayout(
     pageId: string,
     layout: "standard" | "custom",
     keepCustomLayoutDataWhenSwitchingToStandard: boolean,
+    userInitiated: boolean,
 ) {
     return postData("editView/setCustomPageLayout", {
         pageId,
         layout,
         keepCustomLayoutDataWhenSwitchingToStandard:
             keepCustomLayoutDataWhenSwitchingToStandard ? "true" : "false",
+        userInitiated: userInitiated ? "true" : "false",
     });
 }
 
@@ -541,6 +550,7 @@ function renderPageLayoutMenu(page: HTMLElement): void {
                 page.getAttribute("id")!,
                 selection,
                 keepCustomLayoutDataWhenSwitchingToStandard,
+                true,
             );
             if (
                 selection === "custom" &&

--- a/src/BloomBrowserUI/package.json
+++ b/src/BloomBrowserUI/package.json
@@ -145,7 +145,7 @@
         "@types/react-transition-group": "4.4.1",
         "@use-it/event-listener": "0.1.7",
         "axios": "0.21.1",
-        "bloom-ai-image-tools": "github:BloomBooks/bloom-ai-image-tools#dist-v0.1.3",
+        "bloom-ai-image-tools": "github:BloomBooks/bloom-ai-image-tools#dist-v0.1.4",
         "bloom-image-gallery": "github:BloomBooks/bloom-image-gallery",
         "bloom-player": "2.20.1",
         "calculate-aspect-ratio": "0.1.3",

--- a/src/BloomBrowserUI/pnpm-lock.yaml
+++ b/src/BloomBrowserUI/pnpm-lock.yaml
@@ -85,11 +85,11 @@ importers:
                 specifier: 0.21.1
                 version: 0.21.1
             bloom-ai-image-tools:
-                specifier: github:BloomBooks/bloom-ai-image-tools#dist-v0.1.3
-                version: https://codeload.github.com/BloomBooks/bloom-ai-image-tools/tar.gz/c6df5ff386b2c23c6cd86492b3a11836a05cdc34
+                specifier: github:BloomBooks/bloom-ai-image-tools#dist-v0.1.4
+                version: https://codeload.github.com/BloomBooks/bloom-ai-image-tools/tar.gz/c4cd899422ffafffaf2de58444b5b994e9834b23
             bloom-image-gallery:
                 specifier: github:BloomBooks/bloom-image-gallery
-                version: https://codeload.github.com/BloomBooks/bloom-image-gallery/tar.gz/7be5548b663124d5e7544afb66167035b154c5f7(@types/react@18.3.31)(supports-color@5.5.0)
+                version: https://codeload.github.com/BloomBooks/bloom-image-gallery/tar.gz/e376463bcd21b1558750570b63269a2e133b46c0(@types/react@18.3.31)(supports-color@5.5.0)
             bloom-player:
                 specifier: 2.20.1
                 version: 2.20.1
@@ -252,7 +252,7 @@ importers:
                 version: 7.18.5(supports-color@5.5.0)
             "@babel/preset-env":
                 specifier: 7.18.2
-                version: 7.18.2(@babel/core@7.18.5(supports-color@5.5.0))(supports-color@5.5.0)
+                version: 7.18.2(@babel/core@7.18.5(supports-color@5.5.0))
             "@babel/preset-react":
                 specifier: 7.17.12
                 version: 7.17.12(@babel/core@7.18.5(supports-color@5.5.0))
@@ -4049,23 +4049,23 @@ packages:
                 integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==,
             }
 
-    bloom-ai-image-tools@https://codeload.github.com/BloomBooks/bloom-ai-image-tools/tar.gz/c6df5ff386b2c23c6cd86492b3a11836a05cdc34:
+    bloom-ai-image-tools@https://codeload.github.com/BloomBooks/bloom-ai-image-tools/tar.gz/c4cd899422ffafffaf2de58444b5b994e9834b23:
         resolution:
             {
                 gitHosted: true,
-                integrity: sha512-zk8StjhOLVWsHWMGGlIAV/3mBCxUKV/Nq1nehM/7+bHnxoET+eomPFENrKu2hOUg0iOZfqBEuCvs6TzcZeljFQ==,
-                tarball: https://codeload.github.com/BloomBooks/bloom-ai-image-tools/tar.gz/c6df5ff386b2c23c6cd86492b3a11836a05cdc34,
+                integrity: sha512-4l5L0UYKmx3Pq8Zvhp+8XaQxrJFAVc6IzaME/2sM+AgX6cLqJgg6YpOmQUnvYRgSo8/P986rGuFD+lxQuSngSQ==,
+                tarball: https://codeload.github.com/BloomBooks/bloom-ai-image-tools/tar.gz/c4cd899422ffafffaf2de58444b5b994e9834b23,
             }
-        version: 0.1.3
+        version: 0.1.4
 
-    bloom-image-gallery@https://codeload.github.com/BloomBooks/bloom-image-gallery/tar.gz/7be5548b663124d5e7544afb66167035b154c5f7:
+    bloom-image-gallery@https://codeload.github.com/BloomBooks/bloom-image-gallery/tar.gz/e376463bcd21b1558750570b63269a2e133b46c0:
         resolution:
             {
                 gitHosted: true,
-                integrity: sha512-oXHVUCsRpnrfU6r4ai+NrtpxJVpPS5MEdfSVQW0Sbk+BCP7mLB5+t/+Jhqg/3CxSi+QXd5Zu7AhPwVGvLq2dQw==,
-                tarball: https://codeload.github.com/BloomBooks/bloom-image-gallery/tar.gz/7be5548b663124d5e7544afb66167035b154c5f7,
+                integrity: sha512-1wiGK9L0bq8IliknqvotzGEXALKs7qDcJ5U8tTdoIFCECi4nJ+dVj4/0Np1MnrMVeI+VAs7XISRVdsJoIq4WZA==,
+                tarball: https://codeload.github.com/BloomBooks/bloom-image-gallery/tar.gz/e376463bcd21b1558750570b63269a2e133b46c0,
             }
-        version: 0.0.3
+        version: 0.0.4
 
     bloom-player@2.20.1:
         resolution:
@@ -11123,7 +11123,7 @@ snapshots:
             regexpu-core: 6.4.0
             semver: 6.3.1
 
-    "@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.18.5(supports-color@5.5.0))(supports-color@5.5.0)":
+    "@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.18.5(supports-color@5.5.0))":
         dependencies:
             "@babel/core": 7.18.5(supports-color@5.5.0)
             "@babel/helper-compilation-targets": 7.29.7
@@ -11684,7 +11684,7 @@ snapshots:
             "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.18.5(supports-color@5.5.0))
             "@babel/helper-plugin-utils": 7.29.7
 
-    "@babel/preset-env@7.18.2(@babel/core@7.18.5(supports-color@5.5.0))(supports-color@5.5.0)":
+    "@babel/preset-env@7.18.2(@babel/core@7.18.5(supports-color@5.5.0))":
         dependencies:
             "@babel/compat-data": 7.29.7
             "@babel/core": 7.18.5(supports-color@5.5.0)
@@ -11757,7 +11757,7 @@ snapshots:
             "@babel/plugin-transform-unicode-regex": 7.29.7(@babel/core@7.18.5(supports-color@5.5.0))
             "@babel/preset-modules": 0.1.6(@babel/core@7.18.5(supports-color@5.5.0))
             "@babel/types": 7.29.7
-            babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.18.5(supports-color@5.5.0))(supports-color@5.5.0)
+            babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.18.5(supports-color@5.5.0))
             babel-plugin-polyfill-corejs3: 0.5.3(@babel/core@7.18.5(supports-color@5.5.0))
             babel-plugin-polyfill-regenerator: 0.3.1(@babel/core@7.18.5(supports-color@5.5.0))
             core-js-compat: 3.49.0
@@ -13449,11 +13449,11 @@ snapshots:
             cosmiconfig: 7.1.0
             resolve: 1.22.12
 
-    babel-plugin-polyfill-corejs2@0.3.3(@babel/core@7.18.5(supports-color@5.5.0))(supports-color@5.5.0):
+    babel-plugin-polyfill-corejs2@0.3.3(@babel/core@7.18.5(supports-color@5.5.0)):
         dependencies:
             "@babel/compat-data": 7.29.7
             "@babel/core": 7.18.5(supports-color@5.5.0)
-            "@babel/helper-define-polyfill-provider": 0.3.3(@babel/core@7.18.5(supports-color@5.5.0))(supports-color@5.5.0)
+            "@babel/helper-define-polyfill-provider": 0.3.3(@babel/core@7.18.5(supports-color@5.5.0))
             semver: 6.3.1
         transitivePeerDependencies:
             - supports-color
@@ -13461,7 +13461,7 @@ snapshots:
     babel-plugin-polyfill-corejs3@0.5.3(@babel/core@7.18.5(supports-color@5.5.0)):
         dependencies:
             "@babel/core": 7.18.5(supports-color@5.5.0)
-            "@babel/helper-define-polyfill-provider": 0.3.3(@babel/core@7.18.5(supports-color@5.5.0))(supports-color@5.5.0)
+            "@babel/helper-define-polyfill-provider": 0.3.3(@babel/core@7.18.5(supports-color@5.5.0))
             core-js-compat: 3.49.0
         transitivePeerDependencies:
             - supports-color
@@ -13469,7 +13469,7 @@ snapshots:
     babel-plugin-polyfill-regenerator@0.3.1(@babel/core@7.18.5(supports-color@5.5.0)):
         dependencies:
             "@babel/core": 7.18.5(supports-color@5.5.0)
-            "@babel/helper-define-polyfill-provider": 0.3.3(@babel/core@7.18.5(supports-color@5.5.0))(supports-color@5.5.0)
+            "@babel/helper-define-polyfill-provider": 0.3.3(@babel/core@7.18.5(supports-color@5.5.0))
         transitivePeerDependencies:
             - supports-color
 
@@ -13532,10 +13532,10 @@ snapshots:
             file-uri-to-path: 1.0.0
         optional: true
 
-    bloom-ai-image-tools@https://codeload.github.com/BloomBooks/bloom-ai-image-tools/tar.gz/c6df5ff386b2c23c6cd86492b3a11836a05cdc34:
+    bloom-ai-image-tools@https://codeload.github.com/BloomBooks/bloom-ai-image-tools/tar.gz/c4cd899422ffafffaf2de58444b5b994e9834b23:
         {}
 
-    bloom-image-gallery@https://codeload.github.com/BloomBooks/bloom-image-gallery/tar.gz/7be5548b663124d5e7544afb66167035b154c5f7(@types/react@18.3.31)(supports-color@5.5.0):
+    bloom-image-gallery@https://codeload.github.com/BloomBooks/bloom-image-gallery/tar.gz/e376463bcd21b1558750570b63269a2e133b46c0(@types/react@18.3.31)(supports-color@5.5.0):
         dependencies:
             "@emotion/react": 11.14.0(@types/react@18.3.31)(react@18.3.1)
             "@emotion/styled": 11.14.1(@emotion/react@11.14.0(@types/react@18.3.31)(react@18.3.1))(@types/react@18.3.31)(react@18.3.1)

--- a/src/BloomBrowserUI/react_components/image-gallery/ImageGalleryDialog.tsx
+++ b/src/BloomBrowserUI/react_components/image-gallery/ImageGalleryDialog.tsx
@@ -20,7 +20,6 @@ import {
 import { kBloomBlue } from "../../bloomMaterialUITheme";
 import BloomMessageBoxSupport from "../../utils/bloomMessageBoxSupport";
 import { getEditablePageBundleExports } from "../../bookEdit/js/workspaceFrames";
-import { useMountEffect } from "../../utils/useMountEffect";
 import { ShowEditViewDialog } from "../../bookEdit/workspaceRoot";
 
 // The shape of what C# returns from imageGallery/imageGalleryResult
@@ -59,9 +58,6 @@ const ImageGalleryDialog: React.FunctionComponent<{
     // Pixabay's site -- so whether this session had one is the headline number for how much of
     // an obstacle that is.
     const pixabayKeyPresentRef = useRef(false);
-    // How many times this user had opened the chooser before now. A key (or an accept) on the
-    // first visit is a speed bump; one that takes eight visits is a real barrier.
-    const priorChooserSessionsRef = useRef<number | undefined>(undefined);
     // Exactly one "Image Chooser Closed" event per dialog session.
     const closeReportedRef = useRef(false);
 
@@ -84,26 +80,6 @@ const ImageGalleryDialog: React.FunctionComponent<{
             })
             .finally(() => setKeysLoaded(true));
     }, []);
-
-    // Unlike the fetch above, this one WRITES, so it has to happen exactly once per dialog.
-    // React StrictMode runs mount effects twice in development, which would bump the durable
-    // counter by two on every visit -- skewing the very number this exists to provide, and
-    // doing it precisely when a developer is checking the feature.
-    const sessionCountedRef = useRef(false);
-    useMountEffect(() => {
-        if (sessionCountedRef.current) return;
-        sessionCountedRef.current = true;
-        getAsync("app/userSetting?settingName=ImageChooserSessionCount").then(
-            (r) => {
-                const priorSessions = (r?.data?.settingValue as number) ?? 0;
-                priorChooserSessionsRef.current = priorSessions;
-                postJsonAsync("app/userSetting", {
-                    settingName: "ImageChooserSessionCount",
-                    settingValue: priorSessions + 1,
-                });
-            },
-        );
-    });
 
     // Searches are counted, not reported one by one: how many a visit took and which sources it
     // tried are what the close event needs, and a per-query event adds nothing on top of them.
@@ -141,7 +117,6 @@ const ImageGalleryDialog: React.FunctionComponent<{
             providersTried: providersTriedRef.current.size,
             providers: [...providersTriedRef.current].join(","),
             pixabayKeyPresent: pixabayKeyPresentRef.current,
-            priorChooserSessions: priorChooserSessionsRef.current,
         });
     };
 

--- a/src/BloomBrowserUI/react_components/image-gallery/ImageGalleryDialog.tsx
+++ b/src/BloomBrowserUI/react_components/image-gallery/ImageGalleryDialog.tsx
@@ -1,7 +1,11 @@
 import { css } from "@emotion/react";
 import { ImageGallery } from "bloom-image-gallery";
-import type { IImage, IProviderKeysV1 } from "bloom-image-gallery";
-import React, { useEffect, useState } from "react";
+import type {
+    IImage,
+    IProviderKeysV1,
+    ISearchReport,
+} from "bloom-image-gallery";
+import React, { useEffect, useRef, useState } from "react";
 import {
     BloomDialog,
     DialogTitle,
@@ -11,10 +15,12 @@ import {
     getAsync,
     postJsonAsync,
     postDataWithConfigAsync,
+    trackEvent,
 } from "../../utils/bloomApi";
 import { kBloomBlue } from "../../bloomMaterialUITheme";
 import BloomMessageBoxSupport from "../../utils/bloomMessageBoxSupport";
 import { getEditablePageBundleExports } from "../../bookEdit/js/workspaceFrames";
+import { useMountEffect } from "../../utils/useMountEffect";
 import { ShowEditViewDialog } from "../../bookEdit/workspaceRoot";
 
 // The shape of what C# returns from imageGallery/imageGalleryResult
@@ -24,6 +30,9 @@ interface IImageGalleryApiResult {
     creator: string;
     license: string;
 }
+
+// The provider id the gallery stamps on an image the user opened from their own disk.
+const kLocalDiskProviderId = "local-disk";
 
 const ImageGalleryDialog: React.FunctionComponent<{
     img: HTMLElement;
@@ -37,6 +46,25 @@ const ImageGalleryDialog: React.FunctionComponent<{
     >(undefined);
     const [keysLoaded, setKeysLoaded] = useState(false);
 
+    // ----- Analytics for this visit to the chooser (BL-16716) -----
+    // The unit of analysis is the visit, not the query: people usually run several searches
+    // before accepting an image, and a search's outcome is only known later. So a visit
+    // accumulates what it did in the refs below and reports it all in one event when it closes.
+    // Refs, not state: they are written from callbacks, read at close time, and must never cause
+    // a re-render of the gallery.
+    const searchCountRef = useRef(0);
+    // In the order the user tried them, which is more telling than the bare count.
+    const providersTriedRef = useRef(new Set<string>());
+    // Pixabay is the one source a user cannot simply use -- it needs an API key fetched from
+    // Pixabay's site -- so whether this session had one is the headline number for how much of
+    // an obstacle that is.
+    const pixabayKeyPresentRef = useRef(false);
+    // How many times this user had opened the chooser before now. A key (or an accept) on the
+    // first visit is a speed bump; one that takes eight visits is a real barrier.
+    const priorChooserSessionsRef = useRef<number | undefined>(undefined);
+    // Exactly one "Image Chooser Closed" event per dialog session.
+    const closeReportedRef = useRef(false);
+
     // useEffect justified: this is a one-time async fetch that must run after mount
     // so the component can render before the network round-trip completes.
     // There are no dependencies to react to; [] is correct.
@@ -46,7 +74,9 @@ const ImageGalleryDialog: React.FunctionComponent<{
                 const json = r?.data?.settingValue as string;
                 if (json) {
                     try {
-                        setProviderKeys(JSON.parse(json) as IProviderKeysV1);
+                        const keys = JSON.parse(json) as IProviderKeysV1;
+                        setProviderKeys(keys);
+                        pixabayKeyPresentRef.current = !!keys.pixabay;
                     } catch {
                         // ignore malformed stored value
                     }
@@ -55,7 +85,68 @@ const ImageGalleryDialog: React.FunctionComponent<{
             .finally(() => setKeysLoaded(true));
     }, []);
 
+    // Unlike the fetch above, this one WRITES, so it has to happen exactly once per dialog.
+    // React StrictMode runs mount effects twice in development, which would bump the durable
+    // counter by two on every visit -- skewing the very number this exists to provide, and
+    // doing it precisely when a developer is checking the feature.
+    const sessionCountedRef = useRef(false);
+    useMountEffect(() => {
+        if (sessionCountedRef.current) return;
+        sessionCountedRef.current = true;
+        getAsync("app/userSetting?settingName=ImageChooserSessionCount").then(
+            (r) => {
+                const priorSessions = (r?.data?.settingValue as number) ?? 0;
+                priorChooserSessionsRef.current = priorSessions;
+                postJsonAsync("app/userSetting", {
+                    settingName: "ImageChooserSessionCount",
+                    settingValue: priorSessions + 1,
+                });
+            },
+        );
+    });
+
+    // Searches are counted, not reported one by one: how many a visit took and which sources it
+    // tried are what the close event needs, and a per-query event adds nothing on top of them.
+    //
+    // WE DO NOT SEND THE SEARCH TERM. It is the only free-form user text this instrumentation ever
+    // had, an earlier round of BL-16716 did send it, and we were then told not to. It is dropped
+    // here, at Bloom's boundary, deliberately rather than by omission -- `report.term` is still
+    // handed to us by the image gallery (see ISearchReport), because if the decision is revisited
+    // the change is one property and nothing in the gallery has to move.
+    //
+    // What that costs us: we cannot see WHICH subjects people search for and never find, which
+    // was the original argument for the term; and we cannot tell one idea tried in three
+    // languages from three different ideas, so searchCount counts queries and nothing finer.
+    const handleSearch = (report: ISearchReport) => {
+        searchCountRef.current++;
+        providersTriedRef.current.add(report.providerId);
+    };
+
+    // What turns a list of searches into a success rate. Note that a result count could never
+    // do this job: Pixabay and Openverse nearly always return *some* pictures, so the failure
+    // we care about isn't an empty page, it's a full page of pictures that are all wrong -- and
+    // the only reliable sign of that is what the user did next.
+    const reportChooserClosed = (
+        outcome: "accepted" | "local disk" | "cancelled",
+        acceptedProvider?: string,
+    ) => {
+        if (closeReportedRef.current) return;
+        closeReportedRef.current = true;
+        trackEvent("Image Chooser Closed", {
+            outcome,
+            acceptedProvider,
+            // No acceptedTerm: see handleSearch above. Which SOURCE satisfied the user is the part
+            // that makes this a success rate, and that is not user text.
+            searchCount: searchCountRef.current,
+            providersTried: providersTriedRef.current.size,
+            providers: [...providersTriedRef.current].join(","),
+            pixabayKeyPresent: pixabayKeyPresentRef.current,
+            priorChooserSessions: priorChooserSessionsRef.current,
+        });
+    };
+
     const handleClose = () => {
+        reportChooserClosed("cancelled");
         setOpen(false);
     };
 
@@ -86,6 +177,14 @@ const ImageGalleryDialog: React.FunctionComponent<{
                 license: result.license,
                 undoable: "true",
             });
+            // A file the user opened from disk is a different outcome from finding a picture in
+            // one of the collections we offer, even though both end in an image being used.
+            reportChooserClosed(
+                image.providerId === kLocalDiskProviderId
+                    ? "local disk"
+                    : "accepted",
+                image.providerId,
+            );
             setOpen(false);
         } catch {
             BloomMessageBoxSupport.CreateAndShowSimpleMessageBox(
@@ -116,6 +215,11 @@ const ImageGalleryDialog: React.FunctionComponent<{
             thumbnailUrl: previewUrl,
             reasonableSizeUrl: previewUrl,
             localPath: filePath,
+            // Set here as well as by the gallery, so that the "local disk" outcome and the
+            // Change Picture provider do not silently depend on the package continuing to stamp
+            // it. If it ever stopped, every disk-opened picture would be recorded as an ordinary
+            // chooser accept from an unknown provider -- the exact split this event exists for.
+            providerId: kLocalDiskProviderId,
             // C# reports the original file's dimensions and byte count. These matter because
             // previewUrl may serve a downscaled stand-in for an image too large for the
             // browser to display, and we want to report what the user actually chose.
@@ -174,12 +278,17 @@ const ImageGalleryDialog: React.FunctionComponent<{
                         lang={props.searchLang}
                         initialProviderKeys={providerKeys}
                         primaryColor={kBloomBlue}
-                        onProviderKeysChange={(keys) =>
+                        onSearch={handleSearch}
+                        onProviderKeysChange={(keys) => {
+                            // Kept up to date mid-visit as well as read at startup, so that a
+                            // key supplied while the chooser is open is reflected in what this
+                            // visit reports.
+                            pixabayKeyPresentRef.current = !!keys.pixabay;
                             postJsonAsync("app/userSetting", {
                                 settingName: "ImageGalleryProviderKeys",
                                 settingValue: JSON.stringify(keys),
-                            })
-                        }
+                            });
+                        }}
                         onLanguageChange={(lang) =>
                             postJsonAsync("app/userSetting", {
                                 settingName: "ImageSearchLanguage",

--- a/src/BloomBrowserUI/react_components/image-gallery/ImageGalleryDialog.tsx
+++ b/src/BloomBrowserUI/react_components/image-gallery/ImageGalleryDialog.tsx
@@ -70,6 +70,9 @@ const ImageGalleryDialog: React.FunctionComponent<{
                 licenseUrl: image.licenseUrl,
                 credits: image.credits,
                 creator: image.creator,
+                // Which source the picture came from, so C#'s "Change Picture" event can say
+                // where pictures actually come from rather than only how many there were.
+                provider: image.providerId,
             };
             const response = await postJsonAsync(
                 "imageGallery/imageGalleryResult",

--- a/src/BloomBrowserUI/scripts/devLibraries.mjs
+++ b/src/BloomBrowserUI/scripts/devLibraries.mjs
@@ -10,7 +10,8 @@
 //                  resolved from node_modules as installed. Linked: Bloom's vite.config adds
 //                  a resolve.alias to the checkout (see BLOOM_LINKED_LIBS in vite.config.mts)
 //                  and go.mjs runs the checkout's watch-build(s) as managed children so the
-//                  alias target keeps rebuilding.
+//                  alias target keeps rebuilding. A library consumed as source rather than as
+//                  a build product (bloom-image-gallery) simply omits watchCommands.
 //
 //   "iframe-app" – a standalone Vite app Bloom loads in an <iframe> (bloom-ai-image-tools).
 //                  Default: copy the prebuilt dist-app/ out of the installed package into
@@ -42,6 +43,22 @@ export const DEV_LIBRARIES = [
         // chosen URL back from this env var and hands it to Bloom.
         devCommand: "pnpm dev",
         devUrlEnv: "BLOOM_AI_EDITOR_URL",
+    },
+    {
+        name: "bloom-image-gallery",
+        kind: "bundled",
+        checkoutCandidates: [
+            "../bloom-image-gallery",
+            "../../bloom-image-gallery",
+        ],
+        // The package is consumed as SOURCE: its package.json "main"/"module"/"types" all
+        // point at src/index.ts, and Bloom's Vite compiles that directly. So aliasing the
+        // package to the checkout root is the whole job -- there is nothing to build, and
+        // hence no watchCommands: an edit in the checkout is picked up by Bloom's own dev
+        // server like any other source file. React/MUI resolve to Bloom's copies because
+        // vite.config dedupes them (without that, the checkout's own node_modules would give
+        // us a second React and hooks would fail).
+        aliasTo: ".",
     },
     {
         name: "bloom-player",

--- a/src/BloomBrowserUI/scripts/go.mjs
+++ b/src/BloomBrowserUI/scripts/go.mjs
@@ -1084,14 +1084,14 @@ const main = async () => {
     // app for Bloom to serve, before Bloom starts.
     let dev;
     if (iframe) {
-        // Bring Bloom's Vite up and confirm it healthy FIRST, THEN start the editor's own
-        // Vite dev server. Running two Vite startups (and the editor's dependency optimizer)
+        // Bring Bloom's Vite up and confirm it healthy FIRST, THEN start the AI Image Editor's own
+        // Vite dev server. Running two Vite startups (and the AI Image Editor's dependency optimizer)
         // at once starves Bloom's health check and makes it look unreachable.
         dev = await startDevServer();
         const url = await startIframeDevServer(iframe.entry, iframe.dir);
         // Bloom.exe inherits process.env; AiImageEditorApi.GetAiImageEditorUrl reads this.
         process.env[iframe.entry.devUrlEnv] = url;
-        console.log(`[go] AI editor: live dev server at ${url} (HMR).`);
+        console.log(`[go] AI Image Editor: live dev server at ${url} (HMR).`);
     } else {
         // Default staging is best-effort and usually lightweight, so run it alongside
         // Vite startup — but its checkout fallback can run a full editor build, and a
@@ -1107,7 +1107,7 @@ const main = async () => {
         const stagingOrTimeout = new Promise((resolve) => {
             const timer = setTimeout(() => {
                 console.log(
-                    "[go] AI editor: staging is still running after " +
+                    "[go] AI Image Editor: staging is still running after " +
                         `${stagingGraceMs / 1000}s; starting Bloom without waiting for it.`,
                 );
                 resolve();

--- a/src/BloomBrowserUI/scripts/go.mjs
+++ b/src/BloomBrowserUI/scripts/go.mjs
@@ -1062,7 +1062,7 @@ const main = async () => {
             `[go] Linking bundled libraries: ${process.env.BLOOM_LINKED_LIBS}`,
         );
         for (const { entry, dir } of bundled) {
-            for (const command of entry.watchCommands) {
+            for (const command of entry.watchCommands ?? []) {
                 startManagedCommand(command, dir, `[${entry.name}] `);
             }
             if (entry.extraCopy) {

--- a/src/BloomBrowserUI/utils/bloomApi.ts
+++ b/src/BloomBrowserUI/utils/bloomApi.ts
@@ -768,6 +768,44 @@ export async function postJsonAsync(
     });
 }
 
+// Report an analytics event to Segment, by way of C#'s Analytics.Track (see AnalyticsApi.cs).
+// The current book's id arrives as BookId, added by C#; do not pass it yourself unless you mean a
+// different book. The collection's branding needs no property at all: every event already carries
+// it as "BrandingProjectName" (see AnalyticsApi).
+// Property values may be strings, numbers or booleans; they all arrive as strings. Omit a
+// property (or pass undefined) when you don't have a value for it, rather than sending "".
+// Note that DEBUG builds initialize DesktopAnalytics with allowTracking:false, so nothing sent
+// from a developer machine reaches Segment; new events have to be verified on alpha.
+//
+// Recording an event must never break -- or appear to break -- whatever the user was doing.
+// Two ways it otherwise could, both closed here deliberately:
+//   - Callers report events from inside try/catch blocks that mean something else entirely
+//     ("Sorry, there was a problem adding the image"), so anything thrown from here would be
+//     caught there and blamed on that instead.
+//   - A failed request would go through wrapAxios's default error reporting and raise a problem
+//     report about analytics, which is never worth interrupting anyone for. Passing an
+//     errorCallback is what suppresses that -- compare postThatMightNavigate's `report: false`.
+// Both failures still reach the browser console, so a genuinely broken endpoint is findable;
+// an event that goes missing is a far smaller problem than either alternative.
+export function trackEvent(
+    event: string,
+    properties?: Record<string, string | number | boolean | undefined>,
+): void {
+    try {
+        postJson(
+            "analytics/track",
+            { event, properties: properties ?? {} },
+            undefined,
+            (r) => console.error(`analytics/track failed for "${event}"`, r),
+        );
+    } catch (error) {
+        console.error(
+            `analytics/track could not be sent for "${event}"`,
+            error,
+        );
+    }
+}
+
 let debugMessageCount = 0; // used to serialize debug messages
 // This is useful for debugging TypeScript code, especially on Linux.  I wouldn't necessarily expect
 // to see it used anywhere in code that gets submitted and merged.

--- a/src/BloomBrowserUI/utils/bloomApi.ts
+++ b/src/BloomBrowserUI/utils/bloomApi.ts
@@ -775,7 +775,8 @@ export async function postJsonAsync(
 // Property values may be strings, numbers or booleans; they all arrive as strings. Omit a
 // property (or pass undefined) when you don't have a value for it, rather than sending "".
 // Note that DEBUG builds initialize DesktopAnalytics with allowTracking:false, so nothing sent
-// from a developer machine reaches Segment; new events have to be verified on alpha.
+// from a developer machine reaches Segment. What confirms a new event fired is the line
+// BloomAnalytics writes to Bloom's log (Help > Show Event Log) and to standard error.
 //
 // Recording an event must never break -- or appear to break -- whatever the user was doing.
 // Two ways it otherwise could, both closed here deliberately:

--- a/src/BloomBrowserUI/utils/bloomApi.ts
+++ b/src/BloomBrowserUI/utils/bloomApi.ts
@@ -806,6 +806,21 @@ export function trackEvent(
     }
 }
 
+// The "Change Picture" vocabulary for front-end callers, mirroring
+// AnalyticsApi.TrackChangePicture, which does the same job for the routes that report from C#
+// (the image chooser, a file from disk, a paste). One event covers every way a picture gets into
+// a book, so it is worthless if the routes disagree about the words -- hence one spelling of them
+// per side rather than one per call site.
+//
+// source: where the picture came from -- an image-gallery provider id ("pixabay", "openverse", a
+// local collection slug), "local-disk", "clipboard", or "ai-editor".
+//
+// BookId is filled in by the analytics/track endpoint, which has the selected book. Branding needs
+// no property: every event already carries "BrandingProjectName" (see AnalyticsApi).
+export function trackChangePicture(source: string): void {
+    trackEvent("Change Picture", { source });
+}
+
 let debugMessageCount = 0; // used to serialize debug messages
 // This is useful for debugging TypeScript code, especially on Linux.  I wouldn't necessarily expect
 // to see it used anywhere in code that gets submitted and merged.

--- a/src/BloomExe/ApplicationUpdateSupport.cs
+++ b/src/BloomExe/ApplicationUpdateSupport.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using Bloom.Properties;
 using Bloom.web;
-using DesktopAnalytics;
 using L10NSharp;
 using SIL.IO;
 using SIL.PlatformUtilities;

--- a/src/BloomExe/BloomAnalytics.cs
+++ b/src/BloomExe/BloomAnalytics.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using DesktopAnalytics;
 using SIL.Reporting;
@@ -58,7 +57,7 @@ namespace Bloom
             {
                 // Deliberately swallowed, and the only place in this file that is: the channel we
                 // would report a logging failure on is the one that just failed.
-                Debug.WriteLine($"[analytics] could not log \"{eventName}\": {e.Message}");
+                Console.Error.WriteLine($"[analytics] could not log \"{eventName}\": {e.Message}");
             }
         }
 
@@ -92,7 +91,9 @@ namespace Bloom
             }
             catch (Exception e)
             {
-                Debug.WriteLine($"[analytics] could not log an exception report: {e.Message}");
+                Console.Error.WriteLine(
+                    $"[analytics] could not log an exception report: {e.Message}"
+                );
             }
         }
 

--- a/src/BloomExe/BloomAnalytics.cs
+++ b/src/BloomExe/BloomAnalytics.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DesktopAnalytics;
+using SIL.Reporting;
+
+namespace Bloom
+{
+    /// <summary>
+    /// The single place Bloom hands an analytics event to DesktopAnalytics, and so to Segment.
+    ///
+    /// It exists to close a hole that makes new events unverifiable on a developer machine.
+    /// <see cref="Program.InitializeAnalytics"/> constructs DesktopAnalytics with
+    /// allowTracking:false in DEBUG, and DesktopAnalytics makes that decision *inside*
+    /// Analytics.Track. So a new event is easy to write, easy to believe in, and impossible to
+    /// see: nothing is sent, and nothing says that nothing was sent. The only way to confirm one
+    /// was to ship it to alpha and wait.
+    ///
+    /// So every event is logged here, on our side of that call, before it is offered to
+    /// DesktopAnalytics. When tracking is off the log line says so, and also goes to standard
+    /// error, so a developer running ./go.sh watches events scroll past as they exercise the
+    /// feature. In a release run the line still reaches the Bloom log, which means a support log
+    /// now shows what analytics reported at the time -- worth having in its own right.
+    ///
+    /// Call this rather than DesktopAnalytics.Analytics.Track:
+    /// build/check-csharp-analytics.sh fails the commit otherwise. An event that bypasses this is
+    /// invisible again, and a log the reader cannot trust to be complete is worse than no log --
+    /// a missing line would mean "not instrumented" as readily as "did not happen".
+    /// </summary>
+    public static class BloomAnalytics
+    {
+        /// <summary>
+        /// Report an event, with optional properties. The signature deliberately mirrors
+        /// DesktopAnalytics.Analytics.Track so that converting a call site is only a name change.
+        /// </summary>
+        public static void Track(string eventName, Dictionary<string, string> properties = null)
+        {
+            // Recording an event must never be able to affect what it is observing. Callers sit
+            // inside try/catch blocks that mean something else entirely -- one of them turns any
+            // exception into "the app build failed" on the user's screen -- so an exception raised
+            // here would be attributed to their operation, not to analytics. A lost event is a far
+            // smaller problem, and the log line below still records that we meant to send it.
+            try
+            {
+                Log(FormatForLog(eventName, properties, Analytics.AllowTracking));
+                if (properties == null)
+                    Analytics.Track(eventName);
+                else
+                    Analytics.Track(eventName, properties);
+            }
+            catch (Exception e)
+            {
+                Logger.WriteEvent($"[analytics] FAILED to send \"{eventName}\": {e.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Report an exception to analytics (Segment), which is a different thing from reporting a
+        /// problem to Sentry -- see NonFatalProblem, which decides between them. Logged here for
+        /// the same reason as Track: so that "was this reported?" has an answer you can read.
+        /// </summary>
+        public static void ReportException(Exception exception)
+        {
+            // Guarded for the same reason as Track, and more urgently: one caller is Program's
+            // global unhandled-exception handler, so a throw from in here would be a failure while
+            // reporting a failure.
+            try
+            {
+                Log(
+                    FormatForLog(
+                        $"(exception) {exception?.GetType().Name}",
+                        null,
+                        Analytics.AllowTracking
+                    )
+                );
+                Analytics.ReportException(exception);
+            }
+            catch (Exception e)
+            {
+                Logger.WriteEvent($"[analytics] FAILED to report an exception: {e.Message}");
+            }
+        }
+
+        /// <summary>
+        /// One line describing the event, and whether it is actually going anywhere. Properties are
+        /// ordered by name so that the same event reads the same way from one run to the next.
+        ///
+        /// Note that Log passes this to Logger.WriteEvent as the whole message and never as a
+        /// format string with arguments. That matters: Logger.WriteEvent runs string.Format over
+        /// its message when (and only when) it is given arguments, so a brace arriving inside an
+        /// event property -- from a search provider's error message, say, which we pass along as
+        /// we received it -- is harmless here. Keep it that way; adding arguments would turn a
+        /// stray brace in someone else's text into a FormatException.
+        /// </summary>
+        /// <param name="trackingAllowed">Normally DesktopAnalytics.Analytics.AllowTracking. Passed
+        /// in rather than read here so that this stays a pure function and both of its answers can
+        /// be tested -- that flag is read-only and false in a test run, so a version that consulted
+        /// it directly could only ever be tested one way round.</param>
+        internal static string FormatForLog(
+            string eventName,
+            Dictionary<string, string> properties,
+            bool trackingAllowed
+        )
+        {
+            var prefix = trackingAllowed
+                ? "[analytics]"
+                : "[analytics NOT SENT: tracking is off in this build]";
+            if (properties == null || properties.Count == 0)
+                return $"{prefix} {eventName}";
+            var pairs = string.Join(
+                ", ",
+                properties.OrderBy(p => p.Key).Select(p => $"{p.Key}={p.Value}")
+            );
+            return $"{prefix} {eventName} -- {pairs}";
+        }
+
+        private static void Log(string message)
+        {
+            Logger.WriteEvent(message);
+            // The log file is the wrong place to look when you are sitting in front of the running
+            // program, so when nothing is being sent -- a developer or alpha-tester build -- say it
+            // where they will see it. Not in a release run, which would pay a console write per
+            // event for nobody's benefit; and not under test, where it would be pure noise, since
+            // AllowTracking is false there simply because analytics was never initialized.
+            if (!Analytics.AllowTracking && !Program.RunningUnitTests)
+                Console.Error.WriteLine(message);
+        }
+    }
+}

--- a/src/BloomExe/BloomAnalytics.cs
+++ b/src/BloomExe/BloomAnalytics.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using DesktopAnalytics;
 using SIL.Reporting;
@@ -9,23 +10,17 @@ namespace Bloom
     /// <summary>
     /// The single place Bloom hands an analytics event to DesktopAnalytics, and so to Segment.
     ///
-    /// It exists to close a hole that makes new events unverifiable on a developer machine.
-    /// <see cref="Program.InitializeAnalytics"/> constructs DesktopAnalytics with
-    /// allowTracking:false in DEBUG, and DesktopAnalytics makes that decision *inside*
-    /// Analytics.Track. So a new event is easy to write, easy to believe in, and impossible to
-    /// see: nothing is sent, and nothing says that nothing was sent. The only way to confirm one
-    /// was to ship it to alpha and wait.
+    /// All analytics traffic should route through this class; build/check-csharp-analytics.sh
+    /// attempts to enforce that at commit time.
     ///
-    /// So every event is logged here, on our side of that call, before it is offered to
-    /// DesktopAnalytics. When tracking is off the log line says so, and also goes to standard
-    /// error, so a developer running ./go.sh watches events scroll past as they exercise the
-    /// feature. In a release run the line still reaches the Bloom log, which means a support log
-    /// now shows what analytics reported at the time -- worth having in its own right.
+    /// Every event is logged here as well as sent. DEBUG builds construct DesktopAnalytics with
+    /// allowTracking:false, so on a developer machine the log line is what tells you an event
+    /// fired; it says so explicitly, and also goes to standard error, so someone running ./go.sh
+    /// watches events scroll past as they exercise the feature. In a release run the line still
+    /// reaches the Bloom log, so a support log shows what analytics reported at the time.
     ///
-    /// Call this rather than DesktopAnalytics.Analytics.Track:
-    /// build/check-csharp-analytics.sh fails the commit otherwise. An event that bypasses this is
-    /// invisible again, and a log the reader cannot trust to be complete is worse than no log --
-    /// a missing line would mean "not instrumented" as readily as "did not happen".
+    /// The log is only worth reading if it is complete, which is the reason for the commit-time
+    /// check: a missing line would mean "not instrumented" as readily as "did not happen".
     /// </summary>
     public static class BloomAnalytics
     {
@@ -38,11 +33,14 @@ namespace Bloom
             // Recording an event must never be able to affect what it is observing. Callers sit
             // inside try/catch blocks that mean something else entirely -- one of them turns any
             // exception into "the app build failed" on the user's screen -- so an exception raised
-            // here would be attributed to their operation, not to analytics. A lost event is a far
-            // smaller problem, and the log line below still records that we meant to send it.
+            // here would be attributed to their operation, not to analytics.
+            //
+            // Send FIRST, then log, each guarded separately. Logging first would let a failure in
+            // our own logging stop the event ever reaching Segment, which is the wrong way round.
+            // Separate guards also keep the two reports honest: a single try/catch around both
+            // would announce a logging failure as a failure to send.
             try
             {
-                Log(FormatForLog(eventName, properties, Analytics.AllowTracking));
                 if (properties == null)
                     Analytics.Track(eventName);
                 else
@@ -51,6 +49,16 @@ namespace Bloom
             catch (Exception e)
             {
                 Logger.WriteEvent($"[analytics] FAILED to send \"{eventName}\": {e.Message}");
+            }
+            try
+            {
+                Log(FormatForLog(eventName, properties, Analytics.AllowTracking));
+            }
+            catch (Exception e)
+            {
+                // Deliberately swallowed, and the only place in this file that is: the channel we
+                // would report a logging failure on is the one that just failed.
+                Debug.WriteLine($"[analytics] could not log \"{eventName}\": {e.Message}");
             }
         }
 
@@ -63,7 +71,15 @@ namespace Bloom
         {
             // Guarded for the same reason as Track, and more urgently: one caller is Program's
             // global unhandled-exception handler, so a throw from in here would be a failure while
-            // reporting a failure.
+            // reporting a failure. Sent before it is logged, for the reason given in Track.
+            try
+            {
+                Analytics.ReportException(exception);
+            }
+            catch (Exception e)
+            {
+                Logger.WriteEvent($"[analytics] FAILED to report an exception: {e.Message}");
+            }
             try
             {
                 Log(
@@ -73,11 +89,10 @@ namespace Bloom
                         Analytics.AllowTracking
                     )
                 );
-                Analytics.ReportException(exception);
             }
             catch (Exception e)
             {
-                Logger.WriteEvent($"[analytics] FAILED to report an exception: {e.Message}");
+                Debug.WriteLine($"[analytics] could not log an exception report: {e.Message}");
             }
         }
 

--- a/src/BloomExe/Book/HtmlDom.cs
+++ b/src/BloomExe/Book/HtmlDom.cs
@@ -17,7 +17,6 @@ using Bloom.Publish.Epub;
 using Bloom.SafeXml;
 using Bloom.SubscriptionAndFeatures;
 using Bloom.web.controllers;
-using DesktopAnalytics;
 using L10NSharp;
 using Microsoft.CSharp.RuntimeBinder;
 using SIL.Code;
@@ -884,7 +883,7 @@ namespace Bloom.Book
                 var props = new Dictionary<string, string>();
                 props["newLayout"] = templateId;
                 props["oldLineage"] = oldLineage;
-                Analytics.Track("Change Page Layout", props);
+                BloomAnalytics.Track("Change Page Layout", props);
                 return true;
             }
             return false;

--- a/src/BloomExe/Book/ImageUpdater.cs
+++ b/src/BloomExe/Book/ImageUpdater.cs
@@ -33,11 +33,18 @@ namespace Bloom.Book
             //First update the images themselves
 
             int completed = 0;
-            var imgElements = GetImagePaths(folderPath);
+            // ToList matters, twice over. GetImagePaths is an iterator that reads the embedded
+            // metadata of every candidate file (to skip images from official collections), and the
+            // percentage below asks for its Count on every pass -- which re-ran the whole thing,
+            // so a 400-image book did ~160,000 metadata reads instead of 400 and appeared frozen
+            // for minutes. It also re-decided which files to include as it went, while this very
+            // loop is writing metadata INTO those files, so the count it divided by could change
+            // underneath it. Enumerate once, up front, and both problems go away.
+            var imgElements = GetImagePaths(folderPath).ToList();
             foreach (string path in imgElements)
             {
                 progress.ProgressIndicator.PercentCompleted = (int)(
-                    100.0 * (float)completed / imgElements.Count()
+                    100.0 * (float)completed / imgElements.Count
                 );
                 progress.WriteStatus("Copying to " + Path.GetFileName(path));
 

--- a/src/BloomExe/Collection/BloomPack/BloomPackInstallDialog.cs
+++ b/src/BloomExe/Collection/BloomPack/BloomPackInstallDialog.cs
@@ -359,7 +359,7 @@ namespace Bloom.Collection.BloomPack
                     "Common.CancelButton",
                     "&Cancel"
                 );
-                DesktopAnalytics.Analytics.ReportException(e.Error);
+                BloomAnalytics.ReportException(e.Error);
                 ErrorReport.NotifyUserOfProblem(e.Error, _message.Text);
                 return;
             }
@@ -385,7 +385,7 @@ namespace Bloom.Collection.BloomPack
                 }
                 ExitWithoutRunningBloom = true;
             }
-            //Analytics.Track("Install Bloom Pack");
+            //BloomAnalytics.Track("Install Bloom Pack");
         }
 
         private void _backgroundWorker_ProgressChanged(object sender, ProgressChangedEventArgs e)

--- a/src/BloomExe/CollectionCreating/NewCollectionWizard.cs
+++ b/src/BloomExe/CollectionCreating/NewCollectionWizard.cs
@@ -9,7 +9,6 @@ using Bloom.Properties;
 using Bloom.Utils;
 using Bloom.web.controllers;
 using Bloom.WebLibraryIntegration;
-using DesktopAnalytics;
 using L10NSharp;
 using SIL.Extensions;
 using SIL.IO;
@@ -299,7 +298,7 @@ namespace Bloom.CollectionCreating
             _collectionInfo.SetAnalyticsProperties();
 
             Logger.WriteEvent("Finshed New Collection Wizard");
-            Analytics.Track("Create New Vernacular Collection");
+            BloomAnalytics.Track("Create New Vernacular Collection");
 
             Close();
         }

--- a/src/BloomExe/CollectionTab/CollectionModel.cs
+++ b/src/BloomExe/CollectionTab/CollectionModel.cs
@@ -20,7 +20,6 @@ using Bloom.ToPalaso;
 using Bloom.ToPalaso.Experimental;
 using Bloom.Utils;
 using Bloom.web.controllers;
-using DesktopAnalytics;
 using L10NSharp;
 using SIL.IO;
 using SIL.Progress;
@@ -1010,7 +1009,7 @@ namespace Bloom.CollectionTab
                         // show it
                         Logger.WriteEvent("Showing BloomPack on disk");
                         ProcessExtra.ShowFileInExplorerInFront(outputPath);
-                        Analytics.Track("Create BloomPack");
+                        BloomAnalytics.Track("Create BloomPack");
                     }
                     finally
                     {
@@ -1222,7 +1221,7 @@ namespace Bloom.CollectionTab
                 //enhance: would be nice to know if this is a new shell
                 if (!sourceBook.IsInEditableCollection)
                 {
-                    Analytics.Track(
+                    BloomAnalytics.Track(
                         "Create Book",
                         new Dictionary<string, string>()
                         {

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -1819,10 +1819,12 @@ namespace Bloom.Edit
             request.ReplyWithHtml(translationGroupHtml);
         }
 
+        /// <param name="source">For analytics; passed on to UpdateImageInBrowser.</param>
         public void ChangePicture(
             string imageId,
             UrlPathString priorImageSrc,
             PalasoImage imageInfo,
+            string source,
             string pageBackgroundColor = null
         )
         {
@@ -1839,7 +1841,7 @@ namespace Bloom.Edit
                     pageBackgroundColor,
                     undoable: true // All image changes made here are undoable.
                 );
-                UpdateImageInBrowser(args);
+                UpdateImageInBrowser(args, source);
             }
             catch (Exception e)
             {
@@ -1852,7 +1854,13 @@ namespace Bloom.Edit
             }
         }
 
-        public void UpdateImageInBrowser(PageEditingModel.ImageInfoForJavascript args)
+        /// <param name="source">Where this picture came from, for analytics: see
+        /// AnalyticsApi.TrackChangePicture. Every caller here is some form of paste; the image
+        /// chooser and the AI image editor report their own.</param>
+        public void UpdateImageInBrowser(
+            PageEditingModel.ImageInfoForJavascript args,
+            string source
+        )
         {
             // We generally don't need to wait since we don't need to save as part of this operation.
             // If a cover image needs to be made transparent, code in version 6.5 and later takes care of that elsewhere.
@@ -1862,7 +1870,7 @@ namespace Bloom.Edit
                     $"workspaceBundle.getEditablePageBundleExports().changeImage({JsonConvert.SerializeObject(args)})"
                 );
             // not saving, but we still want to log etc.
-            BloomAnalytics.Track("Change Picture");
+            AnalyticsApi.TrackChangePicture(source, CurrentBook?.ID);
             Logger.WriteEvent("ChangePicture {0}...", (object)args.src);
         }
 

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -20,7 +20,6 @@ using Bloom.ToPalaso.Experimental;
 using Bloom.Utils;
 using Bloom.web;
 using Bloom.web.controllers;
-using DesktopAnalytics;
 using L10NSharp;
 using Newtonsoft.Json;
 using SIL.Code;
@@ -570,7 +569,7 @@ namespace Bloom.Edit
                                             : ""
                                     )
                             );
-                            Analytics.Track("Duplicate Page");
+                            BloomAnalytics.Track("Duplicate Page");
                         }
                         catch (Exception error)
                         {
@@ -612,7 +611,7 @@ namespace Bloom.Edit
                         _currentlyDisplayedBook.DeletePage(page);
                         //_view.UpdatePageList(false);  DeletePage calls this via pageListChangedEvent.  See BL-3632 for trouble this causes.
                         Logger.WriteEvent("Delete Page");
-                        Analytics.Track("Delete Page");
+                        BloomAnalytics.Track("Delete Page");
                         return pageToShowNext.Id;
                     }
                     catch (Exception error)
@@ -661,7 +660,7 @@ namespace Bloom.Edit
                 RefreshDisplayOfCurrentPage();
                 _view.UpdatePageList(false);
 
-                Analytics.Track("Relocate Page");
+                BloomAnalytics.Track("Relocate Page");
                 Logger.WriteEvent("Relocate Page");
             }
         }
@@ -705,7 +704,7 @@ namespace Bloom.Edit
                     {
                         try
                         {
-                            Analytics.Track(
+                            BloomAnalytics.Track(
                                 "Insert Template Page",
                                 new Dictionary<string, string>
                                 {
@@ -889,7 +888,7 @@ namespace Bloom.Edit
                     _view.UpdatePageList(true); //counting on this to redo the thumbnails
 
                     Logger.WriteEvent("ChangingContentLanguages");
-                    Analytics.Track("Change Content Languages");
+                    BloomAnalytics.Track("Change Content Languages");
                     return _pageSelection.CurrentSelection.Id;
                 },
                 () => { } // wrong state, do nothing
@@ -1048,7 +1047,7 @@ namespace Bloom.Edit
 
                 _pageSelection.SelectPage(page);
                 Logger.WriteMinorEvent("changing page selection");
-                Analytics.Track("Select Page"); //not "edit page" because at the moment we don't have the capability of detecting that.
+                BloomAnalytics.Track("Select Page"); //not "edit page" because at the moment we don't have the capability of detecting that.
 
                 // Trace memory usage in case it may be useful
                 // First see if we seem to have a problem without taking time (~100ms in a large book/fast computer) to force GC.
@@ -1863,7 +1862,7 @@ namespace Bloom.Edit
                     $"workspaceBundle.getEditablePageBundleExports().changeImage({JsonConvert.SerializeObject(args)})"
                 );
             // not saving, but we still want to log etc.
-            Analytics.Track("Change Picture");
+            BloomAnalytics.Track("Change Picture");
             Logger.WriteEvent("ChangePicture {0}...", (object)args.src);
         }
 

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -755,6 +755,7 @@ namespace Bloom.Edit
                             imageId,
                             priorImageSrc,
                             clipboardImage,
+                            "clipboard",
                             pageBackgroundColor
                         );
                         pictureChanged = true;
@@ -771,6 +772,7 @@ namespace Bloom.Edit
                                 imageId,
                                 priorImageSrc,
                                 clipboardImage,
+                                "clipboard",
                                 pageBackgroundColor
                             );
                             pictureChanged = true;
@@ -789,6 +791,7 @@ namespace Bloom.Edit
                                 imageId,
                                 priorImageSrc,
                                 clipboardImage,
+                                "clipboard",
                                 pageBackgroundColor
                             );
                             pictureChanged = true;
@@ -824,6 +827,7 @@ namespace Bloom.Edit
                                         imageId,
                                         priorImageSrc,
                                         palasoImage,
+                                        "clipboard",
                                         pageBackgroundColor
                                     );
                                     pictureChanged = true;
@@ -1051,7 +1055,7 @@ namespace Bloom.Edit
                 creator = "",
                 undoable = "true",
             };
-            _model.UpdateImageInBrowser(args);
+            _model.UpdateImageInBrowser(args, "clipboard");
         }
 
         /// <summary>
@@ -1180,6 +1184,12 @@ namespace Bloom.Edit
             );
         }
 
+        /// <summary>
+        /// Nothing calls this at present -- it is left from an older path -- so the "clipboard"
+        /// source it reports below is the route it USED to serve, not one derived from anything
+        /// the caller says. Anyone reusing this method from somewhere else must pass the real
+        /// route through instead; see AnalyticsApi.TrackChangePicture for the vocabulary.
+        /// </summary>
         public void SaveChangedImage(
             string imageId,
             UrlPathString priorImageSrc,
@@ -1193,7 +1203,13 @@ namespace Bloom.Edit
             {
                 if (ShouldBailOutBecauseUserAgreedNotToUseJpeg(imageInfo))
                     return;
-                _model.ChangePicture(imageId, priorImageSrc, imageInfo, pageBackgroundColor);
+                _model.ChangePicture(
+                    imageId,
+                    priorImageSrc,
+                    imageInfo,
+                    "clipboard",
+                    pageBackgroundColor
+                );
                 imageChanged = true;
             }
             catch (System.IO.IOException error)

--- a/src/BloomExe/InstallerSupport.cs
+++ b/src/BloomExe/InstallerSupport.cs
@@ -6,7 +6,6 @@ using System.Reflection;
 using System.Windows.Forms;
 using Bloom.web.controllers;
 using Bloom.WebLibraryIntegration;
-using DesktopAnalytics;
 using Microsoft.Win32;
 using SIL.IO;
 using SIL.PlatformUtilities;
@@ -129,7 +128,7 @@ namespace Bloom
                         ["newVersion"] = v.ToString(),
                         ["channel"] = ApplicationUpdateSupport.ChannelName,
                     };
-                    Analytics.Track("Update Version", props);
+                    BloomAnalytics.Track("Update Version", props);
                 })
                 .Run();
             if (commandLineArgs.Length == 0)

--- a/src/BloomExe/NonFatalProblem.cs
+++ b/src/BloomExe/NonFatalProblem.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Windows.Forms;
 using Bloom.web;
 using Bloom.web.controllers;
-using DesktopAnalytics;
 using Sentry;
 using SIL.Reporting;
 using SIL.Windows.Forms.Progress;
@@ -109,7 +108,7 @@ namespace Bloom
                 //thousands of exceptions we were getting as with BL-3280
                 if (modalThreshold != ModalIf.None)
                 {
-                    Analytics.ReportException(exception);
+                    BloomAnalytics.ReportException(exception);
                 }
 
                 Logger.WriteError("NonFatalProblem: " + fullDetailedMessage, exception);

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -2366,9 +2366,7 @@ Anyone looking specifically at our issue tracking system can read what you sent 
                 versionNumber + " " + ApplicationUpdateSupport.ChannelName;
             SIL.Reporting.ExceptionHandler.Init(new FatalExceptionHandler());
 
-            ExceptionHandler.AddDelegate(
-                (w, e) => DesktopAnalytics.Analytics.ReportException(e.Exception)
-            );
+            ExceptionHandler.AddDelegate((w, e) => BloomAnalytics.ReportException(e.Exception));
             if (!ApplicationUpdateSupport.IsDev)
             {
                 ExceptionHandler.AddDelegate(

--- a/src/BloomExe/ProjectContext.cs
+++ b/src/BloomExe/ProjectContext.cs
@@ -224,6 +224,7 @@ namespace Bloom
                                 typeof(ProgressDialogApi),
                                 typeof(EditingViewApi),
                                 typeof(ImageGalleryApi),
+                                typeof(AnalyticsApi),
                                 typeof(ProblemReportApi),
                                 typeof(FontsApi),
                                 typeof(BulkBloomPubCreator),
@@ -513,6 +514,7 @@ namespace Bloom
             _scope.Resolve<ExternalApi>().RegisterWithApiHandler(server.ApiHandler);
             _scope.Resolve<BrandingPreviewApi>().RegisterWithApiHandler(server.ApiHandler);
             _scope.Resolve<LoggerApi>().RegisterWithApiHandler(server.ApiHandler);
+            _scope.Resolve<AnalyticsApi>().RegisterWithApiHandler(server.ApiHandler);
         }
 
         public static string[] SourceRootFolders()

--- a/src/BloomExe/Properties/Settings.Designer.cs
+++ b/src/BloomExe/Properties/Settings.Designer.cs
@@ -142,19 +142,6 @@ namespace Bloom.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
-        public int ImageChooserSessionCount {
-            get {
-                return ((int)(this["ImageChooserSessionCount"]));
-            }
-            set {
-                this["ImageChooserSessionCount"] = value;
-            }
-        }
-
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool ShowLocalizationControls {
             get {

--- a/src/BloomExe/Properties/Settings.Designer.cs
+++ b/src/BloomExe/Properties/Settings.Designer.cs
@@ -142,6 +142,19 @@ namespace Bloom.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int ImageChooserSessionCount {
+            get {
+                return ((int)(this["ImageChooserSessionCount"]));
+            }
+            set {
+                this["ImageChooserSessionCount"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool ShowLocalizationControls {
             get {

--- a/src/BloomExe/Properties/Settings.settings
+++ b/src/BloomExe/Properties/Settings.settings
@@ -29,6 +29,9 @@
     <Setting Name="ImageGalleryProviderKeys" Provider="SIL.Settings.CrossPlatformSettingsProvider" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="ImageChooserSessionCount" Provider="SIL.Settings.CrossPlatformSettingsProvider" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
     <Setting Name="ShowSendReceive" Provider="SIL.Settings.CrossPlatformSettingsProvider" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>

--- a/src/BloomExe/Properties/Settings.settings
+++ b/src/BloomExe/Properties/Settings.settings
@@ -29,9 +29,6 @@
     <Setting Name="ImageGalleryProviderKeys" Provider="SIL.Settings.CrossPlatformSettingsProvider" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
-    <Setting Name="ImageChooserSessionCount" Provider="SIL.Settings.CrossPlatformSettingsProvider" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
-    </Setting>
     <Setting Name="ShowSendReceive" Provider="SIL.Settings.CrossPlatformSettingsProvider" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>

--- a/src/BloomExe/Publish/BloomPub/PublishToBloomPubApi.cs
+++ b/src/BloomExe/Publish/BloomPub/PublishToBloomPubApi.cs
@@ -13,7 +13,6 @@ using Bloom.Publish.BloomPub.wifi;
 using Bloom.SubscriptionAndFeatures;
 using Bloom.web;
 using Bloom.web.controllers;
-using DesktopAnalytics;
 using Newtonsoft.Json;
 using SIL.IO;
 using SIL.Reporting;
@@ -308,7 +307,7 @@ namespace Bloom.Publish.BloomPub
 
         public static void ReportAnalytics(string mode, Book.Book book)
         {
-            Analytics.Track(
+            BloomAnalytics.Track(
                 "Publish Android",
                 new Dictionary<string, string>()
                 {

--- a/src/BloomExe/Publish/Epub/PublishEpubApi.cs
+++ b/src/BloomExe/Publish/Epub/PublishEpubApi.cs
@@ -9,7 +9,6 @@ using Bloom.Collection;
 using Bloom.Utils;
 using Bloom.web;
 using Bloom.Workspace;
-using DesktopAnalytics;
 using SIL.Reporting;
 
 namespace Bloom.Publish.Epub
@@ -306,7 +305,7 @@ namespace Bloom.Publish.Epub
 
         public void ReportAnalytics(string eventName)
         {
-            Analytics.Track(
+            BloomAnalytics.Track(
                 eventName,
                 new Dictionary<string, string>()
                 {

--- a/src/BloomExe/Publish/PDF/PublishPdfApi.cs
+++ b/src/BloomExe/Publish/PDF/PublishPdfApi.cs
@@ -8,7 +8,6 @@ using System.Text;
 using System.Windows.Forms;
 using Bloom.Api;
 using Bloom.Book;
-using DesktopAnalytics;
 using L10NSharp;
 using SIL.Reporting;
 using Application = System.Windows.Forms.Application;
@@ -302,7 +301,7 @@ namespace Bloom.Publish.PDF
 
         private void HandlePrintAnalytics(ApiRequest request)
         {
-            Analytics.Track(
+            BloomAnalytics.Track(
                 "Print PDF",
                 new Dictionary<string, string>()
                 {

--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -15,7 +15,6 @@ using Bloom.SubscriptionAndFeatures;
 using Bloom.ToPalaso;
 using Bloom.Utils;
 using BloomTemp;
-using DesktopAnalytics;
 using L10NSharp;
 using Newtonsoft.Json;
 using SIL.Extensions;
@@ -677,7 +676,7 @@ namespace Bloom.Publish
                     // we want the simple PDF we already made.
                     RobustFile.Copy(PdfFilePath, destFileName, true);
                 }
-                Analytics.Track(
+                BloomAnalytics.Track(
                     "Save PDF",
                     new Dictionary<string, string>()
                     {

--- a/src/BloomExe/Publish/Rab/RabPublishApi.cs
+++ b/src/BloomExe/Publish/Rab/RabPublishApi.cs
@@ -1,6 +1,10 @@
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
 using System.Threading.Tasks;
 using Bloom.Api;
+using SIL.Reporting;
 
 namespace Bloom.Publish.Rab
 {
@@ -43,6 +47,78 @@ namespace Bloom.Publish.Rab
         private void SetWorkspaceTabsEnabled(bool enable)
         {
             _publishView?.WorkspaceView?.SetTabsEnabled(enable);
+        }
+
+        /// <summary>
+        /// Report how one of the long-running App Builder stages turned out.
+        ///
+        /// This is the only continuous coverage this path can have. Nothing under Publish/Rab has
+        /// ever reported anything; the feature shipped as "initial, unpolished, experimental"; and
+        /// CI never runs the real RAB build at all -- only a developer who deliberately sets
+        /// BLOOM_RUN_RAB_MANUAL_TESTS=1 exercises it end to end. So whether the toolchain works on
+        /// real machines, and where it breaks, is something we can otherwise only learn from
+        /// support traffic. BL-16469 improved the error messages; this is how we find out which
+        /// errors people actually hit.
+        ///
+        /// One event, "Publish App", with the stage as a property rather than three event names.
+        /// And one event per stage that finishes rather than one per publish run: a build the user
+        /// never goes on to install still reports its own result and its own duration, which a
+        /// single furthest-stage-reached event would fold away.
+        ///
+        /// The prepare stage is not reported. It is fast and entirely local, so it tells us
+        /// nothing about the toolchain; build and install are where a real RAB installation breaks.
+        /// </summary>
+        /// <param name="stage">"build" or "install".</param>
+        /// <param name="result">"success", "cancelled" or "failed".</param>
+        /// <param name="error">The exception, when it failed. We send its type as a normalised
+        /// errorKind and never the raw Gradle log, which is enormous and full of file paths.</param>
+        private void TrackRabAction(
+            string stage,
+            string result,
+            Stopwatch stopwatch,
+            Exception error = null
+        )
+        {
+            // Everything here is wrapped, not just the send. Gathering the properties calls
+            // GetStatus(), which reads and parses files, and this method is called from inside the
+            // try/catch that decides whether the action succeeded -- so an I/O hiccup here would
+            // have written "the build failed" to the log of a build that finished fine.
+            // (BloomAnalytics.Track guards its own send; this covers the gathering above it.)
+            try
+            {
+                var properties = new Dictionary<string, string>
+                {
+                    { "stage", stage },
+                    { "result", result },
+                    {
+                        "elapsedSeconds",
+                        Math.Round(stopwatch.Elapsed.TotalSeconds, 1)
+                            .ToString(CultureInfo.InvariantCulture)
+                    },
+                };
+                if (error != null)
+                    properties["errorKind"] = error.GetType().Name;
+                // A status read costs a little file poking, which is nothing next to the action that
+                // just finished, and it is the only place the book count and artifact size live.
+                var status = _rabProjectService.GetStatus();
+                if (status != null)
+                {
+                    properties["bookCount"] = (status.TrackedBooks?.Length ?? 0).ToString();
+                    if (status.ApkSizeBytes > 0)
+                        properties["apkSizeMB"] = Math.Round(
+                                status.ApkSizeBytes / 1024.0 / 1024.0,
+                                1
+                            )
+                            .ToString(CultureInfo.InvariantCulture);
+                }
+                BloomAnalytics.Track("Publish App", properties);
+            }
+            catch (Exception e)
+            {
+                Logger.WriteEvent(
+                    $"[analytics] FAILED to report the App Builder {stage} outcome: {e.Message}"
+                );
+            }
         }
 
         /// <summary>
@@ -199,21 +275,25 @@ namespace Bloom.Publish.Rab
                     _ = Task.Run(async () =>
                     {
                         var succeeded = false;
+                        var stopwatch = Stopwatch.StartNew();
                         try
                         {
                             try
                             {
                                 await _rabProjectService.BuildAsync();
                                 succeeded = true;
+                                TrackRabAction("build", "success", stopwatch);
                             }
                             catch (OperationCanceledException)
                                 when (_rabProjectService.IsCancellationRequested)
                             {
                                 _rabProjectService.ReportCancellation("Build");
+                                TrackRabAction("build", "cancelled", stopwatch);
                             }
                             catch (Exception error)
                             {
                                 _rabProjectService.ReportFailure("Build", error);
+                                TrackRabAction("build", "failed", stopwatch, error);
                             }
                         }
                         finally
@@ -241,21 +321,25 @@ namespace Bloom.Publish.Rab
                     _ = Task.Run(async () =>
                     {
                         var succeeded = false;
+                        var stopwatch = Stopwatch.StartNew();
                         try
                         {
                             try
                             {
                                 await _rabProjectService.InstallAsync();
                                 succeeded = true;
+                                TrackRabAction("install", "success", stopwatch);
                             }
                             catch (OperationCanceledException)
                                 when (_rabProjectService.IsCancellationRequested)
                             {
                                 _rabProjectService.ReportCancellation("Try on phone");
+                                TrackRabAction("install", "cancelled", stopwatch);
                             }
                             catch (Exception error)
                             {
                                 _rabProjectService.ReportFailure("Try on phone", error);
+                                TrackRabAction("install", "failed", stopwatch, error);
                             }
                         }
                         finally

--- a/src/BloomExe/Publish/Rab/RabPublishApi.cs
+++ b/src/BloomExe/Publish/Rab/RabPublishApi.cs
@@ -50,23 +50,8 @@ namespace Bloom.Publish.Rab
         }
 
         /// <summary>
-        /// Report how one of the long-running App Builder stages turned out.
-        ///
-        /// This is the only continuous coverage this path can have. Nothing under Publish/Rab has
-        /// ever reported anything; the feature shipped as "initial, unpolished, experimental"; and
-        /// CI never runs the real RAB build at all -- only a developer who deliberately sets
-        /// BLOOM_RUN_RAB_MANUAL_TESTS=1 exercises it end to end. So whether the toolchain works on
-        /// real machines, and where it breaks, is something we can otherwise only learn from
-        /// support traffic. BL-16469 improved the error messages; this is how we find out which
-        /// errors people actually hit.
-        ///
-        /// One event, "Publish App", with the stage as a property rather than three event names.
-        /// And one event per stage that finishes rather than one per publish run: a build the user
-        /// never goes on to install still reports its own result and its own duration, which a
-        /// single furthest-stage-reached event would fold away.
-        ///
-        /// The prepare stage is not reported. It is fast and entirely local, so it tells us
-        /// nothing about the toolchain; build and install are where a real RAB installation breaks.
+        /// Report how one of the long-running App Builder stages turned out. Called for build and
+        /// install; prepare is fast and local, so it is deliberately not reported.
         /// </summary>
         /// <param name="stage">"build" or "install".</param>
         /// <param name="result">"success", "cancelled" or "failed".</param>

--- a/src/BloomExe/Publish/Video/RecordVideoWindow.cs
+++ b/src/BloomExe/Publish/Video/RecordVideoWindow.cs
@@ -16,7 +16,6 @@ using Bloom.MiscUI;
 using Bloom.ToPalaso;
 using Bloom.Utils;
 using Bloom.web;
-using DesktopAnalytics;
 using L10NSharp;
 using Newtonsoft.Json;
 using Sentry;
@@ -1501,7 +1500,7 @@ namespace Bloom.Publish.Video
                 RobustFile.Copy(_finalVideo.Path, destFileName, true);
             }
 
-            Analytics.Track(
+            BloomAnalytics.Track(
                 "Publish Audio/Video",
                 new Dictionary<string, string>()
                 {

--- a/src/BloomExe/Registration/RegistrationManager.cs
+++ b/src/BloomExe/Registration/RegistrationManager.cs
@@ -95,7 +95,7 @@ namespace Bloom.Registration
 
                 if (!hadEmailAlready && !string.IsNullOrWhiteSpace(Registration.Default.Email))
                 {
-                    DesktopAnalytics.Analytics.Track("Register");
+                    BloomAnalytics.Track("Register");
                 }
             }
             catch (Exception)

--- a/src/BloomExe/TeamCollection/TeamCollection.ErrorReporting.cs
+++ b/src/BloomExe/TeamCollection/TeamCollection.ErrorReporting.cs
@@ -7,7 +7,6 @@ using System.Text.RegularExpressions;
 using Bloom.History;
 using Bloom.web;
 using Bloom.web.controllers;
-using DesktopAnalytics;
 using L10NSharp;
 
 namespace Bloom.TeamCollection
@@ -80,7 +79,7 @@ namespace Bloom.TeamCollection
             {
                 ReportProgressAndLog(progress, kind, l10nIdSuffix, message, param0, param1);
                 var msgForAnalytics = string.Format(message, param0, param1);
-                Analytics.Track(
+                BloomAnalytics.Track(
                     "TeamCollectionError",
                     new Dictionary<string, string> { { "message", msgForAnalytics } }
                 );
@@ -107,7 +106,7 @@ namespace Bloom.TeamCollection
 
             var msg =
                 $"{string.Format(message, param0, param1)}\n\n{kDropboxSettingsWarningEnglish}";
-            Analytics.Track(
+            BloomAnalytics.Track(
                 "TeamCollectionError",
                 new Dictionary<string, string> { { "message", msg } }
             );

--- a/src/BloomExe/TeamCollection/TeamCollection.cs
+++ b/src/BloomExe/TeamCollection/TeamCollection.cs
@@ -17,7 +17,6 @@ using Bloom.ToPalaso;
 using Bloom.Utils;
 using Bloom.web;
 using Bloom.web.controllers;
-using DesktopAnalytics;
 using L10NSharp;
 using SIL.Code;
 using SIL.IO;
@@ -2783,7 +2782,7 @@ namespace Bloom.TeamCollection
         /// </summary>
         public void SynchronizeRepoAndLocal(Action whenDone = null)
         {
-            Analytics.Track(
+            BloomAnalytics.Track(
                 "TeamCollectionOpen",
                 new Dictionary<string, string>()
                 {

--- a/src/BloomExe/TeamCollection/TeamCollectionApi.cs
+++ b/src/BloomExe/TeamCollection/TeamCollectionApi.cs
@@ -14,7 +14,6 @@ using Bloom.MiscUI;
 using Bloom.Utils;
 using Bloom.web;
 using Bloom.Workspace;
-using DesktopAnalytics;
 using L10NSharp;
 using Newtonsoft.Json;
 using Sentry;
@@ -221,7 +220,7 @@ namespace Bloom.TeamCollection
 
                 UpdateUiForBook();
 
-                Analytics.Track(
+                BloomAnalytics.Track(
                     "TeamCollectionRevertOtherCheckout",
                     new Dictionary<string, string>()
                     {
@@ -398,7 +397,7 @@ namespace Bloom.TeamCollection
                 // But we may as well handle the situation properly.
                 if (!string.IsNullOrEmpty(joinType))
                 {
-                    Analytics.Track(
+                    BloomAnalytics.Track(
                         "TeamCollectionJoin",
                         new Dictionary<string, string>()
                         {
@@ -719,7 +718,7 @@ namespace Bloom.TeamCollection
                 {
                     UpdateUiForBook();
 
-                    Analytics.Track(
+                    BloomAnalytics.Track(
                         "TeamCollectionCheckoutBook",
                         new Dictionary<string, string>()
                         {
@@ -1016,7 +1015,7 @@ namespace Bloom.TeamCollection
 
                     reportProgressFraction(0); // hides the progress bar (important if a different book has been selected that is still checked out)
 
-                    Analytics.Track(
+                    BloomAnalytics.Track(
                         "TeamCollectionCheckinBook",
                         new Dictionary<string, string>()
                         {
@@ -1056,7 +1055,7 @@ namespace Bloom.TeamCollection
 
                     progress.MessageWithoutLocalizing($"{msgFmt}", ProgressKind.Error);
 
-                    Analytics.Track(
+                    BloomAnalytics.Track(
                         "TeamCollectionConflictingEditOrCheckout",
                         new Dictionary<string, string>()
                         {
@@ -1254,7 +1253,7 @@ namespace Bloom.TeamCollection
                 _tcManager.ConnectToTeamCollection(repoFolderParentPath, _settings.CollectionId);
                 _callbackToReopenCollection?.Invoke();
 
-                Analytics.Track(
+                BloomAnalytics.Track(
                     "TeamCollectionCreate",
                     new Dictionary<string, string>()
                     {

--- a/src/BloomExe/Utils/BloomDebug.cs
+++ b/src/BloomExe/Utils/BloomDebug.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Diagnostics;
+using System.Windows.Forms;
+
+namespace Bloom.Utils
+{
+    /// <summary>
+    /// Debug-only assertions that make a developer mistake impossible to miss, without the one
+    /// failure mode that makes System.Diagnostics.Debug.Fail unusable here: with no debugger
+    /// attached, Debug.Fail becomes Environment.FailFast and kills the process. That takes Bloom
+    /// down for a developer who was doing something else, and mid-test-run it kills the test host,
+    /// which VSTest then reports with a cheerful "Passed!" for however many tests had run (the
+    /// reason build/test-abort-markers.txt exists).
+    ///
+    /// So this picks the loudest thing that suits where it is running: break into the debugger if
+    /// there is one, fail the test if we are under test, and otherwise show the developer a dialog
+    /// they cannot miss and offer to attach a debugger from it.
+    /// </summary>
+    public static class BloomDebug
+    {
+        /// <summary>
+        /// Report a definite programming error. Does nothing in a release build.
+        ///
+        /// [Conditional("DEBUG")] is the same mechanism Debug.Fail uses, and it is stronger than
+        /// wrapping the body in #if DEBUG: the compiler removes the CALL, so in a release build the
+        /// arguments are not evaluated either and an expensive interpolated message costs nothing.
+        /// (It works that way because every caller is compiled in this same assembly.)
+        /// </summary>
+        /// <param name="message">What went wrong. Optional, but a message is what makes the dialog
+        /// or the failed test worth reading.</param>
+        [Conditional("DEBUG")]
+        public static void Fail(string message = null)
+        {
+            var text = string.IsNullOrEmpty(message) ? "A Bloom debug assertion failed." : message;
+
+            // A debugger is watching, so hand it the problem exactly as Debug.Fail would.
+            if (Debugger.IsAttached)
+            {
+                Debug.Fail(text);
+                return;
+            }
+
+            // Under test: throw, so the offending test fails and says why. NUnit's own Assert.Fail
+            // would read a little better, but BloomExe deliberately does not reference a test
+            // framework, and an exception is how NUnit reports a failure anyway. The important part
+            // is that we do NOT reach the dialog below: a modal MessageBox in an automated run
+            // blocks until something kills the suite.
+            if (Program.RunningUnitTests)
+                throw new ApplicationException("BloomDebug.Fail: " + text);
+
+            // A developer running Bloom with no debugger. Stop them: this is a definite mistake,
+            // and the alternative is a log line nobody reads until much later.
+            var answer = MessageBox.Show(
+                text
+                    + Environment.NewLine
+                    + Environment.NewLine
+                    + new StackTrace(1, true)
+                    + Environment.NewLine
+                    + "Attach a debugger and break here?",
+                "Bloom developer error (DEBUG builds only)",
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Error
+            );
+            if (answer != DialogResult.Yes)
+                return;
+
+            // Debugger.Launch() is what gives us the old Debug.Fail "Retry" behaviour for free: it
+            // brings up the just-in-time debugger picker and attaches. Break() then stops on the
+            // line that called us rather than somewhere inside this method's caller chain.
+            if (Debugger.Launch())
+                Debugger.Break();
+        }
+    }
+}

--- a/src/BloomExe/WebLibraryIntegration/BookDownload.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookDownload.cs
@@ -19,7 +19,6 @@ using Bloom.Publish.BloomLibrary;
 using Bloom.ToPalaso;
 using Bloom.web.controllers;
 using BloomTemp;
-using DesktopAnalytics;
 using L10NSharp;
 using Microsoft.VisualBasic;
 using SIL.Extensions;
@@ -94,7 +93,7 @@ namespace Bloom.WebLibraryIntegration
                     return ""; // user cancelled
                 LastBookDownloadedPath = destinationPath;
 
-                Analytics.Track(
+                BloomAnalytics.Track(
                     "DownloadedBook-Success",
                     new Dictionary<string, string>()
                     {
@@ -110,7 +109,7 @@ namespace Bloom.WebLibraryIntegration
                 {
                     // We want to try this before we give a report that may terminate the program. But if something
                     // more goes wrong, ignore it.
-                    Analytics.Track(
+                    BloomAnalytics.Track(
                         "DownloadedBook-Failure",
                         new Dictionary<string, string>()
                         {
@@ -118,7 +117,7 @@ namespace Bloom.WebLibraryIntegration
                             { "title", bookTitleForAnalytics },
                         }
                     );
-                    Analytics.ReportException(e);
+                    BloomAnalytics.ReportException(e);
                 }
                 catch (Exception) { }
                 var showSendReport = true;

--- a/src/BloomExe/WebLibraryIntegration/BookUpload.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookUpload.cs
@@ -21,7 +21,6 @@ using Bloom.SubscriptionAndFeatures;
 using Bloom.web;
 using Bloom.web.controllers;
 using BloomTemp;
-using DesktopAnalytics;
 using L10NSharp;
 using Newtonsoft.Json;
 using SIL.Extensions;
@@ -376,7 +375,7 @@ namespace Bloom.WebLibraryIntegration
 
                     if (IsProductionRun) // don't make it seem like there are more uploads than there really are if this is just a tester pushing to the sandbox
                     {
-                        Analytics.Track(
+                        BloomAnalytics.Track(
                             "UploadBook-Success",
                             new Dictionary<string, string>()
                             {
@@ -411,7 +410,7 @@ namespace Bloom.WebLibraryIntegration
                         )
                     );
                     if (IsProductionRun)
-                        Analytics.Track("UploadBook-Failure-SystemTime");
+                        BloomAnalytics.Track("UploadBook-Failure-SystemTime");
                 }
                 else
                 {
@@ -458,7 +457,7 @@ namespace Bloom.WebLibraryIntegration
         private void ReportFailureToAnalytics(BookMetaData metadata, bool isNewBook, Exception e)
         {
             if (IsProductionRun) // don't make it seem like there are more upload failures than there really are if this is just a tester pushing to the sandbox
-                Analytics.Track(
+                BloomAnalytics.Track(
                     "UploadBook-Failure",
                     new Dictionary<string, string>()
                     {

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -29,7 +29,6 @@ using Bloom.SafeXml;
 using Bloom.web;
 using Bloom.web.controllers;
 using Bloom.WebLibraryIntegration;
-using DesktopAnalytics;
 using L10NSharp;
 using Newtonsoft.Json;
 using SIL.Code;
@@ -1706,7 +1705,7 @@ namespace Bloom.Api
             {
                 ErrorReport.NotifyUserOfProblem(GetServerStartFailureMessage());
                 Logger.WriteEvent("Error: Could not start up internal HTTP Server");
-                Analytics.ReportException(new ApplicationException("Could not start server."));
+                BloomAnalytics.ReportException(new ApplicationException("Could not start server."));
                 ProgramExit.Exit();
             }
 
@@ -2900,7 +2899,7 @@ namespace Bloom.Api
                     throw;
 #else
                     //just quietly report this
-                    DesktopAnalytics.Analytics.ReportException(e);
+                    BloomAnalytics.ReportException(e);
 #endif
                 }
             }

--- a/src/BloomExe/web/controllers/AiImageEditorApi.cs
+++ b/src/BloomExe/web/controllers/AiImageEditorApi.cs
@@ -251,7 +251,7 @@ namespace Bloom.web.controllers
         /// slot's current src — is read from the SAVED book DOM, but an image the user has just
         /// added exists only in the live page (Bloom deliberately doesn't save on an image change;
         /// see EditingModel.UpdateImageInBrowser and BL-16330). Launching against the unsaved DOM
-        /// opened the editor with an empty "Image to Edit" slot (BL-16682); it would also have
+        /// opened the AI Image Editor with an empty "Image to Edit" slot (BL-16682); it would also have
         /// made the current page's commit results describe an image the live page no longer shows,
         /// and left <see cref="DeleteSupersededAiImageFiles"/> blind to a file the live page uses.
         ///
@@ -268,7 +268,7 @@ namespace Bloom.web.controllers
         /// EditingView.StartNavigationToEditPage reloads the whole workspace root when
         /// MemoryUtils.SystemIsShortOfMemory(), which is Bloom's own private bytes past ~2GB —
         /// the ordinary state of a long editing session on a big book. Opening from
-        /// doAfterSaveToDisk there meant the page saved correctly and the editor never appeared,
+        /// doAfterSaveToDisk there meant the page saved correctly and the AI Image Editor never appeared,
         /// with no message: openAiImageEditor doesn't even build the overlay synchronously; it
         /// POSTs launch first and builds it in the reply, a whole round trip after the reload
         /// began. Waiting for the page load costs nothing and is immune to all three routes.
@@ -304,7 +304,7 @@ namespace Bloom.web.controllers
             // Asking now, rather than from the callbacks below: OnTabAboutToChange discards the
             // queued request when the user leaves the Edit tab. If we only queued it later, from
             // doAfterSaveToDisk, that discard could run first — on a save still in flight — and we
-            // would then re-arm behind it, so the editor sprang open when the user came back to
+            // would then re-arm behind it, so the AI Image Editor sprang open when the user came back to
             // that page. (Devin caught that; queueing up front puts the discard reliably after us.)
             var bookDomIsSound = false;
             model.RunAfterNextPageLoad(loadedPageId =>
@@ -313,7 +313,7 @@ namespace Bloom.web.controllers
                 // to edit isn't there to edit.
                 if (loadedPageId != pageId)
                     return;
-                // The save was attempted and failed. Leave the editor closed: the book DOM is
+                // The save was attempted and failed. Leave the AI Image Editor closed: the book DOM is
                 // still stale, so we would be opening it on exactly the out-of-date data this
                 // endpoint exists to prevent, and a commit from there would call book.Save() again
                 // on top of whatever went wrong (disk full, a corrupt image, out of memory). The
@@ -345,7 +345,7 @@ namespace Bloom.web.controllers
 
         /// <summary>
         /// Tells the browser to open the AI image editor overlay on <paramref name="target"/>. The
-        /// browser owns the overlay (only it can postMessage to the editor's iframe), so all this
+        /// browser owns the overlay (only it can postMessage to the AI Image Editor's iframe), so all this
         /// side does is call its entry point; see openAiImageEditor in aiEditorOverlay.ts.
         /// Fire-and-forget, like EditingModel.UpdateImageInBrowser's call to changeImage: there is
         /// nothing here to wait for.
@@ -530,7 +530,7 @@ namespace Bloom.web.controllers
             {
                 request.Failed(
                     HttpStatusCode.Unauthorized,
-                    "The selected book changed since the editor was launched"
+                    "The selected book changed since the AI Image Editor was launched"
                 );
                 return false;
             }
@@ -1188,7 +1188,7 @@ namespace Bloom.web.controllers
             // browser to swap into the live DOM, which can fail (see the comment above this method).
             // So counting a staged slot as applied overstates, in exactly the case the event exists
             // to catch: BL-16702 was a commit that silently did nothing. And it overstates in the
-            // ORDINARY case, not a rare one -- the picture the user right-clicked to open the editor
+            // ORDINARY case, not a rare one -- the picture the user right-clicked to open the AI Image Editor
             // is by definition on the page they have open, so a single-picture commit was always
             // reported as "1 applied, 0 failed" whatever became of it.
             //
@@ -1651,7 +1651,7 @@ namespace Bloom.web.controllers
             // them when it rewrites a PNG as a JPEG — measured, not assumed: creator, copyright and
             // licence all come back empty. That matters because an UPLOADED result can arrive with
             // the user's own credits embedded in it, and nothing downstream would put them back:
-            // EmbedCreditsInNewImageFile writes only the credits the AI editor explicitly sent, and
+            // EmbedCreditsInNewImageFile writes only the credits the AI Image Editor explicitly sent, and
             // only when it sent any. So without this, uploading a credited photo and having it
             // re-encoded would quietly strip its copyright (BL-16645, and John's review of #8188).
             ImageUtils.CopyCoreMetadata(newPath, jpegPath);

--- a/src/BloomExe/web/controllers/AiImageEditorApi.cs
+++ b/src/BloomExe/web/controllers/AiImageEditorApi.cs
@@ -1180,22 +1180,11 @@ namespace Bloom.web.controllers
             // survives.
             DeleteSupersededAiImageFiles(book.FolderPath, book.OurHtmlDom, supersededOffPageFiles);
 
-            // "AI Image Editor Closed" and the per-picture "Change Picture" events are deliberately
-            // NOT reported here; aiEditorOverlay.ts reports both once this reply reaches it.
-            //
-            // The reason is appliedCount. For a slot on the page the user has open we only stage the
-            // replacement -- import the file, work out the credits -- and hand it back for the
-            // browser to swap into the live DOM, which can fail (see the comment above this method).
-            // So counting a staged slot as applied overstates, in exactly the case the event exists
-            // to catch: BL-16702 was a commit that silently did nothing. And it overstates in the
-            // ORDINARY case, not a rare one -- the picture the user right-clicked to open the AI Image Editor
-            // is by definition on the page they have open, so a single-picture commit was always
-            // reported as "1 applied, 0 failed" whatever became of it.
-            //
-            // Everything those events carry is available to the overlay: it sent the replacements,
-            // it gets our per-slot results below, the page frame tells it how many current-page
-            // swaps landed, and the analytics/track endpoint fills in BookId. (Branding needs no
-            // property: every event already carries "BrandingProjectName" -- see AnalyticsApi.)
+            // The "AI Image Editor Closed" and "Change Picture" events are reported by
+            // aiEditorOverlay.ts when it gets this reply, not here. For a slot on the page the user
+            // has open we only STAGE the replacement and hand it back; whether it actually landed
+            // is something only the browser learns, so counting a staged slot as applied here
+            // would report success we do not have.
             request.ReplyWithJson(
                 new
                 {

--- a/src/BloomExe/web/controllers/AiImageEditorApi.cs
+++ b/src/BloomExe/web/controllers/AiImageEditorApi.cs
@@ -1180,6 +1180,22 @@ namespace Bloom.web.controllers
             // survives.
             DeleteSupersededAiImageFiles(book.FolderPath, book.OurHtmlDom, supersededOffPageFiles);
 
+            // "AI Image Editor Closed" and the per-picture "Change Picture" events are deliberately
+            // NOT reported here; aiEditorOverlay.ts reports both once this reply reaches it.
+            //
+            // The reason is appliedCount. For a slot on the page the user has open we only stage the
+            // replacement -- import the file, work out the credits -- and hand it back for the
+            // browser to swap into the live DOM, which can fail (see the comment above this method).
+            // So counting a staged slot as applied overstates, in exactly the case the event exists
+            // to catch: BL-16702 was a commit that silently did nothing. And it overstates in the
+            // ORDINARY case, not a rare one -- the picture the user right-clicked to open the editor
+            // is by definition on the page they have open, so a single-picture commit was always
+            // reported as "1 applied, 0 failed" whatever became of it.
+            //
+            // Everything those events carry is available to the overlay: it sent the replacements,
+            // it gets our per-slot results below, the page frame tells it how many current-page
+            // swaps landed, and the analytics/track endpoint fills in BookId. (Branding needs no
+            // property: every event already carries "BrandingProjectName" -- see AnalyticsApi.)
             request.ReplyWithJson(
                 new
                 {

--- a/src/BloomExe/web/controllers/AnalyticsApi.cs
+++ b/src/BloomExe/web/controllers/AnalyticsApi.cs
@@ -79,6 +79,40 @@ namespace Bloom.web.controllers
         }
 
         /// <summary>
+        /// Report that a picture in a book was replaced, saying where it came from.
+        ///
+        /// The count on its own is not the interesting part -- choosing a picture is an essential
+        /// thing to do and we already know people do it. The source is: it turns a number we don't
+        /// need into the breakdown of picture sources that we do. Which is also why this lives in
+        /// one place: the event has several call sites and would be worthless if they disagreed
+        /// about the vocabulary. This is the one place for the routes that report from here -- a
+        /// paste, the image chooser, a file from disk. The AI image editor route reports from the
+        /// browser instead, because only the browser knows whether a picture on the page being
+        /// edited actually landed (see AiImageEditorApi.HandleCommit), so it uses the mirror of
+        /// this method: trackChangePicture in bloomApi.ts. Change the words here, change them
+        /// there.
+        /// </summary>
+        /// <param name="source">Where the picture came from: an image-gallery ISearchProvider id
+        /// ("pixabay", "openverse", or a local collection's slug such as "art-of-reading"),
+        /// "local-disk", "clipboard", or "ai-editor".
+        ///
+        /// One field rather than the route and the provider separately, because every provider
+        /// worth telling apart belonged to a single route -- the image chooser -- so each is now a
+        /// first-class source in its own right, and the two routes that had no provider of their
+        /// own (a paste, a file off disk) name themselves the same way.</param>
+        public static void TrackChangePicture(string source, string bookId)
+        {
+            BloomAnalytics.Track(
+                "Change Picture",
+                new Dictionary<string, string>
+                {
+                    { "source", source ?? "unknown" },
+                    { "BookId", bookId ?? "" },
+                }
+            );
+        }
+
+        /// <summary>
         /// Parse the request body WITHOUT letting Newtonsoft turn date-looking strings into dates.
         ///
         /// Its default DateParseHandling materializes a JSON string that parses as a date-time --

--- a/src/BloomExe/web/controllers/AnalyticsApi.cs
+++ b/src/BloomExe/web/controllers/AnalyticsApi.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -5,14 +6,15 @@ using Bloom.Api;
 using Bloom.Book;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using SIL.Reporting;
 
 namespace Bloom.web.controllers
 {
     /// <summary>
     /// Lets front-end code report an analytics event. Until this existed, every one of our analytics
     /// events came from C#, so a feature implemented in React could only be measured by inventing a
-    /// bespoke endpoint for it (as publish/pdf/printAnalytics did) -- which in practice meant most of
-    /// them were not measured at all.
+    /// bespoke endpoint for it (as publish/pdf/printAnalytics still does) -- which in practice meant
+    /// most of them were not measured at all.
     /// </summary>
     public class AnalyticsApi
     {
@@ -48,7 +50,18 @@ namespace Bloom.web.controllers
             if (string.IsNullOrWhiteSpace(eventName))
             {
                 // A caller that got the shape of the request wrong should hear about it rather than
-                // quietly recording nothing, which is a very hard thing to notice.
+                // quietly recording nothing, which is a very hard thing to notice. Said three ways
+                // because each reaches a different person: request.Failed goes to the browser
+                // console, the log line to Help > Show Event Log, and standard error to the
+                // terminal a developer already has analytics scrolling past in.
+                //
+                // Deliberately not Debug.Fail: with no debugger attached that is
+                // Environment.FailFast, and taking Bloom down over a mis-shaped analytics call is
+                // the one thing this whole feature is written not to do.
+                const string complaint =
+                    "[analytics] analytics/track was called with no event name";
+                Logger.WriteEvent(complaint);
+                Console.Error.WriteLine(complaint);
                 request.Failed("analytics/track requires an 'event' name");
                 return;
             }
@@ -58,19 +71,16 @@ namespace Bloom.web.controllers
             // current book's id is. A caller that knows better (e.g. it is reporting about some
             // other book) can pass its own and we leave it alone.
             //
-            // NOT the collection's branding, though it is tempting and this endpoint used to do it.
-            // Every event ALREADY carries the branding, as "BrandingProjectName", because
-            // CollectionSettings.SetAnalyticsProperties hands it to DesktopAnalytics as an
-            // application property -- those go out with every subsequent event. And it carries the
-            // better value: the subscription DESCRIPTOR, which also encodes the tier, any flavor,
-            // and the individual subscriber, where Subscription.BrandingKey normalizes all of that
-            // down to a branding folder name ("Acme-LC" becomes "Local-Community",
-            // "Steve-Trainer" and an empty descriptor both become "Default").
+            // Do NOT add a branding property here, tempting though it is. Every event already
+            // carries one, as "BrandingProjectName": CollectionSettings.SetAnalyticsProperties
+            // hands it to DesktopAnalytics as an application property, and those ride on every
+            // subsequent event. It is also the better value -- the subscription descriptor, which
+            // encodes tier, flavor and subscriber, where Subscription.BrandingKey normalizes all
+            // three away.
             //
-            // Worth knowing why this is easy to get wrong: SetAnalyticsProperties returns early when
-            // tracking is off, and BloomAnalytics logs only the per-event properties, so on a
-            // developer build the log line shows no branding at all. That is not evidence it is
-            // missing in production. It cost a round trip to learn; please do not re-add it.
+            // The trap: SetAnalyticsProperties returns early when tracking is off, and the log line
+            // shows only per-event properties, so on a developer build no branding appears
+            // anywhere. That is not evidence it is missing in production.
             var book = _bookSelection?.CurrentSelection;
             if (book != null && !properties.ContainsKey("BookId"))
                 properties["BookId"] = book.ID;

--- a/src/BloomExe/web/controllers/AnalyticsApi.cs
+++ b/src/BloomExe/web/controllers/AnalyticsApi.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using Bloom.Api;
 using Bloom.Book;
+using Bloom.Utils;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using SIL.Reporting;
@@ -49,17 +50,17 @@ namespace Bloom.web.controllers
             var eventName = body["event"]?.ToString();
             if (string.IsNullOrWhiteSpace(eventName))
             {
-                // A caller that got the shape of the request wrong should hear about it rather than
-                // quietly recording nothing, which is a very hard thing to notice. Said three ways
-                // because each reaches a different person: request.Failed goes to the browser
-                // console, the log line to Help > Show Event Log, and standard error to the
-                // terminal a developer already has analytics scrolling past in.
+                // This is a definite programming error in the caller, not a runtime condition, and
+                // it fails silently in the worst way: nothing is recorded and nothing says so.
                 //
-                // Deliberately not Debug.Fail: with no debugger attached that is
-                // Environment.FailFast, and taking Bloom down over a mis-shaped analytics call is
-                // the one thing this whole feature is written not to do.
+                // BloomDebug.Fail stops a developer dead over it -- breaking into the debugger,
+                // failing the test, or putting up a dialog, whichever suits where Bloom is running
+                // -- and compiles away entirely in a release build, where the log line and the
+                // failed request are what remain. We do not use Debug.Fail directly because with
+                // no debugger attached it is Environment.FailFast; see BloomDebug.
                 const string complaint =
                     "[analytics] analytics/track was called with no event name";
+                BloomDebug.Fail(complaint);
                 Logger.WriteEvent(complaint);
                 Console.Error.WriteLine(complaint);
                 request.Failed("analytics/track requires an 'event' name");

--- a/src/BloomExe/web/controllers/AnalyticsApi.cs
+++ b/src/BloomExe/web/controllers/AnalyticsApi.cs
@@ -1,0 +1,146 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using Bloom.Api;
+using Bloom.Book;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Bloom.web.controllers
+{
+    /// <summary>
+    /// Lets front-end code report an analytics event. Until this existed, every one of our analytics
+    /// events came from C#, so a feature implemented in React could only be measured by inventing a
+    /// bespoke endpoint for it (as publish/pdf/printAnalytics did) -- which in practice meant most of
+    /// them were not measured at all.
+    /// </summary>
+    public class AnalyticsApi
+    {
+        private readonly BookSelection _bookSelection;
+
+        public AnalyticsApi(BookSelection bookSelection)
+        {
+            _bookSelection = bookSelection;
+        }
+
+        /// <summary>
+        /// Register the one endpoint. This is project-level (see ProjectContext) rather than
+        /// application-level so that we can fill in the current book's id; every caller so far is
+        /// edit-tab code, which always has a project open. A future need for analytics from the
+        /// collection chooser would have to revisit that.
+        /// </summary>
+        public void RegisterWithApiHandler(BloomApiHandler apiHandler)
+        {
+            // requiresSync: false because sending an event neither reads nor writes anything else in
+            // Bloom, so there is no reason to make it queue behind the rest of the API.
+            apiHandler.RegisterEndpointHandler("analytics/track", HandleTrack, false, false);
+        }
+
+        /// <summary>
+        /// POST analytics/track with {"event": "Some Event", "properties": {...}}. Property values may
+        /// be strings, numbers or booleans; they all reach Segment as strings, which is what
+        /// DesktopAnalytics accepts.
+        /// </summary>
+        private void HandleTrack(ApiRequest request)
+        {
+            var body = ParseTrackRequestBody(request.RequiredPostJson());
+            var eventName = body["event"]?.ToString();
+            if (string.IsNullOrWhiteSpace(eventName))
+            {
+                // A caller that got the shape of the request wrong should hear about it rather than
+                // quietly recording nothing, which is a very hard thing to notice.
+                request.Failed("analytics/track requires an 'event' name");
+                return;
+            }
+            var properties = GetProperties(body["properties"] as JObject);
+            // Supply BookId here rather than making every caller find it: most of our C# events
+            // already carry it, and front-end code in the edit view generally has no idea what the
+            // current book's id is. A caller that knows better (e.g. it is reporting about some
+            // other book) can pass its own and we leave it alone.
+            //
+            // NOT the collection's branding, though it is tempting and this endpoint used to do it.
+            // Every event ALREADY carries the branding, as "BrandingProjectName", because
+            // CollectionSettings.SetAnalyticsProperties hands it to DesktopAnalytics as an
+            // application property -- those go out with every subsequent event. And it carries the
+            // better value: the subscription DESCRIPTOR, which also encodes the tier, any flavor,
+            // and the individual subscriber, where Subscription.BrandingKey normalizes all of that
+            // down to a branding folder name ("Acme-LC" becomes "Local-Community",
+            // "Steve-Trainer" and an empty descriptor both become "Default").
+            //
+            // Worth knowing why this is easy to get wrong: SetAnalyticsProperties returns early when
+            // tracking is off, and BloomAnalytics logs only the per-event properties, so on a
+            // developer build the log line shows no branding at all. That is not evidence it is
+            // missing in production. It cost a round trip to learn; please do not re-add it.
+            var book = _bookSelection?.CurrentSelection;
+            if (book != null && !properties.ContainsKey("BookId"))
+                properties["BookId"] = book.ID;
+            BloomAnalytics.Track(eventName, properties);
+            request.PostSucceeded();
+        }
+
+        /// <summary>
+        /// Parse the request body WITHOUT letting Newtonsoft turn date-looking strings into dates.
+        ///
+        /// Its default DateParseHandling materializes a JSON string that parses as a date-time --
+        /// "2024-01-01T10:00:00Z", say -- as a DateTime rather than a string. We would then record
+        /// whatever the local culture makes of it: "1/1/2024 10:00:00 AM" on this machine, something
+        /// else on the next. (A date-only "2024-01-01" is left alone, so the reachable case is a full
+        /// timestamp.) Property values arrive as JSON strings and must reach Segment exactly as the
+        /// caller sent them: we do not control the shape of all of them -- a search provider's error
+        /// message, a model name, an id from someone else's API -- and a value we silently rewrite is
+        /// a record that disagrees with what happened.
+        /// </summary>
+        internal static JObject ParseTrackRequestBody(string json)
+        {
+            using (
+                var reader = new JsonTextReader(new StringReader(json))
+                {
+                    DateParseHandling = DateParseHandling.None,
+                }
+            )
+            {
+                return JObject.Load(reader);
+            }
+        }
+
+        /// <summary>
+        /// Flatten the properties object into the string dictionary DesktopAnalytics wants. Null and
+        /// undefined values are dropped rather than sent as empty strings, so a caller can pass an
+        /// optional property without having to decide whether to include the key at all.
+        /// </summary>
+        internal static Dictionary<string, string> GetProperties(JObject properties)
+        {
+            var result = new Dictionary<string, string>();
+            if (properties == null)
+                return result;
+            foreach (var property in properties)
+            {
+                var value = property.Value;
+                switch (value?.Type)
+                {
+                    case null:
+                    case JTokenType.Null:
+                    case JTokenType.Undefined:
+                        continue;
+                    case JTokenType.Boolean:
+                        // JValue.ToString() would give us "True"; we want what the JSON said.
+                        result[property.Key] = (bool)value ? "true" : "false";
+                        break;
+                    case JTokenType.Integer:
+                        result[property.Key] = ((long)value).ToString(CultureInfo.InvariantCulture);
+                        break;
+                    case JTokenType.Float:
+                        // Invariant so that a user in a comma-decimal locale doesn't send us "1,5".
+                        result[property.Key] = ((double)value).ToString(
+                            CultureInfo.InvariantCulture
+                        );
+                        break;
+                    default:
+                        result[property.Key] = value.ToString();
+                        break;
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/src/BloomExe/web/controllers/BookCommandsApi.cs
+++ b/src/BloomExe/web/controllers/BookCommandsApi.cs
@@ -19,7 +19,6 @@ using Bloom.Spreadsheet;
 using Bloom.TeamCollection;
 using Bloom.ToPalaso;
 using Bloom.Utils;
-using DesktopAnalytics;
 using L10NSharp;
 using SIL.IO;
 using SIL.Reporting;
@@ -427,7 +426,7 @@ namespace Bloom.web.controllers
 
                 _collectionModel.ExportDocFormat(destPath);
                 ProcessExtra.SafeStartInFront(destPath);
-                Analytics.Track("Exported To Doc format");
+                BloomAnalytics.Track("Exported To Doc format");
             }
             catch (IOException error)
             {
@@ -436,12 +435,12 @@ namespace Bloom.web.controllers
                     error.Message,
                     "Could not export the book"
                 );
-                Analytics.ReportException(error);
+                BloomAnalytics.ReportException(error);
             }
             catch (Exception error)
             {
                 SIL.Reporting.ErrorReport.NotifyUserOfProblem(error, "Could not export the book");
-                Analytics.ReportException(error);
+                BloomAnalytics.ReportException(error);
             }
         }
 

--- a/src/BloomExe/web/controllers/EditingViewApi.cs
+++ b/src/BloomExe/web/controllers/EditingViewApi.cs
@@ -204,6 +204,10 @@ namespace Bloom.web.controllers
             var switchingToCustom = layout == "custom";
             var keepCustomLayoutDataWhenSwitchingToStandard =
                 request.RequiredPostString("keepCustomLayoutDataWhenSwitchingToStandard") == "true";
+            // False only for the revert Bloom performs for itself when a legacy theme cannot
+            // support a custom layout (see setupPageLayoutMenu). Analytics only -- setting the
+            // layout behaves identically either way.
+            var userInitiated = request.RequiredPostString("userInitiated") != "false";
             var book = View.Model.CurrentBook;
             var page = book.GetPage(pageId);
             var pageElt = page.GetDivNodeForThisPage();
@@ -217,6 +221,36 @@ namespace Bloom.web.controllers
             var shouldRemoveCustomLayoutDataWhenSwitchingToStandard =
                 !switchingToCustom && !keepCustomLayoutDataWhenSwitchingToStandard;
             var customLayoutId = pageElt.GetAttribute("data-custom-layout-id");
+            // The baseline nobody has: how much custom-cover use there is at all, and on
+            // which page. The capability has been subscription-gated across two releases
+            // (BL-15902 added it, BL-15976 put it behind Pro) with no usage data at all,
+            // which is a weak position in any pricing or renewal conversation. "page"
+            // separates the long-standing front-cover case from BL-16648's inside-back-cover
+            // extension. Whether that extension generalised past the one project it was built for
+            // is a question of branding, and needs no property here: every event already carries
+            // "BrandingProjectName" (see AnalyticsApi).
+            //
+            // "layout" is the state being switched TO, which is what actually happened. That is
+            // trustworthy now that this endpoint is a "set" rather than a toggle (BL-16725): the
+            // early return above means asking for the layout the page is already in is not
+            // reported at all, so a "standard" event really is someone leaving a custom layout.
+            //
+            // Placed here deliberately, between the two early returns. Above it, the no-op case
+            // has already been answered. Below it, a switch to custom with no saved state replies
+            // "false" and the front end builds the first custom layout itself -- which is every
+            // bit a switch to custom, and has to be counted as one.
+            if (userInitiated)
+            {
+                BloomAnalytics.Track(
+                    "Cover Layout Changed",
+                    new Dictionary<string, string>
+                    {
+                        { "layout", switchingToCustom ? "custom" : "standard" },
+                        { "page", customLayoutId ?? "" },
+                        { "BookId", book.ID },
+                    }
+                );
+            }
             if (switchingToCustom)
             {
                 var customLayoutData = book.BookData.GetVariableOrNull(customLayoutId, "*");

--- a/src/BloomExe/web/controllers/ImageGalleryApi.cs
+++ b/src/BloomExe/web/controllers/ImageGalleryApi.cs
@@ -154,6 +154,9 @@ namespace Bloom.web.controllers
             data.TryGetValue("license", out string license);
             data.TryGetValue("licenseUrl", out string licenseUrl);
             data.TryGetValue("creator", out string galleryCreator);
+            // The image-gallery provider the picture came from ("pixabay", "openverse", a local
+            // collection slug, or "local-disk"). Analytics only.
+            data.TryGetValue("provider", out string provider);
             string sourceFilePath;
             bool isTempFile = false;
 
@@ -216,6 +219,7 @@ namespace Bloom.web.controllers
                         sourceFilePath,
                         Path.Combine(View.Model.CurrentBook.FolderPath, destName)
                     );
+                    TrackPictureChosenFromGallery(provider);
                     request.ReplyWithJson(
                         new
                         {
@@ -281,6 +285,7 @@ namespace Bloom.web.controllers
                         );
                     }
 
+                    TrackPictureChosenFromGallery(provider);
                     request.ReplyWithJson(
                         new
                         {
@@ -301,6 +306,17 @@ namespace Bloom.web.controllers
                 if (isTempFile && RobustFile.Exists(sourceFilePath))
                     RobustFile.Delete(sourceFilePath);
             }
+        }
+
+        /// <summary>
+        /// Report a picture the user chose in the image chooser. The provider id IS the source:
+        /// opening a file from disk arrives here as "local-disk" and counts as its own route
+        /// rather than as a search result, because the user bypassed every collection we offer,
+        /// which is exactly the thing we want to be able to see separately.
+        /// </summary>
+        private void TrackPictureChosenFromGallery(string provider)
+        {
+            AnalyticsApi.TrackChangePicture(provider, View?.Model?.CurrentBook?.ID);
         }
 
         /// <summary>

--- a/src/BloomTests/BloomAnalyticsTests.cs
+++ b/src/BloomTests/BloomAnalyticsTests.cs
@@ -1,0 +1,110 @@
+using System.Collections.Generic;
+using Bloom;
+using NUnit.Framework;
+
+namespace BloomTests
+{
+    /// <summary>
+    /// Tests for the log line <see cref="BloomAnalytics"/> writes for every event.
+    ///
+    /// The line is the whole point of the wrapper: DesktopAnalytics decides not to send anything in
+    /// a build configured with allowTracking:false, and it decides that inside its own Track
+    /// method, so without this line a developer exercising a new event sees nothing whatsoever and
+    /// cannot tell "it fired but was not sent" from "it never fired". These tests pin the two
+    /// things a reader depends on -- that the line says which of those it is, and that the same
+    /// event always reads the same way.
+    /// </summary>
+    [TestFixture]
+    public class BloomAnalyticsTests
+    {
+        private static Dictionary<string, string> SomeProperties =>
+            new Dictionary<string, string>
+            {
+                // Deliberately not in alphabetical order, so the sorting below is doing something.
+                { "provider", "pixabay" },
+                { "resultCount", "20" },
+                { "BookId", "abc123" },
+            };
+
+        [Test]
+        public void FormatForLog_TrackingOff_SaysTheEventIsNotBeingSent()
+        {
+            var line = BloomAnalytics.FormatForLog(
+                "Image Search",
+                SomeProperties,
+                trackingAllowed: false
+            );
+
+            Assert.That(line, Does.Contain("NOT SENT"));
+            // Still says what the event WAS: "nothing was sent" is only useful next to what it was
+            // that went unsent.
+            Assert.That(line, Does.Contain("Image Search"));
+            Assert.That(line, Does.Contain("provider=pixabay"));
+        }
+
+        [Test]
+        public void FormatForLog_TrackingOn_DoesNotClaimTheEventWasDropped()
+        {
+            var line = BloomAnalytics.FormatForLog(
+                "Image Search",
+                SomeProperties,
+                trackingAllowed: true
+            );
+
+            Assert.That(line, Does.StartWith("[analytics]"));
+            Assert.That(line, Does.Not.Contain("NOT SENT"));
+        }
+
+        [Test]
+        public void FormatForLog_Properties_AreOrderedByNameWhateverOrderTheyArrivedIn()
+        {
+            var line = BloomAnalytics.FormatForLog(
+                "Image Search",
+                SomeProperties,
+                trackingAllowed: true
+            );
+
+            Assert.That(
+                line,
+                Is.EqualTo(
+                    "[analytics] Image Search -- BookId=abc123, provider=pixabay, resultCount=20"
+                )
+            );
+        }
+
+        [Test]
+        public void FormatForLog_NoProperties_IsJustTheEventName()
+        {
+            Assert.That(
+                BloomAnalytics.FormatForLog("Delete Page", null, trackingAllowed: true),
+                Is.EqualTo("[analytics] Delete Page")
+            );
+            // An empty dictionary should read the same as none at all, rather than leaving a
+            // trailing separator with nothing after it.
+            Assert.That(
+                BloomAnalytics.FormatForLog(
+                    "Delete Page",
+                    new Dictionary<string, string>(),
+                    trackingAllowed: true
+                ),
+                Is.EqualTo("[analytics] Delete Page")
+            );
+        }
+
+        [Test]
+        public void FormatForLog_APropertyValueContainingABrace_IsLeftAlone()
+        {
+            // We do not control the shape of every value: a search provider's error message reaches
+            // us as it was written. That is safe only because Log passes the line to
+            // Logger.WriteEvent as the message and never as a format string with arguments -- see
+            // the remarks on FormatForLog.
+            var line = BloomAnalytics.FormatForLog(
+                "Image Search",
+                new Dictionary<string, string> { { "error", "rate limit a{0}b" } },
+                trackingAllowed: true
+            );
+
+            Assert.That(line, Does.Contain("error=rate limit a{0}b"));
+        }
+    }
+}

--- a/src/BloomTests/Utils/BloomDebugTests.cs
+++ b/src/BloomTests/Utils/BloomDebugTests.cs
@@ -4,15 +4,31 @@ using NUnit.Framework;
 
 namespace BloomTests.Utils
 {
+#if DEBUG
     /// <summary>
     /// The one branch of BloomDebug.Fail that a test run can and must exercise. The other two
     /// cannot be: one needs a debugger attached, and the other puts up a modal dialog, which in an
     /// automated run would block until something killed the suite. That is precisely why the
     /// under-test branch exists, so it is worth pinning.
+    ///
+    /// This fixture compiles only in DEBUG, and the reason is the whole point of BloomDebug.Fail:
+    /// [Conditional("DEBUG")] removes the CALL from the calling assembly -- which here is
+    /// BloomTests itself. In a Release build of BloomTests the BloomDebug.Fail(...) inside each
+    /// test below would simply not be emitted, nothing would throw, and Assert.Throws would fail.
+    /// That failure would mean nothing: doing nothing is exactly what Fail is supposed to do in a
+    /// release build. So in Release there is nothing to assert and the fixture stands down.
+    ///
+    /// Worth knowing, because it is easy to miss: build/agent-dotnet.sh builds Debug, but
+    /// build/Bloom.proj defaults to Configuration=Release and the nightly runs BloomTests.dll out
+    /// of output/Tests/Release/x64. Without this guard the nightly would be where it broke.
     /// </summary>
     [TestFixture]
     public class BloomDebugTests
     {
+        /// <summary>
+        /// Under test, Fail must throw rather than reach the MessageBox -- a modal dialog in an
+        /// automated run blocks until something kills the suite.
+        /// </summary>
         [Test]
         public void Fail_UnderTest_ThrowsRatherThanShowingADialog()
         {
@@ -27,6 +43,10 @@ namespace BloomTests.Utils
             );
         }
 
+        /// <summary>
+        /// The message argument is optional, so the no-argument call must still produce something
+        /// a developer can act on.
+        /// </summary>
         [Test]
         public void Fail_UnderTestWithNoMessage_StillThrowsSomethingReadable()
         {
@@ -34,4 +54,5 @@ namespace BloomTests.Utils
             Assert.That(e.Message, Does.Contain("BloomDebug.Fail"));
         }
     }
+#endif
 }

--- a/src/BloomTests/Utils/BloomDebugTests.cs
+++ b/src/BloomTests/Utils/BloomDebugTests.cs
@@ -1,0 +1,37 @@
+using System;
+using Bloom.Utils;
+using NUnit.Framework;
+
+namespace BloomTests.Utils
+{
+    /// <summary>
+    /// The one branch of BloomDebug.Fail that a test run can and must exercise. The other two
+    /// cannot be: one needs a debugger attached, and the other puts up a modal dialog, which in an
+    /// automated run would block until something killed the suite. That is precisely why the
+    /// under-test branch exists, so it is worth pinning.
+    /// </summary>
+    [TestFixture]
+    public class BloomDebugTests
+    {
+        [Test]
+        public void Fail_UnderTest_ThrowsRatherThanShowingADialog()
+        {
+            var e = Assert.Throws<ApplicationException>(() =>
+                BloomDebug.Fail("a definite programming error")
+            );
+            Assert.That(
+                e.Message,
+                Does.Contain("a definite programming error"),
+                "the message a developer passed in is what makes the failure worth reading, so it "
+                    + "has to survive into the exception"
+            );
+        }
+
+        [Test]
+        public void Fail_UnderTestWithNoMessage_StillThrowsSomethingReadable()
+        {
+            var e = Assert.Throws<ApplicationException>(() => BloomDebug.Fail());
+            Assert.That(e.Message, Does.Contain("BloomDebug.Fail"));
+        }
+    }
+}

--- a/src/BloomTests/web/controllers/AnalyticsApiTests.cs
+++ b/src/BloomTests/web/controllers/AnalyticsApiTests.cs
@@ -1,0 +1,150 @@
+using System.Globalization;
+using System.Threading;
+using Bloom.web.controllers;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace BloomTests.web.controllers
+{
+    /// <summary>
+    /// Tests for the one piece of real logic in <see cref="AnalyticsApi"/>: turning the JSON
+    /// properties a front-end caller sends into the string dictionary DesktopAnalytics wants.
+    /// HandleTrack itself is not tested here because it ends in a call to the static
+    /// DesktopAnalytics.Analytics, which a unit test cannot observe.
+    ///
+    /// The behaviors that matter, and why:
+    /// - booleans arrive as "true"/"false", not .NET's "True"/"False", so a chart grouping on
+    ///   them matches what the same property looks like coming from our TypeScript.
+    /// - numbers are formatted invariantly, so a user in a comma-decimal locale does not send
+    ///   us "1,5" and quietly poison the numeric columns.
+    /// - a null or absent value is dropped rather than sent as "", so a caller can pass an
+    ///   optional property without deciding whether to include the key.
+    /// </summary>
+    [TestFixture]
+    public class AnalyticsApiTests
+    {
+        [Test]
+        public void GetProperties_Booleans_UseJsonSpellingNotDotNets()
+        {
+            var result = AnalyticsApi.GetProperties(
+                JObject.Parse("{\"cleared\": true, \"demoOnly\": false}")
+            );
+
+            Assert.That(result["cleared"], Is.EqualTo("true"));
+            Assert.That(result["demoOnly"], Is.EqualTo("false"));
+        }
+
+        [Test]
+        public void GetProperties_Numbers_AreFormattedInvariantlyWhateverTheLocale()
+        {
+            var originalCulture = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                // German uses a comma as the decimal separator, so a locale-sensitive
+                // conversion would produce "1,5" here.
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+
+                // Sanity check that this culture really would have changed the answer;
+                // otherwise the assertion below would pass for the wrong reason.
+                Assert.That(
+                    1.5.ToString(),
+                    Is.EqualTo("1,5"),
+                    "setup: expected the de-DE culture to be in effect"
+                );
+
+                var result = AnalyticsApi.GetProperties(
+                    JObject.Parse("{\"elapsedSeconds\": 1.5, \"searchIndex\": 3}")
+                );
+
+                Assert.That(result["elapsedSeconds"], Is.EqualTo("1.5"));
+                Assert.That(result["searchIndex"], Is.EqualTo("3"));
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = originalCulture;
+            }
+        }
+
+        [Test]
+        public void GetProperties_NullValues_AreDroppedRatherThanSentAsEmpty()
+        {
+            var result = AnalyticsApi.GetProperties(
+                JObject.Parse("{\"term\": \"dog\", \"acceptedTerm\": null}")
+            );
+
+            Assert.That(
+                result.ContainsKey("term"),
+                Is.True,
+                "setup: the real value should survive"
+            );
+            Assert.That(result.ContainsKey("acceptedTerm"), Is.False);
+        }
+
+        [Test]
+        public void GetProperties_Strings_ComeThroughUnquoted()
+        {
+            var result = AnalyticsApi.GetProperties(JObject.Parse("{\"outcome\": \"local disk\"}"));
+
+            // A JSON-serializing conversion would have given us "\"local disk\"".
+            Assert.That(result["outcome"], Is.EqualTo("local disk"));
+        }
+
+        [Test]
+        public void GetProperties_NoProperties_GivesAnEmptyDictionary()
+        {
+            Assert.That(AnalyticsApi.GetProperties(null), Is.Empty);
+        }
+
+        // The next two go through ParseTrackRequestBody rather than JObject.Parse, because the
+        // coercion these guard against happens at parse time, not in GetProperties.
+
+        private static JObject ParsedProperties(string propertiesJson)
+        {
+            return AnalyticsApi.ParseTrackRequestBody("{\"properties\": " + propertiesJson + "}")[
+                    "properties"
+                ] as JObject;
+        }
+
+        [Test]
+        public void GetProperties_AValueThatParsesAsADateTime_ComesThroughExactlyAsSent()
+        {
+            // Newtonsoft's default turns a JSON string like this into a DateTime, and we would then
+            // record whatever the local culture makes of it ("1/1/2024 10:00:00 AM" here). Several of
+            // these properties are free user text -- an image search term above all -- so the record
+            // has to say what was sent. A date-ONLY string is left alone by Newtonsoft, which is why
+            // this test uses a full timestamp: that is the reachable case.
+            var result = AnalyticsApi.GetProperties(
+                ParsedProperties("{\"term\": \"2024-01-01T10:00:00Z\"}")
+            );
+
+            Assert.AreEqual("2024-01-01T10:00:00Z", result["term"]);
+        }
+
+        [Test]
+        public void GetProperties_AValueThatParsesAsADateTime_IsNotLocaleFormattedEither()
+        {
+            var wasCulture = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+                // Sanity check: this culture formats date-times its own way, so a coerced value
+                // would be visibly wrong here rather than coincidentally right.
+                Assert.AreNotEqual(
+                    "1/1/2024 10:00:00 AM",
+                    new System.DateTime(2024, 1, 1, 10, 0, 0).ToString(),
+                    "test setup: de-DE should not format date-times the way en-US does"
+                );
+
+                var result = AnalyticsApi.GetProperties(
+                    ParsedProperties("{\"term\": \"2024-01-01T10:00:00Z\"}")
+                );
+
+                Assert.AreEqual("2024-01-01T10:00:00Z", result["term"]);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = wasCulture;
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
## Problem

Bloom's 6.5 features shipped essentially blind. Every existing analytics event came from C#, so
anything implemented in React could only be measured by inventing a bespoke endpoint for it —
which in practice meant it wasn't measured at all. Nothing under `Publish/Rab` reported anything,
the AI Image Editor and the new image chooser reported nothing, and `Change Picture` — the one
event covering how a picture gets into a book — was bypassed by *both* new 6.5 image routes, so
even the old count was quietly low.

## Cause

A second, subtler problem made this hard to fix safely. DesktopAnalytics decides whether to send
an event *inside* its own `Track` method, and Bloom constructs it with `allowTracking: false` in
DEBUG. So a developer could not tell "fired but not sent" from "never fired" — a new event was
easy to write, easy to believe in, and impossible to observe without shipping to alpha.

## Fix

Seven events, chosen by one test: **would the answer change a decision?** Counting use of a
capability we already know is essential does not. Splitting a known behaviour into actionable
parts does.

**Plumbing**

- `POST analytics/track` plus a `trackEvent()` helper, so front-end code can report an event at
  all. C# fills in `BookId`, which React in the edit view does not know. Not the branding: every
  event already carries `BrandingProjectName`, which holds the richer subscription descriptor.
- `BloomAnalytics` wraps DesktopAnalytics and **logs every event as well as sending it**, so a
  developer running `./go.sh` watches events scroll past. Every call site goes through it, and
  `build/check-csharp-analytics.sh` (run from the existing pre-commit hook) keeps it that way: a
  partial log would be worse than none, since a missing line would read as "not instrumented" as
  readily as "did not happen".
- `BloomDebug.Fail` (new, in `Utils`) is the assertion the endpoint uses when a caller sends a
  request with no event name. `Debug.Fail` could not be: with no debugger attached it is
  `Environment.FailFast`, which kills Bloom outright, and mid-suite kills the test host. This one
  breaks into the debugger when there is one, fails the test when under test, and otherwise shows a
  dialog offering to attach a debugger. In a release build the call compiles away entirely. It is
  written for wider use later, not just this call site.

**The events, by what they answer**

- **Where pictures come from** — `Change Picture` gains a `source` field naming the route
  (`pixabay`, `openverse`, a collection slug, `local-disk`, `clipboard`, `ai-editor`), repairing
  the under-count on the way past.
- **Whether searching works** — `Image Chooser Closed`, one event per visit to the chooser. A
  result count could never answer this: Pixabay and Openverse nearly always return *something*,
  so the failure is a full page of wrong pictures, and only what the user did next reveals it.
- **What AI costs and whether it lands** — `AI Image Editor Generate` (from the ai-editor over
  the existing bridge: cost, model, retries, failures) and `AI Image Editor Closed`, one event
  per session, where an `appliedCount` of zero *is* the abandoned case.
- **A Pro feature with no usage data** — `Cover Layout Changed`, the baseline nobody has after
  two releases of charging for custom cover layouts.
- **A heuristic we cannot otherwise evaluate** — `Image Transparency Set`. Every explicit choice
  is a user telling us which way our line-art detection was wrong.
- **A path CI cannot run** — `Publish App`, with the stage as a field. CI never runs a real
  Reading App Builder build, so field telemetry is this path's only continuous coverage.

**One fix that is not analytics.** "Apply this information to all images" re-read every picture's
metadata once per picture — about 160,000 reads on a 400-picture book, appearing to freeze Bloom
for minutes. Found while instrumenting that operation. The event that found it is not being kept;
the fix is.

**No search terms, and nothing persisted.** The image gallery still hands Bloom the search term, so
revisiting that is a one-property change, but it is dropped at Bloom's boundary deliberately rather
than by omission. And this PR writes nothing to the user's disk: the durable count of image-chooser
visits it used to keep was dropped once we established that, since Bloom identifies users to Segment,
a user's earlier visits are simply their earlier events.

**One dependency bump comes with it.** `Image Chooser Closed` reads a search-report callback that
exists in `bloom-image-gallery` 0.0.4 and not in 0.0.3, so this advances the lockfile to the
gallery's current tip (`e376463b`, "Let the host see searches and where an image came from"). Six
lines. Worth a reviewer's eye only because the gallery is declared with no tag, so the lockfile is
the only thing pinning it, and pnpm holds a git dependency at its locked commit until someone runs
an explicit update — which is why master sat on 0.0.3 for five days after that gallery PR merged.

## Scope

This supersedes **#8215**, which instrumented 22 events. That set was reviewed and judged too
large; thirteen event names were dropped and four merged into two. The parked
`BL-16716-analytics` branch keeps the dropped code should any of it be wanted back, and the
[event catalogue](https://bloombooks.github.io/dev-process-artifacts/reports/BL-16716-event-catalogue.html) records
what each dropped event would have told us.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16716
<!-- preflight-narrative:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8228)
<!-- Reviewable:end -->


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8228)

