### PR TITLE
BL-16690 bring the minimum-version startup dialogs to the front

### DIFF
--- a/src/BloomExe/Collection/MinimumBloomVersionCheck.cs
+++ b/src/BloomExe/Collection/MinimumBloomVersionCheck.cs
@@ -625,7 +625,8 @@ namespace Bloom.Collection
             BrowserProgressDialog.DoWorkWithProgressDialog(
                 socketServer,
                 () =>
-                    new ReactDialog(
+                {
+                    var dlg = new ReactDialog(
                         "progressDialogBundle",
                         new
                         {
@@ -651,7 +652,18 @@ namespace Bloom.Collection
                         // empty. The message area scrolls, so a failure with more to say
                         // still fits.
                         Height = 260,
-                    },
+                        // ReactDialog turns this off, which is right for a dialog whose parent
+                        // is on the taskbar. This one has no parent, so without its own button
+                        // there is nothing anywhere to find it by if it loses the foreground.
+                        ShowInTaskbar = true,
+                    };
+                    // By the time this opens, the message box where they clicked Upgrade Bloom
+                    // has closed, so whatever the user launched Bloom from (Windows Explorer,
+                    // say) may hold the foreground again -- and this dialog has no owner and no
+                    // taskbar button, so it would open behind it. See BL-16690.
+                    dlg.BringToFrontWhenShown();
+                    return dlg;
+                },
                 (progress, worker) =>
                 {
                     reporter.WriteTo(progress);

--- a/src/BloomExe/Extensions.cs
+++ b/src/BloomExe/Extensions.cs
@@ -80,6 +80,34 @@ namespace Bloom
             return Uri.UnescapeDataString(uri);
         }
 
+        /// <summary>
+        /// Arrange for the form to put itself in front of other applications when it is first
+        /// shown. A window shown while another application (say, the Windows Explorer window
+        /// Bloom was launched from) holds the foreground opens behind it, and a dialog with no
+        /// owner is then very hard to find. Same idea as Shell.ReallyComeToFront, except that we
+        /// stay topmost for a moment instead of dropping it immediately: when the window we are
+        /// racing was made foreground by the close of a previous dialog, that raise can arrive
+        /// after Shown, and an instant toggle loses to it. Clearing TopMost re-asserts our place
+        /// at the top of the ordinary windows anyway, so the late drop wins the race whichever
+        /// order things happened in. See BL-16690.
+        /// </summary>
+        public static void BringToFrontWhenShown(this Form form)
+        {
+            form.Shown += (sender, args) =>
+            {
+                form.TopMost = true;
+                form.Activate();
+                var timer = new Timer { Interval = 1500 };
+                timer.Tick += (s, e) =>
+                {
+                    timer.Dispose();
+                    if (!form.IsDisposed)
+                        form.TopMost = false;
+                };
+                timer.Start();
+            };
+        }
+
         public static int ToInt(this bool value)
         {
             if (value)

--- a/src/BloomExe/MiscUI/BloomMessageBox.cs
+++ b/src/BloomExe/MiscUI/BloomMessageBox.cs
@@ -57,7 +57,13 @@ namespace Bloom.MiscUI
                 // and remove the control box.
                 dlg.ControlBox = false;
                 if (owner == null)
+                {
                     dlg.StartPosition = FormStartPosition.CenterScreen;
+                    // With no owner there is no other Bloom presence on the taskbar, so without
+                    // its own button an ownerless message box that loses the foreground is
+                    // unfindable. (ReactDialog turns this off, which suits the owned case.)
+                    dlg.ShowInTaskbar = true;
+                }
                 dlg.ShowDialog(owner);
                 return dlg.CloseSource;
             }

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -1838,6 +1838,11 @@ namespace Bloom
                     {
                         dlg.StartPosition = FormStartPosition.Manual; // try not to have it under the splash screen
                         dlg.SetDesktopLocation(50, 50);
+                        // With no owner window to hand it the foreground, this opens behind
+                        // whatever the user launched Bloom from (Windows Explorer, say) --
+                        // notably when the minimum-version gate's "Open a Different Collection"
+                        // brings us here at startup. See BL-16690.
+                        dlg.BringToFrontWhenShown();
                     }
 
                     try


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
**Problem.** QA on BL-16690's test channel found that when Bloom is launched by double-clicking a `.bloomCollection` file and the minimum-version gate fires, the windows that follow the gate dialog open **behind Windows Explorer** with no taskbar button: both the "Upgrade Bloom" progress dialog and the collection chooser ("Open a Different Collection"). Bloom looks hung, and there is nothing on the taskbar to find it by.

**Cause.** Those windows are shown with **no owner**: by the time they open, the gate message box that held the foreground has closed, and Windows hands the foreground back to Explorer — sometimes asynchronously, *after* the new window has already appeared. `ReactDialog` also suppresses taskbar buttons, which is right for owned dialogs but leaves an ownerless one unfindable.

**Fix.**
- A shared `Form` extension, `BringToFrontWhenShown`: on `Shown`, go topmost and `Activate()`, then drop `TopMost` 1.5 s later — the delayed drop re-asserts the window at the top of the ordinary z-band, so it wins the race against Explorer's asynchronous re-raise whichever order the raises land in. (Same idea as `Shell.ReallyComeToFront`, which solves this for the main window after the splash screen.)
- Applied to the Upgrade Bloom progress dialog and to the collection chooser when it opens ownerless at startup. The owned, mid-session paths are untouched.
- The progress dialog and any ownerless `BloomMessageBox` (the gate dialog itself) now get their own taskbar buttons, so a startup dialog that does end up behind something can always be found.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16690
<!-- preflight-narrative:end -->


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8231)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8231)
<!-- Reviewable:end -->
