### PR TITLE
Never touch the WebView2 from a background thread on a book rename (BL-16749)

### DIFF
--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -200,6 +200,11 @@ namespace Bloom.Edit
         /// import's worker thread is what threw "CoreWebView2 can only be accessed from the UI
         /// thread" and abandoned the import (BL-16749). When no window is open (e.g. unit tests)
         /// this just runs inline; the same pattern as CollectionModel.SelectBookOnUiThread.
+        /// The Invoke is deliberately synchronous, which keeps the handler's old ordering (the
+        /// settings write and the page-list refresh both finish before the rename returns). That
+        /// would only deadlock if the UI thread were blocked waiting on this worker, which no
+        /// current path does: the import's progress dialog does not block it, and a modal dialog
+        /// would still pump messages.
         /// </summary>
         private void HandleBookRenamedOnUiThread(KeyValuePair<string, string> oldToNewPath)
         {

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -153,43 +153,7 @@ namespace Bloom.Edit
 
             controlKeyEvent.Subscribe(HandleControlKeyEvent);
 
-            bookRenamedEvent.Subscribe(
-                (oldToNewPath) =>
-                {
-                    // If the selected book is renamed, we should update our saved CurrentBookPath.
-                    // Each branch below saves the settings itself: it used to be enough to change
-                    // the value in memory, because the next SelectBook() would flush it, but
-                    // SelectBook() no longer writes settings at all (BL-16660).
-                    if (model.CurrentBook == null)
-                    {
-                        // Note: possibly all we need is this branch, which doesn't actually depend
-                        // on model.CurrentBook being null. However, if we do have a model.CurrentBook,
-                        // that's the definitive source of truth. We don't want by any chance to
-                        // be updating our settings to indicate that anything else is selected.
-                        // So I decided to use this only when we don't have that...usually only
-                        // during startup, I think because of a duplicate name.
-                        if (oldToNewPath.Key == Settings.Default.CurrentBookPath)
-                        {
-                            Settings.Default.CurrentBookPath = oldToNewPath.Value;
-                            Settings.Default.Save();
-                        }
-                    }
-                    else if (oldToNewPath.Value == _model.CurrentBook?.FolderPath)
-                    {
-                        // This is the usual path, updating the settings to match the model's current book.
-                        Settings.Default.CurrentBookPath = oldToNewPath.Value;
-                        Settings.Default.Save();
-                    }
-                    UpdatePageList(true);
-                    if (_model.CurrentBook != null)
-                    {
-                        var url = _model.GetUrlForPageListFile();
-                        _mainBrowser.RunJavascriptFireAndForget(
-                            $"workspaceBundle.switchThumbnailPage('{url}');"
-                        );
-                    }
-                }
-            );
+            bookRenamedEvent.Subscribe(HandleBookRenamedOnUiThread);
 #if __MonoCS__
             // The inactive button images look garishly pink on Linux/Mono, but look okay on Windows.
             // Merely introducing an "identity color matrix" to the image attributes appears to fix
@@ -225,6 +189,65 @@ namespace Bloom.Edit
                 ColorAdjustType.Bitmap
             );
 #endif
+        }
+
+        /// <summary>
+        /// Runs <see cref="HandleBookRenamed"/> on the UI thread. A book can be renamed from a
+        /// background thread - BookStorage.SetBookName raises BookRenamedEvent inline, and several
+        /// operations that bring a book up to date (notably the .bloomSource import, which runs
+        /// behind a progress dialog) do that off the UI thread - but what we do in response drives
+        /// WinForms and the WebView2, both of which are UI-thread-only. Doing it directly from the
+        /// import's worker thread is what threw "CoreWebView2 can only be accessed from the UI
+        /// thread" and abandoned the import (BL-16749). When no window is open (e.g. unit tests)
+        /// this just runs inline; the same pattern as CollectionModel.SelectBookOnUiThread.
+        /// </summary>
+        private void HandleBookRenamedOnUiThread(KeyValuePair<string, string> oldToNewPath)
+        {
+            var form = Shell.GetShellOrOtherOpenForm();
+            if (form != null && form.InvokeRequired)
+                form.Invoke((Action)(() => HandleBookRenamed(oldToNewPath)));
+            else
+                HandleBookRenamed(oldToNewPath);
+        }
+
+        /// <summary>
+        /// Updates our saved CurrentBookPath and refreshes the page list after a book has been
+        /// renamed. Call it only on the UI thread (see <see cref="HandleBookRenamedOnUiThread"/>).
+        /// </summary>
+        private void HandleBookRenamed(KeyValuePair<string, string> oldToNewPath)
+        {
+            // If the selected book is renamed, we should update our saved CurrentBookPath.
+            // Each branch below saves the settings itself: it used to be enough to change
+            // the value in memory, because the next SelectBook() would flush it, but
+            // SelectBook() no longer writes settings at all (BL-16660).
+            if (_model.CurrentBook == null)
+            {
+                // Note: possibly all we need is this branch, which doesn't actually depend
+                // on model.CurrentBook being null. However, if we do have a model.CurrentBook,
+                // that's the definitive source of truth. We don't want by any chance to
+                // be updating our settings to indicate that anything else is selected.
+                // So I decided to use this only when we don't have that...usually only
+                // during startup, I think because of a duplicate name.
+                if (oldToNewPath.Key == Settings.Default.CurrentBookPath)
+                {
+                    Settings.Default.CurrentBookPath = oldToNewPath.Value;
+                    Settings.Default.Save();
+                }
+            }
+            else if (oldToNewPath.Value == _model.CurrentBook?.FolderPath)
+            {
+                // This is the usual path, updating the settings to match the model's current book.
+                Settings.Default.CurrentBookPath = oldToNewPath.Value;
+                Settings.Default.Save();
+            }
+            UpdatePageList(true);
+            if (_model.CurrentBook != null)
+            {
+                var url = _model.GetUrlForPageListFile();
+                _mainBrowser.RunJavascriptFireAndForget(
+                    $"workspaceBundle.switchThumbnailPage('{url}');"
+                );
+            }
         }
 
         public EditingModel Model => _model;

--- a/src/BloomExe/WebView2Browser.cs
+++ b/src/BloomExe/WebView2Browser.cs
@@ -802,18 +802,53 @@ namespace Bloom
         /// </summary>
         public override void RunJavascriptFireAndForget(string script)
         {
+            if (_webview == null || _webview.IsDisposed || _webview.Disposing)
+                return;
+
+            // Everything below, including the CoreWebView2 readiness check, must happen on the thread
+            // that created the control, which is usually the UI thread. Reading the CoreWebView2 property
+            // from any other thread can throw "CoreWebView2 can only be accessed from the UI thread": the
+            // WinForms wrapper does a COM QueryInterface on the apartment-bound ICoreWebView2Controller,
+            // which fails E_NOINTERFACE across apartments. Whether it actually throws depends on the
+            // apartment that controller ended up in, so it fails on some machines and not others. That
+            // made the readiness guard checking _webview.CoreWebView2 the crash site (BL-16749: a
+            // .bloomSource import runs on a background thread, and the book rename it does raises
+            // BookRenamedEvent inline, which asks the Edit view to refresh the page list).
+            // Since this method is fire-and-forget by contract - the script has not necessarily run by the
+            // time we return - re-posting the whole call to the correct (UI) thread costs the caller nothing.
+            // Do NOT fold this back into the guard below.
+            if (_webview.IsHandleCreated && _webview.InvokeRequired)
+            {
+                try
+                {
+                    _webview.BeginInvoke((Action)(() => RunJavascriptFireAndForget(script)));
+                }
+                catch (Exception e)
+                    when (e is ObjectDisposedException || e is InvalidOperationException)
+                {
+                    // The control can start disposing between the checks above and this call. That
+                    // is the same expected shutdown race the ContinueWith below logs rather than
+                    // reports, and here we are on a background thread, where letting it escape
+                    // would take Bloom down.
+                    Logger.WriteEvent(
+                        "WebView2Browser.RunJavascriptFireAndForget: could not marshal to the UI thread (expected during shutdown): "
+                            + e.Message
+                    );
+                }
+                return;
+            }
+            // With no handle there is no UI thread to post to, and any CoreWebView2 is not usable
+            // yet, so this is the same "not in a usable state" case the guard below covers.
+            if (!_webview.IsHandleCreated)
+                return;
+
             // Guard against running when the browser isn't in a usable state. During app startup
             // (before CoreWebView2 is initialized) or shutdown (while the control is disposing),
             // ExecuteScriptAsync throws from inside its async state machine. Because nothing here
             // awaits or otherwise observes the returned Task, that fault used to reach the GC
             // finalizer thread and get rethrown as an UnobservedTaskException (Sentry
             // BLOOM-DESKTOP-D07). This mirrors the readiness check in UpdateDisplay().
-            if (
-                _webview == null
-                || _webview.IsDisposed
-                || _webview.Disposing
-                || _webview.CoreWebView2 == null
-            )
+            if (_webview.CoreWebView2 == null)
                 return;
 
             // Even with the guard above there is a tiny race window in which the control can start

--- a/src/BloomTests/Book/BookStorageTests.cs
+++ b/src/BloomTests/Book/BookStorageTests.cs
@@ -6,6 +6,8 @@ using System.Drawing.Imaging;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Xml;
 using Bloom;
 using Bloom.Api;
@@ -1109,6 +1111,69 @@ namespace BloomTests.Book
                 Directory.Delete(newFolder.Path);
                 ChangeNameAndCheck(newFolder, storage);
             }
+        }
+
+        /// <summary>
+        /// Renaming is done by several operations that run on a background thread (the .bloomSource
+        /// import, for one), and BookRenamedEvent is raised inline, so its subscribers run on that
+        /// thread. This checks that the whole rename-and-notify chain works from there. It cannot
+        /// cover what actually broke in BL-16749 - a subscriber touching the WebView2, which only
+        /// throws in the real app - but it does pin the rest of the chain, and that a subscriber
+        /// which marshals to the UI thread still runs when there is no window (as in these tests,
+        /// and in the command-line tools).
+        /// </summary>
+        [Test]
+        public void SetBookName_CalledOnBackgroundThread_RenamesAndNotifiesSubscriber()
+        {
+            RobustFile.WriteAllText(
+                _bookPath,
+                "<html><head></head><body><div class='bloom-page'></div></body></html>"
+            );
+            // The book folder has to be inside the collection folder, or RaiseBookRenamedEvent
+            // deliberately says nothing (it doesn't want to report renames of temporary copies).
+            var collectionSettings = new CollectionSettings(
+                Path.Combine(_fixtureFolder.Path, "test.bloomCollection")
+            );
+            var renamedEvent = new BookRenamedEvent();
+            var notifications = new List<KeyValuePair<string, string>>();
+            var threadOfNotification = -1;
+            renamedEvent.Subscribe(pair =>
+            {
+                notifications.Add(pair);
+                threadOfNotification = Thread.CurrentThread.ManagedThreadId;
+            });
+            var storage = new BookStorage(
+                _folder.Path,
+                _fileLocator,
+                renamedEvent,
+                collectionSettings
+            );
+            storage.Save();
+            var newName = "renamed on a worker";
+            var expectedFolder = Path.Combine(_fixtureFolder.Path, newName);
+            // Sanity checks: there is really a rename to do, and nothing has been reported yet.
+            Assert.That(storage.FolderPath, Is.EqualTo(_folder.Path));
+            Assert.That(Directory.Exists(expectedFolder), Is.False);
+            Assert.That(notifications, Is.Empty);
+
+            var testThread = Thread.CurrentThread.ManagedThreadId;
+            Task.Run(() => storage.SetBookName(newName)).GetAwaiter().GetResult();
+
+            Assert.That(
+                threadOfNotification,
+                Is.Not.EqualTo(testThread),
+                "The point of this test is that the rename happened on another thread"
+            );
+            Assert.That(notifications.Count, Is.EqualTo(1));
+            Assert.That(notifications[0].Key, Is.EqualTo(_folder.Path));
+            Assert.That(notifications[0].Value, Is.EqualTo(expectedFolder));
+            Assert.That(storage.FolderPath, Is.EqualTo(expectedFolder));
+            Assert.That(Directory.Exists(expectedFolder), Is.True);
+            Assert.That(
+                RobustFile.Exists(Path.Combine(expectedFolder, newName + ".htm")),
+                Is.True,
+                "the HTML file should have been renamed along with the folder"
+            );
         }
 
         [Test]

--- a/src/BloomTests/Book/BookStorageTests.cs
+++ b/src/BloomTests/Book/BookStorageTests.cs
@@ -1116,11 +1116,11 @@ namespace BloomTests.Book
         /// <summary>
         /// Renaming is done by several operations that run on a background thread (the .bloomSource
         /// import, for one), and BookRenamedEvent is raised inline, so its subscribers run on that
-        /// thread. This checks that the whole rename-and-notify chain works from there. It cannot
-        /// cover what actually broke in BL-16749 - a subscriber touching the WebView2, which only
-        /// throws in the real app - but it does pin the rest of the chain, and that a subscriber
-        /// which marshals to the UI thread still runs when there is no window (as in these tests,
-        /// and in the command-line tools).
+        /// thread. This checks that the rename-and-notify chain works from there: the folder and
+        /// the HTML file are renamed, and the subscriber is called exactly once, on that worker
+        /// thread. It does not cover what actually broke in BL-16749 - EditingView's subscriber
+        /// touching the WebView2 - because that needs a window and a real browser control, so it
+        /// only misbehaves in the running app.
         /// </summary>
         [Test]
         public void SetBookName_CalledOnBackgroundThread_RenamesAndNotifiesSubscriber()


### PR DESCRIPTION
Importing a `.bloomSource` **as a derivative** could fail with `CoreWebView2 can only be accessed from the UI thread`, leaving the new book on disk but telling the user the import failed.

The import runs off the UI thread (`importBloomSource` is registered `handleOnUiThread: false`, and the work runs behind the collection tab's progress dialog). Bringing the new book up to date saves it, which renames its folder to the book's title and raises `BookRenamedEvent` **inline**, on that worker thread. `EditingView` answers by refreshing the page list, which runs javascript in the workspace's WebView2 — and the readiness guard in `RunJavascriptFireAndForget` reads `_webview.CoreWebView2`, which the WinForms wrapper cannot always hand to a thread other than the one that created the control. The guard meant to keep that call safe was the crash site.

Why only some machines: whether that read throws depends on the apartment the `ICoreWebView2Controller` RCW ended up in. On the reporter's machine (a native ARM64 build) the cross-apartment `QueryInterface` fails `E_NOINTERFACE`; the same import completes on x64 here. It also takes a **selected book**, which is what gates the two WebView2 calls in the handler — so a first import into a collection with nothing selected succeeds, and the next one (the import having selected a book) does not.

Two changes, so neither the browser nor its callers depend on that lottery:

- `WebView2Browser.RunJavascriptFireAndForget` re-posts itself to the control's own thread when `Invoke` is required, *before* anything reads `CoreWebView2`. The method is fire-and-forget by contract, so marshalling costs the caller nothing, and this also covers its other callers on book-update, import and publish paths.
- `EditingView`'s `BookRenamedEvent` handler moves out of the constructor into `HandleBookRenamed`, marshalled as a whole by `HandleBookRenamedOnUiThread`. It writes `Settings.Default` and drives WinForms too, so the whole handler wants the UI thread. With no window open (unit tests, command-line tools) it runs inline, as `CollectionModel.SelectBookOnUiThread` does.

Verified in the running app: the rename arrives on the worker thread and the handler body then executes on the UI thread, and the import completes. Adds a test that renames a book from a worker thread and checks the rename and its notification both come through.

Note: the branch name carries BL-16646 (an earlier ticket worked in this worktree); this change fixes **BL-16749**.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16749


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8232)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8232)
<!-- Reviewable:end -->
