### PR TITLE
Paste on a standard-layout xmatter page replaces its background image (BL-16542)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementClipboard.test.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementClipboard.test.ts
@@ -17,6 +17,11 @@ vi.mock("../bloomImages", () => ({
     isPlaceHolderImage: (src: string | null) =>
         !!src && src.toLowerCase().includes("placeholder.png"),
     SetupMetadataButton: vi.fn(),
+    // Mirrors the real helper in bloomImages.ts: the first bloom-backgroundImage in the canvas.
+    getBackgroundCanvasElementFromBloomCanvas: (bloomCanvas: HTMLElement) =>
+        bloomCanvas.getElementsByClassName(
+            "bloom-backgroundImage",
+        )[0] as HTMLElement,
 }));
 
 vi.mock("../bloomEditing", () => ({
@@ -79,11 +84,20 @@ const pastedImageInfo = {
 
 // Build a bloom-canvas holding one canvas element, whose image starts out as a placeholder.
 // isBackground controls whether that canvas element is the background image or an overlay.
-function makeCanvasWithPlaceholder(isBackground: boolean): {
+// pageClasses says what kind of page the canvas sits on; the paste rules depend on that, since
+// a standard-layout xmatter page cannot hold canvas elements at all (BL-16542). The default is
+// an ordinary content page.
+function makeCanvasWithPlaceholder(
+    isBackground: boolean,
+    pageClasses = "bloom-page numberedPage",
+): {
     bloomCanvas: HTMLElement;
     canvasElement: HTMLElement;
     img: HTMLImageElement;
 } {
+    const page = document.createElement("div");
+    page.className = pageClasses;
+    document.body.appendChild(page);
     const bloomCanvas = document.createElement("div");
     bloomCanvas.classList.add("bloom-canvas");
     const canvasElement = document.createElement("div");
@@ -94,7 +108,7 @@ function makeCanvasWithPlaceholder(isBackground: boolean): {
     canvasElement.innerHTML =
         '<div class="bloom-imageContainer"><img src="placeHolder.png" /></div>';
     bloomCanvas.appendChild(canvasElement);
-    document.body.appendChild(bloomCanvas);
+    page.appendChild(bloomCanvas);
     return {
         bloomCanvas,
         canvasElement,
@@ -232,11 +246,11 @@ describe("CanvasElementClipboard only claims a placeholder background (BL-16542)
         expect(wrapWithRequestPageContentDelay).not.toHaveBeenCalled();
     });
 
-    test("a background that already holds a real image is left alone; the paste becomes a new canvas element", () => {
+    test("a background that already holds a real image on an ordinary page is left alone; the paste becomes a new canvas element", () => {
         // Nothing is selected (the state right after the page is displayed), so the only way
         // this paste could replace the background is the empty-canvas branch. That branch must
-        // not fire once the background holds a real image: replacing the picture the user can
-        // see needs them to select it first. See BL-16542.
+        // not fire once the background holds a real image: on a page that can hold overlays,
+        // replacing the picture the user can see needs them to select it first. See BL-16542.
         const { bloomCanvas, img } = makeCanvasWithPlaceholder(true);
         img.setAttribute("src", "realBackground.png");
         const host = makeHost(bloomCanvas, undefined);
@@ -271,5 +285,79 @@ describe("CanvasElementClipboard only claims a placeholder background (BL-16542)
 
         expect(img.getAttribute("src")).toBe("pasted.png");
         expect(host.adjustBackgroundImageSize).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("CanvasElementClipboard replaces the background on a page that can't hold canvas elements (BL-16542)", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+        vi.mocked(SetupMetadataButton).mockReset();
+        vi.mocked(changeImageInfo).mockClear();
+        vi.mocked(wrapWithRequestPageContentDelay).mockClear();
+    });
+
+    test("a standard-layout xmatter page's real background image is replaced even with nothing selected", () => {
+        // The original bug on this card: a Standard Layout front cover cannot hold an overlay,
+        // so a paste there can only mean "replace the cover picture".
+        const { bloomCanvas, canvasElement, img } = makeCanvasWithPlaceholder(
+            true,
+            "bloom-page bloom-frontMatter outsideFrontCover",
+        );
+        img.setAttribute("src", "realBackground.png");
+        const host = makeHost(bloomCanvas, undefined);
+
+        // Sanity checks: nothing is selected, and the background is a real image, so neither of
+        // the earlier branches can be what handles this paste.
+        expect(host.getActiveElement()).toBeUndefined();
+        expect(img.getAttribute("src")).toBe("realBackground.png");
+
+        makeClipboard(host).finishPasteImageFromClipboard(pastedImageInfo);
+
+        expect(img.getAttribute("src")).toBe("pasted.png");
+        expect(host.adjustBackgroundImageSize).toHaveBeenCalledTimes(1);
+        // Replacing a background image must refresh its copyright button (BL-16605).
+        expect(SetupMetadataButton).toHaveBeenCalledTimes(1);
+        expect(vi.mocked(SetupMetadataButton).mock.calls[0][0]).toBe(
+            canvasElement,
+        );
+        // We must not have gone on to add a canvas element to a page that can't hold one.
+        expect(wrapWithRequestPageContentDelay).not.toHaveBeenCalled();
+    });
+
+    test("a placeholder background on a standard-layout xmatter page is still filled in", () => {
+        // Same page kind, but the empty-canvas branch gets there first. Either way the pasted
+        // image becomes the background; this guards against the two branches fighting.
+        const { bloomCanvas, img } = makeCanvasWithPlaceholder(
+            true,
+            "bloom-page bloom-frontMatter outsideFrontCover",
+        );
+        const host = makeHost(bloomCanvas, undefined);
+
+        expect(img.getAttribute("src")).toBe("placeHolder.png");
+
+        makeClipboard(host).finishPasteImageFromClipboard(pastedImageInfo);
+
+        expect(img.getAttribute("src")).toBe("pasted.png");
+        expect(host.adjustBackgroundImageSize).toHaveBeenCalledTimes(1);
+        expect(wrapWithRequestPageContentDelay).not.toHaveBeenCalled();
+    });
+
+    test("a custom-layout xmatter page still gets a new canvas element", () => {
+        // Once the user switches the cover to Custom Layout it holds free-floating items, so
+        // pasting there means "add another item", exactly as on an ordinary page.
+        const { bloomCanvas, img } = makeCanvasWithPlaceholder(
+            true,
+            "bloom-page bloom-frontMatter outsideFrontCover bloom-customLayout",
+        );
+        img.setAttribute("src", "realBackground.png");
+        const host = makeHost(bloomCanvas, undefined);
+
+        makeClipboard(host).finishPasteImageFromClipboard(pastedImageInfo);
+
+        expect(img.getAttribute("src")).toBe("realBackground.png");
+        expect(changeImageInfo).not.toHaveBeenCalled();
+        expect(host.adjustBackgroundImageSize).not.toHaveBeenCalled();
+        expect(SetupMetadataButton).not.toHaveBeenCalled();
+        expect(wrapWithRequestPageContentDelay).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementClipboard.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementClipboard.ts
@@ -11,6 +11,7 @@ import {
     wrapWithRequestPageContentDelay,
 } from "../bloomEditing";
 import {
+    getBackgroundCanvasElementFromBloomCanvas,
     isPlaceHolderImage,
     kImageContainerClass,
     SetupMetadataButton,
@@ -32,6 +33,7 @@ import {
     kCanvasElementClass,
 } from "../../toolbox/canvas/canvasElementConstants";
 import { makeTargetAndMatchSize } from "../../toolbox/canvas/CanvasElementItem";
+import { pageAllowsCanvasElements } from "../../toolbox/canvas/canvasElementDomUtils";
 import { getTarget } from "bloom-player";
 import $ from "jquery";
 import theOneLocalizationManager from "../../../lib/localizationManager/localizationManager";
@@ -159,21 +161,24 @@ export class CanvasElementClipboard {
         );
     }
 
-    // This is called when the user pastes an image from the clipboard.
-    // If there is an active canvas element that is an image, and it is empty (placeholder),
-    // set its image to the pasted image.
-    // Otherwise, if there is a bloom canvas on the page, it will pick the one that has the active element
-    // or the first one if none has an active element.
-    // (If there is no canvas, it returns false.)
-    // If the canvas holds nothing but a background that is still a placeholder, set that
-    // background to the image. (A background that already holds a real image is left alone;
-    // select it first if you want to replace it.)
-    // Else if canvas is allowed by the subscription tier, add the image as a canvas/game item.
-    // Make it up to 1/3 width and 1/3 height of the canvas, roughly centered on the canvas.
-    // Is it a draggable item? Yes, if we are in the "Start" mode of a game.
-    // In that case, we put it a bit higher and further left, so there is room for the target.
-    // Otherwise it's just a normal canvas overlay item (restricted to the appropriate state,
-    // if we're in the Correct or Wrong state of a game).
+    // This is called when the user pastes an image from the clipboard (Ctrl+V or the top-bar
+    // Paste button). It works on the bloom canvas that has the active element, or the first one
+    // on the page if no element is active. (If there is no canvas, it returns false.)
+    // The rules the paste then follows, in the order finishPasteImageFromClipboard() applies them:
+    // 1. If the canvas holds nothing but a background that is still a placeholder, that
+    //    background becomes the pasted image.
+    // 2. If an image canvas element is selected (background or overlay), its image is replaced.
+    // 3. If the page cannot hold canvas elements at all — a standard-layout xmatter page, e.g. a
+    //    Standard Layout front cover — its background image is replaced, even if it already holds
+    //    a real image and nothing is selected, since an overlay is not an option there (BL-16542).
+    // 4. Otherwise, if canvas is allowed by the subscription tier, add the image as a canvas/game
+    //    item. Make it up to 1/3 width and 1/3 height of the canvas, roughly centered on the
+    //    canvas. Is it a draggable item? Yes, if we are in the "Start" mode of a game.
+    //    In that case, we put it a bit higher and further left, so there is room for the target.
+    //    Otherwise it's just a normal canvas overlay item (restricted to the appropriate state,
+    //    if we're in the Correct or Wrong state of a game).
+    // Note that a background holding a real image is left alone on a page that does allow
+    // overlays; select it first if you want to replace it there.
     public pasteImageFromClipboard(): boolean {
         const bloomCanvas = this.host.getActiveOrFirstBloomCanvasOnPage();
         if (!bloomCanvas) {
@@ -291,6 +296,33 @@ export class CanvasElementClipboard {
                 );
                 return;
             }
+        }
+
+        // Reaching here means nothing suitable was selected. On a page that cannot hold canvas
+        // elements — a standard-layout xmatter page, classically a Standard Layout front cover —
+        // "paste as a new overlay" is not a thing, so a paste can only mean "replace this page's
+        // picture", even when that picture is a real image rather than a placeholder. See BL-16542.
+        // This is not gated on the canvas subscription feature: replacing the cover picture is not
+        // the overlay feature.
+        const page = bloomCanvas.closest(".bloom-page");
+        if (!pageAllowsCanvasElements(page)) {
+            const bgCanvasElement =
+                getBackgroundCanvasElementFromBloomCanvas(bloomCanvas);
+            if (bgCanvasElement) {
+                const bgImg = bgCanvasElement
+                    .getElementsByClassName(kImageContainerClass)[0]
+                    ?.getElementsByTagName("img")[0];
+                if (bgImg) {
+                    this.replaceImageInCanvasElement(
+                        bloomCanvas,
+                        bgCanvasElement,
+                        bgImg,
+                        imageInfo,
+                    );
+                }
+            }
+            // Return either way: we must never add a canvas element to a page that can't hold one.
+            return;
         }
 
         // Otherwise we will add a new canvas element...but only if subscription allows it.

--- a/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementManager.ts
+++ b/src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementManager.ts
@@ -2625,24 +2625,15 @@ export class CanvasElementManager {
         return bloomCanvases.length > 0 ? bloomCanvases[0] : null;
     }
 
-    // This is called when the user pastes an image from the clipboard.
-    // If there is an active canvas element that is an image, and it is empty (placeholder),
-    // set its image to the pasted image.
-    // Otherwise, if there is a bloom canvas on the page, it will pick the one that has the active element
-    // or the first one if none has an active element.
-    // (If there is no canvas, it returns false.)
-    // If the canvas holds nothing but a background that is still a placeholder, set that
-    // background to the image. (A background that already holds a real image is left alone;
-    // select it first if you want to replace it.)
-    // Else if canvas is allowed by the subscription tier, add the image as a canvas/game item.
-    // Make it up to 1/3 width and 1/3 height of the canvas, roughly centered on the canvas.
-    // Is it a draggable item? Yes, if we are in the "Start" mode of a game.
-    // In that case, we put it a bit higher and further left, so there is room for the target.
-    // Otherwise it's just a normal canvas overlay item (restricted to the appropriate state,
-    // if we're in the Correct or Wrong state of a game).
+    // This is called when the user pastes an image from the clipboard. See
+    // CanvasElementClipboard.pasteImageFromClipboard() for the rules about where the pasted image
+    // lands; keeping them documented in only that one place stops the two copies from drifting.
+    // Returns false if there is no bloom canvas on the page to paste into.
     public pasteImageFromClipboard(): boolean {
         return this.clipboard.pasteImageFromClipboard();
     }
+    // Called (indirectly) by C# once it has put the clipboard image in a file and knows its
+    // metadata; this is where the paste actually changes the page.
     public finishPasteImageFromClipboard(imageInfo: IImageInfo): void {
         this.clipboard.finishPasteImageFromClipboard(imageInfo);
     }

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlAvailabilityRules.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlAvailabilityRules.ts
@@ -13,6 +13,7 @@
 //
 // Keep rule objects behavior-focused and side-effect free.
 import { AvailabilityRulesMap } from "./canvasControlTypes";
+import { pageAllowsCanvasElements } from "./canvasElementDomUtils";
 
 export const imageAvailabilityRules: AvailabilityRulesMap = {
     chooseImage: {
@@ -62,19 +63,12 @@ export const imageAvailabilityRules: AvailabilityRulesMap = {
             ctx.isCustomPage && ctx.hasImage && !ctx.isNavigationButton,
     },
     becomeBackground: {
-        visible: (ctx) => {
-            const isXmatterPage =
-                !!ctx.page?.classList.contains("bloom-frontMatter") ||
-                !!ctx.page?.classList.contains("bloom-backMatter");
-            const pageAllowsCanvasElements = !isXmatterPage || ctx.isCustomPage;
-            return (
-                ctx.hasImage &&
-                ctx.hasRealImage &&
-                !ctx.isNavigationButton &&
-                !ctx.isBackgroundImage &&
-                pageAllowsCanvasElements
-            );
-        },
+        visible: (ctx) =>
+            ctx.hasImage &&
+            ctx.hasRealImage &&
+            !ctx.isNavigationButton &&
+            !ctx.isBackgroundImage &&
+            pageAllowsCanvasElements(ctx.page),
     },
     imageBackground: {
         visible: (ctx) => ctx.hasImage,

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasElementDomUtils.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasElementDomUtils.ts
@@ -7,6 +7,21 @@ import {
     kHasCanvasElementClass,
 } from "./canvasElementConstants";
 
+// An xmatter page allows canvas elements only when the user has switched it to custom layout;
+// in standard layout it has no way to hold one. Ordinary content pages always allow them.
+// (A missing page counts as allowing them, since only xmatter pages restrict this.)
+export const pageAllowsCanvasElements = (
+    page: Element | null | undefined,
+): boolean => {
+    if (!page) {
+        return true;
+    }
+    const isXmatterPage =
+        page.classList.contains("bloom-frontMatter") ||
+        page.classList.contains("bloom-backMatter");
+    return !isXmatterPage || page.classList.contains("bloom-customLayout");
+};
+
 // For use by bloomImages.ts and other code that needs to keep the bloom canvas class
 // in sync with whether it currently contains any canvas elements.
 export const updateCanvasElementClass = (bloomCanvas: HTMLElement) => {


### PR DESCRIPTION
On a **Standard Layout** front cover, Ctrl+V and the top-bar **Paste** button added the clipboard
image as a *new canvas element on top of* the cover picture. Such a page cannot hold canvas
elements at all, so a paste there can only sensibly mean "replace this page's picture".

`finishPasteImageFromClipboard()` gets a third rule, after "a selected image is replaced" and
before "add a new canvas element": if the page cannot hold canvas elements — a standard-layout
xmatter page — replace its background image, even when that image is real rather than a
placeholder and nothing is selected, and never add an element. It goes through the existing
`replaceImageInCanvasElement()` helper, so the copyright/metadata button is rebuilt as it is
elsewhere (BL-16605). It is deliberately not gated on the canvas subscription feature: replacing a
cover picture is not the overlay feature.

Interior pages and custom-layout covers are unchanged — they still add an overlay, which is why
this card's earlier "nothing selected replaces the picture" rule had to be reversed for them. The
missing distinction was the page, not the selection.

The "does this page allow canvas elements?" test (an xmatter page allows them only in custom
layout) was written inline in the `becomeBackground` availability rule; it is now a shared
`pageAllowsCanvasElements()` in `canvasElementDomUtils.ts` that both callers use.

### Verified in the running app (not just unit tests)

On a Standard Layout front cover of a real book, with a real cover picture and nothing selected:

- toolbar **Paste** → cover picture replaced, canvas-element count stayed at 1, metadata button
  rebuilt;
- **Ctrl+V** → same;
- an **interior page** with a real background image and nothing selected → still adds an overlay
  (1 → 2 canvas elements, background untouched).

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16542


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8234)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8234)
<!-- Reviewable:end -->
