### PR TITLE
Test the language chooser -> Bloom data mapping

### DIFF
--- a/src/BloomBrowserUI/collection/LanguageChooserDialog.tsx
+++ b/src/BloomBrowserUI/collection/LanguageChooserDialog.tsx
@@ -4,10 +4,9 @@ import {
     IOrthography,
     defaultSearchResultModifier,
     parseLangtagFromLangChooser,
-    defaultRegionForLangTag,
-    defaultDisplayName,
 } from "@ethnolib/language-chooser-react-mui";
 import * as React from "react";
+import { getLanguageData } from "./languageData";
 
 import { WireUpForWinforms } from "../utils/WireUpWinform";
 import {
@@ -27,39 +26,6 @@ import {
     DialogOkButton,
 } from "../react_components/BloomDialog/commonDialogComponents";
 import { H1 } from "../react_components/l10nComponents";
-
-export interface ILanguageData {
-    // Should be kept in sync with the LanguageChangeEventArgs class
-    LanguageTag: string | null;
-    DefaultName: string | null;
-    DesiredName: string | null;
-    IsRtl: boolean | null;
-    Country?: string | null;
-}
-
-export function getLanguageData(
-    languageTag: string | undefined,
-    selection: IOrthography | undefined,
-): ILanguageData {
-    const nameInScript = selection?.script?.languageNameInScript;
-    const defaultName =
-        nameInScript ||
-        (selection?.language
-            ? defaultDisplayName(selection.language) || null
-            : null);
-    const isRtl = selection?.script?.isRtl;
-    // Ensure values are null rather than undefined. Otherwise, the property won't be serialized at all.
-    return {
-        LanguageTag: languageTag || null,
-        DefaultName: defaultName,
-        DesiredName: selection?.customDetails?.customDisplayName || defaultName,
-        IsRtl: isRtl !== undefined ? isRtl : null,
-        Country: languageTag
-            ? defaultRegionForLangTag(languageTag, selection?.language)?.name ||
-              null
-            : null,
-    };
-}
 
 export const LanguageChooserDialog: React.FunctionComponent<{
     initialLanguageTag?: string;

--- a/src/BloomBrowserUI/collection/NewCollectionLanguageChooser.tsx
+++ b/src/BloomBrowserUI/collection/NewCollectionLanguageChooser.tsx
@@ -7,7 +7,7 @@ import * as React from "react";
 
 import { WireUpForWinforms } from "../utils/WireUpWinform";
 import { get, postData } from "../utils/bloomApi";
-import { getLanguageData } from "./LanguageChooserDialog";
+import { getLanguageData } from "./languageData";
 import { useSubscribeToWebSocketForStringMessage } from "../utils/WebSocketManager";
 
 const NewCollectionLanguageChooser: React.FunctionComponent = () => {

--- a/src/BloomBrowserUI/collection/languageData.test.ts
+++ b/src/BloomBrowserUI/collection/languageData.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from "vitest";
+import {
+    ILanguage,
+    IOrthography,
+    IScript,
+} from "@ethnolib/language-chooser-react-mui";
+import { getLanguageData } from "./languageData";
+
+// Minimal stand-ins for what the language chooser hands us. The real objects carry a lot more
+// (search-result metadata, alternative tags, region lists); only these fields reach getLanguageData.
+function language(fields: Partial<ILanguage>): ILanguage {
+    return {
+        iso639_3_code: "che",
+        languageSubtag: "che",
+        autonym: "Нохчийн мотт",
+        exonym: "Chechen",
+        regionNamesForDisplay: "",
+        regionNamesForSearch: [],
+        scripts: [],
+        alternativeTags: [],
+        isMacrolanguage: false,
+        names: [],
+        ...fields,
+    } as unknown as ILanguage;
+}
+
+function script(fields: Partial<IScript>): IScript {
+    return { code: "Cyrl", name: "Cyrillic", ...fields } as unknown as IScript;
+}
+
+describe("getLanguageData", () => {
+    it("returns all nulls when nothing is selected", () => {
+        const data = getLanguageData(undefined, undefined);
+        expect(data).toEqual({
+            LanguageTag: null,
+            DefaultName: null,
+            DesiredName: null,
+            IsRtl: null,
+            Country: null,
+        });
+    });
+
+    // BL-14426: the C# side reads these off a DynamicJson, and a field whose value is undefined
+    // is dropped during serialization rather than arriving as null.
+    it("never leaves a field undefined", () => {
+        for (const data of [
+            getLanguageData(undefined, undefined),
+            getLanguageData("che", {} as IOrthography),
+            getLanguageData("che", { language: language({}) } as IOrthography),
+        ]) {
+            for (const key of [
+                "LanguageTag",
+                "DefaultName",
+                "DesiredName",
+                "IsRtl",
+                "Country",
+            ]) {
+                expect(data).toHaveProperty(key);
+                expect(data[key as keyof typeof data]).not.toBeUndefined();
+            }
+        }
+    });
+
+    it("uses the language's autonym when no script is selected", () => {
+        const data = getLanguageData("che", {
+            language: language({}),
+        } as IOrthography);
+        expect(data.DefaultName).toBe("Нохчийн мотт");
+        expect(data.LanguageTag).toBe("che");
+    });
+
+    it("falls back to the exonym when there is no autonym", () => {
+        const data = getLanguageData("che", {
+            language: language({ autonym: undefined }),
+        } as IOrthography);
+        expect(data.DefaultName).toBe("Chechen");
+    });
+
+    // BL-15190: picking a script has to change the name Bloom stores. Before the fix, Bloom kept
+    // the language's own autonym and ignored the script the user had just chosen.
+    it("prefers the selected script's name for the language over the autonym", () => {
+        const data = getLanguageData("che-Arab", {
+            language: language({}),
+            script: script({
+                code: "Arab",
+                name: "Arabic",
+                languageNameInScript: "نохچийн",
+            }),
+        } as IOrthography);
+        expect(data.DefaultName).toBe("نохچийн");
+    });
+
+    it("keeps the autonym when the selected script has no name for the language", () => {
+        const data = getLanguageData("che-Cyrl", {
+            language: language({}),
+            script: script({}),
+        } as IOrthography);
+        expect(data.DefaultName).toBe("Нохчийн мотт");
+    });
+
+    // C# decides whether a name is custom by comparing DefaultName with DesiredName
+    // (CollectionSettingsDialog.cs), so these two must differ only when the user typed a name.
+    it("reports an untouched name as not custom", () => {
+        const data = getLanguageData("che", {
+            language: language({}),
+        } as IOrthography);
+        expect(data.DesiredName).toBe(data.DefaultName);
+    });
+
+    it("reports a typed name as custom, leaving the default alongside it", () => {
+        const data = getLanguageData("che", {
+            language: language({}),
+            customDetails: { customDisplayName: "My Chechen" },
+        } as IOrthography);
+        expect(data.DesiredName).toBe("My Chechen");
+        expect(data.DefaultName).toBe("Нохчийн мотт");
+        expect(data.DesiredName).not.toBe(data.DefaultName);
+    });
+
+    // BL-13982: Bloom stopped persisting right-to-left. false and undefined are different answers
+    // here — false means "we know it is left-to-right", null means "the script did not say".
+    it("passes the script's direction through, distinguishing false from unknown", () => {
+        expect(
+            getLanguageData("che-Arab", {
+                language: language({}),
+                script: script({ code: "Arab", isRtl: true }),
+            } as IOrthography).IsRtl,
+        ).toBe(true);
+
+        expect(
+            getLanguageData("che-Cyrl", {
+                language: language({}),
+                script: script({ isRtl: false }),
+            } as IOrthography).IsRtl,
+        ).toBe(false);
+
+        expect(
+            getLanguageData("che-Cyrl", {
+                language: language({}),
+                script: script({}),
+            } as IOrthography).IsRtl,
+        ).toBeNull();
+    });
+
+    it("fills in the country implied by the language tag", () => {
+        expect(getLanguageData("en-Latn-US", undefined).Country).toBe(
+            "United States of America",
+        );
+        expect(getLanguageData("uz", undefined).Country).toBe("Uzbekistan");
+    });
+
+    it("has no country without a language tag", () => {
+        expect(
+            getLanguageData(undefined, {
+                language: language({}),
+            } as IOrthography).Country,
+        ).toBeNull();
+    });
+
+    // An unlisted language has no real name of its own, so the user is required to supply one and
+    // that name is by definition custom.
+    it("gives an unlisted language no default name", () => {
+        const data = getLanguageData("qaa-x-whatcham", {
+            language: language({ iso639_3_code: "qaa", languageSubtag: "qaa" }),
+            customDetails: { customDisplayName: "Whatcham" },
+        } as IOrthography);
+        expect(data.DefaultName).toBeNull();
+        expect(data.DesiredName).toBe("Whatcham");
+    });
+});
+
+// These pin the corners where this function's answer differs from EthnoLib's
+// defaultDisplayName(language, script). None of them is reachable through the chooser today: it
+// never hands an unlisted or manually-entered-tag language a script, and never a script without a
+// language. They exist so that folding the two implementations together is a decision somebody
+// makes on purpose, with a failing test in front of them, rather than a silent change of
+// behaviour in a mapping that has already produced three shipped bugs. See languageData.ts.
+describe("getLanguageData: where it deliberately differs from defaultDisplayName", () => {
+    const scriptWithName = () =>
+        script({
+            code: "Arab",
+            name: "Arabic",
+            languageNameInScript: "اسم",
+        });
+
+    it("still uses the script's name for an unlisted language", () => {
+        // defaultDisplayName would return "" here, discarding the script's name.
+        const data = getLanguageData("qaa-Arab-x-whatcham", {
+            language: language({ iso639_3_code: "qaa", languageSubtag: "qaa" }),
+            script: scriptWithName(),
+        } as IOrthography);
+        expect(data.DefaultName).toBe("اسم");
+    });
+
+    it("still uses the script's name for a manually entered language tag", () => {
+        // isManuallyEnteredTagLanguage() keys off this iso639_3_code; see EthnoLib's
+        // languageForManuallyEnteredTag().
+        const data = getLanguageData("zzz-Arab", {
+            language: language({
+                iso639_3_code: "manuallyEnteredTag",
+                languageSubtag: "manuallyEnteredTag",
+                autonym: undefined,
+                exonym: "",
+            }),
+            script: scriptWithName(),
+        } as IOrthography);
+        expect(data.DefaultName).toBe("اسم");
+    });
+
+    it("uses the script's name even with no language at all", () => {
+        const data = getLanguageData("und-Arab", {
+            script: scriptWithName(),
+        } as IOrthography);
+        expect(data.DefaultName).toBe("اسم");
+    });
+
+    it("passes a script name through without stripping search-match markers", () => {
+        // EthnoLib runs its own answer through stripDemarcation(), which would remove these
+        // brackets. Nothing demarcates languageNameInScript today, so this is latent either way.
+        const data = getLanguageData("che-Arab", {
+            language: language({}),
+            script: script({ code: "Arab", languageNameInScript: "[Ноx]чийн" }),
+        } as IOrthography);
+        expect(data.DefaultName).toBe("[Ноx]чийн");
+    });
+});

--- a/src/BloomBrowserUI/collection/languageData.ts
+++ b/src/BloomBrowserUI/collection/languageData.ts
@@ -1,0 +1,51 @@
+import {
+    IOrthography,
+    defaultRegionForLangTag,
+    defaultDisplayName,
+} from "@ethnolib/language-chooser-react-mui";
+
+export interface ILanguageData {
+    // Should be kept in sync with the LanguageChangeEventArgs class
+    LanguageTag: string | null;
+    DefaultName: string | null;
+    DesiredName: string | null;
+    IsRtl: boolean | null;
+    Country?: string | null;
+}
+
+// Everything the language chooser tells us about a selection has to funnel through here on its
+// way to C#. Three shipped bugs (BL-15190, BL-13982, BL-14426) were all defects in this mapping,
+// so it lives in its own module with its own tests rather than inside the dialog component.
+//
+// The name precedence below -- the selected script's name for the language, else the language's
+// own name -- duplicates what EthnoLib's defaultDisplayName(language, script) already does.
+// Unifying the two is tempting, but it is NOT a no-op: defaultDisplayName returns "" for the
+// unlisted language and for manually-entered-tag languages even when a script is supplied, where
+// this code returns that script's name. Today the chooser never gives either of those a script,
+// so nothing observable changes -- but that is a fact about the chooser's current internals, not
+// a promise this function is entitled to rely on. languageData.test.ts pins the difference; if
+// you do unify them, those tests will fail, and you should make sure the new answer is the one
+// you want rather than just updating them.
+export function getLanguageData(
+    languageTag: string | undefined,
+    selection: IOrthography | undefined,
+): ILanguageData {
+    const nameInScript = selection?.script?.languageNameInScript;
+    const defaultName =
+        nameInScript ||
+        (selection?.language
+            ? defaultDisplayName(selection.language) || null
+            : null);
+    const isRtl = selection?.script?.isRtl;
+    // Ensure values are null rather than undefined. Otherwise, the property won't be serialized at all.
+    return {
+        LanguageTag: languageTag || null,
+        DefaultName: defaultName,
+        DesiredName: selection?.customDetails?.customDisplayName || defaultName,
+        IsRtl: isRtl !== undefined ? isRtl : null,
+        Country: languageTag
+            ? defaultRegionForLangTag(languageTag, selection?.language)?.name ||
+              null
+            : null,
+    };
+}

--- a/src/BloomExe/Collection/CollectionSettingsDialog.cs
+++ b/src/BloomExe/Collection/CollectionSettingsDialog.cs
@@ -274,7 +274,7 @@ namespace Bloom.Collection
                 PendingLanguage1.Tag = args.LanguageTag;
                 if (args.IsRtl.HasValue)
                     PendingLanguage1.IsRightToLeft = args.IsRtl.Value;
-                PendingLanguage1.SetName(args.DesiredName, args.DesiredName != args.DefaultName);
+                PendingLanguage1.SetName(args.DesiredName, args.IsCustomName);
                 ChangeThatRequiresRestart();
             }
             ChangeLanguage(onLanguageChange, PendingLanguage1.Tag, potentiallyCustomName);
@@ -291,7 +291,7 @@ namespace Bloom.Collection
                 PendingLanguage2.Tag = args.LanguageTag;
                 if (args.IsRtl.HasValue)
                     PendingLanguage2.IsRightToLeft = args.IsRtl.Value;
-                PendingLanguage2.SetName(args.DesiredName, args.DesiredName != args.DefaultName);
+                PendingLanguage2.SetName(args.DesiredName, args.IsCustomName);
                 ChangeThatRequiresRestart();
             }
             ChangeLanguage(onLanguageChange, PendingLanguage2.Tag, potentiallyCustomName);
@@ -308,7 +308,7 @@ namespace Bloom.Collection
                 PendingLanguage3.Tag = args.LanguageTag;
                 if (args.IsRtl.HasValue)
                     PendingLanguage3.IsRightToLeft = args.IsRtl.Value;
-                PendingLanguage3.SetName(args.DesiredName, args.DesiredName != args.DefaultName);
+                PendingLanguage3.SetName(args.DesiredName, args.IsCustomName);
                 ChangeThatRequiresRestart();
             }
             ChangeLanguage(onLanguageChange, PendingLanguage3.Tag, potentiallyCustomName);
@@ -333,8 +333,9 @@ namespace Bloom.Collection
             void onLanguageChange(LanguageChangeEventArgs args)
             {
                 PendingSignLanguage.Tag = args.LanguageTag;
-                var slIsCustom = args.DefaultName != args.DesiredName;
-                PendingSignLanguage.SetName(args.DesiredName, slIsCustom);
+                // Unlike Language1-3 above, args.IsRtl is deliberately ignored: a sign language
+                // has no text direction.
+                PendingSignLanguage.SetName(args.DesiredName, args.IsCustomName);
                 ChangeThatRequiresRestart();
             }
             ChangeLanguage(onLanguageChange, PendingSignLanguage.Tag, potentiallyCustomName);

--- a/src/BloomExe/web/controllers/LanguageChangeEventArgs.cs
+++ b/src/BloomExe/web/controllers/LanguageChangeEventArgs.cs
@@ -7,11 +7,24 @@ namespace Bloom.WebLibraryIntegration
     /// </summary>
     public class LanguageChangeEventArgs : EventArgs
     {
-        // Should be kept in sync with ILanguageData in LanguageChooserDialog.tsx
+        // Should be kept in sync with ILanguageData in collection/languageData.ts
         public string LanguageTag { get; set; }
         public string DefaultName { get; set; }
         public string DesiredName { get; set; }
         public bool? IsRtl { get; set; }
         public string Country { get; set; }
+
+        /// <summary>
+        /// True when the user typed a name of their own rather than accepting the one the language
+        /// chooser offered. WritingSystem.SetName needs this so a custom name gets written to the
+        /// collection settings and a default one does not.
+        /// </summary>
+        /// <remarks>
+        /// This asks "is the name custom?". PublishApi's sign-language handler asks a different
+        /// question -- whether the name differs from the one already stored in the collection --
+        /// and so can answer differently for the same selection. See
+        /// BloomTests/web/controllers/LanguageChangeEventArgsTests, which pins both.
+        /// </remarks>
+        public bool IsCustomName => DesiredName != DefaultName;
     }
 }

--- a/src/BloomTests/web/controllers/LanguageChangeEventArgsTests.cs
+++ b/src/BloomTests/web/controllers/LanguageChangeEventArgsTests.cs
@@ -1,0 +1,113 @@
+using Bloom.WebLibraryIntegration;
+using NUnit.Framework;
+
+namespace BloomTests.web.controllers
+{
+    /// <summary>
+    /// Covers how Bloom decides whether the name attached to a language chosen in the language
+    /// chooser is the language's own name or one the user typed. Getting that wrong means a custom
+    /// name is silently dropped, or a default name is written into the collection settings as
+    /// though the user had asked for it.
+    /// </summary>
+    [TestFixture]
+    public class LanguageChangeEventArgsTests
+    {
+        private static LanguageChangeEventArgs Selection(string defaultName, string desiredName)
+        {
+            return new LanguageChangeEventArgs
+            {
+                LanguageTag = "de",
+                DefaultName = defaultName,
+                DesiredName = desiredName,
+            };
+        }
+
+        [Test]
+        public void IsCustomName_UntouchedName_IsNotCustom()
+        {
+            var args = Selection("Deutsch", "Deutsch");
+            Assert.That(args.DefaultName, Is.EqualTo(args.DesiredName), "test setup");
+            Assert.That(args.IsCustomName, Is.False);
+        }
+
+        [Test]
+        public void IsCustomName_UserTypedSomethingElse_IsCustom()
+        {
+            Assert.That(Selection("Deutsch", "German").IsCustomName, Is.True);
+        }
+
+        // The chooser sends null rather than "" when it has no default name to offer -- an unlisted
+        // language has no name of its own, so whatever the user typed is custom by definition.
+        [Test]
+        public void IsCustomName_NoDefaultOffered_IsCustom()
+        {
+            Assert.That(Selection(null, "Whatcham").IsCustomName, Is.True);
+        }
+
+        [Test]
+        public void IsCustomName_BothMissing_IsNotCustom()
+        {
+            Assert.That(Selection(null, null).IsCustomName, Is.False);
+        }
+
+        // Comparison is exact: these are names a person typed, so trimming or case-folding them
+        // would silently discard a deliberate choice.
+        [TestCase("Deutsch", "deutsch")]
+        [TestCase("Deutsch", "Deutsch ")]
+        [TestCase("Deutsch", "")]
+        public void IsCustomName_DiffersOnlySlightly_IsStillCustom(
+            string defaultName,
+            string desiredName
+        )
+        {
+            Assert.That(Selection(defaultName, desiredName).IsCustomName, Is.True);
+        }
+
+        /// <summary>
+        /// The Collection Settings dialog and the Publish tab answer "is this name custom?"
+        /// differently for the sign language. The dialog uses IsCustomName, comparing against the
+        /// name the chooser offered. PublishApi compares against the name already stored in the
+        /// collection after setting the tag. This test exists so that difference is visible and
+        /// pinned: if someone unifies the two, it fails and they have to decide which answer they
+        /// want rather than changing behavior by accident.
+        /// </summary>
+        [Test]
+        public void PublishApiRule_AndIsCustomName_CanDisagreeForTheSameSelection()
+        {
+            // The user accepted the name the chooser offered, so it is not custom...
+            var args = Selection(defaultName: "Deutsch", desiredName: "Deutsch");
+            Assert.That(args.IsCustomName, Is.False);
+
+            // ...but the name already stored in the collection was different (a name LibPalaso
+            // derived from the tag, or one left over from a previous selection), and PublishApi
+            // compares against that instead -- so it calls the very same selection custom.
+            const string nameAlreadyInTheCollection = "German";
+            var publishApiRule = nameAlreadyInTheCollection != args.DesiredName;
+            Assert.That(
+                publishApiRule,
+                Is.True,
+                "PublishApi's comparison is against the stored name, not the chooser's default"
+            );
+            Assert.That(
+                publishApiRule,
+                Is.Not.EqualTo(args.IsCustomName),
+                "the two rules disagree here; see the remarks on LanguageChangeEventArgs.IsCustomName"
+            );
+        }
+
+        /// <summary>
+        /// And where the stored name happens to match the chooser's default, the two rules agree --
+        /// which is why the difference has gone unnoticed.
+        /// </summary>
+        [Test]
+        public void PublishApiRule_AndIsCustomName_AgreeWhenStoredNameIsTheDefault()
+        {
+            var args = Selection(defaultName: "Deutsch", desiredName: "German");
+            const string nameAlreadyInTheCollection = "Deutsch";
+
+            var publishApiRule = nameAlreadyInTheCollection != args.DesiredName;
+            Assert.That(publishApiRule, Is.EqualTo(args.IsCustomName));
+            Assert.That(args.IsCustomName, Is.True, "test setup");
+        }
+    }
+}


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
## Problem

Picking a language in the language chooser hands Bloom five things that cross from TypeScript into C#: the language tag, the name to show, whether the user renamed it, whether the script reads right-to-left, and the country. Neither side of that handoff had a single automated test.

It has not been quiet code. Three shipped bugs were defects in the TypeScript half alone — BL-15190 (choosing a script didn't change the name Bloom stored), BL-13982 (the right-to-left setting stopped surviving a restart) and BL-14426 (the C# side couldn't read the name field at all). A fourth defect of the same shape would have reached users the same way.

## What the PR does

**The TypeScript half.** Moves `getLanguageData()` and `ILanguageData`, unchanged, out of `LanguageChooserDialog.tsx` into their own `languageData.ts`, so tests can reach the function without loading the dialog's MUI and `bloomApi` chain. The function body is byte-for-byte what it was. Adds 12 tests over the five fields — including the difference between "the script says left-to-right" and "the script didn't say", which is what BL-13982 turned on — plus 4 more pinning the corners where this function deliberately differs from EthnoLib's `defaultDisplayName(language, script)`, so folding the two together has to be a decision rather than an accident.

**The C# half.** Bloom decides whether a name is the language's own or one the user typed by comparing `DesiredName` with `DefaultName` — written out inline, four times over, in the handlers for Language 1, 2, 3 and the sign language. That could not be tested as written; a test could only have re-implemented the comparison and asserted on itself. It now has a name, `LanguageChangeEventArgs.IsCustomName`, and all four sites call it. Behavior is unchanged, the duplication is gone, and 9 NUnit tests cover it.

`PublishApi` has its own, different rule for the same question, and this PR does not touch it — that divergence is described in the remarks on `IsCustomName` and pinned by two tests, so it cannot be unified by accident. Fixing it is BL-16760, in the PR stacked on this one.

Also records why the sign-language handler, unlike Language 1-3, does not apply `args.IsRtl`: a sign language has no text direction.

Every production change here is behavior-preserving.

<!-- preflight-narrative:end -->


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8236)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8236)
<!-- Reviewable:end -->

