### PR TITLE
Fix Team Collection status dialog blanking the whole window (BL-16757)

### DIFF
--- a/src/BloomBrowserUI/react_components/bloomAvatar.tsx
+++ b/src/BloomBrowserUI/react_components/bloomAvatar.tsx
@@ -5,7 +5,9 @@ import Avatar, { Cache, ConfigProvider } from "react-avatar";
 import { getMd5 } from "../bookEdit/toolbox/talkingBook/md5Util";
 
 export const BloomAvatar: React.FunctionComponent<{
-    email: string;
+    // Nullable on purpose: some callers get this from data that genuinely has no user
+    // recorded, such as a book history event written by an older Bloom (BL-16757).
+    email: string | null | undefined;
     name: string;
     borderColor?: string;
     avatarSizeInt?: number;

--- a/src/BloomBrowserUI/react_components/bloomAvatar.tsx
+++ b/src/BloomBrowserUI/react_components/bloomAvatar.tsx
@@ -45,7 +45,11 @@ export const BloomAvatar: React.FunctionComponent<{
             >
                 <ConfigProvider cache={cache}>
                     <Avatar
-                        md5Email={getMd5(props.email)}
+                        // A history event written by an older Bloom can have a null userid
+                        // (BL-16757), and getMd5 throws on null. No email means there is no
+                        // gravatar to look up, so react-avatar falls back to the initials
+                        // generated from `name`.
+                        md5Email={props.email ? getMd5(props.email) : undefined}
                         name={props.name}
                         size={avatarSize}
                         maxInitials={3}

--- a/src/BloomBrowserUI/teamCollection/CollectionHistoryTable.tsx
+++ b/src/BloomBrowserUI/teamCollection/CollectionHistoryTable.tsx
@@ -12,7 +12,10 @@ interface IBookHistoryEvent {
     When: string;
     Message: string;
     Type: number;
-    UserId: string;
+    // The server's userid column is nullable, and older Blooms did leave it null, so this
+    // has to admit null or we are back to the crash in BL-16757: declaring it a plain string
+    // is what let a null through typechecking and into a render in the first place.
+    UserId: string | null;
     UserName: string;
 }
 

--- a/src/BloomBrowserUI/teamCollection/CollectionHistoryTable.tsx
+++ b/src/BloomBrowserUI/teamCollection/CollectionHistoryTable.tsx
@@ -15,6 +15,9 @@ interface IBookHistoryEvent {
     // The server's userid column is nullable, and older Blooms did leave it null, so this
     // has to admit null or we are back to the crash in BL-16757: declaring it a plain string
     // is what let a null through typechecking and into a render in the first place.
+    // `null` rather than the `undefined` this project usually prefers (see AGENTS.md), because
+    // this interface describes JSON we don't control: the field arrives as a literal `null`, so
+    // saying `undefined` would be untrue and would invite an `=== undefined` test that never fires.
     UserId: string | null;
     UserName: string;
 }


### PR DESCRIPTION
Clicking the **Team Collection** button blanked the entire Bloom window — nothing in the outer
window, no recourse but to quit — for collections whose history contains an event with a null
`userid`. Reported against `~/Documents/Bloom/Bunong Bible Materials`; 6.5 was already immune.

### Why it blanked the whole window rather than just the dialog

The Team Collection dialog is not its own window: `TeamCollectionDialogLauncher` is mounted inside
the main app's single React root (`CollectionsTabPane.tsx:694`), and `ErrorBoundary.tsx` is
imported nowhere, so any throw during the dialog's render unmounts the whole tree — top bar, book
list and all.

### The throw

The dialog opens on the History tab, whose `CollectionHistoryTable` renders
`<BloomAvatar email={e.UserId}>` per row. `HistoryEvent.UserId` is a nullable SQLite column
(`[Column("userid")]`), and older Bloom versions did leave it null. `HandleGetHistory` uses plain
`JsonConvert.SerializeObject` with no `NullValueHandling.Ignore`, so those rows arrive as
`"UserId":null`, and `BloomAvatar` passed that straight into `getMd5`, whose first statement is
`message.length` — `TypeError`, blank window.

The collection that prompted this has 88 history events across 12 `history.db` files, three of
which have a NULL `userid` (two written by 6.0.2, one by 5.6.7). Any one of them is enough.

### The fix

Guard the email before hashing it. Guarding inside `BloomAvatar` rather than at the one bad call
site covers every present and future caller, and matches where master's equivalent guard lives:
BL-16514 rewrote this component to fetch avatars from Bloom's own server behind
`props.email ? ... : undefined`, which is why 6.5 does not have the bug. That commit is a
~1500-line login/avatar feature depending on server endpoints 6.4 does not have (`AccountApi`,
`AvatarApi`, `AvatarCache`), so this writes the guard by hand instead of backporting it.

An undefined `md5Email` is what react-avatar already expects for "no gravatar to look up":
`GravatarSource.isCompatible` is `!!email || !!md5Email`, so the gravatar source is skipped and
the fallback chain proceeds — generated initials from `name`, or the placeholder glyph when the
name is empty too (which is the case for these rows). For call sites that pass `""`, the only
change is that we no longer fire a request for `md5("")` that always 404s.

### Testing

- Manually verified with the reporting collection: the dialog now opens on the History tab and
  lists all 88 events, including the three legacy rows, with the rest of the window intact.
- `yarn lint` clean (0 errors). Full front-end suite green: 532 passed, 5 skipped.
- No C# suite run — the diff is one `.tsx` file that no C# test reads or builds.

### Not fixed here (deliberately)

`ErrorBoundary.tsx` exists and is used nowhere, on this branch and on master. That is what turned
one null into "quit the program". Master shares the weakness — `0b405085a` (BL-16209) was the same
failure mode from a different trigger. Worth its own card rather than widening a stable-branch fix.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16757


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8237)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8237)
<!-- Reviewable:end -->
