### PR TITLE
Ask the language chooser, not LibPalaso, whether a sign language name is custom (BL-16760)

### DIFF
--- a/src/BloomExe/web/controllers/LanguageChangeEventArgs.cs
+++ b/src/BloomExe/web/controllers/LanguageChangeEventArgs.cs
@@ -20,10 +20,11 @@ namespace Bloom.WebLibraryIntegration
         /// collection settings and a default one does not.
         /// </summary>
         /// <remarks>
-        /// This asks "is the name custom?". PublishApi's sign-language handler asks a different
-        /// question -- whether the name differs from the one already stored in the collection --
-        /// and so can answer differently for the same selection. See
-        /// BloomTests/web/controllers/LanguageChangeEventArgsTests, which pins both.
+        /// This is the only rule any caller should use. It compares the two names the chooser
+        /// itself sent, so it answers the question the user actually decided. Deriving a "default"
+        /// name some other way -- e.g. reading WritingSystem.Name back after setting its Tag, which
+        /// PublishApi's sign-language handler used to do (BL-16760) -- asks LibPalaso instead, and
+        /// LibPalaso and the chooser do not always agree on a language's name.
         /// </remarks>
         public bool IsCustomName => DesiredName != DefaultName;
     }

--- a/src/BloomExe/web/controllers/PublishApi.cs
+++ b/src/BloomExe/web/controllers/PublishApi.cs
@@ -470,13 +470,10 @@ namespace Bloom.web.controllers
             var collectionSettings = Model.Book.CollectionSettings;
             void onLanguageChange(LanguageChangeEventArgs args)
             {
-                // How to know if the new sign language name is custom or not!?
-                // 1- set the Tag (which also sets the Name to the non-custom default
-                // 2- read the Name
-                // 3- if it's not the same as DesiredName, the new name is custom
+                // As in the Collection Settings dialog's sign-language handler, args.IsRtl is
+                // deliberately ignored: a sign language has no text direction.
                 collectionSettings.SignLanguageTag = args.LanguageTag;
-                var slIsCustom = collectionSettings.SignLanguage.Name != args.DesiredName;
-                collectionSettings.SignLanguage.SetName(args.DesiredName, slIsCustom);
+                collectionSettings.SignLanguage.SetName(args.DesiredName, args.IsCustomName);
                 collectionSettings.Save();
                 Model.UpdateLangDataCache();
 

--- a/src/BloomTests/web/controllers/LanguageChangeEventArgsTests.cs
+++ b/src/BloomTests/web/controllers/LanguageChangeEventArgsTests.cs
@@ -64,50 +64,61 @@ namespace BloomTests.web.controllers
         }
 
         /// <summary>
-        /// The Collection Settings dialog and the Publish tab answer "is this name custom?"
-        /// differently for the sign language. The dialog uses IsCustomName, comparing against the
-        /// name the chooser offered. PublishApi compares against the name already stored in the
-        /// collection after setting the tag. This test exists so that difference is visible and
-        /// pinned: if someone unifies the two, it fails and they have to decide which answer they
-        /// want rather than changing behavior by accident.
+        /// Both places that let you choose the collection's sign language -- the Collection
+        /// Settings dialog and the Publish tab -- must reach the same answer for the same
+        /// selection. They did not before BL-16760: the Publish tab set the writing system's Tag
+        /// first and compared DesiredName against the name LibPalaso derived from it, so for a
+        /// language the two naming systems disagree about (mzc: LibPalaso "Madagascar Sign
+        /// Language", the chooser "Malagasy Sign Language") it recorded an untouched name as
+        /// custom. Both now ask IsCustomName, which compares only the two names the chooser sent.
         /// </summary>
         [Test]
-        public void PublishApiRule_AndIsCustomName_CanDisagreeForTheSameSelection()
+        public void IsCustomName_UntouchedName_IsNotCustom_EvenWhenLibPalasoDisagreesAboutTheName()
         {
-            // The user accepted the name the chooser offered, so it is not custom...
-            var args = Selection(defaultName: "Deutsch", desiredName: "Deutsch");
-            Assert.That(args.IsCustomName, Is.False);
+            // What the chooser sends for mzc when the user accepts the name it offers. The front
+            // end sets DesiredName = customDisplayName || defaultName (see languageData.ts), so
+            // with nothing typed these are identical by construction.
+            var args = new LanguageChangeEventArgs
+            {
+                LanguageTag = "mzc",
+                DefaultName = "Malagasy Sign Language",
+                DesiredName = "Malagasy Sign Language",
+            };
+            Assert.That(args.DefaultName, Is.EqualTo(args.DesiredName), "test setup");
 
-            // ...but the name already stored in the collection was different (a name LibPalaso
-            // derived from the tag, or one left over from a previous selection), and PublishApi
-            // compares against that instead -- so it calls the very same selection custom.
-            const string nameAlreadyInTheCollection = "German";
-            var publishApiRule = nameAlreadyInTheCollection != args.DesiredName;
+            // The old Publish-tab rule, which is what a caller gets if it reads the name back out
+            // of the writing system after setting its Tag. Sanity check that it really does answer
+            // differently here -- otherwise this test would pass for the wrong reason.
+            const string nameLibPalasoDerivesFromTheTag = "Madagascar Sign Language";
+            var oldPublishApiRule = nameLibPalasoDerivesFromTheTag != args.DesiredName;
+            Assert.That(oldPublishApiRule, Is.True, "test setup: the two naming systems disagree");
+
             Assert.That(
-                publishApiRule,
-                Is.True,
-                "PublishApi's comparison is against the stored name, not the chooser's default"
-            );
-            Assert.That(
-                publishApiRule,
-                Is.Not.EqualTo(args.IsCustomName),
-                "the two rules disagree here; see the remarks on LanguageChangeEventArgs.IsCustomName"
+                args.IsCustomName,
+                Is.False,
+                "the user typed nothing, so the name is not custom"
             );
         }
 
         /// <summary>
-        /// And where the stored name happens to match the chooser's default, the two rules agree --
-        /// which is why the difference has gone unnoticed.
+        /// And the error ran the other way too: a name the user really did type was recorded as
+        /// not custom whenever it happened to match LibPalaso's name for the tag.
         /// </summary>
         [Test]
-        public void PublishApiRule_AndIsCustomName_AgreeWhenStoredNameIsTheDefault()
+        public void IsCustomName_TypedNameMatchingLibPalasos_IsStillCustom()
         {
-            var args = Selection(defaultName: "Deutsch", desiredName: "German");
-            const string nameAlreadyInTheCollection = "Deutsch";
+            var args = new LanguageChangeEventArgs
+            {
+                LanguageTag = "mzc",
+                DefaultName = "Malagasy Sign Language",
+                DesiredName = "Madagascar Sign Language", // typed by the user
+            };
 
-            var publishApiRule = nameAlreadyInTheCollection != args.DesiredName;
-            Assert.That(publishApiRule, Is.EqualTo(args.IsCustomName));
-            Assert.That(args.IsCustomName, Is.True, "test setup");
+            const string nameLibPalasoDerivesFromTheTag = "Madagascar Sign Language";
+            var oldPublishApiRule = nameLibPalasoDerivesFromTheTag != args.DesiredName;
+            Assert.That(oldPublishApiRule, Is.False, "test setup: the old rule missed this one");
+
+            Assert.That(args.IsCustomName, Is.True);
         }
     }
 }


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
## Problem

Choosing a sign language from the **Publish** tab can record the language's own name in the
collection settings as though the user had typed a custom name for it. Choosing the very same
language from **Collection Settings** records it correctly. `SignLanguageIsCustomName` is Bloom's
record of "the user deliberately gave this language this name, so never replace it with a
looked-up one", so setting it when nothing was typed is simply wrong data. The error also runs the
other way: a name the user really did type is recorded as *not* custom whenever it happens to
match LibPalaso's name for the tag.

## Cause

`PublishApi` decided the question by setting the writing system's `Tag` — whose setter derives
`Name` through LibPalaso — and then comparing that derived name against the chooser's
`DesiredName`. That predates the new language chooser: when the code was written
`LanguageChangeEventArgs` had no `DefaultName` to compare against, and `be892652b` carried the
workaround across verbatim. LibPalaso and the chooser do not always agree; for `mzc` LibPalaso
says "Madagascar Sign Language" and the chooser says "Malagasy Sign Language".

## Fix

- `PublishApi`'s sign-language handler now asks `args.IsCustomName`, which compares only the two
  names the chooser itself sent — the same rule all four Collection Settings sites already use.
- The `<remarks>` on `LanguageChangeEventArgs.IsCustomName` no longer describe the divergence as
  intentional; it now says this is the only rule a caller should use, and why.
- `LanguageChangeEventArgsTests` loses the test that deliberately pinned the divergence and gains
  two that pin the agreed answer in both directions, using the real `mzc` names.

Verified in a running Bloom: picking Malagasy Sign Language from the Publish tab now writes
`SignLanguageIsCustomName=false`, and typing "Madagascar Sign Language" over it writes `true`
(that case used to come out `false`).
<!-- preflight-narrative:end -->

(Depends on `LanguageChangeEventArgs.IsCustomName` from #8236, now cherry-picked onto
`Version6.5`, so this is a single commit on top of it.)

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16760


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8238)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8238)
<!-- Reviewable:end -->


