### PR TITLE
Debounce the settings-file write when zooming the edit page (BL-16763)

### DIFF
--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -65,6 +65,8 @@ House rules:
   invocation its own subtree, and make the error message say "another agent-dotnet command is
   using this tree" instead of a raw MSBuild copy failure.
 - **Context:** BloomDesktop, `/preflight` of PR #8107 (dev launcher control API).
+- **seen again 2026-08-26:** `/preflight` of PR #8239 (BL-16763). The failed copy was read as a
+  build break for a comment-only commit, which had already been pushed.
 
 ## 2026-07-27 — The component-tester uitest suites still aren't in CI
 

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -315,6 +315,8 @@ namespace Bloom.Edit
         void ParentForm_Deactivate(object sender, EventArgs e)
         {
             _editButtonsUpdateTimer.Enabled = false;
+            // Safe here, unlike the model save the comment below warns about: this only
+            // serializes the in-memory settings, and runs no Javascript.
             SaveZoomSettingNow();
             // Save when we leave the main window, even just switching to the epub a11y check window.
             // See https://silbloom.myjetbrains.com/youtrack/issue/BL-6228. This control can lose/regain

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -51,6 +51,10 @@ namespace Bloom.Edit
         private ZoomModel _zoomModel;
         private PageListApi _pageListApi;
         private Timer _editButtonsUpdateTimer;
+        private Timer _saveZoomSettingTimer;
+
+        /// <summary>How long the zoom must hold still before we write it to the settings file.</summary>
+        private const int kSaveZoomSettingDelayMs = 1000;
         private Browser _mainBrowser => WorkspaceView?.MainBrowser;
         private WorkspaceView _workspaceView;
         private Form _hostFormForEvents;
@@ -135,6 +139,13 @@ namespace Bloom.Edit
             _pageListApi = pageListApi;
             _editButtonsUpdateTimer = new Timer();
             _editButtonsUpdateTimer.Tick += _editButtonsUpdateTimer_Tick;
+            // A Ctrl+mousewheel spin changes the zoom many times a second. A write of the
+            // settings file on each change holds the UI thread while the browser process tries
+            // to call into it, which can freeze Bloom for minutes (BL-16762, BL-16763). So we
+            // write once, after the zoom stops. See SetZoom() and SaveZoomSettingNow().
+            _saveZoomSettingTimer = new Timer();
+            _saveZoomSettingTimer.Interval = kSaveZoomSettingDelayMs;
+            _saveZoomSettingTimer.Tick += (sender, e) => SaveZoomSettingNow();
 
             //SetupThumbnailLists();
             _model.SetView(this);
@@ -304,6 +315,7 @@ namespace Bloom.Edit
         void ParentForm_Deactivate(object sender, EventArgs e)
         {
             _editButtonsUpdateTimer.Enabled = false;
+            SaveZoomSettingNow();
             // Save when we leave the main window, even just switching to the epub a11y check window.
             // See https://silbloom.myjetbrains.com/youtrack/issue/BL-6228. This control can lose/regain
             // focus erratically on Linux, so we don't want this save on its LostFocus event.
@@ -383,6 +395,7 @@ namespace Bloom.Edit
                 // which will also cause a change to NoPage. However, it will be ignored in states where it's not valid,
                 // and may be helpful in some cases (e.g., if somehow we're navigating), so I decided to put it in.
                 _model.StateMachine.ToNoPage();
+                SaveZoomSettingNow();
             }
         }
 
@@ -1515,6 +1528,13 @@ namespace Bloom.Edit
                 _editButtonsUpdateTimer.Dispose();
                 _editButtonsUpdateTimer = null;
             }
+
+            if (_saveZoomSettingTimer != null)
+            {
+                SaveZoomSettingNow();
+                _saveZoomSettingTimer.Dispose();
+                _saveZoomSettingTimer = null;
+            }
         }
 
         public string HelpTopicUrl => "/Tasks/Edit_tasks/Edit_tasks_overview.htm";
@@ -1626,13 +1646,29 @@ namespace Bloom.Edit
             // setting below, so there's no reason to wait for the script to finish.
             _mainBrowser.RunJavascriptFireAndForget($"workspaceBundle.setZoom({zoomFactor});");
             Settings.Default.PageZoom = zoom.ToString(CultureInfo.InvariantCulture);
-            Settings.Default.Save();
+            // Do not write the settings file here. Restart the timer, so that the write happens
+            // one second after the last zoom change. SaveZoomSettingNow() also writes the file
+            // if we leave the Edit tab, lose the main window, or shut down before the tick.
+            _saveZoomSettingTimer.Stop();
+            _saveZoomSettingTimer.Start();
             // Note: July 29 2025 we removed code that handled zoom by reloading the page,
             // with some complicated mess involving timers to make sure one reload for zoom
             // didn't interfere with another. I eventually tracked this down to when we made
             // canvas elements draggable (6/28/2017). I think the old JQuery draggable code was
             // messed up by scaling and had to be adjusted somehow. Now we're not using that,
             // so updating in place is much cleaner (and faster!).
+        }
+
+        /// <summary>
+        /// Writes the deferred zoom setting to disk now, if SetZoom() left one pending, and stops
+        /// the timer that would have written it later. Does nothing if no write is pending.
+        /// </summary>
+        private void SaveZoomSettingNow()
+        {
+            if (_saveZoomSettingTimer == null || !_saveZoomSettingTimer.Enabled)
+                return;
+            _saveZoomSettingTimer.Stop();
+            Settings.Default.Save();
         }
 
         public void AdjustPageZoom(int delta)

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -54,7 +54,7 @@ namespace Bloom.Edit
         private Timer _saveZoomSettingTimer;
 
         /// <summary>How long the zoom must hold still before we write it to the settings file.</summary>
-        private const int kSaveZoomSettingDelayMs = 1000;
+        private const int kSaveZoomSettingDelayMs = 2000;
         private Browser _mainBrowser => WorkspaceView?.MainBrowser;
         private WorkspaceView _workspaceView;
         private Form _hostFormForEvents;
@@ -1649,7 +1649,7 @@ namespace Bloom.Edit
             _mainBrowser.RunJavascriptFireAndForget($"workspaceBundle.setZoom({zoomFactor});");
             Settings.Default.PageZoom = zoom.ToString(CultureInfo.InvariantCulture);
             // Do not write the settings file here. Restart the timer, so that the write happens
-            // one second after the last zoom change. SaveZoomSettingNow() also writes the file
+            // two seconds after the last zoom change. SaveZoomSettingNow() also writes the file
             // if we leave the Edit tab, lose the main window, or shut down before the tick.
             _saveZoomSettingTimer.Stop();
             _saveZoomSettingTimer.Start();


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
## Problem

While the user zooms the edit page with Ctrl+mousewheel, Bloom writes the whole `user.config`
settings file to disk on every zoom step. A fast wheel spin produces many of those synchronous
writes per second, all on the UI thread. This is not the root cause of the multi-minute freeze in
BL-16762, but each write holds the UI thread longer, which widens the window in which the
host-to-browser and browser-to-host calls collide.

## Fix

`EditingView.SetZoom` no longer writes the settings file. It still applies the zoom to the browser
at once, and it still updates `Settings.Default.PageZoom` in memory at once, so nothing the user
sees changes. A two-second timer now does the disk write, and each zoom step restarts that timer,
so a whole wheel spin costs one write instead of one write per notch.

The pending write is also flushed at once when the user leaves the Edit tab, when the main window
becomes inactive, and when the view is disposed. So a zoom made in the last two seconds before any of
those events is still saved.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16763


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8239)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8239)
<!-- Reviewable:end -->

