### PR TITLE
Fix bulk upload failing after the first books (BL-16767)

### DIFF
--- a/build/ci/watch-for-hung-bloom.ps1
+++ b/build/ci/watch-for-hung-bloom.ps1
@@ -42,7 +42,7 @@
 .PARAMETER TriggerPattern
     The log line meaning "the page-checks navigation just gave up". Matched as a regex. Includes the DOM
     name on purpose: Bloom logs "Failed to navigate fully" from two different places (page checks in
-    RemoveUnwantedContentInternal, and the separate font scan in ReportInvalidFontsAsync), and matching
+    RemoveUnwantedContentInternal, and the separate font scan in ReportInvalidFonts), and matching
     the shorter string would let the fonts path spend both captures on a moment we are not asking about.
 
 .PARAMETER HungAfterSeconds

--- a/src/BloomExe/Publish/PublishHelper.cs
+++ b/src/BloomExe/Publish/PublishHelper.cs
@@ -2080,10 +2080,14 @@ namespace Bloom.Publish
             return fixedSomething;
         }
 
-        public static async Task ReportInvalidFontsAsync(
+        /// <summary>
+        /// Report (via progress) any fonts used in the staged book that cannot be published.
+        /// Returns the set of font names actually requested by the book's content, which
+        /// lets a test verify that the browser-based scan really ran.
+        /// </summary>
+        public static IReadOnlyCollection<string> ReportInvalidFonts(
             string destDirName,
-            IProgress progress,
-            Control controlToInvokeOn
+            IProgress progress
         )
         {
             // Make a browser so we can accurately determine what fonts are actually requested by
@@ -2107,96 +2111,41 @@ namespace Bloom.Publish
                 editable.AddClass("bloom-visibility-code-on");
             }
 
-            // This function, which is what we want to do next, may be either invoked
-            // or simply run, depending on whether we need to force running it on the UI thread.
-            // We can only manipulate the browser on the UI thread (except in tests).
-            var getFontsAction = async () =>
+            // Ask a real browser which fonts the stylesheets actually request. We use an
+            // OffScreenBrowser (a WebView2 on its own dedicated thread, driven by blocking calls)
+            // rather than creating a WebView2Browser inline on the calling thread. The inline
+            // approach needed fragile thread juggling (see BL-15292), and in bulk upload it
+            // reliably wedged after a couple of books: each new inline WebView2 failed to finish
+            // initializing, so every subsequent book failed to upload with "The instance of
+            // CoreWebView2 is uninitialized" (BL-16767). This is the same mechanism
+            // RemoveUnwantedContent uses for its page checks.
+            using (var browser = new OffScreenBrowser())
             {
-                // This will usually be the main UI thread, but in tests it could be anything.
-                // In production, we must make sure we're on the UI thread to create and manipulate a browser,
-                // but we may no longer be after we await RunJavaScriptAsync. We have to be on the same
-                // thread to dispose it, so keep track of which thread it is.
-                var threadWhereWeMadeBrowser = Thread.CurrentThread;
-                // Even trying controlToInvokeOn.Invoke everywhere the browser is referenced, I couldn't get
-                // "await WebView2Browser.CreateAsync()" to produce a browser that would successfully navigate
-                // to the page for checking fonts.  The navigation would always time out and report failure,
-                // unless it crashed before the timeout and stopped the program with exit code 0x80000003.
-                // If it didn't crash, often the scan for fonts would return an empty array which looks
-                // innocuous (but possibly misleading) to the user.  When it didn't return an empty array,
-                // it returned an array full of nothing but "Times New Roman", the default browser font on
-                // Windows which is illegal to embed or distribute, and complained vociferously to the user.
-                // See BL-15292 for more details and discussion.
-                var browser = new WebView2Browser(); // NOT await WebView2Browser.CreateAsync();
-                try
+                if (!browser.Navigate(dom, 10000, () => false))
                 {
-                    // Logically, if any await can result in a thread switch, we might need to invoke again here.
-                    // (But invoking again here doesn't work!?)
-                    if (
-                        !browser.NavigateAndWaitTillDone(
-                            dom,
-                            10000,
-                            InMemoryHtmlFileSource.JustCheckingPage,
-                            () => false,
-                            false
-                        )
-                    )
-                    {
-                        // We had problems with timeouts here in similar code (BL-7892).
-                        // We may as well carry on and detect as many problem fonts as we can.
-                        Debug.WriteLine("Failed to navigate fully to ReportInvalidFontsAsync DOM");
-                        Logger.WriteEvent(
-                            "Failed to navigate fully to ReportInvalidFontsAsync DOM"
-                        );
-                    }
+                    // We had problems with timeouts here in similar code (BL-7892).
+                    // We may as well carry on and detect as many problem fonts as we can.
+                    Debug.WriteLine("Failed to navigate fully to ReportInvalidFonts DOM");
+                    Logger.WriteEvent("Failed to navigate fully to ReportInvalidFonts DOM");
+                }
 
-                    // Get and store the display and font information for each element in the DOM.
-                    var rawInfo = await browser.GetObjectFromJavascriptAsync(
-                        GetElementFontFamilyInfoJavascript
-                    );
-                    //Debug.WriteLine($"DEBUG ReportInvalidFontsAsync: rawInfo={rawInfo}");
-                    var fontFamilyInfo = Newtonsoft.Json.JsonConvert.DeserializeObject<string[]>(
-                        rawInfo
-                    );
+                // Get the font-family information for each element in the DOM.
+                var rawInfo = browser.RunJavascript(GetElementFontFamilyInfoJavascript);
+                var fontFamilyInfo = string.IsNullOrEmpty(rawInfo)
+                    ? null
+                    : Newtonsoft.Json.JsonConvert.DeserializeObject<string[]>(rawInfo);
 
-                    if (fontFamilyInfo != null)
+                if (fontFamilyInfo != null)
+                {
+                    foreach (var family in fontFamilyInfo)
                     {
-                        foreach (var family in fontFamilyInfo)
+                        var font = ExtractFontNameFromFontFamily(family);
+                        if (!string.IsNullOrEmpty(font))
                         {
-                            var font = ExtractFontNameFromFontFamily(family);
-                            if (!string.IsNullOrEmpty(font))
-                            {
-                                fontsFound.Add(font);
-                            }
+                            fontsFound.Add(font);
                         }
                     }
                 }
-                finally
-                {
-                    if (threadWhereWeMadeBrowser == Thread.CurrentThread)
-                    {
-                        // This seems to happen in tests. In live code, given the bizarre way
-                        // Windows.Forms implements await and resumes on a different thread,
-                        // we don't take this branch, but we normally have a controlToInvokeOn,
-                        // which is usually null in tests.
-                        browser.Dispose();
-                    }
-                    else if (controlToInvokeOn != null)
-                    {
-                        // If we made the browser on this control's thread, we can dispose of it properly by invoking
-                        // to that thread. This is the usual path in production.
-                        controlToInvokeOn.Invoke(() => browser.Dispose());
-                    }
-                    // Otherwise, we just can't dispose of it properly. Probably we're running tests
-                    // and it doesn't matter much.
-                }
-            };
-            if (controlToInvokeOn == null)
-            {
-                await getFontsAction();
-            }
-            else
-            {
-                await (Task)controlToInvokeOn.Invoke(getFontsAction);
             }
 
             // The old approach. Enhance: this is probably much faster to run. We think its only
@@ -2291,6 +2240,7 @@ namespace Bloom.Publish
                     //progress.WriteWarning("This book has a font, \"{0}\", which is not on this computer and whose license is unknown.", font);
                 }
             }
+            return fontsFound;
         }
 
         private const string AILangTagFragment = "-x-ai";

--- a/src/BloomExe/WebLibraryIntegration/BookUpload.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookUpload.cs
@@ -215,8 +215,7 @@ namespace Bloom.WebLibraryIntegration
             string metadataLang1Code,
             string metadataLang2Code,
             bool isForBulkUpload = false,
-            bool changeUploader = false,
-            Control controlToInvokeOn = null
+            bool changeUploader = false
         )
         {
             var htmlFile = BookStorage.FindBookHtmlInFolder(bookFolder);
@@ -298,7 +297,7 @@ namespace Bloom.WebLibraryIntegration
                     )
                     {
                         var stagingDirectory = stagingDirectoryTempFolder.FolderPath;
-                        await SetUpStagingAsync(
+                        SetUpStaging(
                             bookFolder,
                             stagingDirectory,
                             progress,
@@ -310,8 +309,7 @@ namespace Bloom.WebLibraryIntegration
                             metadataLang1Code,
                             metadataLang2Code,
                             collectionSettings?.SettingsFilePath,
-                            isForBulkUpload,
-                            controlToInvokeOn
+                            isForBulkUpload
                         );
 
                         string[] filesToUpload = null;
@@ -496,7 +494,7 @@ namespace Bloom.WebLibraryIntegration
         }
 
         // Copy the needed files to the staging directory and make any modifications needed before upload.
-        private async Task SetUpStagingAsync(
+        private void SetUpStaging(
             string pathToBloomBookDirectory,
             string stagingDirectory,
             IProgress progress,
@@ -508,8 +506,7 @@ namespace Bloom.WebLibraryIntegration
             string metadataLang1Code,
             string metadataLang2Code,
             string collectionSettingsPath = null,
-            bool isForBulkUpload = false,
-            Control controlToInvokeOn = null
+            bool isForBulkUpload = false
         )
         {
             var filter = new BookFileFilter(pathToBloomBookDirectory)
@@ -538,11 +535,7 @@ namespace Bloom.WebLibraryIntegration
                     metadataLang2Code
                 );
 
-            await PublishHelper.ReportInvalidFontsAsync(
-                stagingDirectory,
-                progress,
-                controlToInvokeOn
-            );
+            PublishHelper.ReportInvalidFonts(stagingDirectory, progress);
 
             // Really crop images, but leave in place the HTML structures that indicates they are cropped.
             // Really cropping them will typically reduce the space needed, and may also have value in
@@ -1051,8 +1044,7 @@ namespace Bloom.WebLibraryIntegration
                     book.BookData.MetadataLanguage1Tag,
                     book.BookData.MetadataLanguage2Tag,
                     bookParams.IsForBulkUpload,
-                    changeUploader,
-                    publishModel.View?.GetHostControlForInvoke()
+                    changeUploader
                 );
 
                 Debug.Assert(

--- a/src/BloomTests/Publish/ReportInvalidFontsTests.cs
+++ b/src/BloomTests/Publish/ReportInvalidFontsTests.cs
@@ -1,0 +1,100 @@
+using System.IO;
+using Bloom;
+using Bloom.Api;
+using Bloom.Book;
+using Bloom.Collection;
+using Bloom.ImageProcessing;
+using Bloom.Publish;
+using Bloom.web;
+using BloomTemp;
+using NUnit.Framework;
+using SIL.Progress;
+
+namespace BloomTests.Publish
+{
+    /// <summary>
+    /// Regression test for BL-16767. Bulk upload runs PublishHelper.ReportInvalidFonts once per
+    /// book, in one process. The pre-fix implementation created an inline WebView2Browser on the
+    /// calling thread for each book; after the first book, each new inline WebView2 failed to
+    /// finish initializing, and every following book failed to upload with "The instance of
+    /// CoreWebView2 is uninitialized". The fix drives the font check through an OffScreenBrowser
+    /// (a WebView2 on its own dedicated thread). This test proves the check survives a series of
+    /// books in one process, which is exactly what bulk upload needs.
+    /// </summary>
+    [TestFixture]
+    public class ReportInvalidFontsTests
+    {
+        private BloomServer _server;
+        private TemporaryFolder _workFolder;
+
+        /// <summary>
+        /// A running BloomServer is required: ReportInvalidFonts navigates a real browser to the
+        /// book (served from memory) so the stylesheets actually resolve.
+        /// </summary>
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            var settings = new CollectionSettings();
+            var locator = new BloomFileLocator(
+                settings,
+                new XMatterPackFinder(new[] { BloomFileLocator.GetFactoryXMatterDirectory() }),
+                ProjectContext.GetFactoryFileLocations(),
+                ProjectContext.GetFoundFileLocations(),
+                ProjectContext.GetAfterXMatterFileLocations()
+            );
+            _server = new BloomServer(
+                new RuntimeImageProcessor(new BookRenamedEvent()),
+                new BookSelection(),
+                locator
+            );
+            _server.EnsureListening();
+            _workFolder = new TemporaryFolder("ReportInvalidFontsTests");
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            _workFolder.Dispose();
+            RetiredTestServers.Retire(_server);
+        }
+
+        /// <summary>
+        /// Make a minimal book folder: one page with one editable div, enough for the font scan
+        /// to have something to compute a font-family for.
+        /// </summary>
+        private string MakeBook(string name)
+        {
+            var folder = Path.Combine(_workFolder.FolderPath, name);
+            Directory.CreateDirectory(folder);
+            File.WriteAllText(
+                Path.Combine(folder, name + ".htm"),
+                XmlHtmlConverter.CreateHtmlString(
+                    // The font scan looks at descendants of .bloom-editable, so the text
+                    // needs to be inside a child element of the editable div.
+                    "<div class='bloom-page'><div class='bloom-editable' lang='fr'><p>Bonjour</p></div></div>"
+                )
+            );
+            return folder;
+        }
+
+        [Test]
+        public void ReportInvalidFonts_FiveBooksInARow_FindsFontsEveryTime()
+        {
+            // Five is comfortably past the point where the pre-fix code started failing
+            // (the second book).
+            for (int i = 1; i <= 5; i++)
+            {
+                var folder = MakeBook("book" + i);
+                var progress = new StringBuilderProgress();
+                var fontsFound = PublishHelper.ReportInvalidFonts(folder, progress);
+                // A failed navigation would not throw; it would just find no fonts. So we
+                // require that the scan really computed a font for the book's one editable div.
+                Assert.That(
+                    fontsFound,
+                    Is.Not.Empty,
+                    $"The font scan found no fonts for book {i} of the series."
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
**Problem.** Bulk upload (`Bloom.exe upload <collection>`) fails for every book after the first one or two. Each failed book reports "The instance of CoreWebView2 is uninitialized and unable to complete this operation. See EnsureCoreWebView2Async." (BL-16767, reported on 6.6.1001 Alpha; also reproduced on 6.5.3002.)

**Cause.** The font check that runs while a book is staged for upload (`PublishHelper.ReportInvalidFontsAsync`) created a new inline `WebView2Browser` on the calling thread for every book. That works for the first book and cannot work for any of the rest. The chain starts with the console message pump:

- Console mode waits for the command's task by spinning `while (!mainTask.IsCompleted) Application.DoEvents();` on the `[STAThread]` main thread (`Program.Main`).
- `Application.DoEvents()`, when it is the **outermost** message loop, uninstalls the `WindowsFormsSynchronizationContext` and leaves a plain base `SynchronizationContext` in its place, whose `Post` queues to the thread pool. (Nested inside `Application.Run` — the normal desktop app — it does not, which is why only console mode is affected.) So the `DoEvents` wait destroys the very synchronization context the comment above it says a synchronous `Main` was kept for.
- Book 1's font check therefore runs on the pumping STA main thread and succeeds, but its `await GetObjectFromJavascriptAsync` resumes on an **MTA thread-pool thread**, and the upload loop stays there. The old code's own comment had noticed this ("the bizarre way Windows.Forms implements await and resumes on a different thread") and declined to dispose the browser because of it, without spotting what it would do to the next book.
- Book 2 thus constructs its `WebView2Browser` on an MTA thread, where `CoreWebView2Environment.CreateAsync` throws `COMException RPC_E_CHANGED_MODE` ("Cannot change thread mode after it is set"), because WebView2 requires an STA thread. The control never even gets a window handle.
- The constructor kicked initialization off as `_ = InitWebView()`, so that exception was discarded unobserved: no log entry, no report, nothing. The only visible state was `_readyToNavigate` stuck at false, so the 10-second navigation wait timed out and the next JavaScript call threw the reported exception — 20 seconds and one layer away from its cause.

This was measured, not inferred. An instrumented copy of the console message pump reproduced it exactly (book 1 passes, books 2-5 fail with the reported error), and isolating the factors showed that WebView2 needs **both** an STA thread (to create the environment at all) and a pumping message loop on the thread that owns its window handle (to finish initialization). `EnsureBrowserReadyToNavigate`'s own `Application.DoEvents()` could never have helped, because it pumps the calling thread's queue and a thread-pool thread owns no windows.

**Fix.**
- The font check is now synchronous `PublishHelper.ReportInvalidFonts` and drives an `OffScreenBrowser`: a WebView2 on its own dedicated STA thread with a real message loop, which satisfies both requirements by construction. `RemoveUnwantedContent` already uses the same mechanism for the ePUB and BloomPUB page checks.
- `BookUpload.SetUpStaging` is synchronous as well, and the `controlToInvokeOn` parameter threading is gone from the upload path.
- A new regression test, `ReportInvalidFontsTests`, runs the font check for five books in a row in one process and requires that each run really finds the book's fonts (`ReportInvalidFonts` now returns the set it found). With the old code, the check failed from book two onward; with this fix, all five pass, and each check is also faster (about 350 ms against 712 ms).

Follow-up work, tracked separately: making a failed `InitWebView` report itself instead of being discarded (so this class of failure can never again surface only as "CoreWebView2 is uninitialized"), giving console mode a real message loop instead of the `DoEvents` spin, and three related findings the investigation turned up elsewhere in the code.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16767


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8246)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8246)
<!-- Reviewable:end -->
