### PR TITLE
Don't crash leaving the Edit tab while a save is in flight (BL-16766)

### DIFF
--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -410,7 +410,7 @@ namespace Bloom.Edit
                             _currentlyDisplayedBook = null;
                         }
                         else
-                            CurrentBook?.Save(); // we need it all the way saved before doing the PostponedWork
+                            CurrentBook?.Save(); // we need it all the way saved before completing the tab change
                         // This bizarre behavior prevents BL-2313 and related problems.
                         // For some reason I cannot discover, switching tabs when focus is in the Browser window
                         // causes Bloom to get deactivated, which prevents various controls from working.
@@ -418,21 +418,28 @@ namespace Bloom.Edit
                         // things get into a very bad state indeed. So arrange to re-activate ourselves as soon as the dust settles.
                         _oldActiveForm = Form.ActiveForm;
                         Application.Idle += ReactivateFormOnIdle;
-                        details.PostponedWork?.Invoke();
+                        details.CompleteTheChange?.Invoke();
                         return null; // leaving this tab, show blank page
                     },
                     () =>
                     {
-                        // We disable the tab control while we're in SavePending or SavedAndStripped.
-                        // We shouldn't be in NoPage while in the edit tab, but if we somehow are, we take the branch above.
-                        // If we're Editing, we will take the branch above.
-                        // So this is just the case where we're Navigating, either because we clicked on the Edit tab
-                        // and then immediately something else, or clicked another tab during the fraction of a second
-                        // while Bloom is navigating to a new page after doing some command. Abort the navigate, then go ahead.
-                        // Earlier versions of Bloom had a Debug guard against reaching this state, but it happened
-                        // often enough to be annoying, and the recovery code here seems to work adequately.
-                        // In particlar, we seem to get here after a Javascript error has been reported, and raising
-                        // an exception here tends to interfere with reporting the error we really want to see.
+                        // We get here when we could not start a save, so we're in Navigating,
+                        // SavePending or SavedAndStripped. (We shouldn't be in NoPage while in the
+                        // edit tab, but if we somehow are, we take the branch above; and if we're
+                        // Editing we take the branch above too.)
+                        //
+                        // We do ask for the tabs to be disabled while saving, but that doesn't take
+                        // effect soon enough to stop a second click on a tab, so SavePending really
+                        // does happen here — that was BL-16766. See WorkspaceView.SetTabsEnabled.
+                        //
+                        // Navigating: we clicked the Edit tab and then immediately something else,
+                        // or clicked another tab during the fraction of a second while Bloom is
+                        // navigating to a new page after doing some command. Abort the navigate,
+                        // then go ahead. Earlier versions of Bloom had a Debug guard against
+                        // reaching this state, but it happened often enough to be annoying, and the
+                        // recovery code here seems to work adequately. In particlar, we seem to get
+                        // here after a Javascript error has been reported, and raising an exception
+                        // here tends to interfere with reporting the error we really want to see.
                         if (StateMachine.Navigating)
                         {
                             StateMachine.ToNoPage();
@@ -448,9 +455,25 @@ namespace Bloom.Edit
                             CurrentBook?.ReloadFromDisk(null);
                             _currentlyDisplayedBook = null;
                         }
+                        // If we are here because a save is still in flight (someone else started
+                        // it, and the browser has not yet handed back the page content), we must
+                        // not let the tab change go ahead now: the tab-changed event would ask the
+                        // state machine to empty the page, which throws while a save is pending,
+                        // and would leave the workspace half switched between the two tabs
+                        // (BL-16766). Wait for the save to finish and then start the tab change
+                        // over from the beginning.
+                        // Note that the retry sees reloadFromDiskInsteadOfSaving as false, because
+                        // this attempt consumed the flag — so it takes the ordinary Save() branch
+                        // above rather than the reload branch. That is correct: the reload has
+                        // already happened, just above, and the discarded save cannot have merged
+                        // anything into the DOM, so the DOM still matches what the external process
+                        // wrote and saving it writes that same content back. There is also no
+                        // second in-flight save for the retry to discard.
+                        if (StateMachine.DeferUntilSaveCompletes(details.StartTheChangeOver))
+                            return;
                         _oldActiveForm = Form.ActiveForm;
                         Application.Idle += ReactivateFormOnIdle;
-                        details.PostponedWork?.Invoke();
+                        details.CompleteTheChange?.Invoke();
                     },
                     skipSaveToDisk: true
                 );
@@ -458,7 +481,7 @@ namespace Bloom.Edit
             else
             {
                 // If the old tab is not Edit, we don't need to save anything, so just do the postponed work.
-                details.PostponedWork?.Invoke();
+                details.CompleteTheChange?.Invoke();
             }
         }
 

--- a/src/BloomExe/Edit/EditingStateMachine.cs
+++ b/src/BloomExe/Edit/EditingStateMachine.cs
@@ -45,6 +45,11 @@ public class EditingStateMachine
     // page content) will be discarded on completion rather than merged into the DOM and written to
     // disk. See DiscardInFlightSave.
     private bool _discardInFlightSave;
+
+    // Work that arrived while a save was in flight and could not be done then. It runs once that
+    // save has completed and we are back in a state that allows transitions.
+    // See DeferUntilSaveCompletes.
+    private Action _workToDoAfterInFlightSave;
     private Action _hidePage;
 
     private Action<bool> _enableStateTransitions; // arg is (enabled)
@@ -57,8 +62,10 @@ public class EditingStateMachine
     /// <param name="updateBookWithPageContents">Called with page ID and pageContentData to update the main DOM with current page content</param>
     /// <param name="saveBook">Called to save the current state of the DOM to disk.</param>
     /// <param name="hidePage">Called to make the transition to NoPage (when edit tab is hidden).</param>
-    /// <param name="enableStateTransitions">Called to enable or disabled UI actions that would result in new state transitions.
-    /// These are not allowed when we are in state SavePending or SavedAndStripped.</param>
+    /// <param name="enableStateTransitions">Called to ask the UI to stop offering actions that would result in new state
+    /// transitions, because they are not valid in SavePending or SavedAndStripped. It is only a request, and does not
+    /// take effect soon enough to stop a click already on its way (see WorkspaceView.SetTabsEnabled and BL-16766), so
+    /// every transition must still refuse or defer an invalid request when one arrives.</param>
     public EditingStateMachine(
         Action<string> navigate,
         Action<string> requestPageSave,
@@ -373,10 +380,53 @@ public class EditingStateMachine
     }
 
     /// <summary>
+    /// For a caller that could not start a save (ToSavePending returned false) because one is
+    /// already in flight, and whose work is not safe to do until that save has finished. If a save
+    /// really is in flight, <paramref name="work"/> is remembered and run when the save completes,
+    /// and this returns true — the caller must then do nothing else. Otherwise it returns false and
+    /// the caller must get on with its own work.
+    ///
+    /// Leaving the Edit tab is the case this exists for (BL-16766): the user clicked another tab
+    /// twice in quick succession, and the second click found the first click's save still waiting
+    /// on the browser for the page content. Pressing on with the tab change then reached
+    /// ToNoPage() while still in SavePending, which throws, and left the workspace half switched
+    /// between the two tabs.
+    ///
+    /// Only one piece of deferred work is kept: a later request supersedes an earlier one, since it
+    /// is the more recent thing the user asked for.
+    /// </summary>
+    public bool DeferUntilSaveCompletes(Action work)
+    {
+        // No save to wait for, or nothing to do: the caller must handle it itself.
+        if (_currentState != State.SavePending || work == null)
+            return false;
+        _workToDoAfterInFlightSave = work;
+        return true;
+    }
+
+    /// <summary>
     /// Source: API call providing content of current page will request this after saving and before executing pending action
     /// (e.g. changing pages)
     /// </summary>
     public bool ToSavedAndStripped(string pageContentData)
+    {
+        // This is the only way out of SavePending, so it is where anything that had to wait for the
+        // in-flight save gets its turn (see DeferUntilSaveCompletes). It runs after the whole save,
+        // including the post-save action, so that we are in a state that allows transitions again;
+        // and in a finally, because a save that fails must not swallow a pending tab change.
+        try
+        {
+            return ToSavedAndStrippedFromSavePending(pageContentData);
+        }
+        finally
+        {
+            var deferredWork = _workToDoAfterInFlightSave;
+            _workToDoAfterInFlightSave = null;
+            deferredWork?.Invoke();
+        }
+    }
+
+    private bool ToSavedAndStrippedFromSavePending(string pageContentData)
     {
         try
         {

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -394,8 +394,11 @@ namespace Bloom.Edit
             {
                 // This will rarely do anything. It's typically called from the OnTabChanged event, which is invoked after
                 // onTabAboutToChange, which (typically, in state Editing) initiates a Save with a pending action that returns null,
-                // which will also cause a change to NoPage. However, it will be ignored in states where it's not valid,
-                // and may be helpful in some cases (e.g., if somehow we're navigating), so I decided to put it in.
+                // which will also cause a change to NoPage. But it may be helpful in some cases
+                // (e.g., if somehow we're navigating), so I decided to put it in.
+                // Careful: it is *not* ignored in the states where emptying the page is invalid; it
+                // throws. So anything that leads here has to have made sure we are not mid-save
+                // first — see EditingModel.OnTabAboutToChange and BL-16766.
                 _model.StateMachine.ToNoPage();
                 SaveZoomSettingNow();
             }

--- a/src/BloomExe/Event.cs
+++ b/src/BloomExe/Event.cs
@@ -90,12 +90,32 @@ namespace Bloom
         public WorkspaceTab? FromTab;
         public WorkspaceTab? ToTab;
 
-        // Must be executed by the subscriber when it is safe to do so, possibly after returning
-        // from the event handler.
+        // The two ways a subscriber can hand the tab change back to us. Exactly one of them is
+        // used, according to what the subscriber is able to do:
+        //
+        //   nothing to do first        -> CompleteTheChange, before returning
+        //   I must save first          -> CompleteTheChange, once my save has finished
+        //   a save is already running  -> StartTheChangeOver, once that save has finished
+        //
+        // The last case is the one that needs the second action: the subscriber can neither let
+        // the change proceed nor take responsibility for finishing it, because the save it is
+        // waiting on belongs to something else (typically an earlier click on a tab). See BL-16766.
+        //
         // This is a bit of a kludge. It works partly because there is currently only one subscriber,
         // so there is no ambiguity about who should do this, or how we know when all the subscribers
         // are done. If we ever have more than one subscriber, we'll need to do something more sophisticated.
-        public Action PostponedWork;
+
+        // Actually switches the tab: everything WorkspaceView.ChangeTab held back until a
+        // subscriber said it was safe. Call this EXACTLY ONCE — it raises the tab-changed event
+        // and records the new tab as current.
+        public Action CompleteTheChange;
+
+        // Abandons this attempt and asks for the whole tab change to be made afresh later, from the
+        // top of WorkspaceView.ChangeTab. Because it starts over, it re-checks everything, so it is
+        // safe to call whenever the way is clear — including when it turns out to be unnecessary,
+        // in which case it does nothing at all because the tab we wanted is already current.
+        // Null if the raiser has nothing to redo.
+        public Action StartTheChangeOver;
     }
 
     /// <summary>

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -1513,7 +1513,7 @@ window.showWorkspaceInitializationFailure = function(message) {
         /// attempt this, also merging the comments with some care. I'm not sure whether we should keep
         /// the argument as an IBloomTabArea of a WorkspaceTab value. If the latter, _previouslySelectedTabArea
         /// probably wants to change too, and perhaps other things.
-        /// Note that we don't want to make any actual changes of state until the PostponedWork callback runs
+        /// Note that we don't want to make any actual changes of state until the CompleteTheChange callback runs
         /// after we raise _selectedTabAboutToChangeEvent. The allows the current tab to shut down cleanly,
         /// before any changes that might do things like cleaning out its iframe. In particular, we have to wait
         /// until any changes are saved if we are leaving the edit tab.
@@ -1545,11 +1545,11 @@ window.showWorkspaceInitializationFailure = function(message) {
                 {
                     FromTab = previousTab,
                     ToTab = currentTab,
-                    PostponedWork = () =>
+                    CompleteTheChange = () =>
                     {
                         CurrentTabView = view;
 
-                        // Mark the tab active only when postponed work actually runs.
+                        // Mark the tab active only when we actually complete the change.
                         // When leaving Edit this is delayed until pending save completes.
                         if (currentTab.HasValue)
                         {
@@ -1576,6 +1576,10 @@ window.showWorkspaceInitializationFailure = function(message) {
                         }
                         // TODO-WV2: Can we clear the cache in WV2?  Do we need to?
                     },
+                    // Starting over means re-running this whole method, so the "already on the
+                    // desired tab" check at the top makes it a no-op if some other path has
+                    // meanwhile switched to the tab we wanted. See BL-16766.
+                    StartTheChangeOver = () => ChangeTab(view),
                 }
             );
         }
@@ -1863,6 +1867,16 @@ window.showWorkspaceInitializationFailure = function(message) {
             ProblemReportApi.ShowProblemDialog(this, null);
         }
 
+        /// <summary>
+        /// Ask the tab bar to stop offering the tabs (or to offer them again).
+        /// </summary>
+        /// <remarks>
+        /// ADVISORY, not a lock: this only pushes new tab states to the React top bar over a
+        /// websocket, and nothing checks _tabsEnabled when a workspace/selectTab request arrives.
+        /// So a click made (or already in flight) before the browser catches up still gets acted
+        /// on — see BL-16766. Whatever must not happen mid-operation has to be handled where it
+        /// happens, not assumed to have been prevented here.
+        /// </remarks>
         public void SetTabsEnabled(bool enable)
         {
             _tabsEnabled = enable;

--- a/src/BloomExe/web/controllers/ExternalApi.cs
+++ b/src/BloomExe/web/controllers/ExternalApi.cs
@@ -933,7 +933,7 @@ namespace Bloom.web.controllers
                         // and reload it from disk. We do NOT touch the editor for any other book, so a
                         // user editing an unrelated book never loses work.
                         // Note: when the Edit tab is live this schedules an async tab-switch (the actual
-                        // switch completes via PostponedWork after the browser returns page content). The
+                        // switch completes via CompleteTheChange after the browser returns page content). The
                         // collection reload below is safe to run immediately only because it doesn't read
                         // tab/selection state.
                         _editingModel.ReloadCurrentBookDiscardingEdits();

--- a/src/BloomTests/Edit/EditingStateMachineTests.cs
+++ b/src/BloomTests/Edit/EditingStateMachineTests.cs
@@ -1,0 +1,280 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace BloomTests.Edit
+{
+    /// <summary>
+    /// Tests of EditingStateMachine, the class that decides which editing transitions are legal.
+    /// These drive it through its public API with recording stubs for the six actions it needs,
+    /// the same way EditingModel wires it up in production.
+    /// </summary>
+    [TestFixture]
+    public class EditingStateMachineTests
+    {
+        private EditingStateMachine _machine;
+        private List<string> _actions;
+        private string _navigatedTo;
+        private string _saveRequestedFor;
+
+        [SetUp]
+        public void Setup()
+        {
+            _actions = new List<string>();
+            _navigatedTo = null;
+            _saveRequestedFor = null;
+            _machine = new EditingStateMachine(
+                navigate: pageId =>
+                {
+                    _navigatedTo = pageId;
+                    _actions.Add("navigate:" + pageId);
+                },
+                requestPageSave: pageId =>
+                {
+                    _saveRequestedFor = pageId;
+                    _actions.Add("requestPageSave:" + pageId);
+                },
+                updateBookWithPageContents: (pageId, content) =>
+                    _actions.Add("updateBook:" + pageId),
+                saveBook: () => _actions.Add("saveBook"),
+                hidePage: () => _actions.Add("hidePage"),
+                enableStateTransitions: enabled => _actions.Add("enableTransitions:" + enabled)
+            );
+        }
+
+        /// <summary>
+        /// Get to the state a user is in while editing a page: navigation finished, no save yet.
+        /// </summary>
+        private void GetToEditing(string pageId)
+        {
+            Assert.That(_machine.ToNavigating(pageId), Is.True, "test setup: should navigate");
+            Assert.That(
+                _navigatedTo,
+                Is.EqualTo(pageId),
+                "test setup: navigation should have been started"
+            );
+            Assert.That(_machine.ToEditing(pageId), Is.True, "test setup: should reach Editing");
+            Assert.That(_machine.SavePending, Is.False, "test setup: no save in flight yet");
+        }
+
+        /// <summary>
+        /// Start the save that leaving the Edit tab does: it returns null from
+        /// doBeforeSaveToDisk, meaning "don't navigate to another page, we're leaving".
+        /// </summary>
+        private bool StartSaveForLeavingEditTab(Action postponedWork)
+        {
+            return _machine.ToSavePending(
+                () =>
+                {
+                    postponedWork?.Invoke();
+                    return null; // leaving this tab, show blank page
+                },
+                saveActionHandlesSaveBook: true
+            );
+        }
+
+        /// <summary>
+        /// What the browser sends back to ReceivePageContent. The state machine only passes it
+        /// on to updateBookWithPageContents, so any non-null string will do here.
+        /// </summary>
+        private const string kPageContentFromBrowser = "<div class='bloom-page'/><SPLIT-DATA>";
+
+        /// <summary>
+        /// The invariant behind BL-16766: while we are waiting for the browser to hand back the
+        /// page content, emptying the page would throw away the user's edits, so the state
+        /// machine refuses. Anything on the path from a tab change to ToNoPage has to respect
+        /// this rather than let the exception reach the user as an error report.
+        /// </summary>
+        [Test]
+        public void ToNoPage_WhileSaveInFlight_Throws()
+        {
+            GetToEditing("page1");
+            Assert.That(StartSaveForLeavingEditTab(null), Is.True);
+            Assert.That(_machine.SavePending, Is.True, "test setup: save should be in flight");
+
+            var error = Assert.Throws<InvalidOperationException>(() => _machine.ToNoPage());
+            Assert.That(error.Message, Does.Contain("Cannot empty page while saving"));
+        }
+
+        /// <summary>
+        /// BL-16766: the user clicked the Collection tab twice in quick succession. The first
+        /// click started a save; the second arrived while that save was still in flight, so it
+        /// could not start one of its own. Rather than pressing on with the tab change — which
+        /// crashed in ToNoPage and left the workspace half-switched — it must be able to wait for
+        /// the in-flight save to finish.
+        /// </summary>
+        [Test]
+        public void DeferUntilSaveCompletes_SaveInFlight_RunsTheWorkOnceTheSaveIsDone()
+        {
+            GetToEditing("page1");
+            var tabChanges = 0;
+            Assert.That(StartSaveForLeavingEditTab(() => tabChanges++), Is.True);
+            Assert.That(_machine.SavePending, Is.True, "test setup: save should be in flight");
+            Assert.That(tabChanges, Is.EqualTo(0), "test setup: nothing has switched tabs yet");
+
+            // The second click. It cannot start a save of its own...
+            Assert.That(
+                StartSaveForLeavingEditTab(() => tabChanges++),
+                Is.False,
+                "a second save must not start while one is in flight"
+            );
+            // ...so it asks to be called back instead.
+            var deferredRuns = 0;
+            Assert.That(_machine.DeferUntilSaveCompletes(() => deferredRuns++), Is.True);
+            Assert.That(
+                deferredRuns,
+                Is.EqualTo(0),
+                "the deferred work must not run while the save is still in flight"
+            );
+
+            // The browser finally hands back the page content, completing the first save.
+            Assert.That(_machine.ToSavedAndStripped(kPageContentFromBrowser), Is.True);
+
+            Assert.That(tabChanges, Is.EqualTo(1), "the first click's tab change should have run");
+            Assert.That(deferredRuns, Is.EqualTo(1), "the deferred work should have run");
+            Assert.That(_machine.SavePending, Is.False, "the save should be finished");
+            // And by now emptying the page is legal, so the deferred tab change can complete.
+            Assert.DoesNotThrow(() => _machine.ToNoPage());
+        }
+
+        /// <summary>
+        /// Only one piece of deferred work is kept; a later request supersedes an earlier one,
+        /// because it represents what the user most recently asked for.
+        /// </summary>
+        [Test]
+        public void DeferUntilSaveCompletes_CalledTwice_RunsOnlyTheLastRequest()
+        {
+            GetToEditing("page1");
+            Assert.That(StartSaveForLeavingEditTab(null), Is.True);
+            var firstRuns = 0;
+            var secondRuns = 0;
+            Assert.That(_machine.DeferUntilSaveCompletes(() => firstRuns++), Is.True);
+            Assert.That(_machine.DeferUntilSaveCompletes(() => secondRuns++), Is.True);
+
+            _machine.ToSavedAndStripped(kPageContentFromBrowser);
+
+            Assert.That(firstRuns, Is.EqualTo(0), "the superseded request should not run");
+            Assert.That(secondRuns, Is.EqualTo(1));
+        }
+
+        /// <summary>
+        /// With no save in flight there is nothing to wait for, so the caller is told to get on
+        /// with its work itself.
+        /// </summary>
+        [Test]
+        public void DeferUntilSaveCompletes_NoSaveInFlight_DoesNotDefer()
+        {
+            GetToEditing("page1");
+            var runs = 0;
+            Assert.That(_machine.DeferUntilSaveCompletes(() => runs++), Is.False);
+            Assert.That(runs, Is.EqualTo(0), "it should not run the work either");
+        }
+
+        /// <summary>
+        /// A caller with nothing to retry (OpenSpecificCollection raises the tab-about-to-change
+        /// event with no postponed work) is not made to wait.
+        /// </summary>
+        [Test]
+        public void DeferUntilSaveCompletes_NothingToRetry_DoesNotDefer()
+        {
+            GetToEditing("page1");
+            Assert.That(StartSaveForLeavingEditTab(null), Is.True);
+            Assert.That(_machine.SavePending, Is.True, "test setup: save should be in flight");
+            Assert.That(_machine.DeferUntilSaveCompletes(null), Is.False);
+        }
+
+        /// <summary>
+        /// BL-16766 end to end: replays the sequence in the crash report through the calls
+        /// production makes — EditingModel.OnTabAboutToChange's two branches, and the ToNoPage()
+        /// that WorkspaceView's postponed work reaches via EditingView.OnVisibleChanged(false).
+        /// Before the fix the second click threw "Cannot empty page while saving" from inside the
+        /// postponed work, which is exactly where the reported stack trace ends.
+        /// </summary>
+        [Test]
+        public void TwoRequestsToLeaveEditTab_SecondArrivesDuringTheFirstsSave_ChangesTabOnce()
+        {
+            var tabChanges = 0;
+            var currentTab = "edit"; // WorkspaceView._previouslySelectedTabArea
+
+            // WorkspaceView.ChangeTab's CompleteTheChange: it raises the tab-changed event, which
+            // reaches EditingView.OnVisibleChanged(false), and only then records the new tab.
+            Action postponedWorkOfTabChange = () =>
+            {
+                tabChanges++;
+                _machine.ToNoPage();
+                currentTab = "collection";
+            };
+
+            // WorkspaceView.ChangeTab, including the EditingModel.OnTabAboutToChange handler it
+            // raises. Assigned rather than declared so that the fallback can pass it as
+            // details.StartTheChangeOver, which is how WorkspaceView supplies it.
+            Action clickTheCollectionTab = null;
+            clickTheCollectionTab = () =>
+            {
+                if (currentTab == "collection")
+                    return; // "Already on the desired tab: nothing to do."
+                if (StartSaveForLeavingEditTab(postponedWorkOfTabChange))
+                    return;
+                // the fallback: doIfNotInRightStateToSave
+                if (_machine.Navigating)
+                    _machine.ToNoPage();
+                if (_machine.DeferUntilSaveCompletes(clickTheCollectionTab))
+                    return;
+                postponedWorkOfTabChange();
+            };
+
+            GetToEditing("page1");
+
+            clickTheCollectionTab();
+            Assert.That(_machine.SavePending, Is.True, "test setup: save should be in flight");
+            Assert.That(
+                _saveRequestedFor,
+                Is.EqualTo("page1"),
+                "test setup: the browser should have been asked for the page content"
+            );
+            Assert.That(tabChanges, Is.EqualTo(0), "test setup: the tab cannot change yet");
+
+            // The user clicks it again before the browser has answered.
+            Assert.DoesNotThrow(() => clickTheCollectionTab());
+            Assert.That(
+                tabChanges,
+                Is.EqualTo(0),
+                "the second click must not switch tabs while the save is in flight"
+            );
+
+            // The browser hands back the page content, completing the save.
+            _machine.ToSavedAndStripped(kPageContentFromBrowser);
+
+            Assert.That(_actions, Does.Contain("updateBook:page1"), "the page should be saved");
+            Assert.That(
+                tabChanges,
+                Is.EqualTo(1),
+                "the tab should have changed exactly once, when the save finished"
+            );
+            Assert.That(_machine.SavePending, Is.False);
+        }
+
+        /// <summary>
+        /// The deferred work must run even if completing the save fails, or a tab click could be
+        /// swallowed for the rest of the session.
+        /// </summary>
+        [Test]
+        public void DeferUntilSaveCompletes_SaveCompletionThrows_StillRunsTheWork()
+        {
+            GetToEditing("page1");
+            Assert.That(
+                _machine.ToSavePending(() => throw new ApplicationException("save failed")),
+                Is.True
+            );
+            var deferredRuns = 0;
+            Assert.That(_machine.DeferUntilSaveCompletes(() => deferredRuns++), Is.True);
+
+            Assert.Throws<ApplicationException>(() =>
+                _machine.ToSavedAndStripped(kPageContentFromBrowser)
+            );
+
+            Assert.That(deferredRuns, Is.EqualTo(1));
+            Assert.That(_machine.SavePending, Is.False);
+        }
+    }
+}


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
## Problem

Leaving the Edit tab could put up an error report — "Cannot empty page while saving" — and leave
the workspace drawn half way between the Edit tab and the tab the user asked for: the new tab's
chrome, but no book preview, no "Edit this book" button, and most of the collection tab's icons
missing. The user's page had not finished saving at that point either, so a book title just typed
had not yet reached the collection's book list.

## Cause

Clicking another tab while editing starts a save, and the tab change is postponed until the
browser hands the page content back. During that window the tab bar still offers the target tab
(the disable travels to React over a websocket, so it cannot win the race) and `WorkspaceView`
still regards the Edit tab as current — so a second click goes straight through `ChangeTab`. That
second request cannot start a save of its own, and the fallback that handled it pressed on with
the tab change anyway. Completing the change reaches
`EditingStateMachine.ToNoPage()`, which throws while a save is pending, out of the middle of
`ChangeTab` — so the rest of the tab switch never ran. Clicking a page thumbnail and then a tab
crashed the same way.

## Fix

- `EditingStateMachine.DeferUntilSaveCompletes(work)` remembers work that arrived while a save
  was in flight and runs it once that save has completed — in a `finally`, so a save that fails
  cannot swallow a pending tab change.
- `WorkspaceView.ChangeTab` now offers `TabChangedDetails.StartTheChangeOver`, which re-attempts
  the whole tab change. Retrying from the top means the existing "already on the desired tab" check
  turns a duplicate click into a clean no-op, while a genuinely queued click is still honoured
  instead of dropped.
- The two continuations on `TabChangedDetails` are now named for what they resume —
  `CompleteTheChange` (finishes the change; call once) and `StartTheChangeOver` (abandons this
  attempt and re-runs `ChangeTab`; safe to call whenever) — with one comment above the pair
  enumerating the three situations a subscriber can be in. Renamed on `TabChangedDetails` only;
  `CollectionClosingArgs.PostponedWork` keeps its name.
- `EditingModel.OnTabAboutToChange`'s fallback defers instead of pressing on.
- Corrected the comment on `EditingView.OnVisibleChanged`, which claimed `ToNoPage()` is ignored
  when it isn't valid. It throws.

The tab now switches exactly once, after the save completes — so the collection list also shows
the title the user just typed.

New `EditingStateMachineTests` covers the deferral, including an end-to-end replay of the
reported double-click sequence. Verified meaningful: with the deferral neutered, 4 of its 7 tests
fail, the replay with the original exception.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16766


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8248)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8248)
<!-- Reviewable:end -->

