### PR TITLE
Fix BL-16768 custom layout of Bloom's 4 quadrants gets reset

### DIFF
--- a/src/BloomBrowserUI/collectionsTab/CollectionsTabPane.tsx
+++ b/src/BloomBrowserUI/collectionsTab/CollectionsTabPane.tsx
@@ -39,6 +39,13 @@ import {
 } from "../react_components/makeReaderTemplateBloomPackDialog";
 import { AboutDialogLauncher } from "../react_components/aboutDialog";
 import { RadioChoiceDialog } from "./RadioChoiceDialog";
+import {
+    kMinPaneSizePx,
+    restoreSizes,
+    savePersistedSplitterSizes,
+    SplitterSizes,
+    usePersistedSplitterSizes,
+} from "../utils/persistedSplitterSizes";
 
 const kResizerSize = 10;
 
@@ -51,6 +58,22 @@ type CollectionInfo = {
     isRemovableFolder: boolean;
     filter?: (book: IBookInfo) => boolean;
 };
+
+// These give the two panes about the same ratio as in the Legacy view.
+const kDefaultSplitterSizes: SplitterSizes = {
+    widths: [31, 50],
+    heights: [1, 1],
+};
+
+// Used instead of the saved heights when there are no source collections to show, so that
+// the bottom pane gets no space at all.
+const kNoBottomPaneHeights = [1, 0];
+
+// App.tsx renders only the active tab, so this pane is unmounted and remounted every time the
+// user leaves the Collections tab and comes back. Keeping the splitter sizes outside the
+// component is what makes a custom layout survive that (BL-16768); saving them in this user
+// setting is what makes it survive restarting Bloom.
+const kSplitterSizesSettingName = "CollectionTabSplitterSizes";
 
 export const CollectionsTabPane: React.FunctionComponent = () => {
     // Temporary: notify c# about clicks so WinForms menus can close.
@@ -168,18 +191,18 @@ export const CollectionsTabPane: React.FunctionComponent = () => {
 
     const [draggingSplitter, setDraggingSplitter] = useState(false);
 
-    // Initially (when Bloom first starts, until we persist splitter settings) the vertical
-    // splitter between the editable collection and the others is set to give them equal space.
-    // When the user drags the splitter, we use a callback to update this, so it will be right
-    // if we need to use it again.
-    // It is passed to the vertical splitter as the "initialSizes", which is ignored except
+    // The sizes the splitters should have: whatever the user last chose.
+    // They are passed to the splitters as their "initialSizes", which is ignored except
     // for the very first render of a particular SplitPane. So to get it to take effect later,
     // we have to modify the key of the SplitPane, forcing React to create a whole new one.
     // The only time we currently need to do this is when Bloom is restored from being
-    // minimized, which somehow puts the vertical splitter into a weird state where apparently
+    // minimized, which somehow puts the top/bottom splitter into a weird state where apparently
     // both panes are collapsed and there is nothing to see. As far as I can tell, all other
     // changes to window size are handled nicely by the SplitPane.
-    const [splitHeights, setSplitHeights] = useState([1, 1]);
+    const savedSplitterSizes = usePersistedSplitterSizes(
+        kSplitterSizesSettingName,
+        kDefaultSplitterSizes,
+    );
     const [generation, setGeneration] = useState(0);
     useSubscribeToWebSocketForEvent("window", "restored", () => {
         setGeneration((old) => old + 1);
@@ -315,16 +338,26 @@ export const CollectionsTabPane: React.FunctionComponent = () => {
         });
     }, []);
     const haveNoSources = collections && collections.length === 1;
+    // If we've got the list of collections and there are no source collections,
+    // we want to set the splitter to hide the bottom pane. That is our own doing rather
+    // than a size the user chose, so it deliberately skips the minimum in restoreSizes().
+    const splitHeights = haveNoSources
+        ? kNoBottomPaneHeights
+        : savedSplitterSizes &&
+          restoreSizes(savedSplitterSizes.heights, window.innerHeight);
+    const splitWidths =
+        savedSplitterSizes &&
+        restoreSizes(savedSplitterSizes.widths, window.innerWidth);
     useEffect(() => {
-        // If we've got the list of collections and there are no source collections,
-        // we want to set the splitter to hide the bottom pane.
+        // A new key is the only way to make a SplitPane notice a change of initialSizes.
         if (haveNoSources) {
-            setSplitHeights([1, 0]);
             setGeneration((old) => old + 1);
         }
     }, [haveNoSources]);
 
-    if (!collections) {
+    // We can't render the splitters until we know what sizes to give them, because a
+    // SplitPane only pays attention to its initialSizes on its very first render.
+    if (!collections || !splitHeights || !splitWidths) {
         return <div />;
     }
 
@@ -516,9 +549,8 @@ export const CollectionsTabPane: React.FunctionComponent = () => {
         >
             <SplitPane
                 split="vertical"
-                // This gives the two panes about the same ratio as in the Legacy view.
-                // Enhance: we'd like to save the user's chosen width.
-                initialSizes={[31, 50]}
+                initialSizes={splitWidths}
+                minSizes={kMinPaneSizePx}
                 resizerOptions={{
                     css: {
                         width: `${kResizerSize}px`,
@@ -534,6 +566,11 @@ export const CollectionsTabPane: React.FunctionComponent = () => {
                     onDragStarted: () => {
                         setDraggingSplitter(true);
                     },
+                    onSaveSizes: (sizes) => {
+                        savePersistedSplitterSizes(kSplitterSizesSettingName, {
+                            widths: sizes,
+                        });
+                    },
                 }}
                 // onDragFinished={() => {
                 //     alert("stopped dragging");
@@ -546,6 +583,7 @@ export const CollectionsTabPane: React.FunctionComponent = () => {
                     // TODO: the splitter library lets us specify a height, but it doesn't apply it correctly an so the pane that follows
                     // does not get pushed down to make room for the thicker resizer
                     initialSizes={splitHeights}
+                    minSizes={kMinPaneSizePx}
                     resizerOptions={{
                         css: {
                             height: `${kResizerSize}px`,
@@ -561,7 +599,10 @@ export const CollectionsTabPane: React.FunctionComponent = () => {
                             setDraggingSplitter(true);
                         },
                         onSaveSizes: (sizes) => {
-                            setSplitHeights(sizes);
+                            savePersistedSplitterSizes(
+                                kSplitterSizesSettingName,
+                                { heights: sizes },
+                            );
                         },
                     }}
                 >

--- a/src/BloomBrowserUI/utils/persistedSplitterSizes.ts
+++ b/src/BloomBrowserUI/utils/persistedSplitterSizes.ts
@@ -1,0 +1,133 @@
+import { useEffect, useState } from "react";
+import { get, postData } from "./bloomApi";
+
+// The sizes of a pair of splitters that divide an area into four quadrants: "widths" for the
+// vertical splitter (left pane, right pane) and "heights" for the horizontal one (top, bottom).
+// The numbers are relative, not absolute, so they stay meaningful at any window size.
+// This deliberately assumes two panes per splitter, which is all we have ever needed.
+export type SplitterSizes = {
+    widths: number[];
+    heights: number[];
+};
+
+// The smallest we ever let a pane get. This is also react-collapse-pane's own default, which it
+// enforces while dragging but not when applying initialSizes, so we enforce it ourselves when
+// restoring a saved layout. See restoreSizes().
+export const kMinPaneSizePx = 50;
+
+// What we have read (and since saved) for each setting, so that a component which gets
+// unmounted and remounted - as the workspace tabs do - does not lose the user's layout, and
+// does not have to wait for the round trip to C# again.
+// Undefined for a setting until we have read it; see usePersistedSplitterSizes().
+const cachedSizes = new Map<string, SplitterSizes>();
+
+// A pair of sizes we are willing to use. Anything else (an older or hand-edited setting,
+// a partly written one) means we fall back to the defaults rather than showing a broken layout.
+function isUsablePair(sizes: unknown): sizes is number[] {
+    return (
+        Array.isArray(sizes) &&
+        sizes.length === 2 &&
+        sizes.every(
+            (size) => typeof size === "number" && isFinite(size) && size >= 0,
+        ) &&
+        sizes[0] + sizes[1] > 0
+    );
+}
+
+function parseSavedSizes(
+    savedJson: string,
+    defaults: SplitterSizes,
+): SplitterSizes {
+    if (!savedJson) return defaults;
+    // Anything unreadable has to end at the defaults, not as an exception: this runs inside
+    // the settings callback, so throwing would leave the caller waiting for sizes forever and
+    // the component stuck rendering nothing.
+    try {
+        const saved = JSON.parse(savedJson);
+        if (!isUsablePair(saved?.widths) || !isUsablePair(saved?.heights)) {
+            return defaults;
+        }
+        return saved;
+    } catch {
+        return defaults;
+    }
+}
+
+/**
+ * Turn a saved pair into the sizes to open with, keeping neither pane below roughly
+ * kMinPaneSizePx. The saved numbers are relative, so a layout chosen in a large window gets
+ * scaled down to fit a smaller one; without this, a pane that was merely small when it was
+ * saved could come back so thin as to look like it had vanished.
+ * Callers pass the window size for availablePx, since the splitter has not been laid out yet
+ * when we need this. Where the splitter gets less room than the whole window, the floor works
+ * out slightly under kMinPaneSizePx. That is fine: this is a guard against a pane
+ * disappearing, not a promise of an exact size. Once the panes are on screen the splitter
+ * library enforces kMinPaneSizePx itself while dragging.
+ */
+export function restoreSizes(
+    savedSizes: number[],
+    availablePx: number,
+): number[] {
+    // Half each, if the window is so small that even the minimum doesn't fit twice.
+    const minFraction = Math.min(kMinPaneSizePx / availablePx, 0.5);
+    const firstFraction = savedSizes[0] / (savedSizes[0] + savedSizes[1]);
+    const clamped = Math.min(
+        Math.max(firstFraction, minFraction),
+        1 - minFraction,
+    );
+    return [clamped, 1 - clamped];
+}
+
+/**
+ * Get the sizes saved under this setting name, reading them from the C# user settings the
+ * first time we need them. Returns undefined until they are available; after that every
+ * remount gets them at once.
+ * The setting must exist in Bloom's Settings.settings as a user-scoped string.
+ */
+export function usePersistedSplitterSizes(
+    settingName: string,
+    defaults: SplitterSizes,
+): SplitterSizes | undefined {
+    const [, setHaveSizes] = useState(false);
+    // An Effect is right here because reading a setting from C# is talking to an external
+    // system, and we want it to happen because the component came on screen. It happens only
+    // once per run of Bloom; later mounts are answered from the cache above.
+    useEffect(() => {
+        if (cachedSizes.has(settingName)) return;
+        get(`app/userSetting?settingName=${settingName}`, (result) => {
+            // Check again, not just when the request went out. Leaving and returning to the
+            // tab while the first request is in flight starts a second one, and by the time
+            // that one answers the user may already have dragged a splitter. Whatever is in
+            // the cache by now is newer than what this reply is carrying.
+            if (!cachedSizes.has(settingName)) {
+                cachedSizes.set(
+                    settingName,
+                    parseSavedSizes(result.data.settingValue, defaults),
+                );
+            }
+            setHaveSizes(true);
+        });
+        // We deliberately read the setting once per run, so a later change of defaults (which
+        // callers pass as a literal) must not send us back to C#.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [settingName]);
+    return cachedSizes.get(settingName);
+}
+
+/**
+ * Remember the user's new layout, both for the rest of this run and for future ones.
+ * Pass only the splitter the user actually dragged; the other one keeps whatever was already
+ * saved, which is not necessarily what is on screen (a caller may be overriding it).
+ * Only call this once usePersistedSplitterSizes() has produced sizes for this setting.
+ */
+export function savePersistedSplitterSizes(
+    settingName: string,
+    draggedSizes: Partial<SplitterSizes>,
+) {
+    const merged = { ...cachedSizes.get(settingName)!, ...draggedSizes };
+    cachedSizes.set(settingName, merged);
+    postData("app/userSetting", {
+        settingName,
+        settingValue: JSON.stringify(merged),
+    });
+}

--- a/src/BloomExe/Properties/Settings.Designer.cs
+++ b/src/BloomExe/Properties/Settings.Designer.cs
@@ -499,5 +499,18 @@ namespace Bloom.Properties {
                 this["ExportImportFileFolder"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string CollectionTabSplitterSizes {
+            get {
+                return ((string)(this["CollectionTabSplitterSizes"]));
+            }
+            set {
+                this["CollectionTabSplitterSizes"] = value;
+            }
+        }
     }
 }

--- a/src/BloomExe/Properties/Settings.settings
+++ b/src/BloomExe/Properties/Settings.settings
@@ -119,5 +119,8 @@
     <Setting Name="ExportImportFileFolder" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="CollectionTabSplitterSizes" Provider="SIL.Settings.CrossPlatformSettingsProvider" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
## Problem

Drag the Collections tab's dividers, switch to Edit, come back — the layout has reset.
A 6.4 regression; it worked in 6.3.

## Cause

The sizes lived only in `CollectionsTabPane`'s React state, and since BL-15894 / BL-16012
`App.tsx` renders only the active tab — so leaving the tab unmounts the pane.

## Fix

New `utils/persistedSplitterSizes.ts` keeps them in a module cache (survives the unmount) and in
a new `CollectionTabSplitterSizes` user setting (survives restart — that part is new). Restored
sizes are validated and floored at ~50px: they're stored as proportions, so a big-monitor layout
rescaled into a small window could otherwise bring a pane back invisibly thin.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16768

---
[Devin review](https://app.devin.ai/review/BloomBooks/BloomDesktop/pull/8250)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8250)
<!-- Reviewable:end -->


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8250)
