### PR TITLE
Throttle Ctrl+mousewheel page zoom (BL-16762)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -59,12 +59,7 @@ import { showInvisibles, hideInvisibles } from "./showInvisibles";
 //import promise = require('es6-promise');
 //promise.Promise.polyfill();
 import axios from "axios";
-import {
-    postBoolean,
-    postJson,
-    postString,
-    postThatMightNavigate,
-} from "../../utils/bloomApi";
+import { post, postBoolean, postJson, postString } from "../../utils/bloomApi";
 import { showRequestStringDialog } from "../../react_components/RequestStringDialog";
 
 import { hookupLinkHandler } from "../../utils/linkHandler";
@@ -1245,30 +1240,50 @@ export function bootstrap() {
     // not to generate them than suppress them if we can help it.
     setupWheelZooming();
 }
+// The minimum time between two zoom requests to the server, in milliseconds.
+// One request per wheel notch could freeze Bloom for minutes (BL-16762): each request
+// runs on the UI thread and calls into the WebView2, while the browser process sends
+// each Ctrl key event to the host synchronously and waits for an answer.
+const kZoomRequestIntervalMs = 150;
+// The wheel notches that we have not sent yet. A positive number zooms in.
+let pendingZoomNotches = 0;
+// Set while we wait out kZoomRequestIntervalMs after a zoom request.
+let zoomRequestTimer: number | undefined;
+
+// Send the notches that came in since the last request, then wait
+// kZoomRequestIntervalMs before we send another. If no notch came in, stop the timer,
+// so that the next notch goes out at once.
+function sendPendingZoom() {
+    const notches = pendingZoomNotches;
+    pendingZoomNotches = 0;
+    if (notches === 0) {
+        zoomRequestTimer = undefined;
+        return;
+    }
+    post("edit/pageControls/zoomBy?notches=" + notches);
+    zoomRequestTimer = window.setTimeout(
+        sendPendingZoom,
+        kZoomRequestIntervalMs,
+    );
+}
+
 // Attach a function to implement zooming on mouse wheel with ctrl.
 // Setting this up should be one of the last things we do when loading the page...
 // see the comment above where it is called.
-// (Unfortunately, this tends to make zooming feel rather sluggish...we could
-// try to optimize that, possibly by trying to keep track of how many wheel events
-// we got and using bigger increments...it should be safe to set up a handler
-// that just counts them, as long as we don't initiate a new page load until we
-// get done loading this one. Or maybe there are some events in page load that
-// we could abort if we already got another zoom event. For now, just trying
-// to stop it crashing.)
 function setupWheelZooming() {
     $("body").on("wheel", (e) => {
         const theEvent = e.originalEvent as WheelEvent;
         if (!theEvent.ctrlKey) return;
-        let command: string = "";
         // Note the direction of the zoom is opposite the direction of the scroll.
         if (theEvent.deltaY < 0) {
-            command = "edit/pageControls/zoomPlus";
+            pendingZoomNotches++;
         } else if (theEvent.deltaY > 0) {
-            command = "edit/pageControls/zoomMinus";
+            pendingZoomNotches--;
         }
-        if (command !== "") {
-            // Zooming re-loads the page (because of a text-over-picture issue)
-            postThatMightNavigate(command);
+        // Nothing is in flight, so send this notch now. Only a fast spin accumulates
+        // notches, and then the server gets one big increment instead of many small ones.
+        if (zoomRequestTimer === undefined) {
+            sendPendingZoom();
         }
         // Setting the zoom is all we want to do in this context.
         e.preventDefault();

--- a/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomEditing.ts
@@ -1233,11 +1233,6 @@ export function bootstrap() {
     if ($("div.bloom-page").length === 1) {
         addScrollbarsToPage($("div.bloom-page")[0]);
     }
-    // We want to do this as late in the page setup process as possible because a
-    // mouse zoom event will regenerate the page, and various things we do in the process
-    // of starting up a page don't like it if the page we are loading is already unloading.
-    // We currently suppress errors for pages which are in the process of going away, but better
-    // not to generate them than suppress them if we can help it.
     setupWheelZooming();
 }
 // The minimum time between two zoom requests to the server, in milliseconds.
@@ -1268,8 +1263,6 @@ function sendPendingZoom() {
 }
 
 // Attach a function to implement zooming on mouse wheel with ctrl.
-// Setting this up should be one of the last things we do when loading the page...
-// see the comment above where it is called.
 function setupWheelZooming() {
     $("body").on("wheel", (e) => {
         const theEvent = e.originalEvent as WheelEvent;

--- a/src/BloomExe/Edit/PageControlsApi.cs
+++ b/src/BloomExe/Edit/PageControlsApi.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using Bloom.Api;
 using Newtonsoft.Json;
 
@@ -14,6 +15,9 @@ namespace Bloom.Edit
         private const string kApiUrlPart = "edit/pageControls/";
         private const string kWebsocketStateId = "edit/pageControls/state";
         private const string kWebsocketContext = "pageThumbnailList-pageControls";
+
+        // How much one Ctrl+mousewheel notch changes the page zoom, in percentage points.
+        private const int kZoomPercentPerNotch = 10;
         private readonly BloomWebSocketServer _webSocketServer;
         private readonly EditingModel _editingModel;
         private DateTime _lastButtonClickedTime = DateTime.Now; // initially, instance creation time
@@ -86,21 +90,19 @@ namespace Bloom.Edit
                 )
                 .Measureable();
 
+            // The browser sends the number of Ctrl+mousewheel notches that it accumulated
+            // since the last request, positive to zoom in. It sends at most one request
+            // every 150ms, because one request per notch could freeze the UI thread for
+            // minutes (BL-16762). See setupWheelZooming in bloomEditing.ts.
             apiHandler.RegisterEndpointHandler(
-                kApiUrlPart + "zoomMinus",
+                kApiUrlPart + "zoomBy",
                 request =>
                 {
-                    _editingModel.AdjustPageZoom(-10);
-                    request.PostSucceeded();
-                },
-                true
-            );
-
-            apiHandler.RegisterEndpointHandler(
-                kApiUrlPart + "zoomPlus",
-                request =>
-                {
-                    _editingModel.AdjustPageZoom(10);
+                    var notches = int.Parse(
+                        request.RequiredParam("notches"),
+                        CultureInfo.InvariantCulture
+                    );
+                    _editingModel.AdjustPageZoom(notches * kZoomPercentPerNotch);
                     request.PostSucceeded();
                 },
                 true


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
## Problem

While zooming the edit page with Ctrl+mousewheel, Bloom goes "Not Responding" for
several minutes, with the UI thread busy on one core, and then recovers on its own.

## Cause

Every wheel notch posted its own zoom request. Each request runs on the UI thread and
calls into the WebView2, while the browser process sends each Ctrl key event to the host
synchronously and waits for the answer. A fast spin therefore left the UI thread waiting
inside WebView2's accelerator-key handshake. A captured native stack shows the UI thread
blocked in `CoWaitForMultipleHandles` under
`Controller::HandleAcceleratorKeyEvent`, with no Bloom frames on it.

## Fix

- `setupWheelZooming` (`bloomEditing.ts`) now counts wheel notches and posts at most one
  zoom request per 150 ms. The first notch still goes out at once, so the zoom stays
  responsive.
- The `zoomPlus` and `zoomMinus` endpoints become one endpoint, `zoomBy`, which takes the
  accumulated notch count. A fast spin therefore produces one large increment instead of
  many small ones, and no notch is lost. This also answers the old comment in
  `setupWheelZooming` about zoom feeling sluggish. Nothing else used those two endpoints.
- Deleted the two stale comments that said zooming re-loads the page, one inside
  `setupWheelZooming` and one at the call site. That reload went away in July 2025, as the
  comment in `EditingView.SetZoom` records.

Verified in a running Bloom over CDP: a burst of 12 notches produced 2 requests
(`notches=1`, then `notches=11`) instead of 12, three slow notches took the zoom from 130%
to 160%, and a fast burst of 3 notches out took it back to 130%.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16762






This PR replaces #8240, which targeted `master`. The two BL-16762 commits are cherry-picked onto `Version6.5`.


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8252)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8252)
<!-- Reviewable:end -->
