### PR TITLE
Fix BL-16774 [6.4] Little Zebra cuts off on 16x9

### DIFF
--- a/src/content/branding/Little-Zebra/branding.less
+++ b/src/content/branding/Little-Zebra/branding.less
@@ -24,9 +24,19 @@
 div.titlePage [data-book="title-page-branding-bottom-html"] {
     max-height: 24mm;
     line-height: 18px;
+    // This block is a flex column (see branding-base.less) and the xmatter lets the flexbox
+    // shrink it when the title page is tight. By default the logo refuses to shrink
+    // (min-height:auto on a replaced element), so the tagline was the only thing that could
+    // give, and its second line ended up off the bottom of the page (BL-16774). Reverse
+    // that: the logo yields height (object-fit:contain keeps its shape), the tagline always
+    // keeps both of its lines. Where there is room, nothing changes.
     img {
         margin-bottom: 5px;
         height: 13mm;
+        min-height: 0;
+    }
+    p {
+        flex-shrink: 0;
     }
 }
 [data-book="credits-page-branding-top-html"] img {


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
**Problem.** On a Little Zebra book at Device 16x9 Landscape, the title page's tagline loses its second line — "in African languages" is cut off by the bottom of the page. Not a regression; it has been this way at least since 6.3. (BL-16774)

**Cause.** The branding block is a flex column the xmatter is allowed to shrink. The logo refused to (`min-height: auto` on a replaced element with a fixed `height: 13mm`), so the tagline absorbed the whole squeeze and overflowed.

**Fix.** In `Little-Zebra/branding.less`: `min-height: 0` on the logo so it yields (`object-fit: contain` is already inherited, so it keeps its shape), and `flex-shrink: 0` on the tagline so it always keeps both lines. Where there is room, nothing changes — the logo is still exactly 13mm.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16774


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8253)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8253)
<!-- Reviewable:end -->

