### PR TITLE
Don't let a failed page save trap the user in Bloom (BL-16776)

### DIFF
--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -1897,10 +1897,17 @@ namespace Bloom.Book
                 {
                     // if we already processed it, we should not do so again,
                     // since doing so might replace some of the nodes in our list with new ones.
-                    if (!nodesToProcessFirst.Contains(elt))
-                    {
-                        UpdateOneElementFromDataSet(data, itemsToDelete, elt);
-                    }
+                    if (nodesToProcessFirst.Contains(elt))
+                        continue;
+                    // Updating one element can replace the entire content of an ancestor of another
+                    // element in this list (for example, restoring a branding html value replaces
+                    // everything inside that element), leaving the descendant orphaned. An orphan is
+                    // no longer part of the book, so there is nothing in it worth updating, and the
+                    // update code rightly assumes it still has the parents it was collected with.
+                    // See BL-16776.
+                    if (!IsStillInDocument(elt))
+                        continue;
+                    UpdateOneElementFromDataSet(data, itemsToDelete, elt);
                 }
             }
             catch (Exception error)
@@ -1913,6 +1920,22 @@ namespace Bloom.Book
                     error
                 );
             }
+        }
+
+        /// <summary>
+        /// True if the node is still attached to its document, that is, we can reach the document's
+        /// root element by following parents. A node we collected earlier may since have been
+        /// detached by an update to one of its ancestors.
+        /// </summary>
+        internal static bool IsStillInDocument(SafeXmlNode node)
+        {
+            var root = node.OwnerDocument.DocumentElement;
+            for (var current = node; current != null; current = current.ParentNode)
+            {
+                if (current == root)
+                    return true;
+            }
+            return false;
         }
 
         private void UpdateOneElementFromDataSet(

--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -1878,7 +1878,13 @@ namespace Bloom.Book
                     .Cast<SafeXmlElement>()
                     .ToArray();
                 foreach (var elt in nodesToProcessFirst)
+                {
+                    // Same reason as the IsStillInDocument check in the second pass below: an
+                    // earlier update in this very loop could have detached a later one of these.
+                    if (!IsStillInDocument(elt))
+                        continue;
                     UpdateOneElementFromDataSet(data, itemsToDelete, elt);
+                }
 
                 // After restoring custom page content from the data-div, prepare any bloom-editables
                 // for languages that weren't present in the saved version (e.g. a newly-added content

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -207,8 +207,27 @@ namespace Bloom.Edit
                             // However, FailureAction should be called in this case which allows closing the collection
                             // to try again. If we do try again and the same page fails again, the state machine will
                             // call this action anyway. So, finally PostponedWork will get called and we can close the collection.
-                            CurrentBook.Save();
-                            CurrentBook.RecordPendingCreatedHistoryEvent();
+                            try
+                            {
+                                CurrentBook.Save();
+                                CurrentBook.RecordPendingCreatedHistoryEvent();
+                            }
+                            catch (Exception e)
+                            {
+                                // Shutting down must not depend on the save succeeding. If it does,
+                                // a page that cannot be saved leaves the user no way out of Bloom at
+                                // all, because every further attempt to close runs this same failing
+                                // save (BL-16776). We deliberately don't put up a dialog: the user is
+                                // trying to quit, and whatever made the save fail will already have
+                                // been reported when it happened.
+                                NonFatalProblem.Report(
+                                    ModalIf.None,
+                                    PassiveIf.All,
+                                    "Bloom could not save the page you were editing as it shut down",
+                                    null,
+                                    e
+                                );
+                            }
                             args.PostponedWork();
                             return null;
                         },
@@ -364,15 +383,25 @@ namespace Bloom.Edit
                         // We are setting skipSaveToDisk true so that we can do it ourselves here BEFORE
                         // the postponed work, which is going to shut everything down and would prevent
                         // the normal automatic save-to-disk from working.
-                        CurrentBook?.Save(); // we need it all the way saved before doing the PostponedWork
-                        // This bizarre behavior prevents BL-2313 and related problems.
-                        // For some reason I cannot discover, switching tabs when focus is in the Browser window
-                        // causes Bloom to get deactivated, which prevents various controls from working.
-                        // Moreover, it seems (BL-2329) that if the user types Alt-F4 while whatever-it-is is active,
-                        // things get into a very bad state indeed. So arrange to re-activate ourselves as soon as the dust settles.
-                        _oldActiveForm = Form.ActiveForm;
-                        Application.Idle += ReactivateFormOnIdle;
-                        details.PostponedWork?.Invoke();
+                        try
+                        {
+                            CurrentBook?.Save(); // we need it all the way saved before doing the PostponedWork
+                        }
+                        finally
+                        {
+                            // Change tabs even if the save threw. The exception still propagates, so the
+                            // user is told the page could not be saved, but a page that cannot be saved
+                            // must not lock them into the Edit tab indefinitely. See BL-16776.
+
+                            // This bizarre behavior prevents BL-2313 and related problems.
+                            // For some reason I cannot discover, switching tabs when focus is in the Browser window
+                            // causes Bloom to get deactivated, which prevents various controls from working.
+                            // Moreover, it seems (BL-2329) that if the user types Alt-F4 while whatever-it-is is active,
+                            // things get into a very bad state indeed. So arrange to re-activate ourselves as soon as the dust settles.
+                            _oldActiveForm = Form.ActiveForm;
+                            Application.Idle += ReactivateFormOnIdle;
+                            details.PostponedWork?.Invoke();
+                        }
                         return null; // leaving this tab, show blank page
                     },
                     () =>

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -387,21 +387,32 @@ namespace Bloom.Edit
                         {
                             CurrentBook?.Save(); // we need it all the way saved before doing the PostponedWork
                         }
-                        finally
+                        catch (Exception e)
                         {
-                            // Change tabs even if the save threw. The exception still propagates, so the
-                            // user is told the page could not be saved, but a page that cannot be saved
-                            // must not lock them into the Edit tab indefinitely. See BL-16776.
-
-                            // This bizarre behavior prevents BL-2313 and related problems.
-                            // For some reason I cannot discover, switching tabs when focus is in the Browser window
-                            // causes Bloom to get deactivated, which prevents various controls from working.
-                            // Moreover, it seems (BL-2329) that if the user types Alt-F4 while whatever-it-is is active,
-                            // things get into a very bad state indeed. So arrange to re-activate ourselves as soon as the dust settles.
-                            _oldActiveForm = Form.ActiveForm;
-                            Application.Idle += ReactivateFormOnIdle;
-                            details.PostponedWork?.Invoke();
+                            // Tell the user, but change tabs anyway: a page that cannot be saved must
+                            // not lock them into the Edit tab indefinitely (BL-16776). We report rather
+                            // than letting this propagate so that we still finish on the same path a
+                            // successful save takes, rather than navigating a tab we have just left.
+                            // Note this is not the kind of swallowing we deliberately removed from
+                            // GetCleanCurrentPageFromBodyAndCss, where catching let a save carry on with
+                            // missing content. By the time we get here the page content has either
+                            // reached the DOM or thrown; all we abandon is writing it out.
+                            NonFatalProblem.Report(
+                                ModalIf.All,
+                                PassiveIf.All,
+                                "Bloom could not save the page you were editing",
+                                null,
+                                e
+                            );
                         }
+                        // This bizarre behavior prevents BL-2313 and related problems.
+                        // For some reason I cannot discover, switching tabs when focus is in the Browser window
+                        // causes Bloom to get deactivated, which prevents various controls from working.
+                        // Moreover, it seems (BL-2329) that if the user types Alt-F4 while whatever-it-is is active,
+                        // things get into a very bad state indeed. So arrange to re-activate ourselves as soon as the dust settles.
+                        _oldActiveForm = Form.ActiveForm;
+                        Application.Idle += ReactivateFormOnIdle;
+                        details.PostponedWork?.Invoke();
                         return null; // leaving this tab, show blank page
                     },
                     () =>

--- a/src/BloomExe/Edit/EditingStateMachine.cs
+++ b/src/BloomExe/Edit/EditingStateMachine.cs
@@ -264,6 +264,12 @@ public class EditingStateMachine
         }
         catch (Exception)
         {
+            // The caller's failure action is how it recovers from work that did not get done;
+            // it is needed just as much when the post-save action is what threw as when saving
+            // the page content did. Without this, an exception here left the caller believing
+            // its work was still in progress forever -- which is what made Bloom impossible to
+            // close in BL-16776.
+            failureAction?.Invoke();
             // We must not get stuck in the SavedAndStripped state, so we'll navigate to the page
             // we were on before the save.
             ToNavigating(pageId);

--- a/src/BloomTests/Book/BookDataTests.cs
+++ b/src/BloomTests/Book/BookDataTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
@@ -1487,6 +1487,48 @@ namespace BloomTests.Book
                         + "='audio/SoundTrack1.mp3' and @"
                         + HtmlDom.musicVolumeName
                         + "='0.17']",
+                    1
+                );
+        }
+
+        [Test]
+        public void UpdateVariablesAndDataDivThroughDOM_ImgOrphanedByUpdatingItsParent_DoesNotThrow()
+        {
+            // A branding html value can itself contain an image marked as the cover image (BL-16776).
+            // Restoring the branding element replaces everything inside it, which orphans the img
+            // that we collected before that happened. We must not then try to update the orphan.
+            var dom = new HtmlDom(
+                @"<html><head></head><body>
+				<div id='bloomDataDiv'>
+					<div data-book='coverImage' lang='*' src='zebra.png'
+						data-canvas-element-style='width: 468px; height: 484px; top: 0px; left: 0px;'
+						data-canvas-imgsizebasedon='469,484'>zebra.png</div>
+					<div data-book='cover-branding-bottom-html' lang='*'><img class='branding' src='zebra.png' data-book='coverImage'/></div>
+				</div>
+				<div class='bloom-page' id='frontCover'>
+					<div class='marginBox'>
+						<div data-book='cover-branding-bottom-html' lang='*'><img class='branding' src='zebra.png' data-book='coverImage'/></div>
+					</div>
+				</div>
+				</body></html>"
+            );
+            // Sanity check: the page really does start out with an img inside the element that is
+            // about to be rewritten, which is what makes this test meaningful.
+            AssertThatXmlIn
+                .Dom(dom.RawDom)
+                .HasSpecifiedNumberOfMatchesForXpath(
+                    "//div[@class='marginBox']/div[@data-book='cover-branding-bottom-html']/img[@data-book='coverImage']",
+                    1
+                );
+
+            var data = new BookData(dom, _collectionSettings, null);
+            Assert.DoesNotThrow(() => data.UpdateVariablesAndDataDivThroughDOM());
+
+            // The branding content should have been restored from the data-div.
+            AssertThatXmlIn
+                .Dom(dom.RawDom)
+                .HasSpecifiedNumberOfMatchesForXpath(
+                    "//div[@class='marginBox']/div[@data-book='cover-branding-bottom-html']/img[@class='branding']",
                     1
                 );
         }


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
## Problem

Switch a front cover to custom layout, add an image to it, and the book can reach a state where
the page can never be saved again. Every action that saves — clicking a page thumbnail, switching
to the Collections or Publish tab, even quitting — puts up "Bloom had trouble saving a page" and
then does nothing else. There is no way out of the program except Task Manager. Reported from
6.5.3007 with Little Zebra branding (BL-16776).

## Cause

A branding html value can itself contain an `<img>` marked as the cover image. `UpdateDomFromDataSet`
collects every `data-book` node up front, then restores the branding element — which replaces
everything inside it, orphaning that img. When the orphan's turn comes, the update code dereferences
parents it no longer has and throws.

That alone would be one failed save. What makes it inescapable is separate: leaving the Edit tab and
shutting down both run their real work only *after* `Book.Save()` returns, so a save that throws
blocks each of them permanently.

## Fix

- `UpdateDomFromDataSet` skips collected nodes that an earlier update has since detached from the
  document. This is the crash itself.
- Leaving the Edit tab now reports a failed `Book.Save()` and changes tabs anyway, instead of
  throwing out of the post-save action.
- Shutdown likewise reports and carries on, so quitting never depends on the save succeeding.
- `EditingStateMachine.DoPostSaveAction` calls the caller's `failureAction` when the post-save
  action throws, not only when applying the page content does — completing the recovery design
  that already existed for the other failure path.
- Regression test for the orphaned-img crash.

The wrong-image half of the report — the branding logo being designated as the cover image in the
first place, by `normalizeCoverImageDesignation` in `bloomImages.ts` — is not touched here, and has
no card of its own yet. BL-16780 (PR #8256) is the nearest work: it stops the same class of image
being picked as the book *icon*, in `Book.GetCoverImagePathAndElt`, and builds exactly the rule the
front end needs (an image counts only inside a `bloom-imageContainer`/`bloom-canvas`, plus a
branding/license/QR class exclusion). But it leaves the front-end designation code untouched, so it
does not prevent the corruption this PR recovers from.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16776


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8254)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8254)
<!-- Reviewable:end -->

