### PR TITLE
Fix TC message log write failure preventing collection from opening (BL-16772)

### DIFF
--- a/src/BloomExe/TeamCollection/TeamCollectionMessageLog.cs
+++ b/src/BloomExe/TeamCollection/TeamCollectionMessageLog.cs
@@ -200,7 +200,23 @@ namespace Bloom.TeamCollection
             // Linux and Windows. But that's OK, because .NET line reading accepts either line
             // break on either platform.
             var toPersist = message.ToPersistedForm + Environment.NewLine;
-            RobustFile.AppendAllText(_logFilePath, toPersist);
+            try
+            {
+                RobustFile.AppendAllText(_logFilePath, toPersist);
+            }
+            catch (Exception ex)
+            {
+                // The message is already in Messages (so the current session still shows it) and in
+                // the Logger above; it just won't survive a restart. Not being able to write it must
+                // not take Bloom down: this very method is called while reporting a TC initialization
+                // failure, and when the underlying problem is an unwritable collection folder
+                // (e.g. read-only files, BL-16772), throwing here turned a degraded-but-working
+                // Team Collection into a collection that could not open at all.
+                SIL.Reporting.Logger.WriteError(
+                    $"Could not persist Team Collection message to {_logFilePath}",
+                    ex
+                );
+            }
         }
 
         private bool MatchParams(string p1, string p2)

--- a/src/BloomTests/TeamCollection/TeamCollectionMessageLogTests.cs
+++ b/src/BloomTests/TeamCollection/TeamCollectionMessageLogTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -557,6 +558,36 @@ namespace BloomTests.TeamCollection
                 _messageLog.TeamCollectionStatus,
                 Is.EqualTo(TeamCollectionStatus.ClobberPending)
             );
+        }
+
+        [Test]
+        public void WriteMessage_LogFileNotWritable_DoesNotThrowAndKeepsMessageInMemory()
+        {
+            // BL-16772: a user's collection folder had read-only files, and the exception from
+            // failing to persist a message escaped all the way up and prevented the collection
+            // from opening at all. The message log must survive an unwritable log file.
+            var attributes = File.GetAttributes(_logFile.Path);
+            File.SetAttributes(_logFile.Path, attributes | FileAttributes.ReadOnly);
+            try
+            {
+                // Sanity check that the file really is read-only now.
+                Assert.That(
+                    File.GetAttributes(_logFile.Path) & FileAttributes.ReadOnly,
+                    Is.EqualTo(FileAttributes.ReadOnly),
+                    "Setup failed: could not make the log file read-only"
+                );
+
+                MakeError1();
+
+                var messages = _messageLog.Messages;
+                Assert.That(messages, Has.Count.EqualTo(1));
+                AssertError1(messages, 0);
+            }
+            finally
+            {
+                // So TearDown can delete the file.
+                File.SetAttributes(_logFile.Path, attributes);
+            }
         }
 
         [Test]


### PR DESCRIPTION
﻿<!-- preflight-narrative:begin -->
**Problem**: A user whose Team Collection's local folder contains read-only files could not open their collection at all. Bloom reported a raw `UnauthorizedAccessException` ("Access to the path ...log.txt is denied") and gave up, even though the TC code has a disconnected-mode fallback (added for BL-16227) designed to let the collection open with Team Collection features degraded.

**Cause**: When TC initialization failed (a sync write to the unwritable folder threw), the recovery path in the `TeamCollectionManager` constructor built a `DisconnectedTeamCollection` and then wrote an error message via `TeamCollectionMessageLog.WriteMessage` — which appends to `log.txt` in the same unwritable folder. That second exception escaped the constructor uncaught, killed the Autofac resolve, and prevented the whole `ProjectContext` from being created.

**Fix**: `TeamCollectionMessageLog.WriteMessage` now catches a failure to persist a message to `log.txt`, logs it via the SIL Logger, and continues. The message is already in the in-memory list and the Logger before the file write, so the current session still shows it; it just won't survive a restart. A regression test makes the log file read-only and verifies `WriteMessage` doesn't throw and keeps the message in memory. The PR targets Version6.4 directly (the affected user is on 6.4 Beta); the change is deliberately minimal. Version6.4 merges forward to 6.5/master per the usual flow.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16772


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8255)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8255)
<!-- Reviewable:end -->



---
[Devin review](https://app.devin.ai/review/BloomBooks/BloomDesktop/pull/8255)


