### PR TITLE
Fix book icon when branding has an image but cover has none (BL-16780)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImages.ts
@@ -52,9 +52,27 @@ function isCustomLayoutOutsideFrontCoverPage(
     );
 }
 
-function getNonUiImages(page: HTMLElement): HTMLImageElement[] {
+// The images that belong to the book itself: one inside an image container, or the old shape of a
+// background image sitting straight inside the bloom-canvas. Being *somewhere* under the
+// bloom-canvas is not enough, because on a custom layout the branding and licence images are canvas
+// elements inside that same bloom-canvas, alongside the real picture. We refuse branding, licence
+// and QR images by class as well. That is belt and braces against a branding pack wrapping its logo
+// in an image container -- unlike the equivalent search in Book.cs, where the cost of being wrong is
+// a wrong book icon, being wrong here writes a wrong cover image into the book. See BL-16776.
+function getContentImages(page: HTMLElement): HTMLImageElement[] {
     return Array.from(page.querySelectorAll("img")).filter(
-        (img) => !img.closest(".bloom-ui"),
+        (img) =>
+            !img.closest(".bloom-ui") &&
+            (!!img.closest(kImageContainerSelector) ||
+                // The old shape: a background image sitting straight inside the bloom-canvas, not
+                // yet converted to a canvas element with an image container. Book.cs makes the same
+                // allowance, and only for a direct child -- deeper descendants of the bloom-canvas
+                // are the other canvas elements on the cover, branding among them.
+                img.parentElement?.classList.contains(kBloomCanvasClass) ===
+                    true) &&
+            !img.classList.contains("branding") &&
+            !img.classList.contains("licenseImage") &&
+            !img.classList.contains("bloom-qrcode"),
     );
 }
 
@@ -76,20 +94,35 @@ export function normalizeCoverImageDesignation(page: HTMLElement): void {
         return;
     }
 
-    const nonUiImages = getNonUiImages(page);
+    const contentImages = getContentImages(page);
     const markedImages = Array.from(
         page.querySelectorAll('[data-book="coverImage"]'),
     ) as HTMLElement[];
-
-    const backgroundImage = getFirstNonPlaceholderImage(
-        nonUiImages.filter((img) => img.closest(`.${kBackgroundImageClass}`)),
+    // A mark on something that is not one of the book's own images is wrong however it got there,
+    // so it does not get a vote here, and the loop below strips it. That is what heals a book
+    // already saved with its branding logo marked as the cover image.
+    const markedContentImages = markedImages.filter((element) =>
+        contentImages.includes(element as HTMLImageElement),
     );
-    const markedRealImage = getFirstNonPlaceholderImage(markedImages);
-    const firstRealImage = getFirstNonPlaceholderImage(nonUiImages);
+    const backgroundImages = contentImages.filter((img) =>
+        img.closest(`.${kBackgroundImageClass}`),
+    );
 
-    // The one we want to be marked as the cover image
+    const backgroundImage = getFirstNonPlaceholderImage(backgroundImages);
+    const markedRealImage = getFirstNonPlaceholderImage(markedContentImages);
+    const firstRealImage = getFirstNonPlaceholderImage(contentImages);
+
+    // The one we want to be marked as the cover image. The last resort is the background image
+    // even when it is still a placeholder: on a custom cover that is the cover image's slot, so
+    // handing the mark back to it restores what a book looked like before it was mis-marked. We
+    // still never mark a placeholder that is not the background image, which would be inventing
+    // a cover image the book does not have.
     const chosenElement =
-        backgroundImage ?? markedRealImage ?? firstRealImage ?? markedImages[0];
+        backgroundImage ??
+        markedRealImage ??
+        firstRealImage ??
+        markedContentImages[0] ??
+        backgroundImages[0];
 
     for (const markedElement of markedImages) {
         if (markedElement !== chosenElement) {

--- a/src/BloomBrowserUI/bookEdit/js/bloomImagesSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomImagesSpec.ts
@@ -1,34 +1,46 @@
 import { describe, expect, it } from "vitest";
 import { normalizeCoverImageDesignation } from "./bloomImages";
 
+// The markup here mirrors what a real custom cover has: every picture that belongs to the book
+// sits in a bloom-imageContainer inside a canvas element, while branding markup is dropped into
+// a canvas element of its own without a container. That difference is what tells the book's own
+// pictures apart from the branding (BL-16776), so the tests have to carry it.
+function makeCustomCover(innerHtml: string): HTMLElement {
+    const page = document.createElement("div");
+    page.className = "bloom-page bloom-customLayout outsideFrontCover";
+    page.innerHTML = `<div class="bloom-canvas">${innerHtml}</div>`;
+    return page;
+}
+
+function picture(id: string, src: string, extraClasses = ""): string {
+    return `
+        <div class="bloom-canvas-element ${extraClasses}">
+            <div class="bloom-imageContainer"><img id="${id}" src="${src}" /></div>
+        </div>`;
+}
+
 describe("normalizeCoverImageDesignation", () => {
     it("marks a newly changed real image on a custom outside front cover", () => {
-        const page = document.createElement("div");
-        page.className = "bloom-page bloom-customLayout outsideFrontCover";
-        page.innerHTML = `
-            <div class="bloom-canvas">
-                <img id="first" src="placeHolder.png" />
-            </div>
-            <div class="bloom-canvas">
-                <img id="second" src="cover.png" />
-            </div>`;
+        const page = makeCustomCover(
+            picture("first", "placeHolder.png") +
+                picture("second", "cover.png"),
+        );
 
-        const second = page.querySelector("#second") as HTMLElement;
         normalizeCoverImageDesignation(page);
 
+        const second = page.querySelector("#second") as HTMLElement;
         expect(second.getAttribute("data-book")).toBe("coverImage");
     });
 
     it("moves the marker from a placeholder to a real remaining image", () => {
-        const page = document.createElement("div");
-        page.className = "bloom-page bloom-customLayout outsideFrontCover";
-        page.innerHTML = `
-            <div class="bloom-canvas">
-                <img id="placeholder" src="placeHolder.png" data-book="coverImage" />
-            </div>
-            <div class="bloom-canvas">
-                <img id="real" src="real-cover.png" />
-            </div>`;
+        const page = makeCustomCover(
+            picture("placeholder", "placeHolder.png") +
+                picture("real", "real-cover.png"),
+        );
+        (page.querySelector("#placeholder") as HTMLElement).setAttribute(
+            "data-book",
+            "coverImage",
+        );
 
         normalizeCoverImageDesignation(page);
 
@@ -39,15 +51,10 @@ describe("normalizeCoverImageDesignation", () => {
     });
 
     it("does not create a new placeholder marker when no real images remain", () => {
-        const page = document.createElement("div");
-        page.className = "bloom-page bloom-customLayout outsideFrontCover";
-        page.innerHTML = `
-            <div class="bloom-canvas">
-                <img id="first" src="placeHolder.png" />
-            </div>
-            <div class="bloom-canvas">
-                <img id="second" src="placeHolder.png" />
-            </div>`;
+        const page = makeCustomCover(
+            picture("first", "placeHolder.png") +
+                picture("second", "placeHolder.png"),
+        );
 
         normalizeCoverImageDesignation(page);
 
@@ -55,36 +62,32 @@ describe("normalizeCoverImageDesignation", () => {
     });
 
     it("keeps an existing real cover image", () => {
-        const page = document.createElement("div");
-        page.className = "bloom-page bloom-customLayout outsideFrontCover";
-        page.innerHTML = `
-            <div class="bloom-canvas">
-                <img id="existing" src="existing.png" data-book="coverImage" />
-            </div>
-            <div class="bloom-canvas">
-                <img id="preferred" src="preferred.png" />
-            </div>`;
+        const page = makeCustomCover(
+            picture("existing", "existing.png") +
+                picture("preferred", "preferred.png"),
+        );
+        (page.querySelector("#existing") as HTMLElement).setAttribute(
+            "data-book",
+            "coverImage",
+        );
 
-        const preferred = page.querySelector("#preferred") as HTMLElement;
         normalizeCoverImageDesignation(page);
 
         const existing = page.querySelector("#existing") as HTMLElement;
+        const preferred = page.querySelector("#preferred") as HTMLElement;
         expect(existing.getAttribute("data-book")).toBe("coverImage");
         expect(preferred.hasAttribute("data-book")).toBe(false);
     });
 
     it("prefers a non-placeholder background image over another designated image", () => {
-        const page = document.createElement("div");
-        page.className = "bloom-page bloom-customLayout outsideFrontCover";
-        page.innerHTML = `
-            <div class="bloom-canvas">
-                <div class="bloom-backgroundImage">
-                    <img id="background" src="background.png" />
-                </div>
-            </div>
-            <div class="bloom-canvas">
-                <img id="existing" src="existing.png" data-book="coverImage" />
-            </div>`;
+        const page = makeCustomCover(
+            picture("background", "background.png", "bloom-backgroundImage") +
+                picture("existing", "existing.png"),
+        );
+        (page.querySelector("#existing") as HTMLElement).setAttribute(
+            "data-book",
+            "coverImage",
+        );
 
         normalizeCoverImageDesignation(page);
 
@@ -92,5 +95,70 @@ describe("normalizeCoverImageDesignation", () => {
         const existing = page.querySelector("#existing") as HTMLElement;
         expect(background.getAttribute("data-book")).toBe("coverImage");
         expect(existing.hasAttribute("data-book")).toBe(false);
+    });
+
+    // The old shape: a background image sitting straight inside the bloom-canvas, not yet
+    // converted to a canvas element with an image container. It is one of the book's own pictures,
+    // so it must still be eligible -- otherwise normalizing would strip the mark off a legacy
+    // cover instead of keeping it.
+    it("counts a background image sitting directly in the bloom-canvas", () => {
+        const page = document.createElement("div");
+        page.className = "bloom-page bloom-customLayout outsideFrontCover";
+        page.innerHTML = `
+            <div class="bloom-canvas">
+                <img id="old-style" src="the-cover.jpg" data-book="coverImage" />
+            </div>`;
+
+        normalizeCoverImageDesignation(page);
+
+        const old = page.querySelector("#old-style") as HTMLElement;
+        expect(old.getAttribute("data-book")).toBe("coverImage");
+    });
+
+    // The reported case: a branded cover whose own picture is still the placeholder. The branding
+    // logo is a real image and comes first on the page, so before BL-16776 it was designated as
+    // the book's cover image and saved that way.
+    it("never designates a branding image as the cover image", () => {
+        const page = makeCustomCover(
+            picture("cover", "placeHolder.png", "bloom-backgroundImage") +
+                `<div class="bloom-canvas-element">
+                    <div data-book="cover-branding-bottom-html">
+                        <img id="logo" class="branding" src="Little-Zebra.png" />
+                    </div>
+                </div>`,
+        );
+
+        normalizeCoverImageDesignation(page);
+
+        const logo = page.querySelector("#logo") as HTMLElement;
+        expect(logo.hasAttribute("data-book")).toBe(false);
+    });
+
+    // Books saved while the bug was live carry the bad mark on disk. Opening the cover has to put
+    // it back rather than leaving the branding logo as the book's cover image forever.
+    it("heals a cover already saved with the branding image marked", () => {
+        const page = makeCustomCover(
+            picture("cover", "placeHolder.png", "bloom-backgroundImage") +
+                `<div class="bloom-canvas-element">
+                    <div data-book="cover-branding-bottom-html">
+                        <img id="logo" class="branding" src="Little-Zebra.png"
+                             data-book="coverImage" />
+                    </div>
+                </div>`,
+        );
+
+        // Sanity check: the page really does start out mis-marked, which is the point of the test.
+        expect(
+            (page.querySelector("#logo") as HTMLElement).getAttribute(
+                "data-book",
+            ),
+        ).toBe("coverImage");
+
+        normalizeCoverImageDesignation(page);
+
+        const logo = page.querySelector("#logo") as HTMLElement;
+        const cover = page.querySelector("#cover") as HTMLElement;
+        expect(logo.hasAttribute("data-book")).toBe(false);
+        expect(cover.getAttribute("data-book")).toBe("coverImage");
     });
 });

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -5292,33 +5292,51 @@ namespace Bloom.Book
                 return null;
 
             // We take the image the book marks as its cover, and failing that an image out of an
-            // image container. Everything else on the cover is off limits: the branding logo, the
-            // license image, and the QR code of the "Made with Bloom" badge belong to the branding
-            // or the license, never to the book, and none of them sits in an image container. We
-            // used to accept any img on the cover, so a branded book whose cover picture was still
-            // a placeholder took the branding logo instead. For the ABC brandings that logo is an
-            // SVG, which PalasoImage cannot load, so such a book had no thumbnail at all (BL-16780).
+            // image container. That is the whole rule: the branding logo, the license image and the
+            // QR code of the "Made with Bloom" badge belong to the branding or the license rather
+            // than to the book, and none of them is in an image container, so nothing needs to name
+            // them. We used to accept any img on the cover, so a branded book whose cover picture
+            // was still a placeholder took the branding logo instead. For the ABC brandings that
+            // logo is an SVG, which PalasoImage cannot load, so such a book had no thumbnail at all
+            // (BL-16780).
             //
-            // Take the mark from either the img or the container. On this branch only the img
-            // carries it; marking the image container came in on Version6.5, which is downstream of
-            // here, so accepting both is what lets this survive the merge forward.
+            // Take the mark from either the img or the container. Both shapes are already here: the
+            // standard xmatter marks the img, while the Afghan Children Read xmatter marks the
+            // bloom-canvas itself (Afghan-Children-Read-XMatter-mixins.pug). We accept an img
+            // inside a marked container too. Nothing in this repo produces that shape today, but a
+            // book on disk or a project-specific xmatter kept elsewhere may, and a marked container
+            // has no image URL of its own, so without it the search would fall through to an
+            // earlier container and take the wrong picture.
             //
             // The container itself is a candidate as well as the imgs inside it, because a book old
             // enough to use an obsolete image representation carries the picture on the container.
             // We handle those here rather than only for editable books, because publish and preview
             // use this code too.
+            // Match whole class names. "contains(@class, 'bloom-canvas')" is also true of
+            // bloom-canvas-element, which is not a container at all.
             const string kImageContainer =
-                "div[contains(@class, 'bloom-imageContainer') or contains(@class, 'bloom-canvas')]";
-            var markedAsTheCover = outsideFrontCover
+                "div[contains(concat(' ', normalize-space(@class), ' '), ' bloom-imageContainer ')]";
+            const string kBloomCanvas =
+                "div[contains(concat(' ', normalize-space(@class), ' '), ' bloom-canvas ')]";
+            var markedAsTheCoverImage = outsideFrontCover
                 .SafeSelectNodes(
                     ".//img[@data-book='coverImage'] | .//div[@data-book='coverImage']"
                         + " | .//div[@data-book='coverImage']//img"
                 )
                 .Cast<SafeXmlElement>();
+            // An img anywhere inside an image container is one of the book's pictures, but under a
+            // bloom-canvas only a direct child is: on a custom-layout cover the whole margin box is
+            // one bloom-canvas and everything on the cover, branding included, is a canvas element
+            // inside it, so a descendant search there would sweep up the branding logo. A direct
+            // child of the bloom-canvas is the old shape, a background image not yet converted to a
+            // canvas element (see SetupImagesInContainer).
             var inAnImageContainer = outsideFrontCover
-                .SafeSelectNodes($".//{kImageContainer} | .//{kImageContainer}//img")
+                .SafeSelectNodes(
+                    $".//{kImageContainer} | .//{kImageContainer}//img"
+                        + $" | .//{kBloomCanvas} | .//{kBloomCanvas}/img"
+                )
                 .Cast<SafeXmlElement>();
-            var candidates = markedAsTheCover.Concat(inAnImageContainer);
+            var candidates = markedAsTheCoverImage.Concat(inAnImageContainer);
 
             // A placeholder means "no picture chosen yet", so keep looking for a real one. Ending
             // up with the placeholder is a fine answer; ending up with the branding logo is not.

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -3290,26 +3290,20 @@ namespace Bloom.Book
                     .Any(NonTrivialImageFileExists);
         }
 
-        /// <summary>
-        /// True for the images that a branding or a license puts on a page: the branding logo, the
-        /// license image, and the QR code of the "Made with Bloom" badge (as much a part of the
-        /// branding as the badge image beside it). None of these belongs to the book itself, so
-        /// neither HasImages() nor the cover-image search should count them.
-        /// </summary>
-        private static bool IsBrandingOrLicenseImage(SafeXmlElement image)
+        private bool NonTrivialImageFileExists(SafeXmlElement image)
         {
-            return image.Name == "img"
-                && (
+            if (image.Name == "img")
+            {
+                // The QR code of the "Made with Bloom" badge is as much a part of the branding as
+                // the badge image itself (which has the "branding" class), so it doesn't count as
+                // one of the book's images.
+                if (
                     image.HasClass("branding")
                     || image.HasClass("licenseImage")
                     || image.HasClass(BookStorage.kQrCodeClass)
-                );
-        }
-
-        private bool NonTrivialImageFileExists(SafeXmlElement image)
-        {
-            if (IsBrandingOrLicenseImage(image))
-                return false;
+                )
+                    return false;
+            }
             var imageUrl = HtmlDom.GetImageElementUrl(image);
             var file = imageUrl.PathOnly.NotEncoded;
             if (string.IsNullOrEmpty(file))
@@ -5297,58 +5291,42 @@ namespace Bloom.Book
             if (outsideFrontCover == null)
                 return null;
 
-            // Prefer the designated cover image if it is present and not placeholder.
-            var designatedCoverImage = outsideFrontCover
-                .SafeSelectNodes(
-                    ".//img[@data-book='coverImage'] | .//div[@data-book='coverImage']"
-                )
-                .Cast<SafeXmlElement>()
-                .FirstOrDefault();
-
-            SafeXmlElement bestPlaceholderElt = null;
-            string bestPlaceholderPath = null;
-
-            if (designatedCoverImage != null)
-            {
-                var designatedPath = GetImagePath(designatedCoverImage);
-                if (designatedPath != null)
-                {
-                    if (!ImageUtils.IsPlaceholderImageFilename(designatedPath))
-                    {
-                        coverImgElt = designatedCoverImage;
-                        return designatedPath;
-                    }
-
-                    bestPlaceholderElt = designatedCoverImage;
-                    bestPlaceholderPath = designatedPath;
-                }
-            }
-
-            // Only a picture inside an image container is a candidate. A cover also carries images
-            // that belong to the branding or the license, never to the book, and those are never in
-            // an image container; without this restriction a branded book whose cover picture was
-            // still a placeholder took its branding logo as its cover image (BL-16780).
-            // We may not need to consider any options other than img, since anything that is old
-            // enough in format to use an obsolete image representation probably only has one image
-            // on the cover, properly designated with data-book. However, it's not much more work or
-            // complexity to handle the older cases here, too, and we do use this code in publish and
-            // preview situations, not only for editable books.
+            // We take the image the book marks as its cover, and failing that an image out of an
+            // image container. Everything else on the cover is off limits: the branding logo, the
+            // license image, and the QR code of the "Made with Bloom" badge belong to the branding
+            // or the license, never to the book, and none of them sits in an image container. We
+            // used to accept any img on the cover, so a branded book whose cover picture was still
+            // a placeholder took the branding logo instead. For the ABC brandings that logo is an
+            // SVG, which PalasoImage cannot load, so such a book had no thumbnail at all (BL-16780).
+            //
+            // Take the mark from either the img or the container. On this branch only the img
+            // carries it; marking the image container came in on Version6.5, which is downstream of
+            // here, so accepting both is what lets this survive the merge forward.
+            //
+            // The container itself is a candidate as well as the imgs inside it, because a book old
+            // enough to use an obsolete image representation carries the picture on the container.
+            // We handle those here rather than only for editable books, because publish and preview
+            // use this code too.
             const string kImageContainer =
                 "div[contains(@class, 'bloom-imageContainer') or contains(@class, 'bloom-canvas')]";
-            foreach (
-                var candidate in outsideFrontCover
-                    .SafeSelectNodes($".//{kImageContainer}//img | .//{kImageContainer}")
-                    .Cast<SafeXmlElement>()
-            )
+            var markedAsTheCover = outsideFrontCover
+                .SafeSelectNodes(
+                    ".//img[@data-book='coverImage'] | .//div[@data-book='coverImage']"
+                        + " | .//div[@data-book='coverImage']//img"
+                )
+                .Cast<SafeXmlElement>();
+            var inAnImageContainer = outsideFrontCover
+                .SafeSelectNodes($".//{kImageContainer} | .//{kImageContainer}//img")
+                .Cast<SafeXmlElement>();
+            var candidates = markedAsTheCover.Concat(inAnImageContainer);
+
+            // A placeholder means "no picture chosen yet", so keep looking for a real one. Ending
+            // up with the placeholder is a fine answer; ending up with the branding logo is not.
+            SafeXmlElement placeholderElt = null;
+            string placeholderPath = null;
+
+            foreach (var candidate in candidates)
             {
-                if (candidate == designatedCoverImage)
-                    continue;
-
-                // The image container is the main guard, but a branding pack supplies its own
-                // markup, so we do not control whether it wraps its logo in a container.
-                if (IsBrandingOrLicenseImage(candidate))
-                    continue;
-
                 var candidatePath = GetImagePath(candidate);
                 if (candidatePath == null)
                     continue;
@@ -5359,15 +5337,15 @@ namespace Bloom.Book
                     return candidatePath;
                 }
 
-                if (bestPlaceholderPath == null)
+                if (placeholderPath == null)
                 {
-                    bestPlaceholderElt = candidate;
-                    bestPlaceholderPath = candidatePath;
+                    placeholderElt = candidate;
+                    placeholderPath = candidatePath;
                 }
             }
 
-            coverImgElt = bestPlaceholderElt;
-            return bestPlaceholderPath;
+            coverImgElt = placeholderElt;
+            return placeholderPath;
         }
 
         private string GetImagePath(SafeXmlElement imageElement)

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -3290,20 +3290,26 @@ namespace Bloom.Book
                     .Any(NonTrivialImageFileExists);
         }
 
-        private bool NonTrivialImageFileExists(SafeXmlElement image)
+        /// <summary>
+        /// True for the images that a branding or a license puts on a page: the branding logo, the
+        /// license image, and the QR code of the "Made with Bloom" badge (as much a part of the
+        /// branding as the badge image beside it). None of these belongs to the book itself, so
+        /// neither HasImages() nor the cover-image search should count them.
+        /// </summary>
+        private static bool IsBrandingOrLicenseImage(SafeXmlElement image)
         {
-            if (image.Name == "img")
-            {
-                // The QR code of the "Made with Bloom" badge is as much a part of the branding as
-                // the badge image itself (which has the "branding" class), so it doesn't count as
-                // one of the book's images.
-                if (
+            return image.Name == "img"
+                && (
                     image.HasClass("branding")
                     || image.HasClass("licenseImage")
                     || image.HasClass(BookStorage.kQrCodeClass)
-                )
-                    return false;
-            }
+                );
+        }
+
+        private bool NonTrivialImageFileExists(SafeXmlElement image)
+        {
+            if (IsBrandingOrLicenseImage(image))
+                return false;
             var imageUrl = HtmlDom.GetImageElementUrl(image);
             var file = imageUrl.PathOnly.NotEncoded;
             if (string.IsNullOrEmpty(file))
@@ -5318,20 +5324,29 @@ namespace Bloom.Book
                 }
             }
 
+            // Only a picture inside an image container is a candidate. A cover also carries images
+            // that belong to the branding or the license, never to the book, and those are never in
+            // an image container; without this restriction a branded book whose cover picture was
+            // still a placeholder took its branding logo as its cover image (BL-16780).
+            // We may not need to consider any options other than img, since anything that is old
+            // enough in format to use an obsolete image representation probably only has one image
+            // on the cover, properly designated with data-book. However, it's not much more work or
+            // complexity to handle the older cases here, too, and we do use this code in publish and
+            // preview situations, not only for editable books.
+            const string kImageContainer =
+                "div[contains(@class, 'bloom-imageContainer') or contains(@class, 'bloom-canvas')]";
             foreach (
-                // we may not need to consider any options other than img, since anything that is old enough
-                // in format to use an obsolete image representation probably only has one image on the
-                // cover, properly designated with data-book. However, it's not much more work or complexity
-                // to handle the older cases here, too, and we do use this code in publish and preview situations,
-                // not only for editable books.
                 var candidate in outsideFrontCover
-                    .SafeSelectNodes(
-                        ".//img | .//div[contains(@class, 'bloom-imageContainer') or contains(@class, 'bloom-canvas')]"
-                    )
+                    .SafeSelectNodes($".//{kImageContainer}//img | .//{kImageContainer}")
                     .Cast<SafeXmlElement>()
             )
             {
                 if (candidate == designatedCoverImage)
+                    continue;
+
+                // The image container is the main guard, but a branding pack supplies its own
+                // markup, so we do not control whether it wraps its logo in a container.
+                if (IsBrandingOrLicenseImage(candidate))
                     continue;
 
                 var candidatePath = GetImagePath(candidate);

--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -1878,14 +1878,27 @@ namespace Bloom.Book
                     .Cast<SafeXmlElement>()
                     .ToArray();
                 foreach (var elt in nodesToProcessFirst)
+                {
+                    // Same reason as the IsStillInDocument check in the second pass below: an
+                    // earlier update in this very loop could have detached a later one of these.
+                    if (!IsStillInDocument(elt))
+                        continue;
                     UpdateOneElementFromDataSet(data, itemsToDelete, elt);
+                }
 
                 // After restoring custom page content from the data-div, prepare any bloom-editables
                 // for languages that weren't present in the saved version (e.g. a newly-added content
                 // language). Without this, the second pass below that updates e.g. bookTitle would
                 // find no destination elements for newly-added languages on the custom page.
                 foreach (var elt in nodesToProcessFirst)
+                {
+                    // Same guard as the loops either side: an update above may have detached one of
+                    // these. Nothing here walks to the document root, so an orphan would not crash,
+                    // but preparing elements in a page the book no longer has is pointless work.
+                    if (!IsStillInDocument(elt))
+                        continue;
                     TranslationGroupManager.PrepareElementsInPageOrDocument(elt, this);
+                }
 
                 // Run this query AFTER that update, so that we're updating the (possibly modified) set of nodes that
                 // result from doing it.
@@ -1897,10 +1910,17 @@ namespace Bloom.Book
                 {
                     // if we already processed it, we should not do so again,
                     // since doing so might replace some of the nodes in our list with new ones.
-                    if (!nodesToProcessFirst.Contains(elt))
-                    {
-                        UpdateOneElementFromDataSet(data, itemsToDelete, elt);
-                    }
+                    if (nodesToProcessFirst.Contains(elt))
+                        continue;
+                    // Updating one element can replace the entire content of an ancestor of another
+                    // element in this list (for example, restoring a branding html value replaces
+                    // everything inside that element), leaving the descendant orphaned. An orphan is
+                    // no longer part of the book, so there is nothing in it worth updating, and the
+                    // update code rightly assumes it still has the parents it was collected with.
+                    // See BL-16776.
+                    if (!IsStillInDocument(elt))
+                        continue;
+                    UpdateOneElementFromDataSet(data, itemsToDelete, elt);
                 }
             }
             catch (Exception error)
@@ -1913,6 +1933,22 @@ namespace Bloom.Book
                     error
                 );
             }
+        }
+
+        /// <summary>
+        /// True if the node is still attached to its document, that is, we can reach the document's
+        /// root element by following parents. A node we collected earlier may since have been
+        /// detached by an update to one of its ancestors.
+        /// </summary>
+        internal static bool IsStillInDocument(SafeXmlNode node)
+        {
+            var root = node.OwnerDocument.DocumentElement;
+            for (var current = node; current != null; current = current.ParentNode)
+            {
+                if (current == root)
+                    return true;
+            }
+            return false;
         }
 
         private void UpdateOneElementFromDataSet(

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -207,8 +207,27 @@ namespace Bloom.Edit
                             // However, FailureAction should be called in this case which allows closing the collection
                             // to try again. If we do try again and the same page fails again, the state machine will
                             // call this action anyway. So, finally PostponedWork will get called and we can close the collection.
-                            CurrentBook.Save();
-                            CurrentBook.RecordPendingCreatedHistoryEvent();
+                            try
+                            {
+                                CurrentBook.Save();
+                                CurrentBook.RecordPendingCreatedHistoryEvent();
+                            }
+                            catch (Exception e)
+                            {
+                                // Shutting down must not depend on the save succeeding. If it does,
+                                // a page that cannot be saved leaves the user no way out of Bloom at
+                                // all, because every further attempt to close runs this same failing
+                                // save (BL-16776). We deliberately don't put up a dialog: the user is
+                                // trying to quit, and whatever made the save fail will already have
+                                // been reported when it happened.
+                                NonFatalProblem.Report(
+                                    ModalIf.None,
+                                    PassiveIf.All,
+                                    "Bloom could not save the page you were editing as it shut down",
+                                    null,
+                                    e
+                                );
+                            }
                             args.PostponedWork();
                             return null;
                         },
@@ -364,7 +383,31 @@ namespace Bloom.Edit
                         // We are setting skipSaveToDisk true so that we can do it ourselves here BEFORE
                         // the postponed work, which is going to shut everything down and would prevent
                         // the normal automatic save-to-disk from working.
-                        CurrentBook?.Save(); // we need it all the way saved before doing the PostponedWork
+                        try
+                        {
+                            CurrentBook?.Save(); // we need it all the way saved before doing the PostponedWork
+                        }
+                        catch (Exception e)
+                        {
+                            // Tell the user, but change tabs anyway: a page that cannot be saved must
+                            // not lock them into the Edit tab indefinitely (BL-16776). We report rather
+                            // than letting this propagate so that we still finish on the same path a
+                            // successful save takes, rather than navigating a tab we have just left.
+                            // Note this is not the kind of swallowing we deliberately removed from
+                            // GetCleanCurrentPageFromBodyAndCss, where catching let a save carry on with
+                            // missing content. By the time we get here the page content has either
+                            // reached the DOM or thrown; all we abandon is writing it out.
+                            NonFatalProblem.Report(
+                                ModalIf.All,
+                                PassiveIf.All,
+                                LocalizationManager.GetString(
+                                    "Errors.CouldNotSavePage",
+                                    "Bloom had trouble saving a page. Please report the problem to us. Then quit Bloom, run it again, and check to see if the page you just edited is missing anything. Sorry!"
+                                ),
+                                null,
+                                e
+                            );
+                        }
                         // This bizarre behavior prevents BL-2313 and related problems.
                         // For some reason I cannot discover, switching tabs when focus is in the Browser window
                         // causes Bloom to get deactivated, which prevents various controls from working.

--- a/src/BloomExe/Edit/EditingStateMachine.cs
+++ b/src/BloomExe/Edit/EditingStateMachine.cs
@@ -264,6 +264,12 @@ public class EditingStateMachine
         }
         catch (Exception)
         {
+            // The caller's failure action is how it recovers from work that did not get done;
+            // it is needed just as much when the post-save action is what threw as when saving
+            // the page content did. Without this, an exception here left the caller believing
+            // its work was still in progress forever -- which is what made Bloom impossible to
+            // close in BL-16776.
+            failureAction?.Invoke();
             // We must not get stuck in the SavedAndStripped state, so we'll navigate to the page
             // we were on before the save.
             ToNavigating(pageId);

--- a/src/BloomTests/Book/BookDataTests.cs
+++ b/src/BloomTests/Book/BookDataTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
@@ -1487,6 +1487,48 @@ namespace BloomTests.Book
                         + "='audio/SoundTrack1.mp3' and @"
                         + HtmlDom.musicVolumeName
                         + "='0.17']",
+                    1
+                );
+        }
+
+        [Test]
+        public void UpdateVariablesAndDataDivThroughDOM_ImgOrphanedByUpdatingItsParent_DoesNotThrow()
+        {
+            // A branding html value can itself contain an image marked as the cover image (BL-16776).
+            // Restoring the branding element replaces everything inside it, which orphans the img
+            // that we collected before that happened. We must not then try to update the orphan.
+            var dom = new HtmlDom(
+                @"<html><head></head><body>
+				<div id='bloomDataDiv'>
+					<div data-book='coverImage' lang='*' src='zebra.png'
+						data-canvas-element-style='width: 468px; height: 484px; top: 0px; left: 0px;'
+						data-canvas-imgsizebasedon='469,484'>zebra.png</div>
+					<div data-book='cover-branding-bottom-html' lang='*'><img class='branding' src='zebra.png' data-book='coverImage'/></div>
+				</div>
+				<div class='bloom-page' id='frontCover'>
+					<div class='marginBox'>
+						<div data-book='cover-branding-bottom-html' lang='*'><img class='branding' src='zebra.png' data-book='coverImage'/></div>
+					</div>
+				</div>
+				</body></html>"
+            );
+            // Sanity check: the page really does start out with an img inside the element that is
+            // about to be rewritten, which is what makes this test meaningful.
+            AssertThatXmlIn
+                .Dom(dom.RawDom)
+                .HasSpecifiedNumberOfMatchesForXpath(
+                    "//div[@class='marginBox']/div[@data-book='cover-branding-bottom-html']/img[@data-book='coverImage']",
+                    1
+                );
+
+            var data = new BookData(dom, _collectionSettings, null);
+            Assert.DoesNotThrow(() => data.UpdateVariablesAndDataDivThroughDOM());
+
+            // The branding content should have been restored from the data-div.
+            AssertThatXmlIn
+                .Dom(dom.RawDom)
+                .HasSpecifiedNumberOfMatchesForXpath(
+                    "//div[@class='marginBox']/div[@data-book='cover-branding-bottom-html']/img[@class='branding']",
                     1
                 );
         }

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -7082,5 +7082,92 @@ namespace BloomTests.Book
                 Is.EqualTo(Path.Combine(_storage.Object.FolderPath, "the-cover.jpg"))
             );
         }
+
+        [Test]
+        public void GetCoverImagePathAndElt_MarkIsOnTheImg_UsesItEvenWhenAnotherContainerComesFirst()
+        {
+            // The ordinary case: the book marks its own cover picture and that picture is real.
+            // The mark must win even though the decoration sits earlier in the page, which is why
+            // the marked candidates are searched before the image containers rather than in one
+            // pass over the document (BL-16780).
+            SetDom(
+                @"
+<div id='bloomDataDiv'>
+	<div data-book='someOtherData' lang='*'>value</div>
+</div>
+<div class='bloom-page bloom-frontMatter outsideFrontCover'>
+	<div class='marginBox'>
+        <div class='bloom-canvas'>
+            <div class='bloom-imageContainer'>
+                <img src='decoration.png' id='decoration-image'/>
+            </div>
+		</div>
+        <div class='bloom-canvas'>
+            <div class='bloom-imageContainer'>
+                <img data-book='coverImage' src='the-cover.jpg' id='the-cover-image'/>
+            </div>
+		</div>
+	</div>
+</div>"
+            );
+            File.WriteAllText(Path.Combine(_storage.Object.FolderPath, "decoration.png"), "test");
+            File.WriteAllText(Path.Combine(_storage.Object.FolderPath, "the-cover.jpg"), "test");
+
+            var book = CreateBook();
+
+            // Sanity check: both files are there, so the choice is made by the mark, not by one of
+            // them being missing.
+            Assert.That(
+                File.Exists(Path.Combine(_storage.Object.FolderPath, "decoration.png")),
+                Is.True,
+                "test setup failed to write the decoration image"
+            );
+
+            var coverImgPath = book.GetCoverImagePathAndElt(out SafeXmlElement coverImgElt);
+
+            Assert.That(coverImgElt.GetAttribute("id"), Is.EqualTo("the-cover-image"));
+            Assert.That(
+                coverImgPath,
+                Is.EqualTo(Path.Combine(_storage.Object.FolderPath, "the-cover.jpg"))
+            );
+        }
+
+        [Test]
+        public void GetCoverImagePathAndElt_ImageContainerCarriesThePicture_UsesTheContainer()
+        {
+            // A book old enough to use an obsolete image representation puts the picture on the
+            // image container itself, as a background image, with no img inside it. The container
+            // is a candidate in its own right so that such a book still gets a cover picture.
+            SetDom(
+                @"
+<div id='bloomDataDiv'>
+	<div data-book='someOtherData' lang='*'>value</div>
+</div>
+<div class='bloom-page bloom-frontMatter outsideFrontCover'>
+	<div class='marginBox'>
+        <div class='bloom-imageContainer' id='old-style-container' style=""background-image:url('old-cover.jpg')""></div>
+	</div>
+</div>"
+            );
+            File.WriteAllText(Path.Combine(_storage.Object.FolderPath, "old-cover.jpg"), "test");
+
+            var book = CreateBook();
+
+            // Sanity check: the file is there, so a null result would mean the container was not
+            // considered, not that the image is missing.
+            Assert.That(
+                File.Exists(Path.Combine(_storage.Object.FolderPath, "old-cover.jpg")),
+                Is.True,
+                "test setup failed to write the old style cover image"
+            );
+
+            var coverImgPath = book.GetCoverImagePathAndElt(out SafeXmlElement coverImgElt);
+
+            Assert.That(coverImgElt.GetAttribute("id"), Is.EqualTo("old-style-container"));
+            Assert.That(
+                coverImgPath,
+                Is.EqualTo(Path.Combine(_storage.Object.FolderPath, "old-cover.jpg"))
+            );
+        }
     }
 }

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -6947,5 +6947,96 @@ namespace BloomTests.Book
             );
             Assert.That(coverImgElt.GetAttribute("id"), Is.EqualTo("front-real-image"));
         }
+
+        [Test]
+        public void GetCoverImagePathAndElt_OnlyOtherImageIsBranding_KeepsThePlaceholder()
+        {
+            // A branded cover carries a branding logo, and often a license image, beside the book's
+            // own cover picture. Neither sits in an image container, and only what is in an image
+            // container is a picture of the book, so neither may stand in for a placeholder cover
+            // image. The ABC brandings make this bite: their logo is an SVG, and PalasoImage throws
+            // on an SVG, which killed the thumbnail (BL-16780).
+            SetDom(
+                @"
+<div id='bloomDataDiv'>
+	<div data-book='someOtherData' lang='*'>value</div>
+</div>
+<div class='bloom-page bloom-frontMatter outsideFrontCover'>
+	<div class='marginBox'>
+        <div class='bloom-canvas'>
+            <div class='bloom-imageContainer'>
+                <img data-book='coverImage' src='placeHolder.png' id='cover-placeholder'/>
+            </div>
+		</div>
+        <div data-book='cover-branding-bottom-html' lang='*'>
+            <img class='branding' src='ABC-BARMM.svg' id='branding-image'/>
+        </div>
+        <img class='licenseImage' src='license.png' id='license-image'/>
+	</div>
+</div>"
+            );
+            File.WriteAllText(Path.Combine(_storage.Object.FolderPath, "ABC-BARMM.svg"), "test");
+            File.WriteAllText(Path.Combine(_storage.Object.FolderPath, "license.png"), "test");
+
+            var book = CreateBook();
+
+            // Sanity check: the branding and license files really are there, so the only reason to
+            // reject them is the rule under test, not a missing file.
+            Assert.That(
+                File.Exists(Path.Combine(_storage.Object.FolderPath, "ABC-BARMM.svg")),
+                Is.True,
+                "test setup failed to write the branding image"
+            );
+
+            var coverImgPath = book.GetCoverImagePathAndElt(out SafeXmlElement coverImgElt);
+
+            Assert.That(coverImgElt.GetAttribute("id"), Is.EqualTo("cover-placeholder"));
+            Assert.That(coverImgPath, Does.Not.Contain("ABC-BARMM.svg"));
+            Assert.That(coverImgPath, Does.Not.Contain("license.png"));
+        }
+
+        [Test]
+        public void GetCoverImagePathAndElt_BrandingIsInsideAnImageContainer_KeepsThePlaceholder()
+        {
+            // A branding pack supplies its own markup, so it may put its logo in an image
+            // container. The class must then keep the logo out of the cover-image search, because
+            // the image container no longer does (BL-16780).
+            SetDom(
+                @"
+<div id='bloomDataDiv'>
+	<div data-book='someOtherData' lang='*'>value</div>
+</div>
+<div class='bloom-page bloom-frontMatter outsideFrontCover'>
+	<div class='marginBox'>
+        <div class='bloom-canvas'>
+            <div class='bloom-imageContainer'>
+                <img data-book='coverImage' src='placeHolder.png' id='cover-placeholder'/>
+            </div>
+		</div>
+        <div data-book='cover-branding-bottom-html' lang='*'>
+            <div class='bloom-imageContainer'>
+                <img class='branding' src='ABC-BARMM.png' id='branding-image'/>
+            </div>
+        </div>
+	</div>
+</div>"
+            );
+            File.WriteAllText(Path.Combine(_storage.Object.FolderPath, "ABC-BARMM.png"), "test");
+
+            var book = CreateBook();
+
+            // Sanity check: the branding file really is there, so the only reason to reject it is
+            // the rule under test, not a missing file.
+            Assert.That(
+                File.Exists(Path.Combine(_storage.Object.FolderPath, "ABC-BARMM.png")),
+                Is.True,
+                "test setup failed to write the branding image"
+            );
+
+            var coverImgPath = book.GetCoverImagePathAndElt(out SafeXmlElement coverImgElt);
+
+            Assert.That(coverImgElt.GetAttribute("id"), Is.EqualTo("cover-placeholder"));
+            Assert.That(coverImgPath, Does.Not.Contain("ABC-BARMM.png"));
+        }
     }
 }

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -6955,7 +6955,7 @@ namespace BloomTests.Book
             // own cover picture. Neither sits in an image container, and only what is in an image
             // container is a picture of the book, so neither may stand in for a placeholder cover
             // image. The ABC brandings make this bite: their logo is an SVG, and PalasoImage throws
-            // on an SVG, which killed the thumbnail (BL-16780).
+            // on an SVG, which killed the thumbnail (BL-16780). This is the reported case.
             SetDom(
                 @"
 <div id='bloomDataDiv'>
@@ -6996,11 +6996,11 @@ namespace BloomTests.Book
         }
 
         [Test]
-        public void GetCoverImagePathAndElt_BrandingIsInsideAnImageContainer_KeepsThePlaceholder()
+        public void GetCoverImagePathAndElt_RealImageIsNotInAnImageContainer_KeepsThePlaceholder()
         {
-            // A branding pack supplies its own markup, so it may put its logo in an image
-            // container. The class must then keep the logo out of the cover-image search, because
-            // the image container no longer does (BL-16780).
+            // Only what is in an image container, or what the book marks as its cover, counts as a
+            // picture of the book. A loose img on the cover is decoration or branding, so it may
+            // not stand in for a placeholder cover image, even though its file is real (BL-16780).
             SetDom(
                 @"
 <div id='bloomDataDiv'>
@@ -7013,30 +7013,74 @@ namespace BloomTests.Book
                 <img data-book='coverImage' src='placeHolder.png' id='cover-placeholder'/>
             </div>
 		</div>
-        <div data-book='cover-branding-bottom-html' lang='*'>
-            <div class='bloom-imageContainer'>
-                <img class='branding' src='ABC-BARMM.png' id='branding-image'/>
-            </div>
-        </div>
+        <img src='loose.png' id='loose-image'/>
 	</div>
 </div>"
             );
-            File.WriteAllText(Path.Combine(_storage.Object.FolderPath, "ABC-BARMM.png"), "test");
+            File.WriteAllText(Path.Combine(_storage.Object.FolderPath, "loose.png"), "test");
 
             var book = CreateBook();
 
-            // Sanity check: the branding file really is there, so the only reason to reject it is
-            // the rule under test, not a missing file.
+            // Sanity check: the loose file really is there, so the only reason to reject it is the
+            // rule under test, not a missing file.
             Assert.That(
-                File.Exists(Path.Combine(_storage.Object.FolderPath, "ABC-BARMM.png")),
+                File.Exists(Path.Combine(_storage.Object.FolderPath, "loose.png")),
                 Is.True,
-                "test setup failed to write the branding image"
+                "test setup failed to write the loose image"
             );
 
             var coverImgPath = book.GetCoverImagePathAndElt(out SafeXmlElement coverImgElt);
 
             Assert.That(coverImgElt.GetAttribute("id"), Is.EqualTo("cover-placeholder"));
-            Assert.That(coverImgPath, Does.Not.Contain("ABC-BARMM.png"));
+            Assert.That(coverImgPath, Does.Not.Contain("loose.png"));
+        }
+
+        [Test]
+        public void GetCoverImagePathAndElt_MarkIsOnTheImageContainer_UsesTheImageInThatContainer()
+        {
+            // Marking the image container, rather than the img in it, came in on Version6.5, which
+            // is downstream of this branch. A cover with two image containers must still honour the
+            // mark and not simply take the first container it meets (BL-16780).
+            SetDom(
+                @"
+<div id='bloomDataDiv'>
+	<div data-book='someOtherData' lang='*'>value</div>
+</div>
+<div class='bloom-page bloom-frontMatter outsideFrontCover'>
+	<div class='marginBox'>
+        <div class='bloom-canvas'>
+            <div class='bloom-imageContainer'>
+                <img src='decoration.png' id='decoration-image'/>
+            </div>
+		</div>
+        <div class='bloom-canvas'>
+            <div class='bloom-imageContainer' data-book='coverImage'>
+                <img src='the-cover.jpg' id='the-cover-image'/>
+            </div>
+		</div>
+	</div>
+</div>"
+            );
+            File.WriteAllText(Path.Combine(_storage.Object.FolderPath, "decoration.png"), "test");
+            File.WriteAllText(Path.Combine(_storage.Object.FolderPath, "the-cover.jpg"), "test");
+
+            var book = CreateBook();
+
+            // Sanity check: both files are there, so the choice is made by the mark, not by one of
+            // them being missing.
+            Assert.That(
+                File.Exists(Path.Combine(_storage.Object.FolderPath, "decoration.png")),
+                Is.True,
+                "test setup failed to write the decoration image"
+            );
+
+            var coverImgPath = book.GetCoverImagePathAndElt(out SafeXmlElement coverImgElt);
+
+            Assert.That(coverImgElt.GetAttribute("id"), Is.EqualTo("the-cover-image"));
+            Assert.That(
+                coverImgPath,
+                Is.EqualTo(Path.Combine(_storage.Object.FolderPath, "the-cover.jpg"))
+            );
         }
     }
 }

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -6996,6 +6996,87 @@ namespace BloomTests.Book
         }
 
         [Test]
+        public void GetCoverImagePathAndElt_UnconvertedBackgroundImgUnderTheCanvas_IsStillFound()
+        {
+            // The old shape: a background image sitting straight inside the bloom-canvas, not yet
+            // converted to a canvas element with an image container. It is one of the book's own
+            // pictures and must still be found, which is why a direct child of the bloom-canvas
+            // counts even though a deeper descendant does not (BL-16780).
+            SetDom(
+                @"
+<div id='bloomDataDiv'>
+	<div data-book='someOtherData' lang='*'>value</div>
+</div>
+<div class='bloom-page bloom-frontMatter outsideFrontCover'>
+	<div class='marginBox'>
+        <div class='bloom-canvas'>
+            <img src='the-cover.jpg' id='old-style-cover'/>
+		</div>
+	</div>
+</div>"
+            );
+            File.WriteAllText(Path.Combine(_storage.Object.FolderPath, "the-cover.jpg"), "test");
+
+            var book = CreateBook();
+
+            var coverImgPath = book.GetCoverImagePathAndElt(out SafeXmlElement coverImgElt);
+
+            Assert.That(coverImgElt.GetAttribute("id"), Is.EqualTo("old-style-cover"));
+            Assert.That(coverImgPath, Does.Contain("the-cover.jpg"));
+        }
+
+        [Test]
+        public void GetCoverImagePathAndElt_CustomLayoutCoverWithBrandingInTheCanvas_KeepsThePlaceholder()
+        {
+            // The same reported case, but on a cover in custom layout. There the whole margin box
+            // is one bloom-canvas and every element on the cover, branding included, is a canvas
+            // element inside it -- so "is it in an image container" does not tell the book's own
+            // picture from the branding, because bloom-canvas counts as an image container here.
+            // Only the branding class does. This is the shape of the Little Zebra book in BL-16776.
+            SetDom(
+                @"
+<div id='bloomDataDiv'>
+	<div data-book='someOtherData' lang='*'>value</div>
+</div>
+<div class='bloom-page bloom-frontMatter outsideFrontCover bloom-customLayout' data-custom-layout-id='customOutsideFrontCover'>
+	<div class='marginBox'>
+        <div class='bloom-canvas bloom-has-canvas-element'>
+            <div class='bloom-canvas-element bloom-backgroundImage'>
+                <div class='bloom-imageContainer'>
+                    <img data-book='coverImage' src='placeHolder.png' id='cover-placeholder'/>
+                </div>
+            </div>
+            <div class='bloom-canvas-element'>
+                <div data-book='cover-branding-bottom-html' lang='*'>
+                    <img class='branding' src='Little-Zebra.png' id='branding-image'/>
+                </div>
+            </div>
+		</div>
+	</div>
+</div>"
+            );
+            File.WriteAllText(Path.Combine(_storage.Object.FolderPath, "Little-Zebra.png"), "test");
+
+            var book = CreateBook();
+
+            // Sanity check: the branding file really is there, so the only reason to reject it is
+            // the rule under test, not a missing file.
+            Assert.That(
+                File.Exists(Path.Combine(_storage.Object.FolderPath, "Little-Zebra.png")),
+                Is.True,
+                "test setup failed to write the branding image"
+            );
+
+            var coverImgPath = book.GetCoverImagePathAndElt(out SafeXmlElement coverImgElt);
+
+            // Restoring a custom page from the data-div strips img ids on the way through, so
+            // identify what came back by its src rather than by an id.
+            Assert.That(coverImgPath, Does.Not.Contain("Little-Zebra.png"));
+            Assert.That(coverImgPath, Does.Contain("placeHolder.png"));
+            Assert.That(coverImgElt.GetAttribute("src"), Is.EqualTo("placeHolder.png"));
+        }
+
+        [Test]
         public void GetCoverImagePathAndElt_RealImageIsNotInAnImageContainer_KeepsThePlaceholder()
         {
             // Only what is in an image container, or what the book marks as its cover, counts as a


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
Fixes BL-16780 and BL-16776. They are one story, and the second cannot ship without the first — see "Why these are one PR" below.

## Problem

Two symptoms of one idea: Bloom treating a branding image as the book's own picture.

**The book icon (BL-16780).** A branded book whose cover picture is still the placeholder gets the wrong icon, or none. Bloom picks the branding logo; with the ABC brandings that logo is an SVG, which `PalasoImage` cannot load, so there is no thumbnail at all. Example book: ABC-BARMM-007297-2656.

**A book that cannot be saved, and a Bloom that cannot be quit (BL-16776).** On a custom-layout front cover whose picture is still the placeholder, the editor marks the *branding logo* as the cover image. That poisons the data-div, and the next save crashes. Because leaving the Edit tab and shutting down both wait for a successful save, every exit is blocked too: the reporter could not change page, change tab, or close Bloom, and had to use Task Manager.

## Cause

`GetCoverImagePathAndElt` fell back to **any** `img` on the front cover, and `normalizeCoverImageDesignation` chose among **any** non-UI image on the page. A cover also carries branding and license images, which are not pictures of the book.

The crash is separate. Once the branding logo is marked, the data-div's `cover-branding-bottom-html` value contains an `<img data-book='coverImage'>`. `UpdateDomFromDataSet` collects every `data-book` node, restores the branding element — which replaces its contents, orphaning that img — then dereferences parents the orphan no longer has.

## Fix

- **Which image is the book's own** — the same rule on both sides: an image anywhere inside a `bloom-imageContainer`, or a **direct child** of a `bloom-canvas` (the old shape of a background image not yet converted to a canvas element; tests pin it on both sides). Not a descendant of the bloom-canvas: on a custom-layout cover the whole margin box is one bloom-canvas with every element, branding included, a canvas element inside it.
- Class names are matched whole, so `bloom-canvas` no longer also matches `bloom-canvas-element`.
- `bloomImages.ts` additionally refuses branding/license/QR by class. `Book.cs` does not, and that asymmetry is deliberate: there, being wrong costs a wrong icon; here it writes a wrong cover image into the book.
- A mark on an image that is not the book's own no longer votes for itself, and the last resort hands the mark back to the background image — so a mis-marked cover repairs itself.
- **The crash**: `UpdateDomFromDataSet` skips collected nodes that an earlier update has detached.
- **The traps**: leaving the Edit tab reports a failed save and changes tabs anyway; shutdown reports and carries on, so quitting never depends on a save.
- The element the book marks as its cover is still preferred whenever it holds a real picture.

## Why these are one PR

Until now the crash was an accidental safety interlock: marking the branding logo made the save throw, so the corruption never reached disk — the reporter's book was still clean hours later. The orphan guard removes that interlock, so a poisoned save would now succeed and persist. The front-end fix that stops the marking must therefore ship with it, not after it.

## Testing

Twelve `GetCoverImagePathAndElt` tests and eight `normalizeCoverImageDesignation` tests; each new rule was checked by removing it and confirming exactly the intended test goes red. Verified in a running Bloom on a Little Zebra book with a custom-layout cover: one image change now marks the real cover slot and leaves the logo alone, and the cover-image API returns the placeholder thumbnail rather than the logo.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16780
Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16776


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8256)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8256)
<!-- Reviewable:end -->



