### PR TITLE
Show the ABC branding grade only when the book has a level (BL-16775)

### DIFF
--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -285,3 +285,46 @@ the editor repo publish its host-harness selectors so this driver can import rat
 copy them.
 
 **Context:** BL-16603, verifying the credits fix end-to-end against a real Bloom.
+
+## 2026-08-27 — No way to make Bloom open a specific collection from an agent
+
+To verify branding/xmatter behaviour you usually need a *particular* collection (here, one with
+an ABC-BARMM subscription so the ABC-Reader xmatter is in play). `launcherControl.mjs` has
+`--start`, `--restart`, `--ensure-running`, but no way to say *which* collection to open, and
+`bloom-automation` documents no other route. Bloom just reopens whatever it had last.
+
+The workaround was to quit Bloom, hand-edit the `MruProjects` list at the top of
+`%LOCALAPPDATA%\SIL\Bloom\<version>\user.config`, then `--start`. That works, but it mutates
+the developer's own recent-collections list, and it only works while Bloom is stopped (Bloom
+rewrites the file on exit). Two smaller traps inside it: the file wants Windows paths, and a
+`\a` in the path (`D:\abc-grade-test`) turns into a BEL character in both `sed` and a Python
+heredoc — forward slashes (`D:/abc-grade-test/…`) sidestep it and Bloom accepts them.
+
+**Idea:** give `launcherControl.mjs` a `--collection <path>` option that passes the path
+through to `Bloom.exe` (it already takes a collection path on its command line), so an agent
+can open a throwaway test collection without touching the developer's settings.
+
+**Context:** BL-16775, verifying how the ABC-Reader grade circle picks its number.
+
+## 2026-08-28 — An xmatter LESS edit does not reach a running Bloom on its own
+
+The dev server pushes `.less` changes into the running Bloom, but an xmatter stylesheet does not
+travel that route. Bloom serves `output/browser/templates/xMatter/.../<pack>.css`, and it also
+*stamps a copy into each book folder*, re-stamping when the book is reopened. So after editing
+`ABC-Reader-XMatter.less` you have to compile it yourself and copy the result over both:
+
+```bash
+node src/BloomBrowserUI/node_modules/less/bin/lessc \
+  src/content/templates/xMatter/project-specific/ABC-Reader-XMatter/ABC-Reader-XMatter.less \
+  output/browser/templates/xMatter/project-specific/ABC-Reader-XMatter/ABC-Reader-XMatter.css
+cp output/browser/.../ABC-Reader-XMatter.css <collection>/<book>/ABC-Reader-XMatter.css
+```
+
+Nothing warns you. The book keeps showing the old rules, which reads as "my fix does not work"
+rather than "my fix is not there yet". A previous session in this repo drew exactly that wrong
+conclusion.
+
+**Idea:** have `go.sh` watch `src/content/**/*.less` and recompile the xmatter packs, the way the
+dev server already handles the rest of the front end.
+
+**Context:** BL-16775, the ABC-Reader grade circle.

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/ReaderToolSwitch.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/ReaderToolSwitch.tsx
@@ -5,7 +5,11 @@ import { toolboxTheme } from "../../../bloomMaterialUITheme";
 import { ToolBox, applyToolboxStateToUpdatedPage } from "../toolbox";
 import { BloomSwitch } from "../../../react_components/BloomSwitch";
 import { postBoolean } from "../../../utils/bloomApi";
-import { isReaderToolEnabledOnCurrentPage } from "./readerToolPageState";
+import {
+    isReaderToolEnabledOnCurrentPage,
+    updateReaderNumbersOnCurrentPage,
+} from "./readerToolPageState";
+import { getTheOneReaderToolsModel } from "./readerToolsModel";
 
 export const ReaderToolSwitch: React.FunctionComponent<{
     isForLeveled: boolean;
@@ -50,6 +54,14 @@ export const ReaderToolSwitch: React.FunctionComponent<{
                     ToolBox.getPage()?.classList.toggle(
                         `${prefix}-reader`,
                         checked,
+                    );
+
+                    // The class alone is not enough: a branding stylesheet reads the level and
+                    // the stage from the page body, so those have to follow the switch.
+                    const model = getTheOneReaderToolsModel();
+                    updateReaderNumbersOnCurrentPage(
+                        model.levelNumber,
+                        model.stageNumber,
                     );
 
                     // If we toggle the reader tool, we need to update the markup.

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolPageState.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolPageState.ts
@@ -1,12 +1,52 @@
-import { ToolBox } from "../toolbox";
+import { getPageIframeBody } from "../../../utils/shared";
 
 export function isReaderToolEnabledOnCurrentPage(
     isForLeveled: boolean,
 ): boolean {
     const prefix = isForLeveled ? "leveled" : "decodable";
-    return !!ToolBox.getPage()?.classList.contains(`${prefix}-reader`);
+    return !!getPageIframeBody()?.classList.contains(`${prefix}-reader`);
 }
 
 export function isReaderToolTurnedOff(isForLeveled: boolean): boolean {
     return !isReaderToolEnabledOnCurrentPage(isForLeveled);
+}
+
+/**
+ * Put the level, the stage, and the number the xmatter shows onto the page body, where a
+ * stylesheet can see them. A branding such as ABC-Reader draws its grade circle from
+ * data-leveledreaderlevel, so the page must carry what the user has just chosen, not what the
+ * book had when the page loaded. The book itself gets the same values from the server
+ * (Book.SetIsLeveled, Book.AddReaderBodyAttributes and BookData).
+ *
+ * Take both numbers, because a book can be a leveled reader and a decodable reader at once, and
+ * turning one of them off then has to fall back to the other. A kind the book is not records 0.
+ * (BL-16775)
+ */
+export function updateReaderNumbersOnCurrentPage(
+    levelNumber: number,
+    stageNumber: number,
+): void {
+    const page = getPageIframeBody();
+    if (!page) return;
+    const leveledOn = isReaderToolEnabledOnCurrentPage(true);
+    const decodableOn = isReaderToolEnabledOnCurrentPage(false);
+    page.setAttribute(
+        "data-leveledreaderlevel",
+        (leveledOn ? levelNumber : 0).toString(),
+    );
+    page.setAttribute(
+        "data-decodablestage",
+        (decodableOn ? stageNumber : 0).toString(),
+    );
+
+    // The xmatter shows the number through this field. Keep the page in step, so the user sees
+    // the change without having to leave the page and come back. The stage wins over the level
+    // when the book is both, which is the order BookData.UpdateToolRelatedDataFromBookInfo
+    // applies on the server.
+    let text = "";
+    if (leveledOn) text = levelNumber.toString();
+    if (decodableOn) text = stageNumber.toString();
+    page.querySelectorAll('[data-book="levelOrStageNumber"]').forEach((e) => {
+        e.textContent = text;
+    });
 }

--- a/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/readers/readerToolsModel.ts
@@ -38,6 +38,7 @@ import {
     allPromiseSettled,
     setTimeoutPromise,
 } from "../../../utils/asyncUtils";
+import { updateReaderNumbersOnCurrentPage } from "./readerToolPageState";
 
 const SortType = {
     alphabetic: "alphabetic",
@@ -167,6 +168,7 @@ export class ReaderToolsModel {
 
         this.stageNumber = stage;
         this.updateStageNumberIfNeeded(); // May change the stage number
+        updateReaderNumbersOnCurrentPage(this.levelNumber, this.stageNumber);
 
         return setTimeoutPromise(async () => {
             if (this.stageNumber === stage) {
@@ -237,6 +239,8 @@ export class ReaderToolsModel {
         }
         this.levelNumber = val;
         this.updateLevelNumberIfNeeded(); // May change the level number
+        // A branding stylesheet draws its grade from these attributes on the page body.
+        updateReaderNumbersOnCurrentPage(this.levelNumber, this.stageNumber);
         if (!skipSave) {
             this.saveState();
             // When we're actually changing the level is the only time we want

--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -2004,11 +2004,11 @@ namespace Bloom.Book
             // these values.
             bookDom.Body.SetAttribute(
                 "data-decodablestage",
-                this.BookInfo.MetaData.DecodableReaderStage.ToString()
+                StageToRecordOnBody(bookDom).ToString()
             );
             bookDom.Body.SetAttribute(
                 "data-leveledreaderlevel",
-                this.BookInfo.MetaData.LeveledReaderLevel.ToString()
+                LevelToRecordOnBody(bookDom).ToString()
             );
         }
 
@@ -6105,16 +6105,50 @@ namespace Bloom.Book
             );
         }
 
+        /// <summary>
+        /// The leveled reader level to record on the body of the given DOM. The Leveled Reader
+        /// tool keeps its level after the user turns the "book is leveled" switch off, so the
+        /// tool state alone does not say whether the book has a level; the "leveled-reader" class
+        /// on the body says that, and BookData already uses it to decide whether to give the book
+        /// a levelOrStageNumber. Without this test the body kept a level the book no longer had,
+        /// and the ABC branding went on showing the grade for it (BL-16775).
+        /// </summary>
+        public int LevelToRecordOnBody(HtmlDom dom)
+        {
+            return dom.HasClassOnBody("leveled-reader") ? BookInfo.MetaData.LeveledReaderLevel : 0;
+        }
+
+        /// <summary>
+        /// The decodable reader stage to record on the body of the given DOM, on the same
+        /// principle as LevelToRecordOnBody.
+        /// </summary>
+        public int StageToRecordOnBody(HtmlDom dom)
+        {
+            return dom.HasClassOnBody("decodable-reader")
+                ? BookInfo.MetaData.DecodableReaderStage
+                : 0;
+        }
+
         public void SetIsDecodable(bool isDecodable)
         {
             OurHtmlDom.SetClassOnBody(isDecodable, "decodable-reader");
             OurHtmlDom.SetClassOnBody(!isDecodable, "decodable-reader-off");
+            // Keep the body attribute honest at once, rather than only when the book is next
+            // brought up to date.
+            OurHtmlDom.Body.SetAttribute(
+                "data-decodablestage",
+                StageToRecordOnBody(OurHtmlDom).ToString()
+            );
         }
 
         public void SetIsLeveled(bool isLeveled)
         {
             OurHtmlDom.SetClassOnBody(isLeveled, "leveled-reader");
             OurHtmlDom.SetClassOnBody(!isLeveled, "leveled-reader-off");
+            OurHtmlDom.Body.SetAttribute(
+                "data-leveledreaderlevel",
+                LevelToRecordOnBody(OurHtmlDom).ToString()
+            );
         }
 
         public bool HasL1Title()

--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -445,7 +445,6 @@ namespace Bloom.Book
                 itemsToDelete,
                 info
             );
-            UpdateToolRelatedDataFromBookInfo(info, incomingData, itemsToDelete);
             incomingData.UpdateGenericLanguageString(
                 "contentLanguage1",
                 XmlString.FromUnencoded(Language1.Tag),
@@ -497,9 +496,13 @@ namespace Bloom.Book
             if (info == null)
                 return; // only in tests
             var tools = info.Tools;
-            var bookClass = _dom.Body.GetAttribute("class");
+            // Test for the class as a whole word. The string "leveled-reader-off" contains
+            // "leveled-reader", so a substring test said a book was leveled when the user had
+            // just said it was not (BL-16775).
+            var isLeveled = _dom.Body.HasClass("leveled-reader");
+            var isDecodable = _dom.Body.HasClass("decodable-reader");
 
-            if (!bookClass.Contains("leveled-reader") && !bookClass.Contains("decodable-reader"))
+            if (!isLeveled && !isDecodable)
             {
                 incomingData.UpdateGenericLanguageString(
                     "levelOrStageNumber",
@@ -511,7 +514,7 @@ namespace Bloom.Book
             }
 
             var levelTool = tools.FirstOrDefault(t => t.ToolId == "leveledReader");
-            if (levelTool != null && bookClass.Contains("leveled-reader"))
+            if (levelTool != null && isLeveled)
             {
                 var level = levelTool.State;
                 incomingData.UpdateGenericLanguageString(
@@ -523,7 +526,7 @@ namespace Bloom.Book
             }
 
             var decodableTool = tools.FirstOrDefault(t => t.ToolId == "decodableReader");
-            if (decodableTool != null && bookClass.Contains("decodable-reader"))
+            if (decodableTool != null && isDecodable)
             {
                 var stageString = decodableTool
                     .State?.Split(';')
@@ -1330,6 +1333,12 @@ namespace Bloom.Book
             GatherDataItemsFromXElement(data, elementToReadFrom, itemsToDelete);
 
             MigrateData(data);
+
+            // This has to happen before we push the data out to the document. The gathered data
+            // holds whatever levelOrStageNumber the pages happen to show, so a book the user has
+            // just said is neither leveled nor decodable would otherwise be given its old number
+            // back, and go on showing that grade for ever (BL-16775).
+            UpdateToolRelatedDataFromBookInfo(info, data, itemsToDelete);
 
             //            SendDataToDebugConsole(data);
             UpdateDomFromDataSet(data, "*", _dom.RawDom, itemsToDelete);

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -1595,8 +1595,9 @@ namespace Bloom.Edit
             var currentLevel = _currentlyDisplayedBook.OurHtmlDom.Body.GetAttribute(
                 "data-leveledreaderlevel"
             );
-            var correctLevel =
-                _currentlyDisplayedBook.BookInfo.MetaData.LeveledReaderLevel.ToString();
+            var correctLevel = _currentlyDisplayedBook
+                .LevelToRecordOnBody(_currentlyDisplayedBook.OurHtmlDom)
+                .ToString();
             if (correctLevel != currentLevel)
             {
                 SaveThen(

--- a/src/BloomTests/Book/BookDataTests.cs
+++ b/src/BloomTests/Book/BookDataTests.cs
@@ -1425,6 +1425,73 @@ namespace BloomTests.Book
                 );
         }
 
+        [Test]
+        public void UpdateVariablesAndDataDivThroughDOM_LeveledTurnedOff_ClearsTheNumberOnThePage()
+        {
+            // The user has clicked "book is not leveled", which leaves the Leveled Reader tool
+            // with its level. The pages still show the number the book had. Both the data div and
+            // the pages must lose it, or the ABC branding goes on showing that grade (BL-16775).
+            // Note also that the class is "leveled-reader-off", which contains the string
+            // "leveled-reader"; a substring test says such a book is leveled.
+            var dom = new HtmlDom(
+                @"<html ><head></head><body class='leveled-reader-off decodable-reader-off'>
+				<div id='bloomDataDiv'>
+					<div data-book='levelOrStageNumber' lang='*'>3</div>
+				</div>
+				<div class='bloom-page frontCover' id='guid2' data-xmatter-page='frontCover'>
+					<div data-book='levelOrStageNumber' lang='*'>3</div>
+				</div>
+				</body></html>"
+            );
+            var data = new BookData(dom, _collectionSettings, null);
+            var info = GetLeveledDecodableInfo();
+            // Sanity check: the tool really does still hold a level, so a fix that simply found
+            // no level would prove nothing.
+            Assert.That(
+                info.Tools.Single(t => t.ToolId == "leveledReader").State,
+                Is.EqualTo("3"),
+                "test setup failed to give the book a leveled reader level"
+            );
+
+            data.UpdateVariablesAndDataDivThroughDOM(info);
+
+            AssertThatXmlIn
+                .Dom(dom.RawDom)
+                .HasNoMatchForXpath(
+                    "//div[@id='bloomDataDiv']/div[@data-book='levelOrStageNumber']"
+                );
+            AssertThatXmlIn
+                .Dom(dom.RawDom)
+                .HasNoMatchForXpath(
+                    "//div[contains(@class,'bloom-page')]//div[@data-book='levelOrStageNumber' and normalize-space(text())!='']"
+                );
+        }
+
+        [Test]
+        public void UpdateVariablesAndDataDivThroughDOM_LeveledOffButDecodableOn_UsesTheStage()
+        {
+            // A book can be decodable and not leveled. It then takes its number from the stage.
+            var dom = new HtmlDom(
+                @"<html ><head></head><body class='decodable-reader leveled-reader-off'>
+				<div id='bloomDataDiv'>
+					<div data-book='levelOrStageNumber' lang='*'>3</div>
+				</div>
+				<div class='bloom-page frontCover' id='guid2' data-xmatter-page='frontCover'>
+					<div data-book='levelOrStageNumber' lang='*'>3</div>
+				</div>
+				</body></html>"
+            );
+            var data = new BookData(dom, _collectionSettings, null);
+            data.UpdateVariablesAndDataDivThroughDOM(GetLeveledDecodableInfo());
+
+            AssertThatXmlIn
+                .Dom(dom.RawDom)
+                .HasSpecifiedNumberOfMatchesForXpath(
+                    "//div[@id='bloomDataDiv']/div[@data-book='levelOrStageNumber' and @lang='*' and text()='4']",
+                    1
+                );
+        }
+
         private BookInfo GetLeveledDecodableInfo()
         {
             // an arbitrary temp folder where we won't find any metadata, to create an empty default BookInfo.

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -7352,5 +7352,34 @@ namespace BloomTests.Book
             );
             Assert.That(coverImgElt.GetAttribute("id"), Is.EqualTo("front-real-image"));
         }
+
+        [Test]
+        public void SetIsLeveled_TurnedOff_ClearsTheLevelOnTheBody()
+        {
+            // A branding stylesheet reads the grade from this attribute, so it has to say the book
+            // has no level as soon as the user says the book is not leveled. The Leveled Reader
+            // tool keeps its level, so the tool state alone cannot answer that (BL-16775).
+            var book = CreateBook();
+            var levelState = Bloom.Edit.ToolboxToolState.CreateFromToolId("leveledReader");
+            levelState.State = "7";
+            levelState.Enabled = true;
+            book.BookInfo.Tools.Add(levelState);
+
+            book.SetIsLeveled(true);
+
+            // Sanity check: with the book leveled, the tool's level does reach the body.
+            Assert.That(
+                book.OurHtmlDom.Body.GetAttribute("data-leveledreaderlevel"),
+                Is.EqualTo("7"),
+                "test setup failed to put the level on the body"
+            );
+
+            book.SetIsLeveled(false);
+
+            Assert.That(
+                book.OurHtmlDom.Body.GetAttribute("data-leveledreaderlevel"),
+                Is.EqualTo("0")
+            );
+        }
     }
 }

--- a/src/content/templates/xMatter/project-specific/ABC-Reader-XMatter/ABC-Reader-XMatter.less
+++ b/src/content/templates/xMatter/project-specific/ABC-Reader-XMatter/ABC-Reader-XMatter.less
@@ -23,8 +23,12 @@
         // Since the font-size differs in all 3 locations that we show the grade, we have to set it individually in each place.
     }
 
-    &:after {
-        content: "1"; // will get overridden for grades 2 and 3
+    // A book with neither a leveled-reader level nor a decodable stage leaves this element
+    // empty. Until 2022 such a book showed no grade at all; :not(:empty) restores that, so the
+    // number appears only when the book really has a level or a stage. The ReaderLevel() rules
+    // at the end of this file override the "1" for grades 2 and 3.
+    &:not(:empty):after {
+        content: "1";
     }
 }
 
@@ -165,6 +169,17 @@ div.bloomPlayer-page {
     }
 }
 
+// The same restoration for the circle itself. Until 2022 a book with neither a level nor a
+// stage got no background colour and no label here, so the circle was invisible. The box stays,
+// which keeps the title at the width it has today.
+.numberCircle:has(.abcLevel:empty) {
+    background-color: transparent;
+
+    .numberLabel {
+        visibility: hidden;
+    }
+}
+
 /* -----------------------------------------------------------------------------
    Rules for the Title Page
    ----------------------------------------------------------------------------*/
@@ -186,7 +201,8 @@ div.bloomPlayer-page {
         font-size: 14px; // the actual grade number
     }
 
-    .abcLevel:before {
+    // Without a number there is nothing to label, so do not leave a bare "Grade " behind.
+    .abcLevel:not(:empty):before {
         content: "Grade " !important;
     }
 
@@ -306,7 +322,12 @@ div.bloomPlayer-page {
     }
 }
 
-.outsideBackCover .levelOrStageAndNumberRow div[data-book]:empty:after {
+// A book with no leveled-reader level and no decodable stage has an empty levelOrStageNumber.
+// On the back cover the customer wants that to read "Kindergarten" instead of the default "1".
+// The selector must match the markup that ABC-Reader-XMatter.pug actually emits, which is a
+// .backCoverRow holding the .abcLevel div. (It used to name .levelOrStageAndNumberRow, a class
+// this xmatter never emits, so the rule never applied.)
+.outsideBackCover .backCoverRow .abcLevel:empty:after {
     content: "Kindergarten";
 }
 
@@ -381,14 +402,22 @@ div.bloomPlayer-page {
    Override the various "Grade 1" labels as needed
    ----------------------------------------------------------------------------*/
 .ReaderLevel(@level, @grade, @color) {
-    body,
-    div.bloomPlayer-page {
+    // The "leveled-reader" class is what says the book has a level at all, and the Leveled
+    // Reader tool switch adds and removes it on the page as soon as the user clicks it. The
+    // level attribute alone is not enough: the tool keeps its level after the switch goes off,
+    // so a decodable book that was once at level 7 kept its grade 2 circle (BL-16775).
+    body.leveled-reader,
+    div.bloomPlayer-page.leveled-reader {
         &[data-leveledreaderlevel="@{level}"] {
             .numberCircle {
                 background-color: @color;
             }
 
-            .abcLevel:after {
+            // The value is the one source of truth for whether the book has a grade at all.
+            // Turning off the "this book is leveled" button clears the value but leaves
+            // data-leveledreaderlevel alone, so without :not(:empty) the book stayed stuck on
+            // the grade it had (BL-16775).
+            .abcLevel:not(:empty):after {
                 content: "@{grade}";
             }
         }


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
## Problem

In a collection that uses an ABC branding (ABC-BARMM and its siblings), every book showed a grade circle on the cover, the title page and the back cover, and the circle often showed the wrong grade. A book that had never been given a level showed "Grade 1". A book whose "This book is leveled" switch the user had just turned off went on showing the grade it had before, and kept it after a restart. The back cover, which is meant to read "Kindergarten" for a book with no level, showed a number instead.

## Cause

The stylesheet drew the grade from `data-leveledreaderlevel` on the page body alone. The Leveled Reader tool keeps its level after the switch goes off, so that attribute outlived the level the book actually had. The server did not clear the number either: a substring test read `leveled-reader-off` as `leveled-reader`, and the routine that clears the number ran after the number had already gone out to the pages.

## Fix

- `ABC-Reader-XMatter.less` shows a grade only when the book has one. The grade rules now require the `leveled-reader` class, and the number and its "Grade " label appear only when the value is not empty. A book with no level gets an invisible circle, which is how it behaved before 2022.
- The back-cover "Kindergarten" rule now names the class the ABC xmatter really emits (`.backCoverRow`), so it applies at all. It never did.
- `Book` records the level and the stage on the body only while the book is of that kind, and writes them as soon as the user flips either switch.
- `BookData` tests the body classes as whole words, and clears the number before the data goes out to the pages rather than after.
- The Leveled Reader and Decodable Reader controls put the level, the stage, and the displayed number onto the page as the user changes them, so the circle follows the switch with no page change. Where a book is both kinds, the decodable stage wins, which is the order the server applies.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16775


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8257)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8257)
<!-- Reviewable:end -->
