### PR TITLE
Let dev, alpha, and internal beta builds choose dev.BloomLibrary.org (BL-16781)

### DIFF
--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -285,3 +285,23 @@ the editor repo publish its host-harness selectors so this driver can import rat
 copy them.
 
 **Context:** BL-16603, verifying the credits fix end-to-end against a real Bloom.
+
+## 2026-08-28 — Moving a worktree between master and Version6.5 changes which settings file Bloom reads
+
+`BloomExe.csproj` sets `<Version>` per branch: 6.6.0.0 on master, 6.5.0.0 on Version6.5.
+`CrossPlatformSettingsProvider` puts the user settings under
+`%LOCALAPPDATA%\SIL\Bloom\<version>\user.config`, so re-basing a worktree from master onto
+Version6.5 silently swaps Bloom onto a different settings file.
+
+The symptom names nothing: Bloom opens some old collection you have not used for weeks, and
+here it was one that crashes on open. Opening a good collection in another dev Bloom does not
+help, because that copy is 6.6.0.0 and writes the other file. `MruProjects` is only the most
+visible setting; every other user setting jumps too.
+
+**Workaround:** edit `%LOCALAPPDATA%\SIL\Bloom\6.5.0.0\user.config` and put the collection you
+want first in `MruProjects`, or delete the entries so Bloom shows the collection chooser.
+
+**Idea:** `./go.sh` could say which settings folder this build uses, or a dev build could name
+the branch rather than the version in that path.
+
+**Context:** BL-16781, after re-basing the `dev-blorgswitch` worktree onto Version6.5.

--- a/src/BloomBrowserUI/react_components/TopBar/TopBarContextMenu.tsx
+++ b/src/BloomBrowserUI/react_components/TopBar/TopBarContextMenu.tsx
@@ -30,6 +30,9 @@ export const TopBarContextMenu: React.FunctionComponent<{
         React.useState(false);
     const [isMeddlingWithNewFiles, setIsMeddlingWithNewFiles] =
         React.useState(false);
+    const [canChooseDevBloomLibrary, setCanChooseDevBloomLibrary] =
+        React.useState(false);
+    const [useDevBloomLibrary, setUseDevBloomLibrary] = React.useState(false);
 
     const onClose = React.useCallback(() => {
         setMenuPoint(undefined);
@@ -49,6 +52,14 @@ export const TopBarContextMenu: React.FunctionComponent<{
         // the back end for the current value.
         getBoolean("app/isMeddlingWithNewFiles", (value) => {
             setIsMeddlingWithNewFiles(value);
+        });
+        // Only some builds offer the choice of web site, and only the back end knows
+        // which web site this run of Bloom uses.
+        getBoolean("app/canChooseDevBloomLibrary", (value) => {
+            setCanChooseDevBloomLibrary(value);
+        });
+        getBoolean("app/useDevBloomLibrary", (value) => {
+            setUseDevBloomLibrary(value);
         });
 
         const target = props.targetRef.current;
@@ -86,7 +97,7 @@ export const TopBarContextMenu: React.FunctionComponent<{
     }
 
     const menuItems = React.useMemo<ITopBarContextMenuItem[]>(() => {
-        return [
+        const items: ITopBarContextMenuItem[] = [
             {
                 label: "1024 x 586 Low-end netbook with windows Task bar",
                 onClick: () => {
@@ -153,7 +164,28 @@ export const TopBarContextMenu: React.FunctionComponent<{
                 },
             },
         ];
-    }, [alwaysMeasurePerformance, currentlyMeasuring, isMeddlingWithNewFiles]);
+        if (canChooseDevBloomLibrary) {
+            items.push({ label: "-" });
+            items.push({
+                // Changing this restarts Bloom, because the upload destination and the login
+                // belong to one run only.
+                label: "Use dev.BloomLibrary.org (restarts Bloom)",
+                selected: useDevBloomLibrary,
+                onClick: () => {
+                    const newValue = !useDevBloomLibrary;
+                    postBoolean("app/useDevBloomLibrary", newValue);
+                    setUseDevBloomLibrary(newValue);
+                },
+            });
+        }
+        return items;
+    }, [
+        alwaysMeasurePerformance,
+        currentlyMeasuring,
+        isMeddlingWithNewFiles,
+        canChooseDevBloomLibrary,
+        useDevBloomLibrary,
+    ]);
 
     return (
         <Menu

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Reflection;
 using System.Text;
 using System.Threading;
@@ -30,6 +31,7 @@ using BloomTemp;
 using CommandLine;
 using L10NSharp;
 using L10NSharp.Windows.Forms;
+using Newtonsoft.Json.Linq;
 using Sentry;
 using SIL.Core.Desktop.i18n;
 using SIL.IO;
@@ -1309,6 +1311,11 @@ namespace Bloom
         {
             try
             {
+                // A Bloom that ./go.sh launched cannot restart itself: the launcher owns the
+                // Vite dev server and the process tree, and it stops the whole stack when
+                // Bloom exits.  So we ask the launcher to do the restart instead.
+                if (args == null && AskDevLauncherToRestartBloom())
+                    return;
                 var program = BloomExePath;
                 if (SIL.PlatformUtilities.Platform.IsLinux)
                 {
@@ -1343,6 +1350,73 @@ namespace Bloom
             catch (Exception e)
             {
                 ErrorReport.NotifyUserOfProblem(e, "Bloom encountered a problem while restarting.");
+            }
+        }
+
+        /// <summary>
+        /// If ./go.sh launched this Bloom, tells its launcher to restart Bloom, and returns
+        /// true.  The launcher rebuilds, relaunches Bloom, and closes this instance itself.
+        /// Returns false for an installed Bloom, and when the launcher does not answer.
+        /// </summary>
+        /// <remarks>
+        /// The launcher writes output/bloom-launcher.json beside the folder that holds
+        /// Bloom.exe.  That file can be stale, so we ask the control API for its status
+        /// before we trust it.  See scripts/watchBloomExeControl.mjs.
+        ///
+        /// The launcher answers before it does the work, so a launcher that accepts and then
+        /// fails leaves this Bloom running.  Whatever the caller saved is still saved, so the
+        /// next start of Bloom uses it.
+        /// </remarks>
+        private static bool AskDevLauncherToRestartBloom()
+        {
+            var exeFolder = Path.GetDirectoryName(BloomExePath);
+            if (string.IsNullOrEmpty(exeFolder))
+                return false;
+            // Bloom.exe is at <repo>/output/Debug/AnyCPU/Bloom.exe, the launcher file at
+            // <repo>/output/bloom-launcher.json.
+            var launcherFile = Path.GetFullPath(
+                Path.Combine(exeFolder, "..", "..", "bloom-launcher.json")
+            );
+            if (!RobustFile.Exists(launcherFile))
+                return false;
+            try
+            {
+                var record = JObject.Parse(RobustFile.ReadAllText(launcherFile));
+                var controlUrl = record["controlUrl"]?.ToString();
+                if (string.IsNullOrEmpty(controlUrl))
+                    return false;
+                var ourProcessId = Process.GetCurrentProcess().Id;
+                // Task.Run keeps this off the user interface thread, which the caller may be on.
+                var launcherAccepted = Task.Run(async () =>
+                {
+                    using (var client = new HttpClient { Timeout = TimeSpan.FromSeconds(3) })
+                    {
+                        // The file survives a hard kill of the launcher, so this probe is
+                        // the only trustworthy sign that somebody is listening.
+                        var response = await client.GetAsync(controlUrl.TrimEnd('/') + "/status");
+                        if (!response.IsSuccessStatusCode)
+                            return false;
+                        var status = JObject.Parse(await response.Content.ReadAsStringAsync());
+                        // The launcher restarts the Bloom that it started.  If that is some
+                        // other Bloom, asking would close that one and leave this one running.
+                        if ((int?)status["bloomProcessId"] != ourProcessId)
+                            return false;
+                        var restart = await client.PostAsync(
+                            controlUrl.TrimEnd('/') + "/restart",
+                            new StringContent("")
+                        );
+                        return restart.IsSuccessStatusCode;
+                    }
+                }).Result;
+                if (!launcherAccepted)
+                    return false;
+                Logger.WriteEvent("Asked the dev launcher to restart Bloom.");
+                return true;
+            }
+            catch (Exception e)
+            {
+                Logger.WriteEvent("Could not ask the dev launcher to restart Bloom: " + e.Message);
+                return false;
             }
         }
 

--- a/src/BloomExe/Properties/Settings.Designer.cs
+++ b/src/BloomExe/Properties/Settings.Designer.cs
@@ -538,5 +538,18 @@ namespace Bloom.Properties {
                 this["CollectionTabSplitterSizes"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string WebSiteDestinationOverride {
+            get {
+                return ((string)(this["WebSiteDestinationOverride"]));
+            }
+            set {
+                this["WebSiteDestinationOverride"] = value;
+            }
+        }
     }
 }

--- a/src/BloomExe/Properties/Settings.settings
+++ b/src/BloomExe/Properties/Settings.settings
@@ -128,5 +128,8 @@
     <Setting Name="CollectionTabSplitterSizes" Provider="SIL.Settings.CrossPlatformSettingsProvider" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="WebSiteDestinationOverride" Provider="SIL.Settings.CrossPlatformSettingsProvider" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/src/BloomExe/Shell.cs
+++ b/src/BloomExe/Shell.cs
@@ -14,6 +14,7 @@ using Bloom.ToPalaso;
 using Bloom.Utils;
 using Bloom.web;
 using Bloom.web.controllers;
+using Bloom.WebLibraryIntegration;
 using Bloom.Workspace;
 using SIL.Extensions;
 using SIL.Reporting;
@@ -555,6 +556,31 @@ namespace Bloom
             {
                 FileMeddlerManager.Stop();
             }
+        }
+
+        /// <summary>
+        /// Records the user's choice between bloomlibrary.org and dev.bloomlibrary.org, then
+        /// restarts Bloom if the choice differs from the web site of this run.  A restart is
+        /// necessary because the upload destination and the login belong to one run only.
+        /// </summary>
+        /// <remarks>
+        /// The restart waits for the idle loop, as the change of the user interface language
+        /// does in WorkspaceView.SetUiLanguage.  We are on the user interface thread inside an
+        /// API request that holds the server's lock, and a restart closes the collection, which
+        /// makes more API requests.
+        /// </remarks>
+        public void SetUseDevBloomLibrary(bool useDevSite)
+        {
+            if (!BookUpload.SetUserChoiceOfDevWebSite(useDevSite))
+                return;
+            Application.Idle -= RestartForWebSiteChange;
+            Application.Idle += RestartForWebSiteChange;
+        }
+
+        private void RestartForWebSiteChange(object sender, EventArgs e)
+        {
+            Application.Idle -= RestartForWebSiteChange;
+            Program.RestartBloom(false);
         }
 
         private void UpdatePerformanceMeasurementStatus()

--- a/src/BloomExe/WebLibraryIntegration/BookUpload.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookUpload.cs
@@ -76,7 +76,10 @@ namespace Bloom.WebLibraryIntegration
             get
             {
                 // A unit test run must not depend on what the developer chose in the menu.
-                if (Program.RunningUnitTests)
+                // A build that does not show the menu must not obey a choice that it cannot
+                // change: user settings live in a folder named for the version, so a build
+                // without the menu could otherwise read a choice that another build wrote.
+                if (Program.RunningUnitTests || !UserCanChooseWebSite)
                     return UseSandboxWithoutUserChoice;
                 switch (Settings.Default.WebSiteDestinationOverride)
                 {

--- a/src/BloomExe/WebLibraryIntegration/BookUpload.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookUpload.cs
@@ -64,7 +64,38 @@ namespace Bloom.WebLibraryIntegration
         /// Implicitly use the sandbox as the destination target.  Can be explicitly overridden
         /// on the command line in upload commands.  See <see cref="Destination"/>.
         /// </summary>
+        /// <remarks>
+        /// On a developer, alpha, unstable, or internal beta build, the user can choose the
+        /// destination with the "Use dev.BloomLibrary.org" item of the top bar context menu.
+        /// We store that choice only while it differs from
+        /// <see cref="UseSandboxWithoutUserChoice"/>, so the "BloomSandbox" environment
+        /// variable controls Bloom again as soon as the user agrees with it.
+        /// </remarks>
         internal static bool UseSandboxByDefault
+        {
+            get
+            {
+                // A unit test run must not depend on what the developer chose in the menu.
+                if (Program.RunningUnitTests)
+                    return UseSandboxWithoutUserChoice;
+                switch (Settings.Default.WebSiteDestinationOverride)
+                {
+                    case UploadDestination.Development:
+                        return true;
+                    case UploadDestination.Production:
+                        return false;
+                    default:
+                        return UseSandboxWithoutUserChoice;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The destination that this build uses when the user makes no choice in the
+        /// "Use dev.BloomLibrary.org" menu item: a DEBUG build, or any build that has the
+        /// "BloomSandbox" environment variable set to yes, true, y, or t.
+        /// </summary>
+        internal static bool UseSandboxWithoutUserChoice
         {
             get
             {
@@ -79,6 +110,38 @@ namespace Bloom.WebLibraryIntegration
 #endif
             }
         }
+
+        /// <summary>
+        /// Records the user's choice from the "Use dev.BloomLibrary.org" menu item, and returns
+        /// true if the choice differs from the destination of the current run.  The caller
+        /// restarts Bloom when it does, because <see cref="Destination"/> and the saved login
+        /// belong to one run only.
+        /// </summary>
+        /// <remarks>
+        /// If the choice matches what this build would do on its own, we clear the setting
+        /// instead of storing it.  See the remarks on <see cref="UseSandboxByDefault"/>.
+        /// </remarks>
+        public static bool SetUserChoiceOfDevWebSite(bool useDevSite)
+        {
+            var wasUsingSandbox = UseSandbox;
+            if (useDevSite == UseSandboxWithoutUserChoice)
+                Settings.Default.WebSiteDestinationOverride = "";
+            else
+                Settings.Default.WebSiteDestinationOverride = useDevSite
+                    ? UploadDestination.Development
+                    : UploadDestination.Production;
+            Settings.Default.Save();
+            return useDevSite != wasUsingSandbox;
+        }
+
+        /// <summary>
+        /// True on the builds that let the user choose between bloomlibrary.org and
+        /// dev.bloomlibrary.org: a developer, alpha, or unstable build, and the internal beta
+        /// build.  A public beta build and a release build always use bloomlibrary.org.
+        /// </summary>
+        public static bool UserCanChooseWebSite =>
+            ApplicationUpdateSupport.IsDevOrAlpha
+            || ApplicationUpdateSupport.ChannelName.ToLowerInvariant().Contains("betainternal");
 
         /// <summary>
         /// whereas we can *download* from anywhere regardless of production, debug, or unit test,

--- a/src/BloomExe/web/controllers/AppApi.cs
+++ b/src/BloomExe/web/controllers/AppApi.cs
@@ -7,6 +7,7 @@ using Bloom.Book;
 using Bloom.Properties;
 using Bloom.ToPalaso;
 using Bloom.web;
+using Bloom.WebLibraryIntegration;
 using Bloom.Workspace;
 using SIL.IO;
 
@@ -158,6 +159,20 @@ namespace Bloom.Api
                 kAppUrlPrefix + "isMeddlingWithNewFiles",
                 request => GetShell()?.GetIsMeddlingWithNewFiles() ?? false,
                 (request, value) => GetShell()?.SetIsMeddlingWithNewFiles(value),
+                true
+            );
+            // True only on the builds that offer the "Use dev.BloomLibrary.org" menu item.
+            apiHandler.RegisterEndpointHandler(
+                kAppUrlPrefix + "canChooseDevBloomLibrary",
+                request => request.ReplyWithBoolean(BookUpload.UserCanChooseWebSite),
+                false
+            );
+            // Reads the web site that this run of Bloom uses, and records the user's choice of
+            // the web site for this run and the runs that follow.  Changing it restarts Bloom.
+            apiHandler.RegisterBooleanEndpointHandler(
+                kAppUrlPrefix + "useDevBloomLibrary",
+                request => BookUpload.UseSandbox,
+                (request, value) => GetShell()?.SetUseDevBloomLibrary(value),
                 true
             );
             apiHandler.RegisterEndpointHandler(


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
## Problem

Which BloomLibrary web site Bloom talks to is fixed when the build is made. A DEBUG build uses
dev.bloomlibrary.org; every other build uses bloomlibrary.org unless someone sets the
`BloomSandbox` environment variable and starts Bloom again. So a tester on an alpha or an
internal beta build cannot point Bloom at dev.bloomlibrary.org from inside Bloom, and a
developer cannot check the production site without a rebuild.

## Fix

- The top bar context menu gets a new item, **Use dev.BloomLibrary.org**. It appears only on a
  developer, alpha, or unstable build, and on the internal beta build. A public beta build and a
  release build do not show it.
- The item's check mark shows the web site of the current run, and it starts checked in exactly
  the situations that use dev.bloomlibrary.org today.
- The choice lives in a new user setting, `WebSiteDestinationOverride`. Bloom stores it only
  while it differs from what the build would do on its own, and clears it when the user agrees
  with the build. So the `BloomSandbox` environment variable controls Bloom again as soon as the
  user chooses the value it asks for.
- Changing the choice restarts Bloom, because the upload destination and the saved login belong
  to one run only.
- `Program.RestartBloom` now asks the `./go.sh` launcher to do the restart, through the control
  API the launcher already publishes in `output/bloom-launcher.json`. Without this, a Bloom that
  restarts itself under `go.sh` dies: the launcher owns the Vite dev server and the process tree,
  and it stops the whole stack when Bloom exits. This also repairs the restart after a user
  interface language change.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16781


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8258)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8258)
<!-- Reviewable:end -->
