### PR TITLE
Teach Bloom to publish its health, and add the Doctor's wire format (BL-16719)

### DIFF
--- a/Bloom.sln
+++ b/Bloom.sln
@@ -1,3 +1,4 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.7.34003.232
@@ -28,6 +29,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebView2PdfMaker", "src\WebView2PdfMaker\WebView2PdfMaker.csproj", "{F697DD7A-2D74-4850-8381-7E4ADB1E4431}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BloomFreezeDoctor.Protocol", "src\BloomFreezeDoctor.Protocol\BloomFreezeDoctor.Protocol.csproj", "{BC16B558-A063-411A-8BF0-C259CBD62E48}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -61,12 +66,21 @@ Global
 		{F697DD7A-2D74-4850-8381-7E4ADB1E4431}.Release|x64.Build.0 = Release|x64
 		{F697DD7A-2D74-4850-8381-7E4ADB1E4431}.Release|ARM64.ActiveCfg = Release|ARM64
 		{F697DD7A-2D74-4850-8381-7E4ADB1E4431}.Release|ARM64.Build.0 = Release|ARM64
+		{BC16B558-A063-411A-8BF0-C259CBD62E48}.Debug|x64.ActiveCfg = Debug|x64
+		{BC16B558-A063-411A-8BF0-C259CBD62E48}.Debug|x64.Build.0 = Debug|x64
+		{BC16B558-A063-411A-8BF0-C259CBD62E48}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{BC16B558-A063-411A-8BF0-C259CBD62E48}.Debug|ARM64.Build.0 = Debug|ARM64
+		{BC16B558-A063-411A-8BF0-C259CBD62E48}.Release|x64.ActiveCfg = Release|x64
+		{BC16B558-A063-411A-8BF0-C259CBD62E48}.Release|x64.Build.0 = Release|x64
+		{BC16B558-A063-411A-8BF0-C259CBD62E48}.Release|ARM64.ActiveCfg = Release|ARM64
+		{BC16B558-A063-411A-8BF0-C259CBD62E48}.Release|ARM64.Build.0 = Release|ARM64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{D38FC737-8C27-46CB-B490-3CB2E7AB3C99} = {04AF3A87-C943-4731-BE3D-659EA705171D}
+		{BC16B558-A063-411A-8BF0-C259CBD62E48} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AFDCD471-511E-432D-B6B3-2F9D5AD1ACED}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -53,7 +53,13 @@
             This lives here rather than as a -p: on the wrapper's command line because a
             global property cannot be varied per project.
         -->
-        <UseAppHost Condition="'$(MSBuildProjectName)' != 'WebView2PdfMaker'">false</UseAppHost>
+        <!--
+            BloomFreezeDoctor joins WebView2PdfMaker for the same reason: Bloom launches it by FILE NAME
+            (BloomFreezeDoctor.exe, see FreezeDoctor/DoctorLauncher.cs), so without its apphost the
+            "Run Freeze Doctor" menu item silently does nothing in an agent-built tree - which is an
+            expensive thing to debug, because nothing reports an error.
+        -->
+        <UseAppHost Condition="'$(MSBuildProjectName)' != 'WebView2PdfMaker' AND '$(MSBuildProjectName)' != 'BloomFreezeDoctor'">false</UseAppHost>
         <!--
             Once obj moves out of the project directory, the SDK no longer treats the
             conventional in-tree obj\ and bin\ as intermediate output, so their stale

--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -19,6 +19,22 @@ House rules:
 
 ---
 
+## 2026-08-26 — A Bloom launched by ./go.sh cannot be watched by the Freeze Doctor
+
+- **Cut:** `go.sh` runs Bloom with `--automation`, and the Doctor deliberately refuses to watch any
+  run whose command line carries that flag (such runs legitimately have no window, so watching them
+  would manufacture zombie reports). So the repo’s sanctioned dev launcher produces the one kind of
+  Bloom the Doctor ignores, and an agent following AGENTS.md cannot test the Doctor at all. Launching
+  the built exe directly instead dies at Velopack init when given no arguments ("Bloom Problem"
+  immediately), though the same binary starts fine with go.sh’s own arguments. F5 works, which is why
+  every successful manual test of this feature so far has been F5.
+- **Idea:** either have go.sh omit `--automation` (or offer a flag to), or say in AGENTS.md that testing
+  the Freeze Doctor needs F5 rather than go.sh, and why. Also worth noting that go.sh builds to
+  `output/Debug/AnyCPU` while launch.json runs `output/Debug/x64`.
+- **Context:** BL-16719, trying to run a crash test unattended. A related false start: 
+  `build/agent-dotnet.sh` builds into `output/agent/<key>/`, so `output/Debug/x64` was eleven commits
+  stale and the first attempt silently exercised old code.
+
 ## 2026-07-30 — Visual regression suite reports only the first stale image per case
 - **Cut:** Each case in `src/BloomVisualRegressionTests/index.spec.ts` compares the book preview
   and then every bloom-player page in sequence, and every comparison throws on failure — so the

--- a/build/check-csharp-ApplicationExit.sh
+++ b/build/check-csharp-ApplicationExit.sh
@@ -22,6 +22,14 @@ if [ -s $filesToCheck ]; then
       # exemption the check fires on any commit that merely stages the file -- a merge
       # of master, say -- for code the committer never touched.
       src/WebView2PdfMaker/*) continue;;
+      # BloomFreezeDoctor is the same case as WebView2PdfMaker above, for the same reason: a separate
+      # executable, its own static Program, no Program.Exit to call instead. Application.Exit is simply
+      # how its WinForms message loop ends.
+      #
+      # Worth noting that this rule, and the RobustFile one next door, both assume every .cs file in the
+      # repo is Bloom. A second application needs them to know WHICH application a file belongs to, and
+      # the WebView2PdfMaker line above shows that was already true before the Doctor arrived.
+      src/BloomFreezeDoctor/*|src/BloomFreezeDoctor.Core/*|src/BloomFreezeDoctor.Tests/*) continue;;
     esac
     # Strip // line comments and /* ... */ single-line block comments before
     # searching, so a mention of Application.Exit in a comment doesn't trip this check.

--- a/build/check-csharp-robustfile.sh
+++ b/build/check-csharp-robustfile.sh
@@ -35,6 +35,12 @@ if [ -s $filesToCheck ]; then
     case "$file" in
       src/BloomExe/RobustFileIO.cs) continue;;
       src/BloomTests/*) continue;;
+      # The Freeze Doctor's TEST project only, matching the src/BloomTests carve-out above for the same
+      # reason. Its production code is NOT exempt: it was converted to RobustFile/RobustIO rather than
+      # excused, because a diagnostic tool writing to a user's disk has no more business losing a file to
+      # a passing virus scanner than Bloom does - and the first thing the conversion found was a real
+      # one, an outbox rename that failed about one run in three and threw away a gathered report.
+      src/BloomFreezeDoctor.Tests/*) continue;;
     esac
     if awk '
       # Flag ordinary banned file APIs directly.

--- a/src/BloomBrowserUI/react_components/TopBar/TopBarContextMenu.tsx
+++ b/src/BloomBrowserUI/react_components/TopBar/TopBarContextMenu.tsx
@@ -30,6 +30,7 @@ export const TopBarContextMenu: React.FunctionComponent<{
         React.useState(false);
     const [isMeddlingWithNewFiles, setIsMeddlingWithNewFiles] =
         React.useState(false);
+    const [runFreezeDoctor, setRunFreezeDoctor] = React.useState(false);
 
     const onClose = React.useCallback(() => {
         setMenuPoint(undefined);
@@ -49,6 +50,11 @@ export const TopBarContextMenu: React.FunctionComponent<{
         // the back end for the current value.
         getBoolean("app/isMeddlingWithNewFiles", (value) => {
             setIsMeddlingWithNewFiles(value);
+        });
+        // Persisted across runs, so the check mark has to come from the back end rather than
+        // from local state: it may well have been turned on during a previous session.
+        getBoolean("app/runFreezeDoctor", (value) => {
+            setRunFreezeDoctor(value);
         });
 
         const target = props.targetRef.current;
@@ -152,8 +158,25 @@ export const TopBarContextMenu: React.FunctionComponent<{
                     setIsMeddlingWithNewFiles(newValue);
                 },
             },
+            {
+                // The Freeze Doctor ships inside Bloom but does nothing unless switched on here.
+                // Turning it on starts it immediately, so you can switch it on while chasing a freeze
+                // rather than having to restart Bloom first.
+                label: "Run Freeze Doctor",
+                selected: runFreezeDoctor,
+                onClick: () => {
+                    const newValue = !runFreezeDoctor;
+                    postBoolean("app/runFreezeDoctor", newValue);
+                    setRunFreezeDoctor(newValue);
+                },
+            },
         ];
-    }, [alwaysMeasurePerformance, currentlyMeasuring, isMeddlingWithNewFiles]);
+    }, [
+        alwaysMeasurePerformance,
+        currentlyMeasuring,
+        isMeddlingWithNewFiles,
+        runFreezeDoctor,
+    ]);
 
     return (
         <Menu

--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -234,6 +234,17 @@
 	<ItemGroup>
 		<PackageReference Include="Autofac" Version="6.0.0" />
 		<PackageReference Include="AWSSDK.Core" Version="3.5.1.32" />
+		<!--
+			The protocol Bloom and the Bloom Freeze Doctor share: the shared-memory health page, the
+			session file, and the named events. This was three files copied into this repo by hand, 750
+			lines of them, kept in step by a drift check because they had already drifted.
+
+			A plain ProjectReference, because on this branch the Doctor lives in this repository too, so
+			both sides compile the same source every build. Note where the ProjectReference sits: this
+			is otherwise a list of PackageReferences, and the only reason this is not one of them is
+			that the Doctor is here rather than in its own repo.
+		-->
+		<ProjectReference Include="..\BloomFreezeDoctor.Protocol\BloomFreezeDoctor.Protocol.csproj" />
 		<PackageReference Include="AWSSDK.S3" Version="3.5.3.10" />
 		<PackageReference Include="CairoSharp-signed" Version="3.22.24.37" />
 		<PackageReference Include="CommandLineParser" Version="2.8.0" />

--- a/src/BloomExe/FatalExceptionHandler.cs
+++ b/src/BloomExe/FatalExceptionHandler.cs
@@ -176,6 +176,12 @@ namespace Bloom
 
         protected override bool DisplayError(Exception exception)
         {
+            // First, before anything below blocks or exits. Both fatal routes - Application.ThreadException
+            // and AppDomain.UnhandledException - funnel through here, so this is the one place that catches
+            // every crash and still runs ahead of the modal dialog, which does not return. When no Doctor is
+            // watching it returns immediately, so the ordinary user's crash pays nothing.
+            FreezeDoctor.FreezeDoctorSupport.RequestDumpBeforeDying();
+
             if (Program.RunningE2eTests)
             {
                 // No human is present during an e2e/visual-regression run to dismiss a modal, so

--- a/src/BloomExe/FreezeDoctor/ApiActivityTracker.cs
+++ b/src/BloomExe/FreezeDoctor/ApiActivityTracker.cs
@@ -1,0 +1,309 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Bloom.FreezeDoctor
+{
+    /// <summary>
+    /// Keeps track of which API requests are in flight and for how long, so that a Freeze Doctor report can
+    /// say what Bloom was actually *doing* when it stopped responding.
+    ///
+    /// This is the single most valuable thing Bloom can tell the Doctor. A stack trace says the UI thread is
+    /// in `Monitor.Wait`; this says "POST /bloom/api/publish/epub/save has been running for 47 seconds",
+    /// which is usually the whole answer. BL-16697 — the freeze this project exists for — is exactly the
+    /// shape of problem it should identify.
+    ///
+    /// **It sits in the hot path, so it is written to be unable to hurt.** Every request in Bloom passes
+    /// through here, so: one dictionary insert and one removal per request, no locks, no allocation beyond a
+    /// single small entry, and nothing that can throw. If it somehow does throw, the caller's `using` still
+    /// removes the entry and the request proceeds regardless.
+    /// </summary>
+    public static class ApiActivityTracker
+    {
+        /// <summary>
+        /// In-flight requests, keyed by a ticket number. A ConcurrentDictionary rather than a lock, because
+        /// this is touched by every server worker thread at once and a lock here would be a new way to
+        /// deadlock the very thing we are trying to diagnose.
+        /// </summary>
+        private static readonly ConcurrentDictionary<long, InFlightRequest> _inFlight = new();
+
+        private static long _nextTicket;
+
+        /// <summary>
+        /// True once Bloom has handled at least one API request. Which is to say: the UI is up and talking to
+        /// the server, so Bloom has finished starting. Used to retire the "starting up" note, which would
+        /// otherwise describe an idle Bloom hours later.
+        /// </summary>
+        internal static bool HasHandledARequest => Volatile.Read(ref _nextTicket) > 0;
+
+        /// <summary>
+        /// How long a request has to have been running before we consider it worth naming. Below this it is
+        /// just normal traffic.
+        /// </summary>
+        private static readonly TimeSpan InterestingDuration = TimeSpan.FromSeconds(2);
+
+        /// <summary>One request that has started and not yet finished.</summary>
+        private readonly struct InFlightRequest
+        {
+            public InFlightRequest(
+                string urlPath,
+                long startedAtMs,
+                int osThreadId,
+                string lockState = null
+            )
+            {
+                UrlPath = urlPath;
+                StartedAtMs = startedAtMs;
+                OsThreadId = osThreadId;
+                LockState = lockState;
+            }
+
+            /// <summary>
+            /// The API request's URL path — <c>api/publish/epub/save</c> and the like. NOT a file path,
+            /// which is what "path" alone would suggest to anyone reading Bloom; and not called
+            /// <c>Path</c>, which would sit here looking like <c>System.IO.Path</c>.
+            ///
+            /// It arrives lowercased, because that is the form the server matches endpoints on, which is
+            /// why a report shows it that way rather than in the casing the caller used.
+            /// </summary>
+            public string UrlPath { get; }
+
+            /// <summary>From <see cref="Environment.TickCount64"/>, so it needs no wall clock.</summary>
+            public long StartedAtMs { get; }
+
+            /// <summary>
+            /// The OS thread id, NOT the managed one. This is the number that joins a request to a stack:
+            /// the Doctor walks stacks with ClrMD, which reports OS thread ids, so a managed id here would
+            /// put two unrelated numbering spaces side by side in one report and invite a reader to match
+            /// the wrong stack to the request that is stuck.
+            ///
+            /// It is the thread the request STARTED on. A request that has since awaited may be continuing
+            /// somewhere else, so the join is exact for the requests that matter most — the ones stuck in a
+            /// synchronous wait, which never left this thread — and a starting point for the rest.
+            /// </summary>
+            public int OsThreadId { get; }
+
+            /// <summary>
+            /// Which of the API's mutual-exclusion locks this request is waiting for or holding, or null for
+            /// the requests that need none. Naming it is what turns "3 workers blocked" into a diagnosis:
+            /// several requests waiting on the one lock a fourth is holding is the shape of an API deadlock,
+            /// and Windows' wait-chain analysis cannot see it, since SemaphoreSlim is invisible there.
+            /// </summary>
+            public string LockState { get; }
+
+            /// <summary>
+            /// How long this request has been running, given a reading of the tick count. Clamped at zero:
+            /// the tick count is monotonic so it should never go backwards, and a negative duration in a
+            /// report would be a puzzle nobody needs.
+            /// </summary>
+            public TimeSpan ElapsedAt(long nowMs) =>
+                TimeSpan.FromMilliseconds(Math.Max(0, nowMs - StartedAtMs));
+
+            /// <summary>The same request, with its lock state replaced.</summary>
+            public InFlightRequest With(string lockState) =>
+                new InFlightRequest(UrlPath, StartedAtMs, OsThreadId, lockState);
+        }
+
+        /// <summary>
+        /// The OS thread id of the calling thread. A TEB read behind a thin P/Invoke, so it is cheap enough
+        /// for the request path; see <see cref="InFlightRequest.OsThreadId"/> for why the managed id will
+        /// not do.
+        /// </summary>
+        [DllImport("kernel32.dll")]
+        private static extern int GetCurrentThreadId();
+
+        /// <summary>
+        /// Records that a request has started. Dispose the result when it finishes — a `using` is the point,
+        /// because it means an exception or an early return cannot leave a phantom request in the table
+        /// making a healthy Bloom look stuck.
+        /// </summary>
+        /// <param name="urlPath">
+        /// The request's URL path, e.g. <c>api/publish/epub/save</c>. Not a file path; see
+        /// <see cref="InFlightRequest.UrlPath"/>.
+        /// </param>
+        public static ApiActivityScope Begin(string urlPath)
+        {
+            try
+            {
+                var ticket = Interlocked.Increment(ref _nextTicket);
+                _inFlight[ticket] = new InFlightRequest(
+                    urlPath,
+                    Environment.TickCount64,
+                    GetCurrentThreadId()
+                );
+                return new ApiActivityScope(ticket);
+            }
+            catch (Exception)
+            {
+                // Never let bookkeeping fail a request. Ticket 0 is the "not recorded" scope, so the caller
+                // needs no special case and every method on it is a no-op.
+                return new ApiActivityScope(0);
+            }
+        }
+
+        /// <summary>
+        /// Describes what Bloom is doing, for the Doctor's activity line: the longest-running request, how
+        /// long it has been going, and how many others are in flight. Returns null when nothing has been
+        /// running long enough to be interesting.
+        ///
+        /// Called from Bloom's watchdog thread rather than from the request path, so the cost of scanning
+        /// falls on the once-a-second thread rather than on every request.
+        /// </summary>
+        public static string DescribeCurrentActivity()
+        {
+            try
+            {
+                var now = Environment.TickCount64;
+                var snapshot = _inFlight.Values.ToArray();
+                if (snapshot.Length == 0)
+                    return null;
+
+                var oldest = snapshot[0];
+                for (var i = 1; i < snapshot.Length; i++)
+                {
+                    if (snapshot[i].StartedAtMs < oldest.StartedAtMs)
+                        oldest = snapshot[i];
+                }
+
+                var elapsed = oldest.ElapsedAt(now);
+                if (elapsed < InterestingDuration)
+                    return null;
+
+                var others = snapshot.Length > 1 ? $" ({snapshot.Length} requests in flight)" : "";
+                return $"api {oldest.UrlPath} running {Describe(elapsed)}{DescribeLock(oldest)} "
+                    + $"on OS thread {oldest.OsThreadId}{others}";
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// How many requests a report will name. A Bloom in real trouble can have a great many in flight,
+        /// and a report is read by a person; past this the list stops being evidence and starts being noise.
+        /// The count of what was dropped is reported rather than the list quietly ending.
+        /// </summary>
+        private const int MaxRequestsDescribed = 20;
+
+        /// <summary>
+        /// Every request that has been in flight longer than <paramref name="longerThan"/>, **longest-running
+        /// first** (which is oldest-started first), as text for a report — the one that has been stuck the
+        /// longest is the one a reader wants at the top. Separate from
+        /// <see cref="DescribeCurrentActivity"/> because a report can afford several lines where the activity
+        /// field has room for one.
+        /// </summary>
+        /// <param name="longerThan">
+        /// Omit for <see cref="InterestingDuration"/>, which is the threshold below which a request is just
+        /// normal traffic.
+        /// </param>
+        public static string[] DescribeStuckRequests(TimeSpan? longerThan = null)
+        {
+            try
+            {
+                var threshold = longerThan ?? InterestingDuration;
+                var now = Environment.TickCount64;
+                var interesting = _inFlight
+                    .Values.Where(r => r.ElapsedAt(now) > threshold)
+                    .OrderBy(r => r.StartedAtMs)
+                    .ToArray();
+                if (interesting.Length == 0)
+                    // The shared cached instance, deliberately: the session record compares arrays by
+                    // reference, so returning a fresh empty array here would make an idle Bloom look
+                    // changed on every refresh and rewrite the session file for nothing.
+                    return Array.Empty<string>();
+
+                var described = interesting
+                    .Take(MaxRequestsDescribed)
+                    .Select(r =>
+                        $"{r.UrlPath} — running {Describe(r.ElapsedAt(now))}{DescribeLock(r)} on OS "
+                        + $"thread {r.OsThreadId}"
+                    )
+                    .ToList();
+                if (interesting.Length > MaxRequestsDescribed)
+                    described.Add(
+                        $"({interesting.Length - MaxRequestsDescribed} further request(s) in flight, "
+                            + "not listed)"
+                    );
+                return described.ToArray();
+            }
+            catch (Exception)
+            {
+                return Array.Empty<string>();
+            }
+        }
+
+        /// <summary>The lock clause for a report line, or nothing for a request that needs no lock.</summary>
+        private static string DescribeLock(InFlightRequest request) =>
+            string.IsNullOrEmpty(request.LockState) ? "" : $", {request.LockState}";
+
+        private static string Describe(TimeSpan elapsed) =>
+            elapsed.TotalSeconds < 90
+                ? $"{elapsed.TotalSeconds:F0}s"
+                : $"{elapsed.TotalMinutes:F1} minutes";
+
+        /// <summary>
+        /// One tracked request: removes it from the table when disposed, and lets the handler say what the
+        /// request is waiting for in the meantime.
+        ///
+        /// A ticket of 0 means the request was never recorded, so every method here does nothing — which is
+        /// why the caller needs neither a null check nor a special case.
+        /// </summary>
+        public sealed class ApiActivityScope : IDisposable
+        {
+            private long _ticket;
+
+            internal ApiActivityScope(long ticket)
+            {
+                _ticket = ticket;
+            }
+
+            /// <summary>
+            /// Says this request is now waiting to acquire one of the API's mutual-exclusion locks. Called
+            /// on the request's own thread, immediately before the wait.
+            /// </summary>
+            public void NoteWaitingForLock(string lockName) =>
+                SetLockState("waiting for " + lockName);
+
+            /// <summary>
+            /// Says this request now HOLDS the lock. The pair matters more than either half: a report
+            /// showing one request holding a lock and three waiting for it has named the deadlock.
+            /// </summary>
+            public void NoteHoldingLock(string lockName) => SetLockState("holding " + lockName);
+
+            private void SetLockState(string state)
+            {
+                try
+                {
+                    var ticket = Volatile.Read(ref _ticket);
+                    if (ticket == 0)
+                        return;
+                    // Replaced rather than mutated, because the entry is a struct — and replaced with
+                    // TryUpdate rather than the indexer, which would write the entry back whether or not it
+                    // was still there. That matters because Dispose removes it: a lock note that arrived
+                    // after disposal would resurrect the entry with nothing left to remove it, and a phantom
+                    // in-flight request makes every later report claim something is stuck. Call-site
+                    // ordering makes that impossible today; this makes it impossible full stop.
+                    if (_inFlight.TryGetValue(ticket, out var existing))
+                        _inFlight.TryUpdate(ticket, existing.With(state), existing);
+                }
+                catch (Exception)
+                {
+                    // Diagnostics must never break the request they describe.
+                }
+            }
+
+            public void Dispose()
+            {
+                // Taking the ticket away atomically makes a second Dispose harmless rather than removing
+                // some later request's entry.
+                var ticket = Interlocked.Exchange(ref _ticket, 0);
+                if (ticket != 0)
+                    _inFlight.TryRemove(ticket, out _);
+            }
+        }
+    }
+}

--- a/src/BloomExe/FreezeDoctor/DoctorLauncher.cs
+++ b/src/BloomExe/FreezeDoctor/DoctorLauncher.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Windows.Forms;
+using Bloom.Properties;
+using SIL.IO;
+using SIL.Reporting;
+
+namespace Bloom.FreezeDoctor
+{
+    /// <summary>
+    /// Starts the Bloom Freeze Doctor, if the user has switched it on.
+    ///
+    /// **The Doctor is only useful if it is already running when Bloom stops responding**, which is why
+    /// Bloom starts it rather than leaving it to the user: nobody launches a diagnostic tool *before* the
+    /// thing they are diagnosing goes wrong. It ships inside Bloom's installer, so the
+    /// <see cref="Settings.RunFreezeDoctor"/> setting is what keeps everyone from paying for a watcher they
+    /// did not ask for; with it off, all of this costs one setting read.
+    ///
+    /// **There is deliberately no handshake.** Bloom's only job is to make sure a Doctor is running; the
+    /// Doctor decides for itself which Blooms to watch, by holding a single-instance mutex and scanning for
+    /// them. So starting a second Doctor is harmless — it hands off to the one already running and exits —
+    /// and Bloom never has to know or care which case it is in. Nothing here waits for the Doctor, checks
+    /// on it, or is affected by whether it worked.
+    /// </summary>
+    public static class DoctorLauncher
+    {
+        /// <summary>The installed executable's name.</summary>
+        private const string ExecutableName = "BloomFreezeDoctor.exe";
+
+        /// <summary>
+        /// Starts the Doctor if the user has asked for it, telling it which process to watch. Returns
+        /// immediately and never throws: this is a diagnostic convenience, and it must not be able to
+        /// affect Bloom's startup in any way a user would notice.
+        ///
+        /// Called at startup, and again when somebody switches it on from the debug menu, so that turning
+        /// it on takes effect straight away rather than at the next restart. Starting a second one is
+        /// harmless: the Doctor holds a singleton mutex and a duplicate exits immediately.
+        /// </summary>
+        public static void LaunchIfWanted()
+        {
+            try
+            {
+                if (!Settings.Default.RunFreezeDoctor)
+                    return;
+
+                var exe = FindTheDoctor();
+                if (exe == null)
+                    return; // A build that did not produce it. Nothing to do, and nothing to say.
+
+                Process.Start(
+                    new ProcessStartInfo(exe)
+                    {
+                        // --adopt tells it which Bloom we are, and also means "start out of the way in the
+                        // notification area": a window appearing every time you started Bloom would get the
+                        // Doctor uninstalled inside a week.
+                        Arguments = "--adopt " + Process.GetCurrentProcess().Id,
+                        UseShellExecute = false,
+                        CreateNoWindow = true,
+                        // Do not inherit our working directory: Bloom's can be a collection folder, and
+                        // holding it open would stop the user moving or renaming it.
+                        WorkingDirectory = Path.GetDirectoryName(exe),
+                    }
+                );
+                Logger.WriteEvent("Asked the Bloom Freeze Doctor to watch this process");
+            }
+            catch (Exception e)
+            {
+                // Swallowed on purpose. If the Doctor cannot be started, Bloom carries on exactly as it
+                // would on a machine where it was never installed.
+                try
+                {
+                    Logger.WriteEvent(
+                        "Could not start the Bloom Freeze Doctor (continuing without it): "
+                            + e.Message
+                    );
+                }
+                catch (Exception) { }
+            }
+        }
+
+        /// <summary>
+        /// BloomFreezeDoctor.exe, or null if this build did not produce one. It is always beside Bloom.exe -
+        /// built into Bloom's own output directory and shipped by Bloom's installer, exactly like
+        /// BloomPdfMaker.exe - so there is nowhere to search.
+        /// </summary>
+        private static string FindTheDoctor()
+        {
+            var beside = Path.Combine(
+                Path.GetDirectoryName(Application.ExecutablePath) ?? "",
+                ExecutableName
+            );
+            return RobustFile.Exists(beside) ? beside : null;
+        }
+    }
+}

--- a/src/BloomExe/FreezeDoctor/FreezeDoctorSupport.cs
+++ b/src/BloomExe/FreezeDoctor/FreezeDoctorSupport.cs
@@ -102,6 +102,12 @@ namespace Bloom.FreezeDoctor
         private static string _statedActivity = "";
 
         /// <summary>
+        /// What Bloom was saying before the outermost long operation opened, so the last one to close can
+        /// put it back. See LongOperationScope.Dispose for why the scope's own saved value will not do.
+        /// </summary>
+        private static string _activityBeforeAnyScope = "";
+
+        /// <summary>
         /// What Bloom says it is doing before it has done anything. Named because two places have to agree
         /// on it: the one that states it, and <see cref="ComposeCurrentActivity"/>, which retires it.
         /// </summary>
@@ -289,6 +295,9 @@ namespace Bloom.FreezeDoctor
         /// </summary>
         internal static int LongOperationDepth => Volatile.Read(ref _longOperationDepth);
 
+        /// <summary>What Bloom currently says it is doing. For tests.</summary>
+        internal static string StatedActivity => Volatile.Read(ref _statedActivity);
+
         /// <summary>
         /// Marks a stretch of work that is *deliberately* slow, so the Doctor waits five minutes rather than
         /// one before deciding Bloom has frozen, and says what Bloom is doing while it runs.
@@ -336,7 +345,12 @@ namespace Bloom.FreezeDoctor
                 {
                     SetActivity(whatBloomIsDoing);
                     if (Interlocked.Increment(ref _longOperationDepth) == 1)
+                    {
+                        // What Bloom was saying before ANY scope opened, remembered here because the
+                        // last scope to close cannot work it out for itself - see Dispose.
+                        Volatile.Write(ref _activityBeforeAnyScope, _previousActivity);
                         SetLongOperation(true);
+                    }
                 });
             }
 
@@ -347,19 +361,34 @@ namespace Bloom.FreezeDoctor
                 _disposed = true;
                 DoSafely(() =>
                 {
-                    if (Interlocked.Decrement(ref _longOperationDepth) == 0)
+                    var stillRunning = Interlocked.Decrement(ref _longOperationDepth);
+                    if (stillRunning == 0)
                         SetLongOperation(false);
-                    // Only put the old activity back if the slot still holds what we put there. If
-                    // somebody else has since described their own operation, theirs is the one still
-                    // running and ours is the stale news — see _myActivity.
+
+                    // What to say now that we have finished. If any scope is still running, the sensible
+                    // answer is whatever was showing when we started; if we were the last, it is whatever
+                    // Bloom was saying before any scope opened.
+                    //
+                    // The distinction matters because scopes can OVERLAP without nesting: A starts, B
+                    // starts, A finishes, B finishes. Restoring "whatever was showing when I started"
+                    // unconditionally made B put A back - naming work that had already completed, so a
+                    // report gathered afterwards described the wrong operation. Falling back to the empty
+                    // string instead would be wrong in the other direction: a standing activity set
+                    // outside any scope (a video recording says what it is doing, then opens a scope to
+                    // merge) would be silently thrown away.
+                    var restoreTo =
+                        stillRunning > 0
+                            ? _previousActivity
+                            : Volatile.Read(ref _activityBeforeAnyScope);
+
+                    // Only change the slot if it still holds what we put there. If somebody else has since
+                    // described their own operation, theirs is the one still running and ours is the stale
+                    // news — see _myActivity.
                     if (
-                        Interlocked.CompareExchange(
-                            ref _statedActivity,
-                            _previousActivity,
-                            _myActivity
-                        ) == _myActivity
+                        Interlocked.CompareExchange(ref _statedActivity, restoreTo, _myActivity)
+                        == _myActivity
                     )
-                        _channel?.SetActivity(_previousActivity);
+                        _channel?.SetActivity(restoreTo);
                 });
             }
         }

--- a/src/BloomExe/FreezeDoctor/FreezeDoctorSupport.cs
+++ b/src/BloomExe/FreezeDoctor/FreezeDoctorSupport.cs
@@ -1,0 +1,937 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Windows.Forms;
+// The wire format Bloom shares with the Freeze Doctor: one project, src/BloomFreezeDoctor.Protocol,
+// compiled into both sides from the same source, so the two cannot hold copies that disagree.
+using BloomFreezeDoctor.Protocol;
+using SIL.Reporting;
+
+namespace Bloom.FreezeDoctor
+{
+    /// <summary>
+    /// Makes just enough of Bloom's health visible to the Bloom Freeze Doctor (which lives in this
+    /// repository, under src/BloomFreezeDoctor) for it to tell a frozen Bloom from a busy one, and a crash
+    /// from an orderly shutdown.
+    ///
+    /// **Why Bloom has to help at all.** Watching from outside cannot detect the freeze we most expect.
+    /// A UI thread blocked in a managed wait on an STA thread — `WaitHandle.WaitOne`, `Task.Wait`, anything
+    /// ending in `CoWaitForMultipleHandles` — keeps dispatching *sent* messages so that COM still works, so
+    /// the window answers `SendMessageTimeout`, `IsHungAppWindow` calls it healthy and `Process.Responding`
+    /// returns true while Bloom is completely stuck. Measured on a real Bloom: nine minutes frozen,
+    /// reported responsive throughout. `WM_TIMER` is *not* dispatched by those restricted pumps, so a timer
+    /// that stops ticking is the one signal that gives the freeze away — and since Bloom's UI thread awaits
+    /// WebView2 constantly, this is the common shape of freeze rather than an exotic one.
+    ///
+    /// **The rules this code lives by**, since it runs on the UI thread and in Bloom's shutdown path:
+    ///
+    /// - It must never throw. Every entry point swallows its own failures; see <see cref="DoSafely"/>.
+    /// - It must never block. Nothing here waits on anything.
+    /// - It must never matter. If the channel cannot be created, Bloom carries on exactly as before and the
+    ///   Doctor falls back to watching from outside, as it does for every Bloom already in the field.
+    /// </summary>
+    public static class FreezeDoctorSupport
+    {
+        /// <summary>
+        /// How often the UI thread reports in. One `WM_TIMER` and a few writes to a resident page, so the
+        /// cost is invisible.
+        ///
+        /// **Twice as often as the watchdog below, deliberately.** This is not a liveness check but the
+        /// measurement the whole tool rests on — its staleness *is* the freeze signal — so its interval sets
+        /// the resolution of that signal and the floor under how tight the Doctor's threshold can safely be
+        /// (5 seconds, ten of these). It is also the fragile one, since `WM_TIMER` is the lowest-priority
+        /// message there is and a busy-but-live UI can starve it, so ticking twice as often means a
+        /// moment's starvation must swallow two ticks rather than one before it looks like a freeze.
+        /// </summary>
+        private static readonly TimeSpan UiHeartbeatInterval = TimeSpan.FromMilliseconds(500);
+
+        /// <summary>
+        /// How often the background thread reports in. Its purpose is comparison: if the UI heartbeat is
+        /// stale and this one is fresh, the UI thread is blocked; if both are stale, the whole process is
+        /// wedged — a garbage collection that will not finish, or a suspended process.
+        ///
+        /// Slower than the UI heartbeat because nothing is measured against *its* resolution: it needs to
+        /// be reliably alive, not finely sampled. It also does real work each tick — records what Bloom is
+        /// doing, polls for a debugger, and every tenth time rewrites the session file. It doubles as the
+        /// latency of the Doctor's quit request, which this thread waits on rather than sleeping blindly, so
+        /// one second is also how long a stuck Bloom takes to notice it has been asked to leave.
+        /// </summary>
+        private static readonly TimeSpan WatchdogInterval = TimeSpan.FromSeconds(1);
+
+        private static DoctorChannelWriter _channel;
+
+        // Explicitly the WinForms timer, and that is the whole point: it delivers WM_TIMER through the
+        // message loop, so it stops ticking exactly when the UI thread stops pumping. A
+        // System.Threading.Timer would keep ticking right through the freeze we are trying to detect.
+        private static System.Windows.Forms.Timer _uiHeartbeat;
+        private static Thread _watchdog;
+
+        /// <summary>Set once the first caller has asked for a crash dump. See RequestDumpBeforeDying.</summary>
+        private static int _dumpAlreadyRequested;
+
+        /// <summary>
+        /// How far Bloom's shutdown has got, as recorded by <see cref="SetShutdownPhase"/>. Still
+        /// <see cref="BloomShutdownPhase.None"/> is how a hard failure is told from an orderly exit; see the
+        /// enum, which is shared with the Doctor.
+        /// </summary>
+        private static BloomShutdownPhase _shutdownPhase;
+        private static bool _started;
+        private static DoctorSession _session;
+
+        /// <summary>
+        /// True once we have exited because the Doctor asked us to. Stops the ProcessExit handler recording
+        /// that as an orderly shutdown, which it very much was not.
+        /// </summary>
+        private static bool _endedAtDoctorsRequest;
+
+        /// <summary>
+        /// Serialises every change to <see cref="_session"/>.
+        ///
+        /// Without it the "Bloom already reported this problem" note could be silently lost: the watchdog
+        /// thread rewrites the session every ten seconds by read-modify-write, and if it read the record
+        /// before the note was applied and wrote its copy afterwards, the note would vanish — from memory and
+        /// from disk. That note is the only thing stopping the Doctor filing a second report about a problem
+        /// the user has already reported themselves.
+        /// </summary>
+        private static readonly object _sessionLock = new object();
+
+        /// <summary>
+        /// What Bloom's own code last said it was doing, via <see cref="SetActivity"/>. Kept separately from
+        /// the request-derived text so the watchdog can combine the two rather than one erasing the other.
+        /// </summary>
+        private static string _statedActivity = "";
+
+        /// <summary>
+        /// What Bloom says it is doing before it has done anything. Named because two places have to agree
+        /// on it: the one that states it, and <see cref="ComposeCurrentActivity"/>, which retires it.
+        /// </summary>
+        internal const string StartupActivity = "starting up";
+
+        /// <summary>
+        /// How often the session file is rewritten. It carries facts that barely change, so this is not
+        /// about freshness — it is so that a Doctor installed *after* Bloom started, or one that had not
+        /// yet been running when Bloom did, still finds a file describing the Bloom in front of it.
+        /// </summary>
+        private static readonly TimeSpan SessionRefreshInterval = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// How long an unexplained session file is kept. Long enough that a Doctor installed the day after
+        /// a crash can still find out about it, short enough not to accumulate.
+        /// </summary>
+        private static readonly TimeSpan SessionRetention = TimeSpan.FromDays(7);
+
+        /// <summary>
+        /// How long a dying Bloom waits for the Doctor to say it has taken up the dump request. The Doctor
+        /// polls once a second, so this is generous for merely picking something up; the point of keeping it
+        /// short is that a Doctor which is alive but not working cannot hold a crashing Bloom for long.
+        /// </summary>
+        private static readonly TimeSpan PatienceForPickup = TimeSpan.FromSeconds(3);
+
+        /// <summary>
+        /// How long to wait once a dump is known to be underway. Generous because it can afford to be: the
+        /// wait ends the moment the Doctor stops existing, so this ceiling only binds a Doctor that is alive
+        /// and taking its time — which is the case we want to be patient with, since a dump of a real Bloom
+        /// takes seconds and longer on a slow or loaded machine.
+        /// </summary>
+        private static readonly TimeSpan PatienceForTheDumpItself = TimeSpan.FromSeconds(60);
+
+        /// <summary>How often that wait re-checks whether the Doctor is still there.</summary>
+        private static readonly TimeSpan WaitSlice = TimeSpan.FromMilliseconds(500);
+
+        /// <summary>
+        /// Starts reporting Bloom's health. Call once, on the UI thread, immediately before entering the
+        /// message loop: the UI heartbeat is a WinForms timer, so it only ticks once messages are being
+        /// pumped, which is exactly the property that makes it a useful signal.
+        /// </summary>
+        public static void Start()
+        {
+            if (_started)
+                return;
+            _started = true;
+
+            // The session file goes first, and happens even if the shared-memory channel cannot be
+            // created: it is what a Doctor reads about a Bloom that has already died, so it is the more
+            // important of the two for the case where nobody was watching at the time.
+            WriteSessionFile();
+
+            // Before anything that can bail out. The on-disk half of the contract does not depend on shared
+            // memory, and a session file with no exit record reads as "this run did not shut down
+            // properly" - so returning early without this hook would manufacture the very false positive
+            // the proof exists to prevent.
+            //
+            // It runs for a normal return from Main and for Environment.Exit, and NOT for FailFast,
+            // TerminateProcess or an access violation, which is exactly the line the Doctor wants drawn and
+            // one no future exit path can forget to honour.
+            AppDomain.CurrentDomain.ProcessExit += (sender, args) => RecordCleanExit();
+
+            try
+            {
+                _channel = new DoctorChannelWriter(Process.GetCurrentProcess().Id);
+                if (!_channel.IsOpen)
+                    return; // Another process owns the name, or the OS refused. Nothing more to do.
+
+                // Through the static wrapper, not _channel directly: the wrapper is what records the text in
+                // _statedActivity, which the watchdog composes from. Writing straight to the channel leaves
+                // that empty, and the next watchdog tick replaces "starting up" with "no request in flight"
+                // - discarding the only clue available about a Bloom that wedges during startup.
+                // ComposeCurrentActivity retires this once Bloom has handled a request.
+                SetActivity(StartupActivity);
+                // Worth more than the Doctor's own guess, and why a developer stopping their debugger never
+                // produces a report. Refreshed every second by the watchdog rather than read once, because a
+                // debugger can be attached to a running Bloom and detached again - exactly the cases that
+                // would otherwise produce a bogus report.
+                _channel.SetDebuggerAttached(IsDebuggerAttached());
+
+                _uiHeartbeat = new System.Windows.Forms.Timer
+                {
+                    Interval = (int)UiHeartbeatInterval.TotalMilliseconds,
+                };
+                _uiHeartbeat.Tick += (sender, args) => RecordUiTick();
+                _uiHeartbeat.Start();
+
+                _watchdog = new Thread(WatchdogLoop)
+                {
+                    Name = "Freeze Doctor watchdog",
+                    // Background, so it can never be the reason Bloom fails to exit. The Doctor treats a
+                    // vanished heartbeat as the process being gone, which by then it is.
+                    IsBackground = true,
+                    // Slightly above normal so that a machine thrashing under load does not starve the
+                    // very signal we use to distinguish thrashing from a deadlock.
+                    Priority = ThreadPriority.AboveNormal,
+                };
+                _watchdog.Start();
+
+                // Ask for a dump on the way down. Hooked here as well as at Program.Run's catch blocks,
+                // which see only TargetInvocationException and AccessViolationException from the message
+                // loop, whereas this fires for an unhandled exception on ANY thread.
+                //
+                // It cannot cover Environment.FailFast, which by design runs no managed handlers at all.
+                // Those crashes are still recognisable from Windows Error Reporting and the absence of a
+                // clean-exit proof; we just get no dump of our own.
+                AppDomain.CurrentDomain.UnhandledException += (sender, args) =>
+                    RequestDumpBeforeDying();
+
+                Logger.WriteEvent(
+                    "Freeze Doctor channel opened; reporting health to any Doctor watching"
+                );
+            }
+            catch (Exception e)
+            {
+                // Deliberately swallowed. Diagnostics that can break the application they diagnose are
+                // worse than no diagnostics at all.
+                TryLog("Freeze Doctor channel could not be opened", e);
+            }
+        }
+
+        /// <summary>
+        /// Says what Bloom is doing, in words fit to appear at the top of a bug report — "Publishing to
+        /// BloomPUB", "Saving Foo.htm". Truncated if very long; safe to call from any thread.
+        /// </summary>
+        public static void SetActivity(string activity) =>
+            DoSafely(() =>
+            {
+                // Remembered as well as written to the channel, because the watchdog rewrites the same slot once
+                // a second; written to the channel alone, the message would survive less than a second. The watchdog
+                // composes this with the in-flight request text instead.
+                Volatile.Write(ref _statedActivity, activity ?? "");
+                _channel?.SetActivity(activity);
+            });
+
+        /// <summary>
+        /// Runs one step, swallowing whatever it throws.
+        ///
+        /// Every entry point here goes through this. Diagnostics that can break the application they
+        /// diagnose are worse than no diagnostics, and there is nothing any caller could usefully do with a
+        /// failure to write a health field — so rather than each method repeating the same empty catch and
+        /// the same explanation, the rule lives here once.
+        /// </summary>
+        private static void DoSafely(Action step)
+        {
+            try
+            {
+                step();
+            }
+            catch (Exception) { }
+        }
+
+        /// <summary>
+        /// Marks work that legitimately blocks the UI for a long time — publishing, uploading, making a
+        /// PDF. This buys Bloom patience rather than silence: the Doctor raises its threshold from one
+        /// minute to five, and still reports if Bloom is stuck beyond that.
+        ///
+        /// Call it through <see cref="LongOperation"/> rather than directly, so the nesting count is kept
+        /// and a description of the work goes with it.
+        ///
+        /// Anything *not* marked that blocks the UI thread for over a minute *without pumping messages* is
+        /// filed as a freeze, which is the false positive this exists to prevent. Work behind a modal
+        /// progress dialog is safe either way, since ShowDialog runs a nested message loop and the UI
+        /// heartbeat keeps ticking.
+        ///
+        /// Which operations to mark is a judgement about how Bloom really behaves, and cannot be inferred
+        /// automatically: "a request has run for a minute" is the same signal as the freeze itself, so it
+        /// cannot tell legitimately-slow from wedged. Hence a deliberate call at the few places that know.
+        /// </summary>
+        public static void SetLongOperation(bool inProgress) =>
+            DoSafely(() => _channel?.SetLongOperation(inProgress));
+
+        /// <summary>
+        /// How many long operations are running. Counted rather than a bare boolean because these nest —
+        /// publishing an app builds a BloomPUB on the way — and a plain <c>SetLongOperation(false)</c> from
+        /// an inner operation would take the patience away while the outer one was still going.
+        /// </summary>
+        private static int _longOperationDepth;
+
+        /// <summary>
+        /// How many long operations are currently running. Exposed for the test that pins the nesting
+        /// arithmetic, which is the part with teeth: the flag reaching the shared page is one line and is
+        /// covered by the protocol round-trip test, whereas getting the counting wrong is silent and lasts
+        /// the whole session — too few decrements and freeze detection stays off for good.
+        /// </summary>
+        internal static int LongOperationDepth => Volatile.Read(ref _longOperationDepth);
+
+        /// <summary>
+        /// Marks a stretch of work that is *deliberately* slow, so the Doctor waits five minutes rather than
+        /// one before deciding Bloom has frozen, and says what Bloom is doing while it runs.
+        ///
+        /// Use it with `using`. That is not style: the alternative is paired calls, and a paired call that
+        /// is skipped by an early return or an exception leaves the Doctor permanently patient — which
+        /// silently disables freeze detection for the rest of the session, the worst possible failure for
+        /// this particular flag.
+        ///
+        /// Which operations get this is a judgement about how Bloom behaves, not something to infer from the
+        /// code: "a request has run for a minute" is the same signal as a freeze, so nothing automatic can
+        /// tell legitimately-slow from wedged. The set is deliberately just the major publishing
+        /// operations — BloomPUB, ePUB, video and app creation, and uploading to or downloading from Bloom
+        /// Library — because those routinely take minutes on a large book or a slow connection and are the
+        /// ones that would otherwise be reported as freezes.
+        /// </summary>
+        /// <param name="whatBloomIsDoing">
+        /// Plain words for the report, e.g. "making a BloomPUB". This becomes the activity line, so it is
+        /// worth writing for whoever reads the card rather than for the code.
+        /// </param>
+        public static IDisposable LongOperation(string whatBloomIsDoing)
+        {
+            return new LongOperationScope(whatBloomIsDoing);
+        }
+
+        private sealed class LongOperationScope : IDisposable
+        {
+            private readonly string _previousActivity;
+
+            /// <summary>
+            /// What this scope itself put in the shared activity slot, so that on the way out it can tell
+            /// whether the slot is still its to restore. Two long operations on different threads do not
+            /// have to nest tidily, and without this check the one that finished first put back the activity
+            /// from *before* it started — overwriting the description of an operation that was still
+            /// running, and then being overwritten in turn by a description of work already finished.
+            /// </summary>
+            private readonly string _myActivity;
+            private bool _disposed;
+
+            public LongOperationScope(string whatBloomIsDoing)
+            {
+                _previousActivity = Volatile.Read(ref _statedActivity);
+                _myActivity = whatBloomIsDoing ?? "";
+                DoSafely(() =>
+                {
+                    SetActivity(whatBloomIsDoing);
+                    if (Interlocked.Increment(ref _longOperationDepth) == 1)
+                        SetLongOperation(true);
+                });
+            }
+
+            public void Dispose()
+            {
+                if (_disposed)
+                    return; // a double Dispose must not decrement twice and cancel somebody else's patience
+                _disposed = true;
+                DoSafely(() =>
+                {
+                    if (Interlocked.Decrement(ref _longOperationDepth) == 0)
+                        SetLongOperation(false);
+                    // Only put the old activity back if the slot still holds what we put there. If
+                    // somebody else has since described their own operation, theirs is the one still
+                    // running and ours is the stale news — see _myActivity.
+                    if (
+                        Interlocked.CompareExchange(
+                            ref _statedActivity,
+                            _previousActivity,
+                            _myActivity
+                        ) == _myActivity
+                    )
+                        _channel?.SetActivity(_previousActivity);
+                });
+            }
+        }
+
+        /// <summary>
+        /// Records how far shutdown has got. Called at the points Bloom passes through on its way out, so
+        /// that a Bloom which dies mid-shutdown can say *where* it stopped rather than merely that it did
+        /// — which is the same evidence the "UI gone but process alive" case needs.
+        /// </summary>
+        public static void SetShutdownPhase(BloomShutdownPhase phase) =>
+            DoSafely(() =>
+            {
+                _shutdownPhase = phase;
+                _channel?.SetShutdownPhase(phase);
+            });
+
+        /// <summary>
+        /// Records that shutdown ran to completion. Its ABSENCE is what the Doctor treats as evidence, so
+        /// this must be written only when Bloom really did shut down in an orderly way.
+        /// </summary>
+        private static void RecordCleanExit()
+        {
+            try
+            {
+                _channel?.SetShutdownPhase(_shutdownPhase);
+                // Only claim a clean exit when the shutdown sequence actually ran.
+                //
+                // ProcessExit fires for EVERY Environment.Exit, including Bloom's several hard-failure
+                // exits, so reaching here proves nothing on its own. The phase is what distinguishes them —
+                // see BloomShutdownPhase.None.
+                if (_shutdownPhase != BloomShutdownPhase.None && !_endedAtDoctorsRequest)
+                    _channel?.RecordCleanExit();
+                // Also on disk, because the shared-memory page vanishes once the last handle closes and a
+                // Doctor may not have been watching. The file is what a Doctor started tomorrow will read.
+                WriteSessionExit();
+            }
+            catch (Exception)
+            {
+                // Losing the proof means the Doctor may report an exit that was in fact clean. Annoying,
+                // but far better than delaying or breaking Bloom's shutdown to avoid it.
+            }
+        }
+
+        /// <summary>
+        /// Records that Bloom's own reporting has already told us about a problem this run, so the Doctor
+        /// does not file a second report about the same thing. Called when a **tracker card** goes out
+        /// successfully — the one place a duplicate is possible.
+        ///
+        /// Deliberately NOT called for a Sentry event. A Sentry event creates no card, so a Doctor report
+        /// about the same trouble is not a duplicate of it — it is the only thing that would put the problem
+        /// on the board at all, and suppressing on Sentry would lose it.
+        /// </summary>
+        public static void NoteBloomReportedAProblem(string reportedId)
+        {
+            try
+            {
+                lock (_sessionLock)
+                {
+                    if (_session == null)
+                        return;
+                    // On the session itself, NOT inside an Exit record. A user can file a problem report and
+                    // then carry on working for hours; writing an exit here would describe a running Bloom as
+                    // finished, which a later reader would take as proof it shut down properly.
+                    _session = _session with
+                    {
+                        BloomAlreadyReported = true,
+                        ReportedId = reportedId,
+                        // The Doctor stops filing for a few minutes after this, not for the rest of the
+                        // run, so it needs to know when rather than only whether.
+                        ReportedAtUtc = DateTimeOffset.UtcNow,
+                    };
+                    DoctorSessionStore.TryWrite(_session);
+                }
+            }
+            catch (Exception) { }
+        }
+
+        /// <summary>
+        /// Records that this Bloom has been deliberately told to break, and how, so a Doctor can tell a
+        /// rehearsal from the real thing.
+        ///
+        /// Called when the simulator ARMS rather than when the environment variable is seen: the variable
+        /// alone proves nothing, since a Beta or Release channel refuses and so does an unrecognised kind.
+        ///
+        /// Written into the session file rather than the shared page because it has to survive the process:
+        /// `failfast`, `crashthread` and `zombie` are exactly the cases where the wreckage is all there is.
+        /// </summary>
+        public static void NoteSimulatedFailureArmed(string kind)
+        {
+            try
+            {
+                lock (_sessionLock)
+                {
+                    if (_session == null)
+                        return;
+                    _session = _session with { SimulatedFailure = kind };
+                    DoctorSessionStore.TryWrite(_session);
+                }
+            }
+            catch (Exception) { }
+        }
+
+        /// <summary>
+        /// Records the facts a Doctor needs but cannot reliably work out from outside — above all the log
+        /// file we are actually writing to, and the ports.
+        /// </summary>
+        private static void WriteSessionFile()
+        {
+            try
+            {
+                var process = Process.GetCurrentProcess();
+                var httpPort = Api.BloomServer.portForHttp;
+                // Under the same lock as every other mutation. This one runs before the watchdog thread
+                // exists, so nothing can race it today — but a rule with an exception in it is a rule
+                // somebody will follow into a bug later.
+                var session = new DoctorSession
+                {
+                    ProcessId = process.Id,
+                    StartedAtUtc = process.StartTime.ToUniversalTime(),
+                    ExePath = SafeExePath(process),
+                    Version = Shell.GetShortVersionInfo(),
+                    Channel = ApplicationUpdateSupport.ChannelName,
+                    CommandLine = Environment.CommandLine,
+                    // The point of the whole file: Bloom recreates Log.txt each run and only falls back to
+                    // a random name when another Bloom holds it, so from outside the newest log is the
+                    // wrong answer exactly when it matters most.
+                    LogPath = Logger.LogPath ?? "",
+                    HttpPort = httpPort,
+                    // Kept in step with WebView2Browser.RemoteDebuggingPort rather than recomputed
+                    // independently, so the two cannot drift apart.
+                    CdpPort = httpPort > 0 ? Api.BloomServer.RemoteDebuggingPort : 0,
+                    CollectionName = SafeCollectionName(),
+                    // Settled long before we get here - Program acquires (or declines) the token during
+                    // startup, and Start() is called well after that - so this is right the first time and
+                    // never changes for the life of the process.
+                    OwnsSingleInstanceToken = Program.OwnsSingleInstanceToken,
+                };
+                lock (_sessionLock)
+                {
+                    _session = session;
+                    DoctorSessionStore.TryWrite(_session);
+                }
+                // Note what is NOT done here: pruning old session files. This method runs on the UI thread
+                // during startup, and enumerating and deleting a directory's worth of files is exactly the
+                // sort of synchronous I/O that has no business on Bloom's startup path. The watchdog thread
+                // does it instead, on its first beat.
+            }
+            catch (Exception e)
+            {
+                TryLog("Freeze Doctor session file could not be written", e);
+            }
+        }
+
+        /// <summary>
+        /// Rewrites the session file with how this run ended. Called from the same place as the clean-exit
+        /// flag, so the on-disk record and the shared-memory record agree.
+        /// </summary>
+        private static void WriteSessionExit()
+        {
+            try
+            {
+                lock (_sessionLock)
+                {
+                    if (_session == null)
+                        return;
+                    // Always recorded, even when Bloom has already reported a problem: "the user reported
+                    // something" and "we then shut down properly" are independent facts, both worth
+                    // knowing, and they live in separate fields.
+                    _session = _session with
+                    {
+                        Exit = new DoctorSessionExit
+                        {
+                            AtUtc = DateTimeOffset.UtcNow,
+                            // Two independent facts, recorded as such: how far shutdown got, and whether
+                            // it was our idea. Combining them here would produce a flag that lies about one
+                            // of its meanings, and each reader wants a different combination anyway.
+                            ShutdownPhase = _shutdownPhase,
+                            EndedAtDoctorsRequest = _endedAtDoctorsRequest,
+                        },
+                    };
+                    DoctorSessionStore.TryWrite(_session);
+                }
+            }
+            catch (Exception) { }
+        }
+
+        private static bool ProcessIsAlive(int processId)
+        {
+            try
+            {
+                using (var process = Process.GetProcessById(processId))
+                    return !process.HasExited;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        private static string SafeExePath(Process process)
+        {
+            try
+            {
+                return process.MainModule?.FileName ?? "";
+            }
+            catch (Exception)
+            {
+                return "";
+            }
+        }
+
+        private static string SafeCollectionName()
+        {
+            try
+            {
+                var path = Bloom.Properties.Settings.Default.MruProjects?.Latest;
+                return string.IsNullOrEmpty(path)
+                    ? ""
+                    : System.IO.Path.GetFileNameWithoutExtension(path);
+            }
+            catch (Exception)
+            {
+                return "";
+            }
+        }
+
+        /// <summary>
+        /// The background heartbeat. Deliberately does almost nothing beyond proving the process as a whole
+        /// is still scheduling threads — anything more would only add ways for it to stop for reasons that
+        /// are not the ones we care about. It does also refresh the session file, which is cheap and keeps
+        /// that work off the UI thread.
+        /// </summary>
+        /// <summary>
+        /// Reads the PEB's BeingDebugged flag for this process. Wanted alongside
+        /// <see cref="Debugger.IsAttached"/> because that one only sees a MANAGED debugger: a native one
+        /// (WinDbg without SOS, say) can attach to a running Bloom and stop it while IsAttached stays false
+        /// the whole time, which is precisely the case that would otherwise be reported as a crash.
+        /// </summary>
+        [System.Runtime.InteropServices.DllImport("kernel32.dll")]
+        [return: System.Runtime.InteropServices.MarshalAs(
+            System.Runtime.InteropServices.UnmanagedType.Bool
+        )]
+        internal static extern bool IsDebuggerPresent();
+
+        /// <summary>
+        /// Whether anything is debugging us, managed or native.
+        ///
+        /// Cheap enough to poll every second, which is what the watchdog does: IsAttached reads a runtime
+        /// flag, and IsDebuggerPresent reads a single byte out of our own process's PEB. Neither is a
+        /// blocking call and neither touches Bloom's UI thread.
+        ///
+        /// What it cannot see, for the record: a NON-INVASIVE attach (`windbg -pv`) sets neither flag, and a
+        /// debugger that attaches and detaches entirely between two polls is missed — though one that
+        /// actually breaks or kills lasts far longer than a second.
+        /// </summary>
+        internal static bool IsDebuggerAttached()
+        {
+            if (Debugger.IsAttached)
+                return true;
+            try
+            {
+                return IsDebuggerPresent();
+            }
+            catch (Exception)
+            {
+                // A P/Invoke that cannot be resolved must not be able to break the watchdog; the managed
+                // answer above is still worth having.
+                return false;
+            }
+        }
+
+        private static void WatchdogLoop()
+        {
+            var sinceSessionRefresh = TimeSpan.Zero;
+            var quitRequestSignal = DoctorSignals.TryCreate(
+                DoctorSignals.QuitRequestName(Process.GetCurrentProcess().Id)
+            );
+
+            // Tidy up previous runs' session files here rather than at startup: this is file enumeration and
+            // deletion, and it belongs on a background thread rather than on Bloom's startup path. Once,
+            // before the loop, and cheap enough to do at this thread's raised priority - see
+            // DoctorSessionStore.Prune, which carries the measurements.
+            try
+            {
+                DoctorSessionStore.Prune(ProcessIsAlive, SessionRetention);
+            }
+            catch (Exception) { }
+
+            while (true)
+            {
+                try
+                {
+                    _channel?.RecordWatchdogTick();
+                    RecordWhatBloomIsDoing();
+                    _channel?.SetDebuggerAttached(IsDebuggerAttached());
+                    sinceSessionRefresh += WatchdogInterval;
+                    if (sinceSessionRefresh >= SessionRefreshInterval)
+                    {
+                        sinceSessionRefresh = TimeSpan.Zero;
+                        RefreshSessionFile();
+                    }
+
+                    // Sleep on the quit request rather than sleeping blindly, so one thread does both jobs
+                    // and a request is acted on within a second rather than whenever we next wake.
+                    if (quitRequestSignal != null)
+                    {
+                        if (quitRequestSignal.WaitOne(WatchdogInterval))
+                        {
+                            ExitAtDoctorsRequest();
+                            return;
+                        }
+                        continue;
+                    }
+                    Thread.Sleep(WatchdogInterval);
+                }
+                catch (Exception)
+                {
+                    // Never let this thread die of an exception; the Doctor reads its silence as the
+                    // process being wedged, which would be a false alarm.
+                    try
+                    {
+                        Thread.Sleep(WatchdogInterval);
+                    }
+                    catch (Exception)
+                    {
+                        return;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Records what Bloom is doing right now, worked out from the in-flight API requests, along with
+        /// the server's worker counts.
+        ///
+        /// This is where the Doctor's most useful sentence comes from. A stack trace says the UI thread is
+        /// waiting; this says *which request* has been running for 47 seconds, which is usually the answer.
+        /// Computed on this thread rather than in the request path, so the cost falls on a once-a-second
+        /// thread instead of on every request.
+        /// </summary>
+        /// <summary>
+        /// Composes what Bloom's own code last said it was doing with what the request table says, rather
+        /// than letting either clobber the other.
+        ///
+        /// Two mistakes to avoid, one on each side. Leaving the last interesting value in place means the
+        /// field keeps naming a request that finished minutes ago, and a freeze report blames work that had
+        /// already completed. But overwriting it every second makes the public <see cref="SetActivity"/>
+        /// entry point useless — "starting up" would survive less than a second, so a Bloom that wedged
+        /// during startup would report "no request in flight", which is both wrong and the least helpful
+        /// thing it could say.
+        ///
+        /// Separated out, and internal, so a test can pin that chain: every version of this has been got
+        /// wrong once — first by the refresh overwriting the stated text, then by <see cref="Start"/> writing
+        /// to the channel directly so there was nothing to carry forward, then by "starting up" never being
+        /// retired and so describing an idle Bloom hours later.
+        /// </summary>
+        internal static string ComposeCurrentActivity() =>
+            Compose(
+                Volatile.Read(ref _statedActivity),
+                ApiActivityTracker.DescribeCurrentActivity(),
+                ApiActivityTracker.HasHandledARequest
+            );
+
+        /// <summary>
+        /// The composition rule on its own, with nothing static in it, so both of its failure directions can
+        /// be tested deterministically. Called by <see cref="ComposeCurrentActivity"/> with the live values.
+        /// </summary>
+        internal static string Compose(string stated, string request, bool bloomHasHandledARequest)
+        {
+            // "starting up" is true until it isn't, and nothing else was ever going to replace it: Bloom
+            // states it once and has no natural "finished starting" moment to clear it at. Handling an API
+            // request IS that moment — the UI is up and talking to the server — and deciding it here means no
+            // future startup path has to remember to say so.
+            if (stated == StartupActivity && bloomHasHandledARequest)
+                stated = "";
+            return (string.IsNullOrEmpty(stated), request == null) switch
+            {
+                (false, false) => stated + " | " + request,
+                (false, true) => stated,
+                (true, false) => request,
+                _ => "no request in flight",
+            };
+        }
+
+        private static void RecordWhatBloomIsDoing()
+        {
+            try
+            {
+                _channel?.SetActivity(ComposeCurrentActivity());
+
+                var server = Api.BloomServer._theOneInstance;
+                if (server != null)
+                    _channel?.SetServerWorkerCounts(
+                        server.BusyWorkerCount,
+                        server.BlockedWorkerCount,
+                        server.WorkerCount,
+                        server.QueuedRequestCount
+                    );
+            }
+            catch (Exception) { }
+        }
+
+        /// <summary>
+        /// Rewrites the session file with anything that may have changed since startup — the ports, which
+        /// are assigned after we first wrote it, and the collection, which changes when the user switches.
+        /// </summary>
+        private static void RefreshSessionFile()
+        {
+            try
+            {
+                lock (_sessionLock)
+                {
+                    if (_session == null)
+                        return;
+                    var httpPort = Api.BloomServer.portForHttp;
+                    // Composed on the CURRENT value inside the lock, so a note written by another thread a
+                    // moment ago is carried forward rather than overwritten.
+                    // The requests in flight right now. This is the only part of the session that goes
+                    // stale, and it is here rather than on the shared page because the page has room for one
+                    // line. A freeze is not reported until the UI has been unresponsive for a minute (five
+                    // during a long operation), so by then this has been rewritten several times over and
+                    // the list describes requests that have been stuck for most of the freeze.
+                    //
+                    // It is also the one field that makes the write below fire regularly: while anything has
+                    // been running more than a second or two, the list differs each time and the session is
+                    // rewritten every ten seconds. That is the point — it is worth a small write while
+                    // something is slow — and an idle Bloom still writes nothing at all.
+                    var inFlight = ApiActivityTracker.DescribeStuckRequests();
+                    var refreshed = _session with
+                    {
+                        LogPath = Logger.LogPath ?? _session.LogPath,
+                        HttpPort = httpPort,
+                        CdpPort = httpPort > 0 ? Api.BloomServer.RemoteDebuggingPort : 0,
+                        CollectionName = SafeCollectionName(),
+                        InFlightRequests = inFlight,
+                        // Left null when there is nothing in flight, so that an idle Bloom compares equal to
+                        // its own last state and the write below is skipped.
+                        InFlightRequestsAtUtc =
+                            inFlight.Length > 0 ? DateTimeOffset.UtcNow : (DateTimeOffset?)null,
+                    };
+                    // Only touch the disk when something actually changed: this runs every ten seconds for
+                    // the life of the process, and a pointless write every ten seconds is a pointless write.
+                    if (refreshed == _session)
+                        return;
+                    _session = refreshed;
+                    DoctorSessionStore.TryWrite(_session);
+                }
+            }
+            catch (Exception) { }
+        }
+
+        /// <summary>
+        /// Exits because the Doctor asked us to, having decided our UI is gone and we are in the user's way.
+        ///
+        /// We exit *ourselves* rather than being killed, which is worth the round trip: `Environment.Exit`
+        /// runs the `ProcessExit` handlers, so Bloom's single-instance token is released properly and its own
+        /// record of the shutdown is written. Being killed from outside would leave both undone. Note we do
+        /// NOT try to shut down gracefully — a Bloom in this state has already failed to do that, which is
+        /// why anyone is asking.
+        /// </summary>
+        private static void ExitAtDoctorsRequest()
+        {
+            try
+            {
+                Logger.WriteEvent(
+                    "The Bloom Freeze Doctor asked this process to exit (its UI is gone and it is holding "
+                        + "the single-instance token). Exiting."
+                );
+            }
+            catch (Exception) { }
+
+            // Mark this as what it is BEFORE exiting. Environment.Exit runs the ProcessExit handler, which
+            // writes the clean-exit proof — and this was emphatically not a clean exit. Without this flag a
+            // zombie we had to end would be recorded as having shut down properly, which is exactly the
+            // conclusion the proof exists to prevent anyone drawing.
+            _endedAtDoctorsRequest = true;
+
+            try
+            {
+                // 1 rather than 0: this was not a normal exit, and the exit code should say so.
+                Environment.Exit(1);
+            }
+            catch (Exception)
+            {
+                // If even that fails, the Doctor's fallback is to kill us, which is what it is there for.
+            }
+        }
+
+        /// <summary>
+        /// Asks a watching Doctor to dump this process, and waits briefly for it. Call from a crash path, as
+        /// late as possible: a dump taken from outside is worth more than one a dying process takes of
+        /// itself, but only if the process is still there to dump.
+        ///
+        /// **The zero-timeout check comes first, and it is the important part.** Nearly every user has no
+        /// Doctor installed, and an unconditional pause here would make every crash worse for all of them to
+        /// benefit the few. So: if nobody is watching, this returns immediately and costs nothing.
+        ///
+        /// **And when nobody is watching, that is the end of it — Bloom does NOT dump itself.** That is
+        /// deliberate, not an omission: with no Doctor running there is nothing to file the
+        /// dump, so it would sit on a user's disk at 15-20 MB a crash waiting for somebody to think of
+        /// asking for it. If that ever looks worth building, the shape that fits what already exists is to
+        /// record the path in the session file - which is designed to outlive the process - so that a Doctor
+        /// started or installed later finds the crash and attaches it; not a parallel collection mechanism.
+        /// </summary>
+        public static void RequestDumpBeforeDying()
+        {
+            // Once per process, whoever asks. Two routes reach here for one crash - Bloom's fatal handler
+            // and the AppDomain hook - and only the first should pay the wait.
+            if (Interlocked.Exchange(ref _dumpAlreadyRequested, 1) != 0)
+                return;
+            try
+            {
+                var pid = Process.GetCurrentProcess().Id;
+                if (!DoctorSignals.Exists(DoctorSignals.WatchingName(pid)))
+                    return; // No Doctor. Do not delay this crash by even a millisecond.
+
+                // Past that check a Doctor is there, so the logging below costs only the few users who have
+                // one - and on a path whose entire purpose is gathering diagnostics, silence is the one
+                // unaffordable failure. Each outcome says which it was.
+                Logger.WriteEvent("Asking the Bloom Freeze Doctor for a dump of this crash");
+
+                if (!DoctorSignals.TrySignal(DoctorSignals.DumpRequestName(pid)))
+                {
+                    Logger.WriteEvent(
+                        "Could not signal the Bloom Freeze Doctor for a dump; it may have stopped watching"
+                    );
+                    return;
+                }
+
+                // Wait briefly for the Doctor to say it has started. Its tick is a second, so this is
+                // generous for merely picking a request up; if nothing does, there is nothing to wait for
+                // and a crashing Bloom should not be held any longer.
+                if (!DoctorSignals.WaitFor(DoctorSignals.DumpStartedName(pid), PatienceForPickup))
+                {
+                    Logger.WriteEvent(
+                        "Asked the Bloom Freeze Doctor for a crash dump, but nothing picked it up"
+                    );
+                    return;
+                }
+
+                // Underway, so be patient: a dump of a real Bloom takes seconds, longer on the slow machines
+                // that need it most, and giving up early does not merely delay it but loses it, since the
+                // dying process is what writes the dump over the diagnostics pipe. Patience is safe here
+                // because the wait ends as soon as the Doctor stops existing - see
+                // DoctorSignals.WaitWhileTheOtherSideLives for how that is known.
+                var dumped = DoctorSignals.WaitWhileTheOtherSideLives(
+                    DoctorSignals.DumpCompleteName(pid),
+                    DoctorSignals.WatchingName(pid),
+                    PatienceForTheDumpItself,
+                    WaitSlice
+                );
+                Logger.WriteEvent(
+                    dumped
+                        ? "The Bloom Freeze Doctor captured a dump of this crash"
+                        : "The Bloom Freeze Doctor began a dump of this crash but did not finish it"
+                );
+            }
+            catch (Exception)
+            {
+                // A crash path is the last place to introduce a new way to fail.
+            }
+        }
+
+        private static void RecordUiTick() => DoSafely(() => _channel?.RecordUiTick());
+
+        private static void TryLog(string message, Exception e)
+        {
+            try
+            {
+                Logger.WriteError(message, e);
+            }
+            catch (Exception) { }
+        }
+    }
+}

--- a/src/BloomExe/FreezeDoctor/FreezeSimulator.cs
+++ b/src/BloomExe/FreezeDoctor/FreezeSimulator.cs
@@ -1,0 +1,315 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Windows.Forms;
+using SIL.Reporting;
+
+namespace Bloom.FreezeDoctor
+{
+    /// <summary>
+    /// Makes Bloom fail on purpose, so that the Freeze Doctor's detection can be tested against a real
+    /// Bloom rather than only against a stand-in.
+    ///
+    /// This exists because the alternative is worse. Without it, testing the Doctor against Bloom means
+    /// waiting for a real freeze — which is precisely the thing we cannot reproduce, and the reason the
+    /// Doctor is being built at all.
+    ///
+    /// **Two safeguards, because this deliberately breaks Bloom.** It does nothing unless the
+    /// `BLOOM_SIMULATE_FREEZE` environment variable is set, and it does nothing on a Release channel. So
+    /// there is no menu item, no API endpoint and no keystroke that could set it off on a user's machine:
+    /// somebody has to have deliberately arranged both conditions.
+    ///
+    /// Usage: set `BLOOM_SIMULATE_FREEZE=&lt;kind&gt;[:&lt;delaySeconds&gt;]` before launching Bloom.
+    /// Kinds: `sleep`, `stawait`, `spin`, `failfast`, `throw`, `crashthread`, `zombie`, `mutexchain` — each
+    /// documented at its case below, with the state it imitates.
+    /// </summary>
+    public static class FreezeSimulator
+    {
+        /// <summary>
+        /// Keeps the countdown timer alive. A WinForms timer referenced only by a local would be eligible for
+        /// collection the moment the method returns, and a simulator that sometimes forgets to fire is worse
+        /// than no simulator: it looks like the Doctor failing to detect something.
+        /// </summary>
+        private static System.Windows.Forms.Timer _countdown;
+
+        /// <summary>The environment variable that arms this. Absent means absent; there is no other route in.</summary>
+        public const string EnvironmentVariable = "BLOOM_SIMULATE_FREEZE";
+
+        /// <summary>
+        /// The plain kernel wait, used by the `mutexchain` kind. See that case for why the managed
+        /// <c>Mutex.WaitOne</c> will not do.
+        /// </summary>
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern uint WaitForSingleObject(IntPtr handle, uint milliseconds);
+
+        /// <summary>How long to wait before misbehaving, if the variable does not say.</summary>
+        private static readonly TimeSpan DefaultDelay = TimeSpan.FromSeconds(45);
+
+        /// <summary>
+        /// The kinds this understands. Kept beside <see cref="Simulate"/>'s switch and checked BEFORE
+        /// arming, so an unrecognised value refuses outright instead of half-arming — see the check in
+        /// <see cref="ArmIfRequested"/> for why that distinction matters.
+        /// </summary>
+        internal static readonly string[] KnownKinds =
+        {
+            "sleep",
+            "stawait",
+            "spin",
+            "mutexchain",
+            "failfast",
+            "throw",
+            "crashthread",
+            "zombie",
+        };
+
+        /// <summary>
+        /// Channels on which the simulator is allowed to act.
+        ///
+        /// Developer builds are obvious. **Alpha and the internal channels are here deliberately**, because
+        /// they are where the Doctor is actually exercised: BetaInternal carries the bulk of our in-house
+        /// testing of a new version, and reproducing a freeze usually means working with somebody who is
+        /// experiencing it, who is on Alpha rather than running a build from source. Restricting this to
+        /// builds from source would leave the simulator useful only on the machines where we can least often
+        /// reproduce the problem.
+        ///
+        /// **Beta and Release are excluded, and that is the line that matters**: those are the channels a
+        /// member of the public is on, and nothing there may be broken on purpose. The internal channels are
+        /// named one by one rather than matched on a suffix, so a channel invented later is refused until
+        /// somebody decides otherwise.
+        ///
+        /// Note this is the second of two conditions - <see cref="EnvironmentVariable"/> has to be set as
+        /// well - so widening this list does not arm anything by itself.
+        /// </summary>
+        private static bool IsChannelWhereWeMayBreakBloomDeliberately(string channelName)
+        {
+            if (string.IsNullOrEmpty(channelName))
+                return false;
+            return channelName.StartsWith("Developer", StringComparison.OrdinalIgnoreCase)
+                || channelName.Equals("Alpha", StringComparison.OrdinalIgnoreCase)
+                || channelName.Equals("BetaInternal", StringComparison.OrdinalIgnoreCase)
+                || channelName.Equals("ReleaseInternal", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Arms the simulator if it has been asked for. Call once during startup; it returns immediately
+        /// and does its damage later, so that Bloom has time to finish starting and the Doctor has time to
+        /// adopt it.
+        /// </summary>
+        /// <param name="channelName">
+        /// Bloom's release channel. Anything outside
+        /// <see cref="IsChannelWhereWeMayBreakBloomDeliberately"/> is refused, so that a stray environment
+        /// variable on an ordinary user's machine cannot break their Bloom.
+        /// </param>
+        /// <returns>
+        /// True if the simulator is now armed. Returned so a test can tell "armed" from "declined" without
+        /// waiting for Bloom to actually break.
+        /// </returns>
+        public static bool ArmIfRequested(string channelName)
+        {
+            string request;
+            try
+            {
+                request = Environment.GetEnvironmentVariable(EnvironmentVariable);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            if (string.IsNullOrWhiteSpace(request))
+                return false;
+
+            if (!IsChannelWhereWeMayBreakBloomDeliberately(channelName))
+            {
+                Logger.WriteEvent(
+                    $"{EnvironmentVariable} is set but this is the '{channelName}' channel, so it is being "
+                        + "ignored. Deliberate breakage is for developer, Alpha and internal builds only."
+                );
+                return false;
+            }
+
+            var parts = request.Split(':');
+            var kind = parts[0].Trim().ToLowerInvariant();
+            var delay =
+                parts.Length > 1 && int.TryParse(parts[1], out var seconds)
+                    ? TimeSpan.FromSeconds(seconds)
+                    : DefaultDelay;
+
+            // Refuse a kind we do not know HERE, before the marker below tells the Doctor this Bloom is a
+            // rehearsal. An unrecognised value - a typo like `slep`, or a stale name - arms nothing, so
+            // marking first would leave the Doctor declining to file a card for every GENUINE freeze for
+            // the rest of the session. A misspelled environment variable silently turning off freeze
+            // reporting would be far worse than the typo that caused it.
+            if (Array.IndexOf(KnownKinds, kind) < 0)
+            {
+                Logger.WriteEvent(
+                    $"*** FreezeSimulator: '{kind}' is not a kind it knows about, so nothing is armed. "
+                        + $"Expected one of: {string.Join(", ", KnownKinds)}."
+                );
+                return false;
+            }
+
+            Logger.WriteEvent(
+                $"*** FreezeSimulator armed: will simulate '{kind}' in {delay.TotalSeconds:F0} seconds. "
+                    + $"This Bloom is deliberately going to misbehave. Unset {EnvironmentVariable} to stop it."
+            );
+
+            // Tell any Doctor that this Bloom is a rehearsal, so it does not file a card about a freeze we
+            // asked for. Said here rather than where the variable is read, because only now do we know the
+            // simulator will actually act: the channel check and the kind have both been accepted.
+            FreezeDoctorSupport.NoteSimulatedFailureArmed(kind);
+
+            // Arming twice would otherwise abandon the first timer still running, leaving a simulation
+            // nobody asked for to go off later. Startup only calls this once, but the tests call it per
+            // channel, and a booby trap that only appears under test is still a booby trap.
+            Disarm();
+
+            // A UI-thread timer, because most of these have to happen ON the UI thread to be the failure
+            // we are imitating. A background timer would produce a quite different (and uninteresting)
+            // kind of stuck.
+            _countdown = new System.Windows.Forms.Timer
+            {
+                Interval = (int)Math.Max(1000, delay.TotalMilliseconds),
+            };
+            _countdown.Tick += (sender, args) =>
+            {
+                _countdown.Stop();
+                Simulate(kind);
+            };
+            _countdown.Start();
+            return true;
+        }
+
+        /// <summary>
+        /// Cancels a pending simulation. Exists for the tests: they arm the simulator to prove that a
+        /// channel is allowed to, and an armed timer left behind would be a Bloom-breaking booby trap
+        /// waiting for whichever later test happens to pump messages.
+        /// </summary>
+        public static void Disarm()
+        {
+            _countdown?.Stop();
+            _countdown?.Dispose();
+            _countdown = null;
+        }
+
+        /// <summary>
+        /// Carries out one kind of failure. Each corresponds to a state the Doctor claims to detect; the
+        /// comments name which, because that correspondence is the whole purpose of this class.
+        /// </summary>
+        private static void Simulate(string kind)
+        {
+            Logger.WriteEvent($"*** FreezeSimulator: simulating '{kind}' NOW");
+            switch (kind)
+            {
+                // The freeze an outside watcher CAN see: the UI thread stops pumping altogether.
+                case "sleep":
+                    Thread.Sleep(TimeSpan.FromMinutes(10));
+                    break;
+
+                // The freeze an outside watcher CANNOT see, and the reason this whole channel exists. A
+                // managed wait on the STA thread keeps dispatching sent messages, so the window still
+                // answers probes and Windows reports Bloom as responsive while it is entirely stuck. Only
+                // the UI heartbeat gives it away.
+                case "stawait":
+                    using (var never = new ManualResetEventSlim(false))
+                        never.Wait(TimeSpan.FromMinutes(10));
+                    break;
+
+                // Frozen but burning a core, which the report should tell apart from a deadlock.
+                case "spin":
+                    var until = Stopwatch.StartNew();
+                    while (until.Elapsed < TimeSpan.FromMinutes(10)) { }
+                    break;
+
+                // A hard crash that runs no orderly shutdown: no ProcessExit, so no clean-exit proof.
+                case "failfast":
+                    Environment.FailFast("FreezeSimulator was asked to fail fast");
+                    break;
+
+                // An exception on the UI thread. Note this does NOT kill Bloom: Bloom's own error handling
+                // catches it and reports it, which is the correct behaviour and is also the case where the
+                // Doctor should stay quiet because Bloom has already told us.
+                case "throw":
+                    throw new ApplicationException("FreezeSimulator was asked to throw");
+
+                // A genuinely fatal crash: an exception on a plain background thread, which nothing catches.
+                // AppDomain.UnhandledException fires and the process dies — the path the Doctor's
+                // crash-dump handshake exists for, and the only one we can actually exercise, since a direct
+                // FailFast runs no managed handlers at all.
+                case "crashthread":
+                    new Thread(() =>
+                    {
+                        Thread.Sleep(500);
+                        throw new ApplicationException(
+                            "FreezeSimulator was asked to crash a background thread"
+                        );
+                    })
+                    {
+                        IsBackground = false,
+                        Name = "FreezeSimulator crashing thread",
+                    }.Start();
+                    break;
+
+                // A freeze WINDOWS ITSELF can explain, which none of the others are, and the only way to
+                // exercise the Doctor's wait-chain reading against real data.
+                //
+                // The Wait Chain Traversal API - what Resource Monitor's "Analyze Wait Chain" runs on - is
+                // blind to `Monitor`, `SemaphoreSlim` and async waits, so every other kind here produces
+                // an empty chain. That code once reported thread ids that were pure garbage (the native
+                // structure's second half is a union) and nothing noticed, because nothing had ever fed
+                // it a wait it could see. A mutex is a genuine kernel object whose owner the kernel
+                // tracks, so this produces a real chain: this thread, blocked on a mutex, owned by that
+                // thread - a thread id that can be checked against the managed stacks in the same report.
+                case "mutexchain":
+                {
+                    var mutex = new Mutex(false);
+                    var holderHasIt = new ManualResetEventSlim(false);
+                    // A Mutex has thread affinity, so the holder must take it itself rather than be handed
+                    // it. Foreground, so the process cannot quietly exit from under the wait.
+                    new Thread(() =>
+                    {
+                        mutex.WaitOne();
+                        holderHasIt.Set();
+                        // Never released. This Bloom is not going to recover on purpose.
+                        Thread.Sleep(TimeSpan.FromMinutes(10));
+                    })
+                    {
+                        IsBackground = false,
+                        Name = "FreezeSimulator mutex holder",
+                    }.Start();
+                    // Do not block until the other thread genuinely owns it, or the UI thread would take
+                    // the mutex itself and simulate nothing at all.
+                    holderHasIt.Wait(TimeSpan.FromSeconds(5));
+                    // Deliberately the raw Win32 wait rather than Mutex.WaitOne. On an STA thread the
+                    // managed wait becomes CoWaitForMultipleHandles, which pumps messages and may leave
+                    // the thread looking to the kernel like it is waiting on COM rather than on the mutex.
+                    // Since the entire point here is to hand WCT a wait it can attribute, we ask for the
+                    // plain kernel wait and leave nothing to interpretation.
+                    WaitForSingleObject(
+                        mutex.SafeWaitHandle.DangerousGetHandle(),
+                        (uint)TimeSpan.FromMinutes(10).TotalMilliseconds
+                    );
+                    break;
+                }
+
+                // The UI goes away but the process lives on, held up by a foreground thread: the state
+                // whose symptom users report as "Bloom won't start".
+                case "zombie":
+                    new Thread(() => Thread.Sleep(TimeSpan.FromMinutes(20)))
+                    {
+                        IsBackground = false,
+                        Name = "FreezeSimulator zombie keeper",
+                    }.Start();
+                    foreach (Form form in Application.OpenForms)
+                        form.Hide();
+                    break;
+
+                default:
+                    Logger.WriteEvent(
+                        $"*** FreezeSimulator: '{kind}' is not a kind it knows about"
+                    );
+                    break;
+            }
+        }
+    }
+}

--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -16,6 +16,7 @@ using Bloom.Collection;
 using Bloom.Collection.BloomPack;
 using Bloom.CollectionChoosing;
 using Bloom.ErrorReporter;
+using Bloom.FreezeDoctor;
 using Bloom.MiscUI;
 using Bloom.Properties;
 using Bloom.Registration;
@@ -26,6 +27,7 @@ using Bloom.Utils;
 using Bloom.web;
 using Bloom.web.controllers;
 using Bloom.WebLibraryIntegration;
+using BloomFreezeDoctor.Protocol;
 using BloomTemp;
 using CommandLine;
 using L10NSharp;
@@ -1409,6 +1411,18 @@ namespace Bloom
             // Crashes if initialized twice, and there's at least once case when joining a TC
             // where we can come here twice.
             WritingSystem.EnsureSldrInitialized();
+
+            // Publish our health for the Freeze Doctor. Started here, just before the message loop,
+            // because the UI heartbeat is a WinForms timer: it only ticks while messages are being pumped,
+            // which is exactly what makes its silence meaningful.
+            FreezeDoctorSupport.Start();
+            // And start the Doctor itself if the user has switched it on, since a diagnostic tool is no use
+            // unless it is already running when the trouble starts.
+            DoctorLauncher.LaunchIfWanted();
+            // Deliberate breakage for testing the Doctor, and inert unless BLOOM_SIMULATE_FREEZE is set
+            // AND this is a developer build.
+            FreezeSimulator.ArmIfRequested(ApplicationUpdateSupport.ChannelName);
+
             try
             {
                 Application.Run();
@@ -1431,6 +1445,8 @@ namespace Bloom
                 {
                     exceptMsg += $" (Sentry report failed: {e})";
                 }
+                // Ask a watching Freeze Doctor to dump us while we still exist.
+                FreezeDoctorSupport.RequestDumpBeforeDying();
                 ShowUserEmergencyShutdownMessage(bad);
                 System.Environment.FailFast(exceptMsg);
             }
@@ -1446,6 +1462,7 @@ namespace Bloom
                 {
                     exceptMsg += $" (Sentry report failed: {e})";
                 }
+                FreezeDoctorSupport.RequestDumpBeforeDying();
                 ShowUserEmergencyShutdownMessage(nasty);
                 System.Environment.FailFast(exceptMsg);
             }
@@ -1455,6 +1472,10 @@ namespace Bloom
                     FileMeddlerManager.Stop();
                 WebView2Browser.CleanupWebView2UserFolders();
             }
+
+            // From here on we mark how far shutdown has got, so that a Bloom which dies part way through
+            // can say WHERE it stopped rather than only that it did.
+            FreezeDoctorSupport.SetShutdownPhase(BloomShutdownPhase.MessageLoopReturned);
 
             try
             {
@@ -1472,6 +1493,7 @@ namespace Bloom
                 }
             }
 
+            FreezeDoctorSupport.SetShutdownPhase(BloomShutdownPhase.SettingsSaved);
             Sldr.Cleanup();
             Logger.WriteMinorEvent("shutting down logger, about to dispose project context");
             // Force the log file to include the minor events.  I don't know why this isn't the default. (BL-16290)
@@ -1482,9 +1504,11 @@ namespace Bloom
                 logPath = Path.Combine(Path.GetTempPath(), "SIL", "Bloom", "Log.txt");
             Directory.CreateDirectory(Path.GetDirectoryName(logPath));
             RobustFile.WriteAllText(logPath, logText);
+            FreezeDoctorSupport.SetShutdownPhase(BloomShutdownPhase.LogWritten);
 
             if (_projectContext != null)
                 _projectContext.Dispose();
+            FreezeDoctorSupport.SetShutdownPhase(BloomShutdownPhase.ProjectContextDisposed);
         }
 
         /// <summary>
@@ -2441,6 +2465,15 @@ namespace Bloom
 
         // Only the token owner may release it and run Bloom's global temp cleanup on exit.
         private static bool _ownsSingleInstanceToken;
+
+        /// <summary>
+        /// Whether this Bloom holds the single-instance token, which the channels deliberately share, so
+        /// that at most one Bloom is normally running. Published in the Doctor's session file: it is what
+        /// tells the Doctor which running Bloom is actually standing in the way of a restart, as against
+        /// the ones that bypassed the token (an --automation run) or never took it (a Ctrl-held launch
+        /// that was not first).
+        /// </summary>
+        internal static bool OwnsSingleInstanceToken => _ownsSingleInstanceToken;
 
         /// <summary>
         /// Decides whether a Sentry event is the benign "unobserved Task socket/IO abort" noise

--- a/src/BloomExe/Properties/Settings.Designer.cs
+++ b/src/BloomExe/Properties/Settings.Designer.cs
@@ -427,6 +427,19 @@ namespace Bloom.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool RunFreezeDoctor {
+            get {
+                return ((bool)(this["RunFreezeDoctor"]));
+            }
+            set {
+                this["RunFreezeDoctor"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.SettingsProviderAttribute(typeof(SIL.Settings.CrossPlatformSettingsProvider))]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
         public bool AutoUpdate {
             get {

--- a/src/BloomExe/Properties/Settings.settings
+++ b/src/BloomExe/Properties/Settings.settings
@@ -101,6 +101,9 @@
     <Setting Name="AlwaysMeasurePerformance" Provider="SIL.Settings.CrossPlatformSettingsProvider" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="RunFreezeDoctor" Provider="SIL.Settings.CrossPlatformSettingsProvider" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
     <Setting Name="AutoUpdate" Provider="SIL.Settings.CrossPlatformSettingsProvider" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>

--- a/src/BloomExe/Publish/BloomPub/BloomPubMaker.cs
+++ b/src/BloomExe/Publish/BloomPub/BloomPubMaker.cs
@@ -9,6 +9,7 @@ using System.Xml;
 using Bloom;
 using Bloom.Book;
 using Bloom.FontProcessing;
+using Bloom.FreezeDoctor;
 using Bloom.ImageProcessing;
 using Bloom.Publish.Epub;
 using Bloom.SafeXml;
@@ -128,6 +129,10 @@ namespace Bloom.Publish.BloomPub
             bool isTemplateBook = false
         )
         {
+            // Marked at the innermost worker rather than at the publish screens, because every route to a
+            // BloomPUB comes through here - including the bulk publisher and app building, which run longest.
+            using var _longOperation = FreezeDoctorSupport.LongOperation("making a BloomPUB");
+
             // PrepareBookForBloomReader is about to modify sTheMostRecentBloomFileLocator.
             // Record the previous value so we can restore it later.
             var previousLocator = BloomFileLocator.sTheMostRecentBloomFileLocator;

--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -13,6 +13,7 @@ using Bloom;
 using Bloom.Api;
 using Bloom.Book;
 using Bloom.FontProcessing;
+using Bloom.FreezeDoctor;
 using Bloom.ImageProcessing;
 using Bloom.SafeXml;
 using Bloom.SubscriptionAndFeatures;
@@ -246,6 +247,10 @@ namespace Bloom.Publish.Epub
         /// </summary>
         public void StageEpub(WebSocketProgress progress, bool publishWithoutAudio = false)
         {
+            // Staging is the expensive half of making an ePUB - it walks every page and every audio file -
+            // so it is the part that would be mistaken for a freeze on a large book.
+            using var _longOperation = FreezeDoctorSupport.LongOperation("making an ePUB");
+
             if (Unpaginated && Book.OurHtmlDom.HasComicalCanvasElements())
                 Unpaginated = false; // comics require fixed layout to align canvas elements.
             if (!Unpaginated)

--- a/src/BloomExe/Publish/Rab/RabProjectService.cs
+++ b/src/BloomExe/Publish/Rab/RabProjectService.cs
@@ -19,6 +19,7 @@ using Bloom.Api;
 using Bloom.Book;
 using Bloom.Collection;
 using Bloom.CollectionTab;
+using Bloom.FreezeDoctor;
 using Bloom.Publish.BloomPub;
 using Bloom.ToPalaso;
 using Bloom.web;
@@ -812,6 +813,13 @@ namespace Bloom.Publish.Rab
 
         private void Build()
         {
+            // The longest deliberate operation Bloom has: a Gradle build exceeds a minute even on a fast
+            // machine. BloomPubMaker marks its own work nested inside this; the scope counts depth, so the
+            // inner one finishing does not end the patience for this one.
+            using var _longOperation = FreezeDoctorSupport.LongOperation(
+                "building an app with Reading App Builder"
+            );
+
             // Build reuses BloomPUBs created during the current Apps-screen session and regenerates only missing ones.
             var paths = GetPaths();
             EnsureWorkspaceFolders(paths);

--- a/src/BloomExe/Publish/Video/RecordVideoWindow.cs
+++ b/src/BloomExe/Publish/Video/RecordVideoWindow.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using Bloom.Api;
 using Bloom.Book;
+using Bloom.FreezeDoctor;
 using Bloom.MiscUI;
 using Bloom.ToPalaso;
 using Bloom.Utils;
@@ -328,8 +329,23 @@ namespace Bloom.Publish.Video
         /// We get a notification through the API when bloom player has loaded the first page content
         /// and is in a good state for us to start recording video from the window content.
         /// </summary>
+        /// <summary>
+        /// What Bloom says it is doing while a recording runs, for a Freeze Doctor report.
+        ///
+        /// Recording needs no <c>LongOperation</c> mark, because the window has to keep rendering for
+        /// ffmpeg to capture it, so the UI heartbeat keeps ticking and the Doctor never mistakes it for a
+        /// freeze. But nothing else describes it either: the request that starts a recording returns at
+        /// once, and the next one arrives only when the book finishes playing — so without this, a report
+        /// gathered during a recording says "no request in flight" for however many minutes it ran, and a
+        /// crash in the middle of one would produce a card that never mentions the video.
+        /// </summary>
+        private const string RecordingActivity = "recording a video";
+
         public void StartFfmpegForVideoCapture()
         {
+            // Said before the early return below, because an MP3 recording still plays the whole book.
+            FreezeDoctorSupport.SetActivity(RecordingActivity);
+
             // Enhance: what on earth should we do if it's not found??
 
             // If we're doing audio there's no more to do just now; we will play the book
@@ -465,6 +481,12 @@ namespace Bloom.Publish.Video
 
             ClearPreventSleepTimer();
             Close();
+
+            // The encode-and-merge is the slow part, and being CPU-bound it could be taken for a freeze.
+            // Opened after the Close above, deliberately: closing raises OnClosed, which retires the
+            // recording note, and a scope spanning that would capture the note as the activity to restore
+            // and leave it stated long after the video was finished.
+            using var _longOperation = FreezeDoctorSupport.LongOperation("making a video");
 
             await BrowserProgressDialog.DoWorkWithProgressDialogAsync(
                 _webSocketServer,
@@ -1354,6 +1376,17 @@ namespace Bloom.Publish.Video
             // properly, BEFORE we do the next stage of processing the video; don't clean
             // up anything we will need for that. See code at start of StopRecordingAsync,
             // which sets things up so that Close will not mess things up.
+            // Retire the recording note here rather than at the end of StopRecordingAsync, because this
+            // runs on every path out, including the user closing the window to cancel. A stated activity has
+            // no natural expiry, so a path that forgot to clear it would leave every later report claiming
+            // Bloom was recording a video.
+            //
+            // Note this blanks the slot rather than retiring only our own note, so it would also drop the
+            // text of a long operation running at the same moment. Nothing in the Publish tab can produce
+            // that overlap, and the cost if it ever did is a report with less to say rather than one that
+            // says something false.
+            FreezeDoctorSupport.SetActivity("");
+
             _saveReceived = false;
             if (_webSocketServer != null)
                 _webSocketServer.SendString("recordVideo", "recording", "false");

--- a/src/BloomExe/WebLibraryIntegration/AccessKeys.cs
+++ b/src/BloomExe/WebLibraryIntegration/AccessKeys.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using BloomFreezeDoctor.Protocol;
 using SIL.IO;
 
 namespace Bloom.WebLibraryIntegration
@@ -10,7 +11,8 @@ namespace Bloom.WebLibraryIntegration
     /// and easily find our keys and use our storage.
     /// The keys are currently stored in a file called connections.dll. The installer must place a version of this
     /// in the EXE directory. Developers get it automatically, along with other dependencies.
-    /// You can see what keys are stored in what order by checking the constructor.
+    /// Which line holds which key is named once, in <see cref="SupportUploadCredentials"/>, because the
+    /// Freeze Doctor reads the same file.
     /// </summary>
     public class AccessKeys
     {
@@ -26,25 +28,33 @@ namespace Bloom.WebLibraryIntegration
         //Factory
         public static AccessKeys GetAccessKeys(string bucket)
         {
-            var connectionsPath = FileLocationUtilities.GetFileDistributedWithApplication(
-                "connections.dll"
-            );
-            var lines = RobustFile.ReadAllLines(connectionsPath);
+            // Located and read by the project Bloom and the Freeze Doctor share, which needs the same keys
+            // to upload a minidump too large for a tracker attachment. One definition of where this file is
+            // and what its lines mean: two independent readers of an undocumented line-ordered file is how
+            // a line added at the top comes to mean different things in two programs.
+            var lines =
+                SupportUploadCredentials.TryReadLines()
+                ?? throw new ApplicationException(
+                    "Could not find or read " + SupportUploadCredentials.ConnectionsFileName
+                );
             switch (bucket)
             {
                 case BloomS3Client.SandboxBucketName:
                     // S3 'uploaderDev' user, who has permission to use the BloomLibraryBooks-Sandbox bucket.
                     if (BookUpload.IsDryRun)
                         return new AccessKeys(null, null);
-                    return new AccessKeys(lines[2], lines[3]);
+                    return UploaderDev(lines);
                 case BloomS3Client.UnitTestBucketName:
                 case BloomS3Client.ProblemBookUploadsBucketName:
-                    return new AccessKeys(lines[2], lines[3]);
+                    return UploaderDev(lines);
                 case BloomS3Client.ProductionBucketName:
                     //S3 'uploader' user, who has permission to use the BloomLibraryBooks bucket
                     if (BookUpload.IsDryRun)
                         return new AccessKeys(null, null);
-                    return new AccessKeys(lines[0], lines[1]);
+                    return new AccessKeys(
+                        lines[SupportUploadCredentials.UploaderAccessKeyLine],
+                        lines[SupportUploadCredentials.UploaderSecretLine]
+                    );
                 case BloomS3Client.BloomDesktopFiles:
                     // For now, this is public read, and no one needs to write.
                     return new AccessKeys(null, null);
@@ -53,5 +63,14 @@ namespace Bloom.WebLibraryIntegration
                     throw new ApplicationException("Bucket name not recognized: " + bucket);
             }
         }
+
+        /// <summary>
+        /// The <c>uploaderDev</c> credentials, which three of the buckets above share.
+        /// </summary>
+        private static AccessKeys UploaderDev(string[] lines) =>
+            new AccessKeys(
+                lines[SupportUploadCredentials.UploaderDevAccessKeyLine],
+                lines[SupportUploadCredentials.UploaderDevSecretLine]
+            );
     }
 }

--- a/src/BloomExe/WebLibraryIntegration/BookDownload.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookDownload.cs
@@ -14,6 +14,7 @@ using Amazon.Runtime;
 using Bloom.Book;
 using Bloom.Collection;
 using Bloom.CollectionCreating;
+using Bloom.FreezeDoctor;
 using Bloom.MiscUI;
 using Bloom.Publish.BloomLibrary;
 using Bloom.ToPalaso;
@@ -57,6 +58,11 @@ namespace Bloom.WebLibraryIntegration
             bool forEdit = false
         )
         {
+            // Slowest exactly where our users are: a large book over a poor connection can take many minutes.
+            using var _longOperation = FreezeDoctorSupport.LongOperation(
+                "downloading a book from Bloom Library"
+            );
+
             string storageKeyOfBookFolderParentOnS3 = "unknown";
             try
             {

--- a/src/BloomExe/WebLibraryIntegration/BookUpload.cs
+++ b/src/BloomExe/WebLibraryIntegration/BookUpload.cs
@@ -13,6 +13,7 @@ using Amazon.S3;
 using Bloom.Api;
 using Bloom.Book;
 using Bloom.Collection;
+using Bloom.FreezeDoctor;
 using Bloom.ImageProcessing;
 using Bloom.Properties;
 using Bloom.Publish;
@@ -908,6 +909,12 @@ namespace Bloom.WebLibraryIntegration
             bool changeUploader = false
         )
         {
+            // Slowest exactly where our users are: a book with audio and video over a poor connection
+            // routinely takes many minutes.
+            using var _longOperation = FreezeDoctorSupport.LongOperation(
+                "uploading a book to Bloom Library"
+            );
+
             // this (isForPublish:true) is dangerous and the product of much discussion.
             // See "finally" block later to see that we put branding files back
             book.Storage.CleanupUnusedSupportFiles(isForPublish: true);

--- a/src/BloomExe/web/BloomApiHandler.cs
+++ b/src/BloomExe/web/BloomApiHandler.cs
@@ -382,6 +382,29 @@ namespace Bloom.Api
             string localPathLc
         )
         {
+            // Note this request while it runs, so that a Freeze Doctor report can say what Bloom was
+            // actually doing when it stopped responding. Instrumented HERE rather than at the outer
+            // dispatch because this is where the work — and the waiting on the sync locks in the method below —
+            // actually happens, which is where a hung request sits. The tracker is deliberately incapable
+            // of failing a request; see its class comment.
+            using (var activity = FreezeDoctor.ApiActivityTracker.Begin(localPathLc))
+            {
+                return await ProcessRequestInnerAsync(
+                    endpointRegistration,
+                    info,
+                    localPathLc,
+                    activity
+                );
+            }
+        }
+
+        private async Task<bool> ProcessRequestInnerAsync(
+            BaseEndpointRegistration endpointRegistration,
+            IRequestInfo info,
+            string localPathLc,
+            FreezeDoctor.ApiActivityTracker.ApiActivityScope activity
+        )
+        {
             if (endpointRegistration.RequiresSync)
             {
                 // A single synchronization object won't do, because when processing a request to create a thumbnail or update a preview,
@@ -398,6 +421,12 @@ namespace Bloom.Api
                 // other api requests, so it seems safe to have one lock that prevents working on multiple
                 // thumbnails/previews at the same time, and one that prevents working on other api requests at the same time.
                 var syncOn = SyncObj;
+                // Named as well as chosen, purely so a Freeze Doctor report can say WHICH lock a stuck
+                // request is waiting on. Three requests waiting on the lock a fourth is holding is the
+                // signature of an API deadlock, and it is invisible otherwise: the blocked-thread count
+                // does not distinguish the locks, and Windows' wait-chain analysis cannot see a
+                // SemaphoreSlim at all.
+                var syncName = "the main API lock";
                 if (
                     localPathLc.StartsWith(
                         "api/pagetemplatethumbnail",
@@ -407,9 +436,15 @@ namespace Bloom.Api
                     || localPathLc == "api/publish/bloompub/updatepreview"
                     || localPathLc == "api/publish/epub/updatepreview"
                 )
+                {
                     syncOn = ThumbnailsAndPreviewsSyncObj;
+                    syncName = "the thumbnail/preview lock";
+                }
                 else if (localPathLc.StartsWith("api/i18n/"))
+                {
                     syncOn = I18NLock;
+                    syncName = "the i18n lock";
+                }
 
                 // We report the thread as blocked around ACQUIRING the lock -- not around holding it, since
                 // once we have it we are working rather than waiting.
@@ -419,11 +454,13 @@ namespace Bloom.Api
                 try
                 {
                     // Try to acquire lock
+                    activity.NoteWaitingForLock(syncName);
                     using (BloomServer._theOneInstance.ReportThreadBlocking())
                     {
                         syncOn.Wait();
                         lockAcquired = true;
                     }
+                    activity.NoteHoldingLock(syncName);
 
                     // Lock has been acquired.
                     await ApiRequest.Handle(

--- a/src/BloomExe/web/BloomServer.cs
+++ b/src/BloomExe/web/BloomServer.cs
@@ -2664,9 +2664,26 @@ namespace Bloom.Api
 
         /// <summary>
         /// How many workers currently report themselves blocked. For tests, which need to prove that a
-        /// reported block is undone even when the scope is disposed on a different thread than reported it.
+        /// reported block is undone even when the scope is disposed on a different thread than reported it —
+        /// and for the Freeze Doctor, to which "every worker is blocked" says a great deal about a frozen
+        /// publish.
         /// </summary>
         internal int BlockedWorkerCount => _countBlockedThreads;
+
+        /// <summary>
+        /// How many workers are currently handling a request. Read without the lock deliberately: this is
+        /// only ever used for diagnostics, where a value that is one out of date is worth far more than a
+        /// diagnostic that can block on the very lock a frozen server is fighting over.
+        /// </summary>
+        internal int BusyWorkerCount => _busyThreads;
+
+        /// <summary>
+        /// How many requests are waiting for a worker. Read without the lock for the same reason as
+        /// <see cref="BusyWorkerCount"/>, and it is the reading that tells a shortage of workers from work
+        /// actually being held up: every worker blocked matters much more when requests are queued behind
+        /// them.
+        /// </summary>
+        internal int QueuedRequestCount => _queue.Count;
 
         // Ordinal deliberately: the default overloads of both StartsWith and IndexOf(string) are
         // culture-sensitive, which is the wrong kind of comparison for a thread name we generated

--- a/src/BloomExe/web/controllers/AppApi.cs
+++ b/src/BloomExe/web/controllers/AppApi.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using Bloom.Book;
+using Bloom.FreezeDoctor;
 using Bloom.Properties;
 using Bloom.ToPalaso;
 using Bloom.web;
@@ -158,6 +159,30 @@ namespace Bloom.Api
                 kAppUrlPrefix + "isMeddlingWithNewFiles",
                 request => GetShell()?.GetIsMeddlingWithNewFiles() ?? false,
                 (request, value) => GetShell()?.SetIsMeddlingWithNewFiles(value),
+                true
+            );
+            // Whether to run the Bloom Freeze Doctor, which ships inside Bloom but is off by default.
+            // Not routed through the Shell, unlike its neighbours: this is a plain application setting
+            // about a separate process, and it has nothing to do with any window.
+            apiHandler.RegisterBooleanEndpointHandler(
+                kAppUrlPrefix + "runFreezeDoctor",
+                request => Settings.Default.RunFreezeDoctor,
+                (request, value) =>
+                {
+                    Settings.Default.RunFreezeDoctor = value;
+                    Settings.Default.Save();
+                    if (value)
+                    {
+                        // Start it now rather than at the next restart. Someone switching this on is
+                        // usually in the middle of chasing a freeze and would like to be watched from
+                        // this moment, not from whenever they next happen to restart Bloom.
+                        DoctorLauncher.LaunchIfWanted();
+                    }
+                    // Switching it OFF deliberately leaves any Doctor already running alone. It is
+                    // watching this Bloom and holding evidence; killing it here could throw away a report
+                    // that has been gathered but not yet filed. It quits by itself when Bloom goes, and
+                    // it will not start with the next Bloom.
+                },
                 true
             );
             apiHandler.RegisterEndpointHandler(

--- a/src/BloomExe/web/controllers/ProblemReportApi.cs
+++ b/src/BloomExe/web/controllers/ProblemReportApi.cs
@@ -360,6 +360,11 @@ namespace Bloom.web.controllers
             else
             {
                 issueLink = "https://issues.bloomlibrary.org/youtrack/issue/" + issueId;
+                // Tell any Freeze Doctor that this problem has already been reported, so it does not file a
+                // second card about the same trouble. Cheap insurance against duplicate reports, since a
+                // user reporting a problem by hand and a Doctor noticing the same problem are exactly the
+                // situation where both would fire.
+                FreezeDoctor.FreezeDoctorSupport.NoteBloomReportedAProblem(issueId);
                 if (includeBook || _additionalPathsToInclude?.Any() == true)
                 {
                     try

--- a/src/BloomFreezeDoctor.Protocol/BloomFreezeDoctor.Protocol.csproj
+++ b/src/BloomFreezeDoctor.Protocol/BloomFreezeDoctor.Protocol.csproj
@@ -1,0 +1,44 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    The protocol Bloom and the Freeze Doctor share: the shared-memory health page, the session file, and
+    the named events they use to reach each other.
+
+    Both consumers - BloomExe and BloomFreezeDoctor.Core - reference this project directly, so there is one
+    definition compiled into both sides from the same source every build. Drift is therefore not merely
+    detected but impossible, which matters because drift here produces confident, wrong reports rather than
+    an error. Nothing is packaged or versioned: no NuGet package, no API key, no version to keep in step.
+  -->
+  <PropertyGroup>
+    <!--
+      net8.0-windows rather than plain net8.0, and not merely by inheritance from its consumers: the named
+      kernel objects this uses - a named EventWaitHandle, a memory-mapped file in the `Local\` namespace -
+      are annotated Windows-only in .NET, so a neutral target reports every use as a platform warning, and
+      warnings are errors here. Both consumers are Windows-only anyway.
+    -->
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <RootNamespace>BloomFreezeDoctor.Protocol</RootNamespace>
+    <AssemblyName>BloomFreezeDoctor.Protocol</AssemblyName>
+    <Platforms>x64;ARM64</Platforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+      libpalaso, for SIL.IO.RobustFile: DoctorSession writes and reads a file on a user's disk, and this
+      repository's rule is that such writes retry rather than fail the first time a virus scanner happens to
+      be holding the file. S3, for uploading a support file too large for a tracker attachment; see
+      SupportUpload.cs.
+
+      Every version here must match BloomExe.csproj, kept in step by hand: both projects land in one output
+      directory, so two versions of the same assembly is a problem worth avoiding. If this layout settles,
+      they belong in Directory.Build.props alongside VelopackVersion.
+    -->
+    <PackageReference Include="SIL.Core.Desktop" Version="18.0.0-beta0028" />
+    <PackageReference Include="AWSSDK.Core" Version="3.5.1.32" />
+    <PackageReference Include="AWSSDK.S3" Version="3.5.3.10" />
+  </ItemGroup>
+
+</Project>

--- a/src/BloomFreezeDoctor.Protocol/DoctorChannel.cs
+++ b/src/BloomFreezeDoctor.Protocol/DoctorChannel.cs
@@ -1,0 +1,725 @@
+using System;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using System.Text;
+using System.Threading;
+
+namespace BloomFreezeDoctor.Protocol;
+
+// =====================================================================================================
+//  THIS FILE IS THE CONTRACT BETWEEN BLOOM AND THE FREEZE DOCTOR.
+//
+//  Both programs must agree about this layout exactly, so there is deliberately only ONE definition of
+//  it: this project, compiled into both sides from the same source every build. Two copies would drift,
+//  and that drift shows up as confident, wrong reports rather than as an error, because Bloom would be
+//  writing one set of offsets while the Doctor read another.
+//
+//  There are two ways this format changes, and only one of them is a version bump:
+//
+//    * ADDING a field is the likely case. Append it, grow PayloadBytes, leave SchemaVersion alone. Old
+//      readers ignore it; new readers can tell whether an older Bloom wrote it. See the long note on
+//      DoctorChannelLayout.
+//    * MOVING, RESIZING or REPURPOSING a field breaks every existing reader, so it bumps SchemaVersion —
+//      which also changes the section's name, so old Doctors stop finding the channel rather than
+//      misreading it. REPURPOSING includes changing what a field's VALUES mean and not only its extent:
+//      renumbering BloomShutdownPhase would leave every offset intact and every reader wrong.
+//
+//  Both are pinned by tests rather than trusted to discipline: the tests in this repo assert every offset
+//  by value, assert that PayloadBytes really is the end of the last field, and assert that the writer
+//  never touches a byte beyond it. BloomDesktop has its own test asserting the layout it was compiled
+//  against, so a change Bloom has not caught up with fails Bloom's build rather than going quietly.
+//
+//  Why shared memory rather than a pipe, a socket, or Bloom's own web server: the Doctor has to be able
+//  to read this when Bloom is wedged. A request/response channel needs Bloom to be well enough to
+//  answer, which is exactly what we cannot assume — and Bloom's HTTP server in particular can be
+//  deadlocked or starved of worker threads, which is one of the failures we are hunting. Reading a page
+//  of memory needs nothing from Bloom at all.
+//
+//  A memory-mapped section also outlives the process that created it for as long as any handle stays
+//  open, so the Doctor, which holds one, can still read Bloom's final state after Bloom has gone. That
+//  is what makes the clean-exit flag here (rather than only on disk) useful.
+// =====================================================================================================
+
+/// <summary>
+/// A consistent snapshot of what Bloom last published about itself.
+/// </summary>
+public sealed record DoctorChannelSnapshot
+{
+    /// <summary>Layout version Bloom wrote with.</summary>
+    public required int SchemaVersion { get; init; }
+
+    /// <summary>
+    /// How far into the page the Bloom that wrote this actually wrote — one past its last byte. Nothing
+    /// reads it yet, because every Bloom writing this generation writes all of it; it is here so that when
+    /// the layout does grow, a reader can tell a field an older Bloom never wrote from a real zero. A field
+    /// is present only if <c>offset + size &lt;= PayloadBytes</c>. See the note in
+    /// <see cref="DoctorChannelLayout"/>.
+    /// </summary>
+    public required int PayloadBytes { get; init; }
+
+    /// <summary>The process this describes.</summary>
+    public required int ProcessId { get; init; }
+
+    /// <summary>
+    /// How many times Bloom's UI-thread timer has fired. Its *staleness* is the freeze signal — see
+    /// <see cref="UiHeartbeatAge"/>.
+    /// </summary>
+    public required long UiTicks { get; init; }
+
+    /// <summary>
+    /// How long since the UI thread last ticked. This is the only signal that catches a UI thread blocked
+    /// in a managed wait on an STA thread, where the window still answers messages and every outside
+    /// probe reports the application as healthy.
+    /// </summary>
+    public required TimeSpan UiHeartbeatAge { get; init; }
+
+    /// <summary>How many times Bloom's background watchdog thread has ticked.</summary>
+    public required long WatchdogTicks { get; init; }
+
+    /// <summary>
+    /// How long since the watchdog thread last ticked. Compare with <see cref="UiHeartbeatAge"/>: a stale
+    /// UI heartbeat with a healthy watchdog means the UI thread is blocked, while both stale means the
+    /// whole process is wedged (a GC that will not finish, or a suspended process).
+    /// </summary>
+    public required TimeSpan WatchdogHeartbeatAge { get; init; }
+
+    /// <summary>What Bloom says it is doing, for the report's opening lines.</summary>
+    public required string Activity { get; init; }
+
+    /// <summary>
+    /// How far shutdown has got. Lets a Bloom that dies mid-shutdown say *where* it stopped rather than
+    /// merely that it did.
+    /// </summary>
+    public required BloomShutdownPhase ShutdownPhase { get; init; }
+
+    /// <summary>True once Bloom has recorded that its shutdown ran to completion.</summary>
+    public required bool CleanExitRecorded { get; init; }
+
+    /// <summary>
+    /// True if Bloom saw a debugger attached when it last looked (once a second). Authoritative, unlike our
+    /// outside guess, and the reason a developer stopping their debugger never produces a report.
+    ///
+    /// Covers a NATIVE debugger as well as a managed one: Bloom checks the PEB flag alongside
+    /// <c>Debugger.IsAttached</c>, which only sees managed debuggers.
+    /// </summary>
+    public required bool DebuggerAttached { get; init; }
+
+    /// <summary>
+    /// True if a debugger has been attached at any point in this run, whether or not one is now. **This is
+    /// usually the flag worth acting on, not <see cref="DebuggerAttached"/>**: a debugger that has come and
+    /// gone leaves behind exactly the evidence of a freeze or a crash, and there is nothing left attached to
+    /// explain it.
+    /// </summary>
+    public required bool DebuggerEverAttached { get; init; }
+
+    /// <summary>
+    /// How long ago a debugger was last detached, or <see cref="TimeSpan.MaxValue"/> if none ever has been
+    /// (including while one is still attached).
+    ///
+    /// This is what makes <see cref="DebuggerEverAttached"/> usable without writing off a whole run: compare
+    /// it with the length of the gap being judged, and a debugger that detached hours before a genuine
+    /// freeze stops being an excuse for ignoring it.
+    /// </summary>
+    public required TimeSpan DebuggerLastDetachedAge { get; init; }
+
+    /// <summary>
+    /// True while Bloom is deliberately busy — publishing, uploading, making a PDF. Raises the Doctor's
+    /// patience rather than silencing it.
+    /// </summary>
+    public required bool LongOperationInProgress { get; init; }
+
+    /// <summary>Server worker threads currently doing work, when Bloom reports it.</summary>
+    public required int ServerBusyWorkers { get; init; }
+
+    /// <summary>
+    /// Server worker threads currently blocked. Bloom already tracks this for its own deadlock
+    /// avoidance; surfacing it costs nothing and says a great deal about a frozen publish.
+    /// </summary>
+    public required int ServerBlockedWorkers { get; init; }
+
+    /// <summary>
+    /// How many worker threads the pool holds. Without it the two counts above cannot be judged: "3
+    /// blocked" is unremarkable in a pool of twelve and total starvation in a pool of three, and the
+    /// server's own rule for growing the pool is that every live worker is blocked.
+    /// </summary>
+    public required int ServerWorkers { get; init; }
+
+    /// <summary>
+    /// How many requests are waiting for a worker. This is what separates a pool that is merely busy from
+    /// one that is holding work up.
+    /// </summary>
+    public required int ServerQueuedRequests { get; init; }
+}
+
+/// <summary>
+/// The layout of the shared page, and the names used to find it. Both the writer (in Bloom) and the
+/// reader (in the Doctor) work from these constants, so there is one description of the format rather
+/// than two.
+/// </summary>
+public static class DoctorChannelLayout
+{
+    /// <summary>
+    /// The compatibility GENERATION. Bump this only for a change that an older reader could not survive:
+    /// moving a field, resizing one, or reusing it for something else. **Do not bump it to add a field** —
+    /// see <see cref="PayloadBytes"/>, which is how growth is meant to happen.
+    ///
+    /// Note that this number is part of the section's NAME, so a bump does not merely make readers reject
+    /// the page: an old Doctor stops finding a channel at all and degrades to watching from outside, which
+    /// is the right outcome but a total loss of the good data. A reader that wants to support two
+    /// generations has to look for both names deliberately.
+    /// </summary>
+    public const int SchemaVersion = 1;
+
+    /// <summary>
+    /// One page is ample and keeps the whole record on a single page of memory. `Local\` scope, not
+    /// `Global\`: the Doctor cannot open processes in another Windows session anyway.
+    /// </summary>
+    public const int Size = 4096;
+
+    /// <summary>The name for a given Bloom process.</summary>
+    public static string NameFor(int processId) =>
+        $@"Local\BloomFreezeDoctor.v{SchemaVersion}.{processId}";
+
+    // =================================================================================================
+    //  HOW THIS FORMAT IS MEANT TO GROW
+    //
+    //  Adding a field is by far the likeliest change, so it has its own mechanism and does NOT need a
+    //  SchemaVersion bump. Within one generation the rules are:
+    //
+    //    * Existing fields never move, never change size, and never change meaning. (A test pins every
+    //      offset by value, so breaking this fails the build rather than the field.)
+    //    * New fields are APPENDED at the current PayloadBytes, and PayloadBytes grows to match.
+    //
+    //  The writer records how far it wrote, so a reader can tell what is actually there. The direction
+    //  that needs this is a NEW Doctor reading an OLD Bloom: the page is zero-filled at creation, so a
+    //  field the writer never wrote reads as 0, which is indistinguishable from a real 0. Without
+    //  PayloadBytes a new Doctor would confidently report "0" where the truth is "this Bloom is too old
+    //  to say" — exactly the plausible-but-wrong report this whole design exists to avoid. (The opposite
+    //  direction needs nothing: an old Doctor only ever looks at offsets that append-only growth leaves
+    //  untouched.)
+    //
+    //  That case is the common one in the field, not a curiosity: the Doctor updates itself through
+    //  Velopack while Bloom versions linger on people's machines, and the planned 6.4 backport
+    //  guarantees more than one Bloom vintage writing this page at any given time.
+    //
+    //  The rule for a reader, when there is eventually more than one vintage to handle, is on the END of
+    //  the field and not its start — a field that begins inside the written region but runs past the end
+    //  of it must be treated as absent, not read half-way:
+    //
+    //        readable  <=>  fieldOffset + fieldSize <= snapshot.PayloadBytes
+    //
+    //  Nothing needs that yet, because every Bloom that writes generation 1 writes all of it. It is
+    //  written down, and PayloadBytes is recorded and surfaced on the snapshot, so that the day it is
+    //  needed the data is already there to work from.
+    // =================================================================================================
+
+    // The layout. Offsets are explicit rather than computed so a change is visible in a diff.
+    internal const int OffsetSchemaVersion = 0;
+
+    /// <summary>
+    /// Where <see cref="PayloadBytes"/> itself lives. In the header, before anything that can grow,
+    /// because every reader of every future vintage has to be able to find it.
+    /// </summary>
+    internal const int OffsetPayloadBytes = 4;
+
+    /// <summary>
+    /// A sequence number, incremented before and after every write. Odd means a write is in progress.
+    /// The reader takes it before and after reading and retries if it changed, which is what stops it
+    /// seeing half of one update and half of the next — mattering most for the strings, since a torn
+    /// activity name would be gibberish on a card.
+    ///
+    /// Deliberately 8-byte aligned, which is why the two ints above it come first and ProcessId moved
+    /// below it: an unaligned 64-bit read is not guaranteed to be atomic.
+    /// </summary>
+    internal const int OffsetWriteSequence = 8;
+
+    internal const int OffsetProcessId = 16;
+    internal const int OffsetShutdownPhase = 20;
+    internal const int OffsetUiTicks = 24;
+    internal const int OffsetUiTimestamp = 32;
+    internal const int OffsetWatchdogTicks = 40;
+    internal const int OffsetWatchdogTimestamp = 48;
+    internal const int OffsetFlags = 56;
+    internal const int OffsetServerBusy = 60;
+    internal const int OffsetServerBlocked = 64;
+
+    /// <summary>
+    /// Four bytes nobody writes, so that the payload ENDS on an 8-byte boundary. Without it the next
+    /// field appended would start at 324 and a 64-bit one would be unaligned, which the writer above
+    /// explains is not safe to read atomically. Cheap now; awkward to retrofit, because fixing it later
+    /// would mean moving a field, which is a generation bump.
+    /// </summary>
+    internal const int OffsetReserved = 68;
+
+    internal const int OffsetActivity = 72;
+
+    /// <summary>
+    /// How much room the activity string gets, and so the reason the next offset jumps by 256 rather than
+    /// by the handful of bytes the offsets above move by.
+    ///
+    /// Public because it is part of the contract a caller has to respect: anything longer is truncated
+    /// rather than allowed to run into the next field.
+    ///
+    /// Changing this number resizes an existing field, so it is a <see cref="SchemaVersion"/> bump and not
+    /// an additive change.
+    /// </summary>
+    public const int ActivityMaxBytes = 256;
+
+    /// <summary>
+    /// When a debugger was last detached, as <see cref="Environment.TickCount64"/>, or 0 if none ever has
+    /// been. Appended after the activity block, which is why the four reserved bytes above matter: this is
+    /// a 64-bit field and it lands 8-byte aligned.
+    /// </summary>
+    internal const int OffsetDebuggerLastDetached = 328;
+
+    /// <summary>
+    /// How many worker threads the server pool holds, and how many requests are waiting for one.
+    ///
+    /// These are what make <see cref="OffsetServerBusy"/> and <see cref="OffsetServerBlocked"/> readable.
+    /// "3 blocked" says nothing on its own; "3 blocked of 3" is the server's own starvation condition —
+    /// BloomServer grows the pool exactly when every live worker is blocked — and a queue depth alongside
+    /// it says whether anything is actually stuck behind the shortage.
+    /// </summary>
+    internal const int OffsetServerWorkers = 336;
+    internal const int OffsetServerQueued = 340;
+
+    /// <summary>
+    /// One past the last byte a writer of THIS build ever writes, recorded in the page so a reader can
+    /// tell how much of it is real. Grows as fields are appended; see the long note above.
+    /// </summary>
+    public const int PayloadBytes = OffsetServerQueued + sizeof(int);
+
+    /// <summary>
+    /// The floor for generation 1: the least any writer of this generation provides, so a reader can read
+    /// everything up to here without checking whether it is present.
+    ///
+    /// It is raised to match <see cref="PayloadBytes"/> while generation 1 is **unreleased** — no Bloom has
+    /// shipped writing this page, so there is no older vintage to stay compatible with, and requiring the
+    /// whole layout is simpler and stricter than tolerating a shorter one nobody can produce.
+    ///
+    /// **It freezes the moment a Bloom ships writing this page.** After that, appending a field grows
+    /// PayloadBytes and leaves this alone, and a reader that wants the new field has to check for it — see
+    /// the note above. Raising it after release would make a newer Doctor reject every older Bloom.
+    /// </summary>
+    public const int BaselinePayloadBytes = PayloadBytes;
+
+    /// <summary>One field's position and extent, for the tests that pin the layout.</summary>
+    public readonly record struct FieldExtent(string Name, int Offset, int Size);
+
+    /// <summary>
+    /// Every field, in order. This exists so the layout can be *checked* rather than merely described:
+    /// the tests assert each offset by value, that no two fields overlap, that everything fits inside
+    /// <see cref="Size"/>, and that <see cref="PayloadBytes"/> really is the end of the last field — which
+    /// is what catches appending a field and forgetting to grow PayloadBytes.
+    /// </summary>
+    public static IReadOnlyList<FieldExtent> Fields { get; } =
+        new[]
+        {
+            new FieldExtent(nameof(SchemaVersion), OffsetSchemaVersion, sizeof(int)),
+            new FieldExtent(nameof(PayloadBytes), OffsetPayloadBytes, sizeof(int)),
+            new FieldExtent("WriteSequence", OffsetWriteSequence, sizeof(long)),
+            new FieldExtent("ProcessId", OffsetProcessId, sizeof(int)),
+            new FieldExtent("ShutdownPhase", OffsetShutdownPhase, sizeof(int)),
+            new FieldExtent("UiTicks", OffsetUiTicks, sizeof(long)),
+            new FieldExtent("UiTimestamp", OffsetUiTimestamp, sizeof(long)),
+            new FieldExtent("WatchdogTicks", OffsetWatchdogTicks, sizeof(long)),
+            new FieldExtent("WatchdogTimestamp", OffsetWatchdogTimestamp, sizeof(long)),
+            new FieldExtent("Flags", OffsetFlags, sizeof(int)),
+            new FieldExtent("ServerBusy", OffsetServerBusy, sizeof(int)),
+            new FieldExtent("ServerBlocked", OffsetServerBlocked, sizeof(int)),
+            new FieldExtent("Reserved", OffsetReserved, sizeof(int)),
+            new FieldExtent("Activity", OffsetActivity, ActivityMaxBytes),
+            new FieldExtent("DebuggerLastDetached", OffsetDebuggerLastDetached, sizeof(long)),
+            new FieldExtent("ServerWorkers", OffsetServerWorkers, sizeof(int)),
+            new FieldExtent("ServerQueued", OffsetServerQueued, sizeof(int)),
+        };
+
+    internal const int FlagCleanExitRecorded = 1 << 0;
+    internal const int FlagDebuggerAttached = 1 << 1;
+    internal const int FlagLongOperation = 1 << 2;
+
+    /// <summary>
+    /// Set the first time a debugger is seen and never cleared. "Is a debugger attached right now" is not
+    /// the question worth answering: a developer who attaches, sits at a breakpoint for five minutes, and
+    /// detaches leaves a five-minute hole in the UI heartbeat and no debugger in sight, which is a freeze
+    /// report about nothing. Same for a process a debugger terminated — that is a TerminateProcess, so no
+    /// clean exit is recorded and it otherwise looks exactly like an unreported crash.
+    /// </summary>
+    internal const int FlagDebuggerEverAttached = 1 << 3;
+}
+
+/// <summary>
+/// Reads what a Bloom has published. Used by the Doctor; harmless if Bloom is an older version that
+/// publishes nothing, in which case <see cref="TryRead"/> simply returns false and the Doctor falls back
+/// to watching from outside.
+/// </summary>
+public static class DoctorChannelReader
+{
+    /// <summary>
+    /// Reads a consistent snapshot, or returns false if this Bloom publishes no channel (an older
+    /// version), the schema is one we do not understand, or the data would not settle.
+    /// </summary>
+    public static bool TryRead(int processId, out DoctorChannelSnapshot? snapshot)
+    {
+        snapshot = null;
+        try
+        {
+            using var file = MemoryMappedFile.OpenExisting(
+                DoctorChannelLayout.NameFor(processId),
+                MemoryMappedFileRights.Read
+            );
+            using var view = file.CreateViewAccessor(
+                0,
+                DoctorChannelLayout.Size,
+                MemoryMappedFileAccess.Read
+            );
+
+            // Retry a few times: a write in progress is momentary, and giving up after a handful of
+            // attempts is better than looping while Bloom is busy.
+            //
+            // **The yield matters as much as the count.** Three back-to-back reads all land inside one
+            // scheduling quantum, so a writer that was preempted mid-write (holding the sequence odd)
+            // defeats every attempt and TryRead returns false. Callers cannot tell that from "this Bloom
+            // publishes nothing": the report then states that Bloom published no health channel, which is
+            // untrue, and the check for work in progress answers "no" - one of the guards against ending
+            // a Bloom that is part-way through saving. So give the writer a chance to be rescheduled, and
+            // take a few more attempts while we are at it; the whole loop is still bounded and brief.
+            for (var attempt = 0; attempt < 8; attempt++)
+            {
+                if (attempt > 0)
+                    Thread.Yield();
+
+                var before = view.ReadInt64(DoctorChannelLayout.OffsetWriteSequence);
+                if (before % 2 != 0)
+                    continue; // a write is in flight
+
+                var candidate = ReadFields(view, processId);
+                var after = view.ReadInt64(DoctorChannelLayout.OffsetWriteSequence);
+                if (before != after)
+                    continue; // it changed under us
+
+                if (candidate == null)
+                    return false; // schema we do not understand: better nothing than nonsense
+                snapshot = candidate;
+                return true;
+            }
+        }
+        catch (FileNotFoundException)
+        {
+            // No channel: an older Bloom, or one that has not got that far in startup. Expected.
+        }
+        catch (Exception)
+        {
+            // Anything else (permissions, a half-created section) also means "no channel".
+        }
+        return false;
+    }
+
+    private static DoctorChannelSnapshot? ReadFields(MemoryMappedViewAccessor view, int processId)
+    {
+        var schema = view.ReadInt32(DoctorChannelLayout.OffsetSchemaVersion);
+        if (schema != DoctorChannelLayout.SchemaVersion)
+            return null;
+
+        // How much of the page the writer filled in. Two things are being rejected here, and the first is
+        // the one that matters most: a section that has been CREATED but not yet initialised is
+        // zero-filled, so it would otherwise present itself as a settled, sane-looking page of zeroes.
+        // (The schema check above catches that too; this is the same guard on the field that will
+        // eventually be load-bearing.) The upper bound catches a value that cannot be true of any writer.
+        //
+        // Note it is compared against the BASELINE and not against our own PayloadBytes: a Doctor built
+        // against a later, larger layout must still accept an older Bloom that wrote less. Requiring our
+        // own extent here would throw away the whole page for the sake of one field we happen to know
+        // about and it does not.
+        var payloadBytes = view.ReadInt32(DoctorChannelLayout.OffsetPayloadBytes);
+        if (
+            payloadBytes < DoctorChannelLayout.BaselinePayloadBytes
+            || payloadBytes > DoctorChannelLayout.Size
+        )
+            return null;
+
+        var now = Environment.TickCount64;
+        var flags = view.ReadInt32(DoctorChannelLayout.OffsetFlags);
+        var activityBytes = new byte[DoctorChannelLayout.ActivityMaxBytes];
+        view.ReadArray(DoctorChannelLayout.OffsetActivity, activityBytes, 0, activityBytes.Length);
+
+        return new DoctorChannelSnapshot
+        {
+            SchemaVersion = schema,
+            PayloadBytes = payloadBytes,
+            ProcessId = view.ReadInt32(DoctorChannelLayout.OffsetProcessId),
+            UiTicks = view.ReadInt64(DoctorChannelLayout.OffsetUiTicks),
+            // Both sides use Environment.TickCount64, which counts since the machine booted and is
+            // therefore directly comparable between processes — unlike a wall clock, which a time
+            // change or a sleep would skew.
+            UiHeartbeatAge = AgeOf(view.ReadInt64(DoctorChannelLayout.OffsetUiTimestamp), now),
+            WatchdogTicks = view.ReadInt64(DoctorChannelLayout.OffsetWatchdogTicks),
+            WatchdogHeartbeatAge = AgeOf(
+                view.ReadInt64(DoctorChannelLayout.OffsetWatchdogTimestamp),
+                now
+            ),
+            Activity = DecodeString(activityBytes),
+            ShutdownPhase = (BloomShutdownPhase)
+                view.ReadInt32(DoctorChannelLayout.OffsetShutdownPhase),
+            CleanExitRecorded = (flags & DoctorChannelLayout.FlagCleanExitRecorded) != 0,
+            DebuggerAttached = (flags & DoctorChannelLayout.FlagDebuggerAttached) != 0,
+            DebuggerEverAttached = (flags & DoctorChannelLayout.FlagDebuggerEverAttached) != 0,
+            DebuggerLastDetachedAge = AgeOf(
+                view.ReadInt64(DoctorChannelLayout.OffsetDebuggerLastDetached),
+                now
+            ),
+            LongOperationInProgress = (flags & DoctorChannelLayout.FlagLongOperation) != 0,
+            ServerBusyWorkers = view.ReadInt32(DoctorChannelLayout.OffsetServerBusy),
+            ServerBlockedWorkers = view.ReadInt32(DoctorChannelLayout.OffsetServerBlocked),
+            ServerWorkers = view.ReadInt32(DoctorChannelLayout.OffsetServerWorkers),
+            ServerQueuedRequests = view.ReadInt32(DoctorChannelLayout.OffsetServerQueued),
+        };
+    }
+
+    private static TimeSpan AgeOf(long timestamp, long now) =>
+        timestamp <= 0
+            ? TimeSpan.MaxValue
+            : TimeSpan.FromMilliseconds(Math.Max(0, now - timestamp));
+
+    private static string DecodeString(byte[] bytes)
+    {
+        var length = Array.IndexOf(bytes, (byte)0);
+        if (length < 0)
+            length = bytes.Length;
+        return length == 0 ? "" : Encoding.UTF8.GetString(bytes, 0, length);
+    }
+}
+
+/// <summary>
+/// Publishes Bloom's state into the shared page. Lives in Bloom; here in the Doctor's repo only so that
+/// the two sides share one description of the format, and so the Doctor's own tests can write a channel
+/// to read back.
+///
+/// **Every method must be safe to call from anywhere and must never throw**, because the callers are
+/// Bloom's UI thread and Bloom's shutdown path. Diagnostics that can break the application they
+/// diagnose are worse than no diagnostics.
+/// </summary>
+public sealed class DoctorChannelWriter : IDisposable
+{
+    private readonly MemoryMappedFile? _file;
+    private readonly MemoryMappedViewAccessor? _view;
+
+    /// <summary>
+    /// Serialises the whole of <see cref="Write"/>.
+    ///
+    /// This is not belt-and-braces: without it the sequence protocol is broken, and broken in a way that
+    /// silently disables the channel for the rest of the run. Two threads publish here — the UI-thread timer
+    /// and the watchdog thread — and `++_writeSequence` is a non-atomic read-modify-write, so a lost update
+    /// can leave the counter resting on an ODD value, which every reader interprets as "a write is in
+    /// progress" and gives up on, for ever. Even with an atomic counter, two overlapping writers can let a
+    /// reader see an unchanged even sequence around a half-written state, which is precisely the torn read
+    /// the sequence exists to prevent.
+    ///
+    /// A private lock cannot deadlock anything we are diagnosing: only these two diagnostic callers ever take
+    /// it, neither holds another lock, and the critical section is a handful of writes to a resident page.
+    /// </summary>
+    private readonly object _writeLock = new();
+
+    private long _writeSequence;
+    private long _uiTicks;
+    private long _watchdogTicks;
+
+    /// <summary>
+    /// Creates the channel for this process. If it cannot be created, every method afterwards does
+    /// nothing: publishing diagnostics is never worth failing a startup over.
+    /// </summary>
+    public DoctorChannelWriter(int processId)
+    {
+        try
+        {
+            _file = MemoryMappedFile.CreateNew(
+                DoctorChannelLayout.NameFor(processId),
+                DoctorChannelLayout.Size,
+                MemoryMappedFileAccess.ReadWrite
+            );
+            _view = _file.CreateViewAccessor(
+                0,
+                DoctorChannelLayout.Size,
+                MemoryMappedFileAccess.ReadWrite
+            );
+            _view.Write(DoctorChannelLayout.OffsetSchemaVersion, DoctorChannelLayout.SchemaVersion);
+            // How far this build writes, so a future reader can tell what is really here rather than
+            // reading zero-filled space as data. Written once, at creation, and never changed.
+            _view.Write(DoctorChannelLayout.OffsetPayloadBytes, DoctorChannelLayout.PayloadBytes);
+            _view.Write(DoctorChannelLayout.OffsetProcessId, processId);
+            // The heartbeats are deliberately NOT seeded here, and a test pins that
+            // (A_heartbeat_that_never_ticked_reads_as_infinitely_old_rather_than_as_fresh). Seeding them
+            // to "now" would read as healthy, which sounds tidier and is the dangerous direction: a Bloom
+            // that hangs BEFORE its first tick - during startup, which is a real freeze - would then look
+            // perfectly well. "Never ticked" erring towards alarm is the correct bias.
+        }
+        catch (Exception)
+        {
+            _file = null;
+            _view = null;
+        }
+    }
+
+    /// <summary>True if the channel was created and is being published.</summary>
+    public bool IsOpen => _view != null;
+
+    /// <summary>
+    /// Records that the UI thread is alive. Call from a UI-thread timer; the Doctor watches how long ago
+    /// this last happened.
+    /// </summary>
+    public void RecordUiTick() =>
+        Write(view =>
+        {
+            view.Write(DoctorChannelLayout.OffsetUiTicks, ++_uiTicks);
+            view.Write(DoctorChannelLayout.OffsetUiTimestamp, Environment.TickCount64);
+        });
+
+    /// <summary>
+    /// Records that the background watchdog thread is alive, which is how the Doctor distinguishes "the
+    /// UI thread is blocked" from "the whole process is wedged".
+    /// </summary>
+    public void RecordWatchdogTick() =>
+        Write(view =>
+        {
+            view.Write(DoctorChannelLayout.OffsetWatchdogTicks, ++_watchdogTicks);
+            view.Write(DoctorChannelLayout.OffsetWatchdogTimestamp, Environment.TickCount64);
+        });
+
+    /// <summary>Says what Bloom is doing, in words fit for a bug report.</summary>
+    public void SetActivity(string activity) =>
+        Write(view =>
+        {
+            var bytes = new byte[DoctorChannelLayout.ActivityMaxBytes];
+            var encoded = Encoding.UTF8.GetBytes(activity ?? "");
+            var length = Math.Min(encoded.Length, bytes.Length - 1);
+            // Truncate on a character boundary. Activity text can carry a book title or a file path, so
+            // cutting mid-sequence through a multi-byte character leaves the reader decoding a broken byte,
+            // and the report quoting a mangled name. Guarded on having actually truncated, because
+            // `encoded[length]` is past the end otherwise, and throwing here would leave the write sequence
+            // odd for ever - silently disabling the whole channel.
+            if (length < encoded.Length)
+            {
+                while (length > 0 && (encoded[length] & 0xC0) == 0x80)
+                    length--;
+            }
+            Array.Copy(encoded, bytes, length);
+            view.WriteArray(DoctorChannelLayout.OffsetActivity, bytes, 0, bytes.Length);
+        });
+
+    /// <summary>Marks a deliberately long operation, which buys Bloom patience rather than silence.</summary>
+    public void SetLongOperation(bool inProgress) =>
+        SetFlag(DoctorChannelLayout.FlagLongOperation, inProgress);
+
+    /// <summary>
+    /// Publishes whether a debugger is attached, which is authoritative and stops false reports.
+    ///
+    /// This method REMEMBERS, which is the point of it: the first attach also sets a sticky "ever attached"
+    /// flag that is never cleared, and a detach records when it happened. Call it repeatedly — it detects the
+    /// transitions by comparing against what is already in the page, so the caller does not have to track any
+    /// state of its own.
+    ///
+    /// Why remembering matters: a debugger that has come and gone leaves behind precisely the evidence of a
+    /// freeze (a long hole in the UI heartbeat) or of a crash (no clean exit, because terminating from a
+    /// debugger is a TerminateProcess), with nothing still attached to account for it.
+    /// </summary>
+    public void SetDebuggerAttached(bool attached) =>
+        Write(view =>
+        {
+            var flags = view.ReadInt32(DoctorChannelLayout.OffsetFlags);
+            var wasAttached = (flags & DoctorChannelLayout.FlagDebuggerAttached) != 0;
+
+            if (attached)
+            {
+                flags |=
+                    DoctorChannelLayout.FlagDebuggerAttached
+                    | DoctorChannelLayout.FlagDebuggerEverAttached;
+            }
+            else
+            {
+                flags &= ~DoctorChannelLayout.FlagDebuggerAttached;
+                // Only on the transition. Writing it every time we are called with false would keep moving
+                // the timestamp forward for a run that never had a debugger at all, and "last detached: one
+                // second ago" would then excuse every freeze there ever was.
+                if (wasAttached)
+                    view.Write(
+                        DoctorChannelLayout.OffsetDebuggerLastDetached,
+                        Environment.TickCount64
+                    );
+            }
+
+            view.Write(DoctorChannelLayout.OffsetFlags, flags);
+        });
+
+    /// <summary>Records how far shutdown has got.</summary>
+    public void SetShutdownPhase(BloomShutdownPhase phase) =>
+        Write(view => view.Write(DoctorChannelLayout.OffsetShutdownPhase, (int)phase));
+
+    /// <summary>Records that shutdown ran to completion — the proof whose absence is itself evidence.</summary>
+    public void RecordCleanExit() => SetFlag(DoctorChannelLayout.FlagCleanExitRecorded, true);
+
+    /// <summary>Publishes the server's worker counts, which say a great deal about a frozen publish.</summary>
+    public void SetServerWorkerCounts(int busy, int blocked, int workers, int queued) =>
+        Write(view =>
+        {
+            view.Write(DoctorChannelLayout.OffsetServerBusy, busy);
+            view.Write(DoctorChannelLayout.OffsetServerBlocked, blocked);
+            view.Write(DoctorChannelLayout.OffsetServerWorkers, workers);
+            view.Write(DoctorChannelLayout.OffsetServerQueued, queued);
+        });
+
+    private void SetFlag(int flag, bool value) =>
+        Write(view =>
+        {
+            var flags = view.ReadInt32(DoctorChannelLayout.OffsetFlags);
+            flags = value ? flags | flag : flags & ~flag;
+            view.Write(DoctorChannelLayout.OffsetFlags, flags);
+        });
+
+    /// <summary>
+    /// Performs one update between two increments of the sequence number, so a reader can tell whether
+    /// it saw a settled state. Swallows everything: see the class comment.
+    /// </summary>
+    private void Write(Action<MemoryMappedViewAccessor> update)
+    {
+        var view = _view;
+        if (view == null)
+            return;
+        try
+        {
+            lock (_writeLock)
+            {
+                // EVERY increment is inside this try, so the finally can restore parity from whatever value
+                // we actually reached. An increment outside it could throw and leave the counter odd with
+                // nothing to correct it - and an odd resting value means "a write is in progress" to every
+                // reader, for ever, so the channel would silently disable itself for the rest of the run
+                // and the Doctor would fall back to watching from outside with no indication why. Letting
+                // one reader see a single inconsistent state is a far smaller loss.
+                try
+                {
+                    _writeSequence++; // now odd: a write is in progress
+                    view.Write(DoctorChannelLayout.OffsetWriteSequence, _writeSequence);
+                    update(view);
+                }
+                finally
+                {
+                    if (_writeSequence % 2 != 0)
+                        _writeSequence++;
+                    view.Write(DoctorChannelLayout.OffsetWriteSequence, _writeSequence);
+                }
+            }
+        }
+        catch (Exception)
+        {
+            // Never let publishing state break the thing whose state we are publishing. Note that the
+            // counter itself is even by now whatever happened above, so even a failure that stopped the
+            // final view.Write is repaired by the next successful write rather than lasting for ever.
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _view?.Dispose();
+        _file?.Dispose();
+    }
+}

--- a/src/BloomFreezeDoctor.Protocol/DoctorSession.cs
+++ b/src/BloomFreezeDoctor.Protocol/DoctorSession.cs
@@ -1,0 +1,357 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SIL.IO;
+
+namespace BloomFreezeDoctor.Protocol;
+
+// =====================================================================================================
+//  SECOND HALF OF THE CONTRACT BETWEEN BLOOM AND THE FREEZE DOCTOR.
+//
+//  DoctorChannel.cs carries what changes moment to moment, in shared memory. This file carries the facts
+//  that do not change, and — crucially — the ones that must OUTLIVE the process. Shared memory dies when
+//  the last handle closes, so a Bloom that crashes while no Doctor is watching leaves nothing behind. A
+//  file survives a crash, a Doctor restart, and a reboot.
+//
+//  Everything here also removes a guess the Doctor would otherwise have to make from outside. Two are
+//  worth naming, because both were measured as getting it wrong:
+//
+//   * WHICH LOG IS THIS BLOOM'S. Bloom recreates Log.txt every run and falls back to a randomly-named
+//     Log-tmpXXXX.txt only when another Bloom already holds it — so in the restart-after-a-freeze case,
+//     the frozen Bloom owns Log.txt and the healthy new one owns the tmp file, and "newest file wins"
+//     picks the wrong one. Bloom simply telling us the path retires that whole problem.
+//   * WHICH DEBUG PORT. The arithmetic differs by Bloom version, Bloom's own HTTP port belongs to http.sys
+//     rather than to Bloom, and a machine running two Blooms can hand the Doctor the wrong browser.
+// =====================================================================================================
+
+/// <summary>
+/// What Bloom records about itself when it starts, for any Doctor that comes looking — including one
+/// installed after the fact, or started after Bloom has already died.
+/// </summary>
+public sealed record DoctorSession
+{
+    /// <summary>Layout version, so a newer Doctor can read an older machine's files.</summary>
+    public int SchemaVersion { get; init; } = DoctorSessionStore.SchemaVersion;
+
+    /// <summary>The process this describes.</summary>
+    public int ProcessId { get; init; }
+
+    /// <summary>When it started, which is how a log file is matched to it.</summary>
+    public DateTimeOffset StartedAtUtc { get; init; }
+
+    /// <summary>Full path to Bloom's executable.</summary>
+    public string ExePath { get; init; } = "";
+
+    /// <summary>Bloom's version.</summary>
+    public string Version { get; init; } = "";
+
+    /// <summary>Release channel: Release, Beta, Developer/Debug…</summary>
+    public string Channel { get; init; } = "";
+
+    /// <summary>The command line, which reveals an automation or headless run.</summary>
+    public string CommandLine { get; init; } = "";
+
+    /// <summary>
+    /// The log file Bloom is actually writing to. The single most valuable field here: see the note at the
+    /// top of this file about why guessing it from outside is systematically wrong.
+    /// </summary>
+    public string LogPath { get; init; } = "";
+
+    /// <summary>
+    /// Whether this Bloom holds Bloom's machine-wide single-instance token. Bloom will not start a
+    /// second copy while somebody holds it, so this is what says whether a given Bloom is actually in the
+    /// way of a restart - and most running Blooms are not: a `--automation` run bypasses the token by
+    /// design, and a Ctrl-held launch only takes it if it happened to be first.
+    ///
+    /// **Nullable, and the null case is the point.** Null means this Bloom did not say, which is not the
+    /// same as saying no. An older Bloom writes no session file at all, and one built before this field
+    /// existed writes a session without it; either can be the very process holding the token, since the
+    /// channels deliberately share one mutex. Callers must read null as "possibly in the way" - reading
+    /// it as false would let the Doctor leave the real blocker running and start a Bloom that quietly
+    /// exits, which is the "Bloom will not start" complaint that brought the user to the Doctor.
+    /// </summary>
+    public bool? OwnsSingleInstanceToken { get; init; }
+
+    /// <summary>Bloom's own HTTP port, which cannot be discovered from outside because http.sys owns it.</summary>
+    public int HttpPort { get; init; }
+
+    /// <summary>The WebView2 debugging port, so the Doctor need not infer it.</summary>
+    public int CdpPort { get; init; }
+
+    /// <summary>The collection in use, for the report's context.</summary>
+    public string CollectionName { get; init; } = "";
+
+    /// <summary>
+    /// True when Bloom's own reporting has already told us about a problem this run — a Sentry event or a
+    /// tracker card. The Doctor defers to it rather than filing a second report about the same thing.
+    ///
+    /// This lives on the session rather than inside <see cref="Exit"/>, and that placement is the whole
+    /// point: a user can file a problem report and then carry on working for hours. Recording it as an exit
+    /// would describe a running Bloom as finished, which then reads as proof of an orderly shutdown for a
+    /// process that may go on to crash.
+    /// </summary>
+    public bool BloomAlreadyReported { get; init; }
+
+    /// <summary>The card or event Bloom filed, if it filed one.</summary>
+    public string? ReportedId { get; init; }
+
+    /// <summary>
+    /// When Bloom filed it. The Doctor's suppression expires, so it needs the time and not only the fact:
+    /// a user reports something non-fatal and keeps working, and an unrelated freeze two hours later is
+    /// worth a card of its own. See BloomsOwnReport.
+    ///
+    /// Null means a Bloom too old to say. That is not the same as "never reported", which is
+    /// <see cref="BloomAlreadyReported"/> being false.
+    /// </summary>
+    public DateTimeOffset? ReportedAtUtc { get; init; }
+
+    /// <summary>
+    /// The API requests that were in flight when this file was last written, longest-running first.
+    ///
+    /// **This is the one part of the session that is about the present rather than the run.** The shared
+    /// memory page has room for a single line of activity, so without this a report can name the
+    /// longest-running request and nothing else — and in a freeze the other requests, and which lock each
+    /// one wants, are most of the picture. Bloom's watchdog thread rewrites this file while the UI is
+    /// wedged, which is what makes the list current enough to be worth reading; see
+    /// <see cref="InFlightRequestsAtUtc"/> for how current.
+    /// </summary>
+    public IReadOnlyList<string> InFlightRequests { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// When <see cref="InFlightRequests"/> was captured, or null when there was nothing to capture.
+    ///
+    /// Recorded because the list is a snapshot on a timer rather than a reading taken at the moment of
+    /// gathering, so a report has to be able to say how old it is. It is also what keeps an idle Bloom from
+    /// rewriting this file every ten seconds: with no requests there is no list and no timestamp, so
+    /// nothing has changed.
+    /// </summary>
+    public DateTimeOffset? InFlightRequestsAtUtc { get; init; }
+
+    /// <summary>
+    /// The kind of failure Bloom was deliberately told to simulate — `stawait`, `zombie`, `mutexchain` and
+    /// so on — or null, which is every real Bloom.
+    ///
+    /// Bloom publishes this so the Doctor can tell a rehearsal from the real thing, and it lives HERE
+    /// rather than in the shared-memory page for the usual reason: the page dies with the process, and
+    /// three of the simulated kinds (`failfast`, `crashthread`, `zombie`) are precisely the cases where
+    /// what remains afterwards is all we have.
+    ///
+    /// It records that the simulator ARMED, not merely that somebody set the environment variable. Those
+    /// differ: a Beta or Release channel refuses, and so does an unrecognised kind, and marking a Bloom
+    /// that was never going to misbehave would be worse than not marking at all.
+    ///
+    /// **What may depend on this: whether a report is filed, and a line in the report saying so. Nothing
+    /// else.** Detection, gathering and the zombie-ending policy must behave exactly as they would for a
+    /// real freeze, or a simulated run stops testing the thing it exists to test.
+    /// </summary>
+    public string? SimulatedFailure { get; init; }
+
+    /// <summary>
+    /// How this run ended, once it has. Null while Bloom is running — and null *after* Bloom has gone is
+    /// itself the evidence that it did not shut down properly, which is why nothing may set it while Bloom
+    /// is still running: an exit record on a live Bloom reads as proof it shut down cleanly.
+    /// </summary>
+    public DoctorSessionExit? Exit { get; init; }
+}
+
+/// <summary>How a Bloom run ended, written on the way out.</summary>
+public sealed record DoctorSessionExit
+{
+    /// <summary>When it ended.</summary>
+    public DateTimeOffset AtUtc { get; init; }
+
+    /// <summary>How far shutdown got.</summary>
+    public BloomShutdownPhase ShutdownPhase { get; init; }
+
+    /// <summary>
+    /// True when Bloom exited because the Doctor asked it to — ending a zombie, or clearing the way for a
+    /// restart. Recorded so that a Bloom we ended is not later mistaken for one that chose to leave.
+    ///
+    /// **One fact, not a verdict.** Whether an exit was ORDERLY is a different question, answered by
+    /// <see cref="ShutdownPhase"/>, and the two are independent: the Doctor can end a Bloom that had walked
+    /// most of the orderly path and then wedged, and Bloom can fail hard with no involvement from the Doctor
+    /// at all. Consumers want different combinations of the two, so the record keeps them apart rather than
+    /// pre-combining them into a flag whose name can then only be true for one of its meanings.
+    /// </summary>
+    public bool EndedAtDoctorsRequest { get; init; }
+}
+
+/// <summary>
+/// Reads and writes the session files. Both sides use this, so there is one description of where the
+/// files live and how they are named.
+/// </summary>
+public static class DoctorSessionStore
+{
+    /// <summary>Bump only for an incompatible change; readers ignore versions they do not know.</summary>
+    public const int SchemaVersion = 1;
+
+    /// <summary>
+    /// Where the files live. Under the user's own local application data, because that is writable
+    /// without any privilege and is per-user, which matches who can watch whose processes anyway.
+    /// </summary>
+    public static string DefaultDirectory =>
+        Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "SIL",
+            "BloomFreezeDoctor",
+            "sessions"
+        );
+
+    /// <summary>
+    /// The file for one process.
+    ///
+    /// Keyed by process id, which Windows reuses — so a reader that finds a file for a *live* pid must check
+    /// <see cref="DoctorSession.StartedAtUtc"/> against that process's actual start time before believing the
+    /// file describes it. The alternative (a unique id in the name) would stop a Doctor finding the file for a
+    /// pid it is watching, which is the common case this has to be good at.
+    /// </summary>
+    public static string PathFor(int processId, string? directory = null) =>
+        Path.Combine(directory ?? DefaultDirectory, $"bloom-{processId}.json");
+
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        // Enums by name, so this file says "SettingsSaved" rather than "2". These sessions are read by
+        // people as often as by the Doctor, and a name also survives the phases being renumbered.
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    /// <summary>
+    /// Writes a session file, temp-then-rename so that a reader never sees half a JSON document. Returns
+    /// false rather than throwing: Bloom must not fail because a diagnostic file could not be written.
+    /// </summary>
+    public static bool TryWrite(DoctorSession session, string? directory = null)
+    {
+        try
+        {
+            var path = PathFor(session.ProcessId, directory);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            var temp = path + ".tmp";
+            RobustFile.WriteAllText(temp, JsonSerializer.Serialize(session, Options));
+            // A rename within one volume is atomic; a copy is not, and this file is rewritten repeatedly.
+            //
+            // Replace-or-Move rather than an overwriting Move, because RobustFile.Move has no overwrite
+            // overload. Replace is the better primitive anyway when the target exists: it swaps the file
+            // in one step, so a reader never sees the path missing, which an unlink-then-rename would
+            // allow. Move covers the first write, when there is nothing to replace.
+            if (RobustFile.Exists(path))
+                RobustFile.Replace(temp, path, null);
+            else
+                RobustFile.Move(temp, path);
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>Reads one session file, or null if it is absent or unreadable.</summary>
+    public static DoctorSession? TryRead(int processId, string? directory = null)
+    {
+        try
+        {
+            var path = PathFor(processId, directory);
+            if (!RobustFile.Exists(path))
+                return null;
+            var session = JsonSerializer.Deserialize<DoctorSession>(
+                RobustFile.ReadAllText(path),
+                Options
+            );
+            // Refuse a schema we do not understand rather than misreading it.
+            return session != null && session.SchemaVersion == SchemaVersion ? session : null;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Every session file on the machine, for a Doctor that has just started and wants to know what has
+    /// been happening — including sessions whose processes are long gone, which is how an unreported crash
+    /// is discovered after the fact.
+    /// </summary>
+    public static List<DoctorSession> ReadAll(string? directory = null)
+    {
+        var sessions = new List<DoctorSession>();
+        try
+        {
+            var folder = directory ?? DefaultDirectory;
+            if (!Directory.Exists(folder))
+                return sessions;
+            foreach (var path in Directory.GetFiles(folder, "bloom-*.json"))
+            {
+                try
+                {
+                    var session = JsonSerializer.Deserialize<DoctorSession>(
+                        RobustFile.ReadAllText(path),
+                        Options
+                    );
+                    if (session != null && session.SchemaVersion == SchemaVersion)
+                        sessions.Add(session);
+                }
+                catch (Exception)
+                {
+                    // One unreadable file must not hide the rest.
+                }
+            }
+        }
+        catch (Exception) { }
+        return sessions;
+    }
+
+    /// <summary>
+    /// Deletes session files that are of no further interest: their process is gone, and it either recorded
+    /// an orderly exit that nobody asked for or it is older than the cutoff. Anything else survives until it
+    /// ages out, because an unexplained exit is precisely the evidence a Doctor installed after the fact
+    /// comes looking for.
+    ///
+    /// **What it costs**, which matters because Bloom calls this from its watchdog thread and that thread
+    /// runs at raised priority: measured at 1 ms for a real developer folder of 14 files, and 16 ms for 300
+    /// — far more than the seven-day retention lets accumulate. It is one pass per Bloom run, so there is no
+    /// case for deferring it, splitting it up, or dropping the priority around it.
+    ///
+    /// **Do not "optimise" the liveness check into a single sweep.** Asking
+    /// <paramref name="processIsAlive"/> once per file looks wasteful and is not:
+    /// <c>Process.GetProcessById</c> fails fast for a dead id, measured at 0.01 ms, while one
+    /// <c>Process.GetProcesses()</c> sweep costs 19 ms on its own, because it builds an object per process
+    /// on a machine running five hundred of them.
+    /// </summary>
+    public static void Prune(
+        Func<int, bool> processIsAlive,
+        TimeSpan maxAge,
+        string? directory = null
+    )
+    {
+        foreach (var session in ReadAll(directory))
+        {
+            try
+            {
+                if (processIsAlive(session.ProcessId))
+                    continue;
+                var tooOld = DateTimeOffset.UtcNow - session.StartedAtUtc > maxAge;
+                // "Explained" means an ORDERLY exit. An exit that was forced — a hard failure, or the Doctor
+                // ending a zombie — is not an explanation, it is the evidence; deleting it early would throw
+                // away the record of the very thing we exist to report.
+                // Both halves matter, and for different reasons. A phase of None means the orderly path was
+                // never begun — a hard failure, which is evidence. An exit we asked for is not an
+                // explanation either; it is the record of our own doing, and worth keeping for the window in
+                // which somebody might ask why that Bloom went.
+                var explained =
+                    session.Exit != null
+                    && session.Exit.ShutdownPhase != BloomShutdownPhase.None
+                    && !session.Exit.EndedAtDoctorsRequest;
+                if (tooOld || explained)
+                    RobustFile.Delete(PathFor(session.ProcessId, directory));
+            }
+            catch (Exception)
+            {
+                // Locked or already gone; the next pass will deal with it.
+            }
+        }
+    }
+}

--- a/src/BloomFreezeDoctor.Protocol/DoctorSignals.cs
+++ b/src/BloomFreezeDoctor.Protocol/DoctorSignals.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Threading;
+
+namespace BloomFreezeDoctor.Protocol;
+
+// =====================================================================================================
+//  THIRD PART OF THE CONTRACT BETWEEN BLOOM AND THE FREEZE DOCTOR.
+//
+//  Shared memory lets the Doctor watch. These named events let the two actually ask each other for
+//  something, in the two cases where waiting is worth it:
+//
+//   * ENDING A ZOMBIE. When Bloom's UI is gone but the process lives on, the Doctor can ask Bloom to exit
+//     under its own power. That is much better than killing it from outside: Bloom's ProcessExit runs, so
+//     its single-instance token is released properly and its own clean-exit record is written. Killing is
+//     the fallback for when nobody is listening.
+//
+//   * DUMPING A DYING BLOOM. A crash gives us one short window in which the process still exists. Bloom
+//     signals, the Doctor dumps it from outside, and Bloom waits briefly. Dumping from outside beats
+//     self-dumping a process whose state is already suspect.
+//
+//  Everything here is built so that the ABSENCE of the other side costs nothing. Bloom never waits unless
+//  it has first confirmed, with a zero timeout, that a Doctor is actually watching — because an
+//  unconditional pause would make every crash worse for the majority of users, who have no Doctor
+//  installed.
+// =====================================================================================================
+
+/// <summary>
+/// The named events Bloom and the Doctor use to ask each other for something. All in the `Local\`
+/// namespace, since neither can act on the other across Windows sessions anyway.
+/// </summary>
+public static class DoctorSignals
+{
+    /// <summary>
+    /// Created by the Doctor while it is watching a particular Bloom. Bloom tests for it with a zero
+    /// timeout before it ever agrees to wait for anything: no Doctor, no waiting.
+    /// </summary>
+    public static string WatchingName(int processId) =>
+        $@"Local\BloomFreezeDoctor.watching.{processId}";
+
+    /// <summary>
+    /// Set by the Doctor to ask Bloom to exit under its own power. Bloom's watchdog thread waits on this,
+    /// which is the point: that thread is still running even when the UI thread is long gone.
+    /// </summary>
+    public static string QuitRequestName(int processId) =>
+        $@"Local\BloomFreezeDoctor.quit.{processId}";
+
+    /// <summary>Set by Bloom as it dies, to ask for a dump while the process still exists.</summary>
+    public static string DumpRequestName(int processId) =>
+        $@"Local\BloomFreezeDoctor.dumpme.{processId}";
+
+    /// <summary>
+    /// Set by the Doctor the moment it takes up a dump request, before it begins the work, so that Bloom can
+    /// tell "nobody picked this up" from "it is underway" — and be impatient about the first while being
+    /// patient about the second.
+    ///
+    /// Both halves matter. A dump of a real Bloom takes seconds, more on a slow or loaded machine, and
+    /// giving up early does not merely delay it but loses it: the dying Bloom is what writes the dump over
+    /// the diagnostics pipe, so exiting mid-write aborts it and the report ends up with no managed stacks at
+    /// all. Yet a flat, generous timeout would hold a crashing Bloom open for its whole length whenever no
+    /// Doctor answers — which includes one that died between Bloom's "is anyone watching" check and its wait.
+    /// </summary>
+    public static string DumpStartedName(int processId) =>
+        $@"Local\BloomFreezeDoctor.dumping.{processId}";
+
+    /// <summary>Set by the Doctor when the dump is written, so Bloom can stop waiting.</summary>
+    public static string DumpCompleteName(int processId) =>
+        $@"Local\BloomFreezeDoctor.dumped.{processId}";
+
+    /// <summary>
+    /// Creates (or opens) a manual-reset event by name, or returns null if that is not possible. Never
+    /// throws: a signal we cannot create simply means that capability is unavailable, and both sides are
+    /// written to carry on without it.
+    /// </summary>
+    public static EventWaitHandle? TryCreate(string name)
+    {
+        try
+        {
+            return new EventWaitHandle(false, EventResetMode.ManualReset, name);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Opens an existing event, or null if nobody has created it.</summary>
+    public static EventWaitHandle? TryOpen(string name)
+    {
+        try
+        {
+            // TryOpenExisting, not OpenExisting. "Nobody has created it" is the ORDINARY answer here —
+            // most Blooms run on a machine with no Doctor installed — and OpenExisting reports that by
+            // throwing WaitHandleCannotBeOpenedException. Using an exception for the expected case is
+            // wrong on its own terms, and it is worse than usual given where this is called from:
+            // Exists() and TrySignal() both come through here, and Exists() is what Bloom asks on its
+            // CRASH path to find out whether a Doctor is listening before it waits for a dump. Throwing
+            // and catching inside a process that is already dying is the last thing that code needs.
+            //
+            // The try/catch stays, for the genuinely unexpected: a name that is malformed or too long, or
+            // an existing handle we are not permitted to open. Those are worth swallowing too — a signal
+            // we cannot reach just means that capability is unavailable — but they are not the common
+            // path, which is the distinction that matters.
+            return EventWaitHandle.TryOpenExisting(name, out var handle) ? handle : null;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// True if the named event exists. Used for the question "is a Doctor watching me?", which must be
+    /// answerable instantly and without waiting.
+    /// </summary>
+    public static bool Exists(string name)
+    {
+        using var handle = TryOpen(name);
+        return handle != null;
+    }
+
+    /// <summary>Sets an existing event, if there is one. Returns whether anyone was listening.</summary>
+    public static bool TrySignal(string name)
+    {
+        try
+        {
+            using var handle = TryOpen(name);
+            if (handle == null)
+                return false;
+            handle.Set();
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Waits for an event to be set, up to a limit. Returns false if it was not set in time, or could not
+    /// be opened at all — the caller treats both the same way, by carrying on.
+    /// </summary>
+    public static bool WaitFor(string name, TimeSpan timeout)
+    {
+        try
+        {
+            using var handle = TryOpen(name);
+            return handle != null && handle.WaitOne(timeout);
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Waits for an event, but gives up the moment the other side stops existing — checked by testing
+    /// whether <paramref name="whileThisExists"/> is still there.
+    ///
+    /// This is what lets a wait be generous without being a gamble. A flat timeout has to be short enough
+    /// to survive the other side vanishing, which then makes it too short for the other side doing real
+    /// work. Bounding it by the other side's *presence* instead separates the two: it can be long, because
+    /// the case a short timeout was protecting against now ends the wait immediately rather than after the
+    /// full period.
+    ///
+    /// The presence test is exact rather than a heuristic. A named event lives while a handle to it is
+    /// open, and the Doctor holds its "watching" event open for precisely as long as it watches — so if
+    /// that Doctor dies, however abruptly, Windows closes the handle, the event ceases to exist, and the
+    /// next slice here sees it gone. Nothing has to be cleaned up for this to be true.
+    ///
+    /// <paramref name="ceiling"/> remains as a backstop, for a Doctor that is alive but not answering.
+    /// </summary>
+    public static bool WaitWhileTheOtherSideLives(
+        string name,
+        string whileThisExists,
+        TimeSpan ceiling,
+        TimeSpan slice
+    )
+    {
+        try
+        {
+            using var handle = TryOpen(name);
+            if (handle == null)
+                return false;
+            var waited = TimeSpan.Zero;
+            while (waited < ceiling)
+            {
+                var thisSlice = slice < ceiling - waited ? slice : ceiling - waited;
+                if (handle.WaitOne(thisSlice))
+                    return true;
+                waited += thisSlice;
+                // Checked AFTER waiting rather than before, so that an event already signalled is honoured
+                // even if the other side has since gone. It did the work; we should not discard it.
+                if (!Exists(whileThisExists))
+                    return handle.WaitOne(TimeSpan.Zero);
+            }
+            return false;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+}

--- a/src/BloomFreezeDoctor.Protocol/README.md
+++ b/src/BloomFreezeDoctor.Protocol/README.md
@@ -1,0 +1,29 @@
+# BloomFreezeDoctor.Protocol
+
+The protocol between Bloom and the Bloom Freeze Doctor — a diagnostic tool that watches Bloom and
+reports freezes, unreported crashes, and processes whose window has gone but which are still
+running. Both live in this repository: Bloom's side is `src/BloomExe/FreezeDoctor/`, the Doctor is
+`src/BloomFreezeDoctor` and `src/BloomFreezeDoctor.Core`.
+
+"Protocol" rather than "contract" because it is more than the shared data: alongside the layouts it
+defines the kernel object naming scheme and the signalling handshakes the two use to ask each other
+for something.
+
+It is a plain project both sides reference, not a published package. It exists so that one wire
+format has one definition instead of two hand-maintained copies. It contains:
+
+- **`DoctorChannel`** — a small fixed-layout page in shared memory, written by Bloom and read by the
+  Doctor, carrying a UI-thread heartbeat and what Bloom believes it is doing. Shared memory rather
+  than a request/response API because the Doctor has to be able to read it when Bloom is wedged, and
+  a wedged Bloom cannot answer anything.
+- **`DoctorSession`** — a small JSON file per Bloom run, holding the facts that must outlive the
+  process: above all which log file that run is writing to, which a watcher cannot reliably work out
+  from outside.
+- **`DoctorSignals`** — the named events the two use to reach each other: the Doctor announcing that
+  it is watching, asking a stuck Bloom to exit, and the handshake around dumping a dying one.
+
+Both sides pin the layout by value in a test. There is only one definition of it now, so the two
+cannot hold copies that disagree — but they can still get out of step over a *version*, and the
+pinned tests are what turn that into a failed build rather than a stream of plausible wrong reports.
+
+Licensed under the MIT licence. © SIL Global.

--- a/src/BloomFreezeDoctor.Protocol/ShutdownPhase.cs
+++ b/src/BloomFreezeDoctor.Protocol/ShutdownPhase.cs
@@ -1,0 +1,58 @@
+namespace BloomFreezeDoctor.Protocol;
+
+/// <summary>
+/// How far Bloom's orderly shutdown had got. Bloom records this as it goes out, so that a Bloom which
+/// dies part way can say *where* it stopped rather than merely that it did.
+///
+/// <see cref="None"/> is load-bearing rather than merely a default: Bloom has several exits that are hard
+/// failures rather than shutdowns — WebView2 failing to initialise, the non-message-loop branch of the
+/// fatal exception handler, the Doctor asking a zombie to go — and none of them passes a phase marker. So
+/// "still None" is how a hard failure is told from an orderly exit, and it needs no cooperation from each
+/// exit site, which is what makes the next such exit somebody adds covered automatically.
+///
+/// **Both the numbers and the names are frozen, and they break in opposite directions.** The NUMBER
+/// travels in the shared page as a raw int, so renumbering leaves every offset intact and every reader
+/// wrong — which makes it a <c>SchemaVersion</c> bump, not an edit. The NAME travels in the session file,
+/// which is JSON written with names, so renaming makes a session an older Bloom wrote unreadable, and
+/// there is no version to bump for that. Both halves are pinned by a test on each side; appending a later
+/// phase is the safe change, and a Doctor too old to know it says so rather than guessing (see
+/// <see cref="ShutdownPhaseDescription.Describe"/>).
+/// </summary>
+public enum BloomShutdownPhase
+{
+    /// <summary>The orderly shutdown never began.</summary>
+    None = 0,
+
+    /// <summary>The message loop has returned, so Bloom is on its way out.</summary>
+    MessageLoopReturned = 1,
+
+    /// <summary>Settings have been saved.</summary>
+    SettingsSaved = 2,
+
+    /// <summary>The log has been written.</summary>
+    LogWritten = 3,
+
+    /// <summary>The project context has been disposed — the last of the phases.</summary>
+    ProjectContextDisposed = 4,
+}
+
+/// <summary>Puts a shutdown phase into words, for the reports a person actually reads.</summary>
+public static class ShutdownPhaseDescription
+{
+    /// <summary>
+    /// The phase in plain words, e.g. "settings had been saved". Written for whoever reads the card: a bare
+    /// number there means nothing without this file open beside it.
+    /// </summary>
+    public static string Describe(this BloomShutdownPhase phase) =>
+        phase switch
+        {
+            BloomShutdownPhase.None => "the orderly shutdown never began",
+            BloomShutdownPhase.MessageLoopReturned => "the message loop had returned",
+            BloomShutdownPhase.SettingsSaved => "settings had been saved",
+            BloomShutdownPhase.LogWritten => "the log had been written",
+            BloomShutdownPhase.ProjectContextDisposed => "the project context had been disposed",
+            // A phase added to Bloom after this Doctor was built. Saying so beats inventing a description,
+            // and beats hiding a number the reader could still look up.
+            _ => $"an unrecognised phase ({(int)phase}), newer than this Doctor knows about",
+        };
+}

--- a/src/BloomFreezeDoctor.Protocol/SupportUpload.cs
+++ b/src/BloomFreezeDoctor.Protocol/SupportUpload.cs
@@ -1,0 +1,193 @@
+using Amazon.S3;
+using Amazon.S3.Model;
+using Amazon.S3.Transfer;
+using SIL.IO;
+
+namespace BloomFreezeDoctor.Protocol;
+
+/// <summary>
+/// The access keys for the support-uploads bucket, read from the file the installer places beside the
+/// executable.
+///
+/// This lives here, in the project both Bloom and the Freeze Doctor reference, because both need it and
+/// neither should have its own idea of where the keys are or which lines they occupy. Bloom's
+/// <c>AccessKeys</c> reads the file through this class rather than opening it itself, so adding a line in
+/// future cannot silently shift the meaning of the keys for one consumer and not the other.
+/// </summary>
+public static class SupportUploadCredentials
+{
+    /// <summary>
+    /// The file the keys live in. Named `.dll` so it looks uninteresting; it is a plain text file, one
+    /// value per line. The installer puts it in the executable's directory, and a developer build finds
+    /// it in the repository's DistFiles.
+    /// </summary>
+    public const string ConnectionsFileName = "connections.dll";
+
+    /// <summary>
+    /// Which line holds what. The file is a pair of credentials per S3 user, in this order, and these are
+    /// the only names for those positions anywhere: Bloom's <c>AccessKeys</c> indexes the file through them
+    /// too, so a line inserted at the top is one edit here rather than a silent change of meaning in
+    /// whichever consumer nobody thought to look at.
+    ///
+    /// <c>uploader</c> owns the production bucket; <c>uploaderDev</c> owns the sandbox, the unit-test and
+    /// problem-book buckets, and the support uploads this class exists for.
+    /// </summary>
+    public const int UploaderAccessKeyLine = 0;
+
+    /// <summary>See <see cref="UploaderAccessKeyLine"/>.</summary>
+    public const int UploaderSecretLine = 1;
+
+    /// <summary>See <see cref="UploaderAccessKeyLine"/>.</summary>
+    public const int UploaderDevAccessKeyLine = 2;
+
+    /// <summary>See <see cref="UploaderAccessKeyLine"/>.</summary>
+    public const int UploaderDevSecretLine = 3;
+
+    /// <summary>
+    /// The keys, or null if the file is missing or too short — which is a real possibility rather than a
+    /// theoretical one: the file is not in source control's build output, so it is found beside the
+    /// installed exe or in the repository, and a stripped-down deployment may have neither. Callers treat
+    /// null as "cannot upload" and say so, rather than failing.
+    /// </summary>
+    public static (string AccessKey, string Secret)? ForSupportUploads()
+    {
+        var lines = TryReadLines();
+        if (lines == null || lines.Length <= UploaderDevSecretLine)
+            return null;
+        var accessKey = lines[UploaderDevAccessKeyLine].Trim();
+        var secret = lines[UploaderDevSecretLine].Trim();
+        if (accessKey.Length == 0 || secret.Length == 0)
+            return null;
+        return (accessKey, secret);
+    }
+
+    /// <summary>
+    /// The lines of the connections file, or null if it cannot be found or read. Public so Bloom's own
+    /// AccessKeys, which needs other lines for other buckets, can share the locating and reading of it.
+    /// </summary>
+    public static string[]? TryReadLines()
+    {
+        foreach (var path in CandidatePaths())
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(path) && RobustFile.Exists(path))
+                    return RobustFile.ReadAllLines(path);
+            }
+            catch (Exception)
+            {
+                // Unreadable is the same as absent as far as the caller is concerned; try the next place.
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Where to look, in order: beside the executable, which is where an installed Bloom and an installed
+    /// Doctor both find it since they share a directory; then libpalaso's lookup, which walks to the
+    /// repository's DistFiles and so covers a developer build, whose executables sit in
+    /// `output/Debug/&lt;platform&gt;` while the file stays in the source tree.
+    /// </summary>
+    private static IEnumerable<string?> CandidatePaths()
+    {
+        yield return Path.Combine(AppContext.BaseDirectory, ConnectionsFileName);
+
+        string? viaPalaso = null;
+        try
+        {
+            viaPalaso = FileLocationUtilities.GetFileDistributedWithApplication(
+                true,
+                ConnectionsFileName
+            );
+        }
+        catch (Exception)
+        {
+            // Its dev-mode search throws if it cannot work out where the solution is.
+        }
+        yield return viaPalaso;
+    }
+}
+
+/// <summary>
+/// Uploads one file to the support bucket and returns a link to it.
+///
+/// **Why this exists at all**, rather than attaching the file to the tracker card: YouTrack will not take
+/// an attachment much over 10 MB (measured at about that in July 2020 and recorded in Bloom's own
+/// ProblemReportApi), and a minidump of a real Bloom is 16-17 MB. Bloom's problem reporter reached the
+/// same wall years ago and answered it the same way — its `AttachFileToExistingIssue` call is still there,
+/// commented out, above the S3 upload that replaced it. So the Doctor's dumps go to the bucket and the
+/// card carries a link.
+///
+/// Objects are uploaded **public-read**, exactly as Bloom's problem-book uploads are: the bucket serves
+/// them over plain HTTPS to whoever has the URL, so the URL is the only protection. That is a deliberate
+/// trade, on the grounds that the link only ever appears on a tracker card that is itself private — but it
+/// does mean the key must not be guessable, which is why <see cref="MakeUnguessableKey"/> exists rather
+/// than this simply using the file name.
+/// </summary>
+public static class SupportFileUploader
+{
+    /// <summary>
+    /// The bucket, the same one Bloom uploads problem books to. Kept as a literal here rather than
+    /// referenced from Bloom's BloomS3Client, because this project deliberately does not depend on Bloom.
+    /// </summary>
+    public const string BucketName = "bloom-problem-books";
+
+    /// <summary>
+    /// A key nobody can guess, and nobody else will collide with.
+    ///
+    /// Both halves matter, and Bloom's existing single-file upload has neither: it uses the bare file name
+    /// as the key, so two users uploading `bloom-1234.dmp` overwrite each other, and anybody who knows the
+    /// naming pattern can fetch other people's uploads from a public-read bucket by trying names. A random
+    /// prefix fixes both at no cost, and the readable suffix keeps the URL self-describing for whoever
+    /// opens the card.
+    /// </summary>
+    public static string MakeUnguessableKey(string fileName) =>
+        $"freeze-doctor/{Guid.NewGuid():N}/{Path.GetFileName(fileName)}";
+
+    /// <summary>
+    /// Uploads the file and returns its URL, or null if it could not be uploaded — no credentials, no
+    /// network, a bucket that refuses us. Never throws: this runs while filing a report about somebody's
+    /// freeze, and losing the whole report because an attachment would not go is a poor trade.
+    /// </summary>
+    public static async Task<string?> TryUploadAsync(
+        string path,
+        CancellationToken cancellation = default
+    )
+    {
+        try
+        {
+            if (!RobustFile.Exists(path))
+                return null;
+            var credentials = SupportUploadCredentials.ForSupportUploads();
+            if (credentials == null)
+                return null;
+
+            using var client = new AmazonS3Client(
+                credentials.Value.AccessKey,
+                credentials.Value.Secret,
+                Amazon.RegionEndpoint.USEast1
+            );
+            using var transfer = new TransferUtility(client);
+            var key = MakeUnguessableKey(path);
+            var request = new TransferUtilityUploadRequest
+            {
+                BucketName = BucketName,
+                FilePath = path,
+                Key = key,
+                CannedACL = S3CannedACL.PublicRead,
+            };
+            request.Headers.CacheControl = "no-cache";
+            await transfer.UploadAsync(request, cancellation).ConfigureAwait(false);
+            // Escaped per path segment, so the separators stay separators. Escaping the whole key turns
+            // them into %2F, which S3's path-style URLs do generally decode - both forms were checked
+            // against a real upload and returned the file - but some proxies and clients take %2F
+            // literally and 404, and it makes an ugly link on a card a human has to read.
+            var escaped = string.Join("/", key.Split('/').Select(Uri.EscapeDataString));
+            return $"https://s3.amazonaws.com/{BucketName}/{escaped}";
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+}

--- a/src/BloomTests/FreezeDoctor/ApiActivityTrackerTests.cs
+++ b/src/BloomTests/FreezeDoctor/ApiActivityTrackerTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Linq;
+using Bloom.FreezeDoctor;
+using NUnit.Framework;
+
+namespace BloomTests.FreezeDoctor
+{
+    /// <summary>
+    /// What Bloom tells the Freeze Doctor about the requests it has in flight.
+    ///
+    /// This is the richest thing Bloom knows about its own trouble: in a freeze, which requests are stuck,
+    /// for how long, and which of them are queued behind a lock another one is holding. The tests ask for
+    /// everything in flight however brief, since a request they have just started has run for no time at
+    /// all; in production the threshold is a couple of seconds, below which a request is only normal
+    /// traffic.
+    /// </summary>
+    [TestFixture]
+    public class ApiActivityTrackerTests
+    {
+        /// <summary>
+        /// Everything in flight, regardless of how briefly. The table is process-wide static, so every test
+        /// here disposes what it starts.
+        ///
+        /// The threshold is a shade below zero because the filter is "longer THAN", and a request begun in
+        /// this same millisecond has run for exactly nothing. Production asks for a couple of seconds, where
+        /// the distinction cannot arise.
+        /// </summary>
+        private static string[] Everything() =>
+            ApiActivityTracker.DescribeStuckRequests(TimeSpan.FromMilliseconds(-1));
+
+        [Test]
+        public void A_request_is_named_with_its_path_and_thread()
+        {
+            Assert.That(
+                Everything(),
+                Is.Empty,
+                "sanity: nothing should be in flight before we start"
+            );
+
+            using (ApiActivityTracker.Begin("api/publish/epub/save"))
+            {
+                var described = Everything();
+
+                Assert.That(described.Length, Is.EqualTo(1));
+                Assert.That(described[0], Does.Contain("api/publish/epub/save"));
+                Assert.That(
+                    described[0],
+                    Does.Contain("OS thread"),
+                    "the OS thread id is what joins this request to its stack in the dump"
+                );
+            }
+
+            Assert.That(
+                Everything(),
+                Is.Empty,
+                "disposing must remove it, or a healthy Bloom looks stuck"
+            );
+        }
+
+        [Test]
+        public void The_lock_a_request_wants_is_named_and_then_the_one_it_holds()
+        {
+            using (var activity = ApiActivityTracker.Begin("api/publish/bloompub/updatepreview"))
+            {
+                Assert.That(
+                    Everything()[0],
+                    Does.Not.Contain("lock"),
+                    "sanity: a request says nothing about locks until it asks for one"
+                );
+
+                activity.NoteWaitingForLock("the thumbnail/preview lock");
+                Assert.That(
+                    Everything()[0],
+                    Does.Contain("waiting for the thumbnail/preview lock")
+                );
+
+                activity.NoteHoldingLock("the thumbnail/preview lock");
+                var holding = Everything()[0];
+                Assert.That(holding, Does.Contain("holding the thumbnail/preview lock"));
+                Assert.That(
+                    holding,
+                    Does.Not.Contain("waiting for"),
+                    "holding replaces waiting; a request cannot be doing both"
+                );
+            }
+        }
+
+        [Test]
+        public void Longest_running_comes_first()
+        {
+            using (ApiActivityTracker.Begin("api/first"))
+            using (ApiActivityTracker.Begin("api/second"))
+            {
+                var described = Everything();
+
+                Assert.That(described.Length, Is.EqualTo(2));
+                Assert.That(
+                    described[0],
+                    Does.Contain("api/first"),
+                    "the one stuck longest is the one a reader wants at the top"
+                );
+            }
+        }
+
+        [Test]
+        public void A_flood_of_requests_is_capped_and_says_how_many_it_dropped()
+        {
+            // A Bloom in real trouble can have a great many in flight. The list has to stop somewhere, but
+            // stopping silently would let a report look complete when it was truncated.
+            var scopes = Enumerable
+                .Range(0, 25)
+                .Select(i => ApiActivityTracker.Begin($"api/request/{i:D2}"))
+                .ToList();
+            try
+            {
+                var described = Everything();
+
+                Assert.That(described.Length, Is.EqualTo(21), "twenty requests plus the note");
+                Assert.That(described[20], Does.Contain("5 further request(s) in flight"));
+            }
+            finally
+            {
+                foreach (var scope in scopes)
+                    scope.Dispose();
+            }
+
+            Assert.That(Everything(), Is.Empty);
+        }
+
+        [Test]
+        public void Nothing_in_flight_returns_the_shared_empty_array()
+        {
+            // Not a curiosity: the session record compares this by reference, and Bloom skips writing the
+            // file when nothing has changed. A fresh empty array each time would make an idle Bloom look
+            // different from itself and rewrite the session every ten seconds for the life of the process.
+            Assert.That(Everything(), Is.Empty, "sanity: nothing in flight");
+
+            Assert.That(
+                Everything(),
+                Is.SameAs(Everything()),
+                "the empty result must be the cached instance, or an idle Bloom rewrites its session file forever"
+            );
+        }
+
+        [Test]
+        public void A_request_below_the_threshold_is_not_worth_naming()
+        {
+            using (ApiActivityTracker.Begin("api/quick"))
+            {
+                Assert.That(
+                    ApiActivityTracker.DescribeStuckRequests(TimeSpan.FromMinutes(1)),
+                    Is.Empty,
+                    "a request that has just started is normal traffic, not evidence"
+                );
+                Assert.That(Everything().Length, Is.EqualTo(1), "sanity: it IS in flight");
+            }
+        }
+    }
+}

--- a/src/BloomTests/FreezeDoctor/FreezeDoctorProtocolTests.cs
+++ b/src/BloomTests/FreezeDoctor/FreezeDoctorProtocolTests.cs
@@ -181,6 +181,69 @@ namespace BloomTests.FreezeDoctor
         }
 
         [Test]
+        public void OverlappingLongOperationsDoNotLeaveFinishedWorkOnDisplay()
+        {
+            // Scopes do not always nest. A starts, B starts, A finishes, B finishes - and B's notion of
+            // "what was showing when I started" is A, which by then has been over for some time. Putting
+            // that back made the card name work that had already completed, which is exactly the class of
+            // wrongness the activity string exists to avoid.
+            Assert.That(
+                FreezeDoctorSupport.LongOperationDepth,
+                Is.Zero,
+                "setup: nothing long is running yet"
+            );
+
+            var a = FreezeDoctorSupport.LongOperation("making a BloomPUB");
+            var b = FreezeDoctorSupport.LongOperation("uploading to Bloom Library");
+            Assert.That(
+                FreezeDoctorSupport.StatedActivity,
+                Is.EqualTo("uploading to Bloom Library"),
+                "setup: the later operation is the one on display"
+            );
+
+            a.Dispose();
+            Assert.That(
+                FreezeDoctorSupport.StatedActivity,
+                Is.EqualTo("uploading to Bloom Library"),
+                "the one that finished must not disturb the one still running"
+            );
+
+            b.Dispose();
+
+            Assert.That(
+                FreezeDoctorSupport.StatedActivity,
+                Is.Empty,
+                "with both finished, Bloom must not still claim to be making a BloomPUB"
+            );
+        }
+
+        [Test]
+        public void ALongOperationGivesBackTheActivityItInterrupted()
+        {
+            // The other direction, and the reason the fix is not simply "clear it when the last scope
+            // closes": recording a video says what it is doing, and only then opens a scope to merge the
+            // result. That standing description has to survive the scope it contains.
+            FreezeDoctorSupport.SetActivity("recording a video");
+            try
+            {
+                using (FreezeDoctorSupport.LongOperation("making a video"))
+                {
+                    Assert.That(FreezeDoctorSupport.StatedActivity, Is.EqualTo("making a video"));
+                }
+
+                Assert.That(
+                    FreezeDoctorSupport.StatedActivity,
+                    Is.EqualTo("recording a video"),
+                    "the standing activity must come back, not be cleared"
+                );
+            }
+            finally
+            {
+                FreezeDoctorSupport.SetActivity("");
+            }
+        }
+
+        [Test]
         public void DisposingALongOperationTwiceDoesNotStealSomebodyElsesPatience()
         {
             // A double Dispose is easy to arrange by accident, and an unguarded decrement would drive the

--- a/src/BloomTests/FreezeDoctor/FreezeDoctorProtocolTests.cs
+++ b/src/BloomTests/FreezeDoctor/FreezeDoctorProtocolTests.cs
@@ -1,0 +1,607 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using Bloom.FreezeDoctor;
+using BloomFreezeDoctor.Protocol;
+using NUnit.Framework;
+
+namespace BloomTests.FreezeDoctor
+{
+    /// <summary>
+    /// Bloom's side of the protocol it shares with the Bloom Freeze Doctor
+    /// (src/BloomFreezeDoctor, in this repository): the layout it expects, and the health it
+    /// publishes through it.
+    ///
+    /// **What this fixture is for changed when the protocol became a package.** It used to guard against
+    /// two hand-maintained copies of the same file drifting apart. There is only one definition now — the
+    /// `BloomFreezeDoctor.Protocol` package — so drift in that sense is no longer possible.
+    ///
+    /// It still earns its place, for a different reason: it pins the layout Bloom *expects* against the
+    /// layout the referenced package version actually has. A package upgrade that changed an offset or
+    /// the schema version would otherwise be silent — Bloom would compile, run, and publish its health to
+    /// offsets the Doctor no longer reads, and the reports would be plausible nonsense that nobody could
+    /// tell from real ones. Asserting the numbers BY VALUE here turns that into a failed build.
+    ///
+    /// So: if this fails after a version bump, the layout changed, and Bloom's side needs looking at
+    /// rather than the numbers here being updated to match.
+    /// </summary>
+    [TestFixture]
+    public class FreezeDoctorProtocolTests
+    {
+        /// <summary>A process id no real Bloom will have, so a test run cannot collide with a live channel.</summary>
+        private const int TestProcessId = 999_002;
+
+        [Test]
+        public void ShutdownPhasesAreWhatBloomWasBuiltAgainst()
+        {
+            // Bloom's own copy of the pin in the Doctor's DoctorChannelTests, for the same reason the
+            // layout above is pinned twice: a package upgrade that renumbered these would otherwise make
+            // Bloom write phases the Doctor reads as something else, silently. The NUMBER is what goes
+            // into the shared page; the NAME is what goes into the session file. Neither may change.
+            var expected = new[]
+            {
+                "None=0",
+                "MessageLoopReturned=1",
+                "SettingsSaved=2",
+                "LogWritten=3",
+                "ProjectContextDisposed=4",
+            };
+            Assert.That(
+                Enum.GetValues<BloomShutdownPhase>().Select(p => $"{p}={(int)p}").ToArray(),
+                Is.EqualTo(expected),
+                "the shutdown phases, pinned by name AND number"
+            );
+        }
+
+        [Test]
+        public void LayoutIsWhatBloomWasBuiltAgainst()
+        {
+            // If you are here because this failed, a package upgrade changed the layout. Do NOT just update
+            // these numbers to match: check what moved and why. Adding a field should never reach this test
+            // (see the next one); anything that MOVES a field is a SchemaVersion bump, and Bloom's side of
+            // the protocol needs looking at before the numbers here are touched.
+            Assert.That(DoctorChannelLayout.SchemaVersion, Is.EqualTo(1), "schema version");
+            Assert.That(DoctorChannelLayout.Size, Is.EqualTo(4096), "page size");
+            Assert.That(
+                DoctorChannelLayout.ActivityMaxBytes,
+                Is.EqualTo(256),
+                "room for the activity string"
+            );
+            Assert.That(
+                DoctorChannelLayout.NameFor(1234),
+                Is.EqualTo(@"Local\BloomFreezeDoctor.v1.1234"),
+                "the name must stay in the Local namespace and carry both version and pid"
+            );
+
+            // Every field, by value, from the layout's own published description of itself. This is what
+            // turns "the package quietly moved a field" from a silent wrong-offset bug into a failed build.
+            var expected = new[]
+            {
+                "SchemaVersion@0+4",
+                "PayloadBytes@4+4",
+                "WriteSequence@8+8",
+                "ProcessId@16+4",
+                "ShutdownPhase@20+4",
+                "UiTicks@24+8",
+                "UiTimestamp@32+8",
+                "WatchdogTicks@40+8",
+                "WatchdogTimestamp@48+8",
+                "Flags@56+4",
+                "ServerBusy@60+4",
+                "ServerBlocked@64+4",
+                "Reserved@68+4",
+                "Activity@72+256",
+                "DebuggerLastDetached@328+8",
+                "ServerWorkers@336+4",
+                "ServerQueued@340+4",
+            };
+            Assert.That(
+                DoctorChannelLayout.Fields.Select(f => $"{f.Name}@{f.Offset}+{f.Size}").ToArray(),
+                Is.EqualTo(expected),
+                "the field layout Bloom publishes to"
+            );
+        }
+
+        [Test]
+        public void AddingAFieldToTheProtocolDoesNotBreakBloom()
+        {
+            // The counterpart to the test above, and the reason it can be strict without being a nuisance.
+            //
+            // The protocol is allowed to GROW without a version bump: new fields are appended and
+            // PayloadBytes grows to match. When that happens the pinned list above gains an entry, but
+            // nothing Bloom does changes — Bloom keeps writing the fields it knows about, at the offsets it
+            // knows, and an older Doctor keeps reading them.
+            //
+            // So what is pinned here is not a number that may not change; it is the *invariant* that makes
+            // growth safe. If this fails, the layout has been rearranged rather than extended, and every
+            // Doctor already installed is reading Bloom's page wrongly.
+            var end = DoctorChannelLayout.Fields.Max(f => f.Offset + f.Size);
+
+            Assert.That(
+                DoctorChannelLayout.PayloadBytes,
+                Is.EqualTo(end),
+                "PayloadBytes must be one past the last field, or a new field is outside what Bloom claims to have written"
+            );
+            Assert.That(
+                DoctorChannelLayout.PayloadBytes,
+                Is.GreaterThanOrEqualTo(DoctorChannelLayout.BaselinePayloadBytes),
+                "the layout may only grow past the generation-1 baseline"
+            );
+            // Equal to PayloadBytes for now, because generation 1 is unreleased and there is no older Bloom
+            // writing less. Once a Bloom ships writing this page, this number freezes and appending a field
+            // grows only PayloadBytes.
+            Assert.That(
+                DoctorChannelLayout.BaselinePayloadBytes,
+                Is.EqualTo(344),
+                "the generation-1 floor"
+            );
+        }
+
+        [Test]
+        public void NestedLongOperationsDoNotEndEachOthersPatience()
+        {
+            // The failure this guards against is silent and lasts the whole session. The Doctor waits five
+            // minutes instead of one while a long operation runs; if an inner operation's exit cleared the
+            // flag, the outer one would lose its patience half way through — and if an exit were MISSED,
+            // the flag would stay set for ever and freeze detection would be off for the rest of the run.
+            //
+            // Nesting is not hypothetical: building an app makes a BloomPUB on the way, so those two scopes
+            // are genuinely inside one another in production.
+            Assert.That(
+                FreezeDoctorSupport.LongOperationDepth,
+                Is.Zero,
+                "setup: nothing long is running yet"
+            );
+
+            using (FreezeDoctorSupport.LongOperation("building an app"))
+            {
+                Assert.That(FreezeDoctorSupport.LongOperationDepth, Is.EqualTo(1), "outer entered");
+
+                using (FreezeDoctorSupport.LongOperation("making a BloomPUB"))
+                {
+                    Assert.That(
+                        FreezeDoctorSupport.LongOperationDepth,
+                        Is.EqualTo(2),
+                        "inner entered"
+                    );
+                }
+
+                Assert.That(
+                    FreezeDoctorSupport.LongOperationDepth,
+                    Is.EqualTo(1),
+                    "the inner operation finishing must NOT end the outer one's patience"
+                );
+            }
+
+            Assert.That(
+                FreezeDoctorSupport.LongOperationDepth,
+                Is.Zero,
+                "and the outermost finishing must clear it, or freeze detection stays off for good"
+            );
+        }
+
+        [Test]
+        public void DisposingALongOperationTwiceDoesNotStealSomebodyElsesPatience()
+        {
+            // A double Dispose is easy to arrange by accident, and an unguarded decrement would drive the
+            // count negative — after which the NEXT operation's exit would not clear the flag, leaving the
+            // Doctor permanently patient. Guarded in the scope; pinned here.
+            var outer = FreezeDoctorSupport.LongOperation("building an app");
+            var inner = FreezeDoctorSupport.LongOperation("making a BloomPUB");
+            inner.Dispose();
+            inner.Dispose();
+
+            Assert.That(
+                FreezeDoctorSupport.LongOperationDepth,
+                Is.EqualTo(1),
+                "the second Dispose must be ignored, not counted again"
+            );
+
+            outer.Dispose();
+            Assert.That(FreezeDoctorSupport.LongOperationDepth, Is.Zero);
+        }
+
+        [Test]
+        public void ALongOperationEndsEvenWhenItThrows()
+        {
+            // `using` is the whole reason the API is a scope rather than paired calls: an exception on a
+            // publish path must not leave the Doctor permanently patient.
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                using (FreezeDoctorSupport.LongOperation("making an ePUB"))
+                {
+                    throw new InvalidOperationException("pretend the publish failed");
+                }
+            });
+
+            Assert.That(
+                FreezeDoctorSupport.LongOperationDepth,
+                Is.Zero,
+                "an operation that threw must still have ended"
+            );
+        }
+
+        [Test]
+        public void TheNativeDebuggerCheckActuallyResolves()
+        {
+            // Bloom's debugger check swallows exceptions, because a diagnostic must never be able to break
+            // the watchdog thread. That means a wrong DllImport signature would not fail loudly — it would
+            // just report "no debugger" for ever, and the sticky flag would never be set on any machine.
+            // Calling it here, outside that catch, is what turns a broken P/Invoke into a failing test.
+            Assert.DoesNotThrow(
+                () => FreezeDoctorSupport.IsDebuggerPresent(),
+                "the kernel32 IsDebuggerPresent import should resolve"
+            );
+
+            // Whatever the environment, the combined answer must agree with the managed one when that says
+            // a debugger is attached — this is the direction that matters, since it is what suppresses
+            // reports while a developer is stepping through Bloom.
+            if (Debugger.IsAttached)
+                Assert.That(
+                    FreezeDoctorSupport.IsDebuggerAttached(),
+                    Is.True,
+                    "a managed debugger must always count as attached"
+                );
+            else
+                Assert.DoesNotThrow(() => FreezeDoctorSupport.IsDebuggerAttached());
+        }
+
+        [Test]
+        public void ADebuggerThatHasComeAndGoneIsStillVisibleToTheDoctor()
+        {
+            // Bloom's end of the sticky flag. The Doctor's repo tests the mechanism; what is worth checking
+            // here is that Bloom is publishing through the call that remembers, so that a debugger which
+            // attached and left does not leave a heartbeat gap looking like a genuine freeze.
+            using (var writer = new DoctorChannelWriter(TestProcessId))
+            {
+                Assert.That(writer.IsOpen, Is.True, "setup: the channel should have been created");
+
+                writer.SetDebuggerAttached(true);
+                writer.SetDebuggerAttached(false);
+
+                Assert.That(DoctorChannelReader.TryRead(TestProcessId, out var snapshot), Is.True);
+                Assert.That(
+                    snapshot.DebuggerAttached,
+                    Is.False,
+                    "setup: it should have gone again"
+                );
+                Assert.That(
+                    snapshot.DebuggerEverAttached,
+                    Is.True,
+                    "but the Doctor must still be able to tell that one was here"
+                );
+                Assert.That(
+                    snapshot.DebuggerLastDetachedAge,
+                    Is.LessThan(TimeSpan.FromMinutes(1)),
+                    "and roughly when it left, so an unrelated freeze later is still reportable"
+                );
+            }
+        }
+
+        [Test]
+        public void WhatBloomPublishesSaysHowMuchOfItIsReal()
+        {
+            // A Doctor newer than this Bloom needs to be able to tell a field Bloom never wrote from a real
+            // zero. That only works if Bloom actually records its extent, so it is worth asserting that it
+            // reaches the page rather than trusting the constant.
+            using (var writer = new DoctorChannelWriter(TestProcessId))
+            {
+                Assert.That(writer.IsOpen, Is.True, "setup: the channel should have been created");
+
+                Assert.That(
+                    DoctorChannelReader.TryRead(TestProcessId, out var snapshot),
+                    Is.True,
+                    "setup: the channel should be readable"
+                );
+                Assert.That(
+                    snapshot.PayloadBytes,
+                    Is.EqualTo(DoctorChannelLayout.PayloadBytes),
+                    "Bloom must record how far it wrote, or a newer Doctor cannot tell absent from zero"
+                );
+            }
+        }
+
+        [Test]
+        public void WhatBloomWritesCanBeReadBack()
+        {
+            using (var writer = new DoctorChannelWriter(TestProcessId))
+            {
+                Assert.That(writer.IsOpen, Is.True, "setup: the channel should have been created");
+
+                writer.SetActivity("Publishing to BloomPUB");
+                writer.SetLongOperation(true);
+                writer.RecordUiTick();
+                writer.RecordWatchdogTick();
+                writer.SetShutdownPhase(BloomShutdownPhase.SettingsSaved);
+
+                Assert.That(
+                    DoctorChannelReader.TryRead(TestProcessId, out var snapshot),
+                    Is.True,
+                    "a Doctor should be able to read what we just published"
+                );
+                Assert.That(snapshot.Activity, Is.EqualTo("Publishing to BloomPUB"));
+                Assert.That(snapshot.LongOperationInProgress, Is.True);
+                Assert.That(snapshot.UiTicks, Is.EqualTo(1));
+                Assert.That(snapshot.WatchdogTicks, Is.EqualTo(1));
+                Assert.That(snapshot.ShutdownPhase, Is.EqualTo(BloomShutdownPhase.SettingsSaved));
+                Assert.That(snapshot.CleanExitRecorded, Is.False, "we have not exited");
+            }
+        }
+
+        [Test]
+        public void AnUntickedHeartbeatReadsAsInfinitelyOldRatherThanFresh()
+        {
+            // The dangerous direction: if an unticked heartbeat read as "just now", a Bloom that wedged
+            // during startup would look healthy for ever.
+            using (var writer = new DoctorChannelWriter(TestProcessId))
+            {
+                writer.SetActivity("starting up");
+
+                DoctorChannelReader.TryRead(TestProcessId, out var snapshot);
+
+                Assert.That(snapshot.UiHeartbeatAge, Is.EqualTo(TimeSpan.MaxValue));
+            }
+        }
+
+        [Test]
+        public void PublishingNeverThrowsEvenWhenTheChannelCouldNotBeCreated()
+        {
+            // Two writers for one process id: the second cannot create the section. Bloom must not care,
+            // because publishing diagnostics is never worth failing a startup over.
+            using (var first = new DoctorChannelWriter(TestProcessId))
+            using (var second = new DoctorChannelWriter(TestProcessId))
+            {
+                Assert.That(
+                    second.IsOpen,
+                    Is.False,
+                    "setup: the second writer should have failed to create the section"
+                );
+                Assert.DoesNotThrow(() =>
+                {
+                    second.RecordUiTick();
+                    second.SetActivity("this goes nowhere");
+                    second.RecordCleanExit();
+                });
+            }
+        }
+
+        [Test]
+        public void WhatBloomIsDoingIsComposedFromBothSourcesRatherThanEitherWinning()
+        {
+            // Regression test for a bug introduced three times, in three different ways, which is what earns
+            // it a test rather than a comment. Every version got one of the two directions wrong: the refresh
+            // overwrote what Bloom stated ("starting up" survived less than a second); then "starting up" went
+            // straight into the shared page so there was nothing for the refresh to carry forward; then it was
+            // carried forward for ever and described an idle Bloom hours later. The two failures are opposite,
+            // so both directions are pinned here.
+            const string startup = FreezeDoctorSupport.StartupActivity;
+
+            Assert.Multiple(() =>
+            {
+                // Nothing stated, nothing running.
+                Assert.That(
+                    FreezeDoctorSupport.Compose(null, null, false),
+                    Is.EqualTo("no request in flight")
+                );
+
+                // Direction 1: what Bloom stated must not be lost. This is the startup-freeze case, where the
+                // stated text is the only clue there is.
+                Assert.That(
+                    FreezeDoctorSupport.Compose(startup, null, false),
+                    Is.EqualTo(startup),
+                    "the startup note must survive until Bloom has actually started"
+                );
+
+                // Direction 2: it must not outlive its truth. Handling a request means Bloom is up.
+                Assert.That(
+                    FreezeDoctorSupport.Compose(startup, null, true),
+                    Is.EqualTo("no request in flight"),
+                    "once Bloom has handled a request it is no longer starting up"
+                );
+
+                // A stated activity that is not the startup note is the caller's business and is never
+                // retired on their behalf — a long publish must keep saying so.
+                Assert.That(
+                    FreezeDoctorSupport.Compose("Publishing to BloomPUB", null, true),
+                    Is.EqualTo("Publishing to BloomPUB")
+                );
+
+                // Neither source silences the other.
+                Assert.That(
+                    FreezeDoctorSupport.Compose(
+                        "Publishing to BloomPUB",
+                        "api/publish running 9s",
+                        true
+                    ),
+                    Is.EqualTo("Publishing to BloomPUB | api/publish running 9s")
+                );
+                Assert.That(
+                    FreezeDoctorSupport.Compose(null, "api/publish running 9s", true),
+                    Is.EqualTo("api/publish running 9s")
+                );
+            });
+        }
+
+        [Test]
+        public void SetActivityIsWhatTheComposerReads()
+        {
+            // The chain the second version of the bug broke: Start() wrote to the shared page directly, so
+            // SetActivity had never recorded anything and the composer had nothing to carry forward.
+            FreezeDoctorSupport.SetActivity("Saving Foo.htm");
+            try
+            {
+                Assert.That(
+                    FreezeDoctorSupport.ComposeCurrentActivity(),
+                    Does.Contain("Saving Foo.htm"),
+                    "SetActivity must reach the composer, not just the shared page"
+                );
+            }
+            finally
+            {
+                // Static state shared with the rest of the assembly.
+                FreezeDoctorSupport.SetActivity(null);
+            }
+        }
+
+        [Test]
+        public void FreezeSimulatorIsInertOnReleaseChannels()
+        {
+            // The safeguard that matters: this class deliberately breaks Bloom, so a stray environment
+            // variable on a user's machine must not be able to set it off. Arming it for a Release channel
+            // must do nothing at all, and must certainly not throw.
+            var saved = Environment.GetEnvironmentVariable(FreezeSimulator.EnvironmentVariable);
+            try
+            {
+                Environment.SetEnvironmentVariable(FreezeSimulator.EnvironmentVariable, "sleep:1");
+
+                Assert.That(
+                    FreezeSimulator.ArmIfRequested("Release"),
+                    Is.False,
+                    "a stray environment variable must not be able to break a Release Bloom"
+                );
+                Assert.That(FreezeSimulator.ArmIfRequested("Beta"), Is.False, "nor a Beta one");
+                Assert.That(
+                    FreezeSimulator.ArmIfRequested("SomethingNew"),
+                    Is.False,
+                    "nor a channel nobody has considered; the list is named, not pattern-matched"
+                );
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(FreezeSimulator.EnvironmentVariable, saved);
+            }
+        }
+
+        [Test]
+        public void FreezeSimulatorArmsOnAlphaInternalAndDeveloperChannels()
+        {
+            // Alpha and the internal channels are allowed on purpose, because they are where the Doctor is
+            // actually exercised: BetaInternal carries the bulk of in-house testing of a new version, and
+            // reproducing a freeze usually means working with somebody experiencing one, who is on Alpha
+            // rather than a build from source. This is the other half of the safeguard above — the pair of
+            // tests together say exactly which channels may be broken deliberately, so widening or
+            // narrowing that set breaks a test.
+            var saved = Environment.GetEnvironmentVariable(FreezeSimulator.EnvironmentVariable);
+            try
+            {
+                // A delay far longer than the test run, so nothing ever actually fires. There is no message
+                // loop here either, so the UI-thread timer it arms cannot tick.
+                Environment.SetEnvironmentVariable(
+                    FreezeSimulator.EnvironmentVariable,
+                    "sleep:100000"
+                );
+
+                Assert.That(FreezeSimulator.ArmIfRequested("Alpha"), Is.True, "Alpha");
+                Assert.That(
+                    FreezeSimulator.ArmIfRequested("Developer/Debug"),
+                    Is.True,
+                    "developer"
+                );
+                Assert.That(
+                    FreezeSimulator.ArmIfRequested("BetaInternal"),
+                    Is.True,
+                    "BetaInternal, where most in-house testing of a new version happens"
+                );
+                Assert.That(
+                    FreezeSimulator.ArmIfRequested("ReleaseInternal"),
+                    Is.True,
+                    "ReleaseInternal, in-house for the same reason"
+                );
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(FreezeSimulator.EnvironmentVariable, saved);
+                FreezeSimulator.Disarm();
+            }
+        }
+
+        [Test]
+        public void AMisspeltSimulationKindArmsNothingAtAll()
+        {
+            // The failure this guards against is worse than the typo that causes it. An unrecognised kind
+            // used to arm no simulation - the switch merely logged "not a kind it knows about" 45 seconds
+            // later - while still recording in the session file that this Bloom was a deliberate
+            // rehearsal. The Doctor reads that marker and declines to file a card, so one misspelt
+            // environment variable silently turned off freeze reporting for the whole session, on a Bloom
+            // that was behaving perfectly normally and might genuinely freeze.
+            var saved = Environment.GetEnvironmentVariable(FreezeSimulator.EnvironmentVariable);
+            try
+            {
+                // Sanity check first, so this test cannot pass merely because arming never works here.
+                Environment.SetEnvironmentVariable(
+                    FreezeSimulator.EnvironmentVariable,
+                    "sleep:100000"
+                );
+                Assert.That(
+                    FreezeSimulator.ArmIfRequested("Alpha"),
+                    Is.True,
+                    "setup: a known kind on an allowed channel must arm, or this test proves nothing"
+                );
+                FreezeSimulator.Disarm();
+
+                Environment.SetEnvironmentVariable(
+                    FreezeSimulator.EnvironmentVariable,
+                    "slep:100000"
+                );
+                Assert.That(
+                    FreezeSimulator.ArmIfRequested("Alpha"),
+                    Is.False,
+                    "a kind we do not recognise must refuse outright, not half-arm"
+                );
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(FreezeSimulator.EnvironmentVariable, saved);
+                FreezeSimulator.Disarm();
+            }
+        }
+
+        [Test]
+        public void EverySimulationKindTheSwitchHandlesIsAlsoAcceptedByTheGuard()
+        {
+            // The guard and the switch are two lists that must not drift apart: a kind the switch knows
+            // but the guard rejects is a simulation nobody can run, and the reverse is the silent-marker
+            // bug above. Asserting every advertised kind arms is the cheap half of keeping them together.
+            var saved = Environment.GetEnvironmentVariable(FreezeSimulator.EnvironmentVariable);
+            try
+            {
+                foreach (var kind in FreezeSimulator.KnownKinds)
+                {
+                    Environment.SetEnvironmentVariable(
+                        FreezeSimulator.EnvironmentVariable,
+                        kind + ":100000"
+                    );
+                    Assert.That(
+                        FreezeSimulator.ArmIfRequested("Alpha"),
+                        Is.True,
+                        $"'{kind}' is advertised as a kind, so it must arm"
+                    );
+                    FreezeSimulator.Disarm();
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(FreezeSimulator.EnvironmentVariable, saved);
+                FreezeSimulator.Disarm();
+            }
+        }
+
+        [Test]
+        public void FreezeSimulatorStaysInertWithNoEnvironmentVariableEvenOnAlpha()
+        {
+            // Belt and braces: the channel is a gate, not a trigger. Nobody on Alpha gets a broken Bloom
+            // unless they asked for one.
+            var saved = Environment.GetEnvironmentVariable(FreezeSimulator.EnvironmentVariable);
+            try
+            {
+                Environment.SetEnvironmentVariable(FreezeSimulator.EnvironmentVariable, null);
+
+                Assert.That(FreezeSimulator.ArmIfRequested("Alpha"), Is.False);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(FreezeSimulator.EnvironmentVariable, saved);
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
**This is the first of two stacked PRs.** It contains everything that goes *inside Bloom*, plus the wire format both sides share. The Doctor process itself is #8229, which targets this branch.

## Problem

When Bloom freezes, we get almost nothing. The user kills it and carries on, and freezes are exactly the failure people don't report — so a bug like BL-16697 can only be guessed at. Worse, Bloom cannot reliably tell us it is frozen, and nor can Windows: a WinForms UI thread blocked in a managed wait **still dispatches sent messages**, so `IsHungAppWindow` and `Process.Responding` report a thoroughly wedged Bloom as healthy. That was measured at nine minutes frozen and reported responsive.

## What this PR changes

Bloom starts publishing enough about itself that a separate process can tell it has stopped, and can say something useful about why:

- **A UI-thread heartbeat** written to a small shared-memory page by a WinForms timer. Because of the measurement above, this is the only signal that actually detects a freeze — everything else in the report is evidence, this is detection.
- **A per-run session file** carrying the facts a watcher cannot work out from outside — above all *which log file this run is writing to*. Bloom recreates `Log.txt` each run and falls back to a random name only when another Bloom holds it, so from outside the newest log is the wrong answer exactly in the restart-after-a-freeze case.
- **In-flight API request tracking** (`ApiActivityTracker`) recording which requests are running and which lock each is waiting on, so a server deadlock can be read off a report rather than reproduced.
- **Long-operation scopes** at the half-dozen places Bloom legitimately stops answering for minutes — BloomPUB, ePUB, Reading App Builder, video recording, upload, download. These raise the freeze threshold from 1 to 5 minutes so a legitimate slow job is not reported as a freeze.
- **`DoctorLauncher`** and a debug-menu toggle, which start the companion process when the setting is on. **Off by default.**
- **`FreezeSimulator`**, which makes Bloom break itself on purpose so the detection and crash paths can be exercised at all. It refuses to arm on the release channels.

`BloomFreezeDoctor.Protocol` is a plain project both sides reference rather than a published package, so one wire format has one definition instead of two hand-maintained copies. Its layout is pinned by value in tests on both sides.

**Nothing here does anything on its own.** With no Doctor installed — the default — Bloom writes a heartbeat that nobody reads.
<!-- preflight-narrative:end -->

---

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16719

**Why the split:** at ~19,600 lines the combined change defeated every automated reviewer we have — Devin's analysis never completed on it across four attempts on four separate commits. It also mixes two very different risk profiles: the Doctor is a separate process, so if it is wrong a card is wrong, whereas this half runs inside the shipping application. This is the half that deserves the scrutiny.


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8259)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8259)
<!-- Reviewable:end -->
