### PR TITLE
Give console mode a real message loop, so command-line Bloom can use a browser (BL-16773)

### DIFF
--- a/src/BloomExe/Program.cs
+++ b/src/BloomExe/Program.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -200,6 +201,8 @@ namespace Bloom
             // Bloom has several command line scenarios, without a coherent system for them.
             // The following is how we will do things from now on, and things can be moved
             // into this as time allows. See CommandLineOptions.cs.
+            // The command itself runs inside RunConsoleCommandLoop, which gives this thread a real
+            // message loop; see that method for why that matters so much to WebView2.
             if (
                 args.Length > 0
                 && new[]
@@ -223,80 +226,9 @@ namespace Bloom
 
                 RunningInConsoleMode = true;
 
-                var mainTask = CommandLine
-                    .Parser.Default.ParseArguments(
-                        args,
-                        new[]
-                        {
-                            typeof(HydrateParameters),
-                            typeof(UploadParameters),
-                            typeof(DownloadBookOptions),
-                            typeof(GetUsedFontsParameters),
-                            typeof(ChangeLayoutParameters),
-                            typeof(CreateArtifactsParameters),
-                            typeof(SendFontAnalyticsParameters),
-                            typeof(SpreadsheetExportParameters),
-                            typeof(SpreadsheetImportParameters),
-                        }
-                    )
-                    .MapResult(
-                        (HydrateParameters opts) => HydrateBookCommand.Handle(opts),
-                        (UploadParameters opts) => HandleUpload(opts),
-                        (DownloadBookOptions opts) =>
-                            DownloadBookCommand.HandleSilentDownload(opts),
-                        (GetUsedFontsParameters opts) => GetUsedFontsCommand.Handle(opts),
-                        (ChangeLayoutParameters opts) => ChangeLayoutCommand.Handle(opts),
-                        (CreateArtifactsParameters opts) => CreateArtifactsCommand.Handle(opts),
-                        (SendFontAnalyticsParameters opts) => SendFontAnalyticsCommand.Handle(opts),
-                        (SpreadsheetExportParameters opts) => SpreadsheetExportCommand.Handle(opts),
-                        // We don't have a way to get the CollectionSettings object for the Import process.
-                        // This means that if we use this CLI version, care should be taken to update the book,
-                        // so the pages get the correct "side" classes (side-left, side-right). (BL-10884)
-                        (SpreadsheetImportParameters opts) => SpreadsheetImportCommand.Handle(opts),
-                        async errors =>
-                        {
-                            var code = 0;
-                            foreach (var error in errors)
-                            {
-                                if (
-                                    !(error is HelpVerbRequestedError)
-                                    && !(error is HelpRequestedError)
-                                )
-                                {
-                                    // All of the errors have already been reported in English text. This would just add
-                                    // a cryptic class name to the output, possibly in the middle of a line in the usage
-                                    // message displayed as a result of the errors.
-                                    // Console.WriteLine(error.ToString());
-                                    code = 1;
-                                }
-                            }
-
-                            return code;
-                        }
-                    );
-                // What we want to do here is await mainTask. But to do that we have to make
-                // Main async. That is allowed since C# 7.1, but if we do it, we don't get
-                // a Windows.Forms synchronization context, which means async tasks started on
-                // the UI thread don't have to complete on the UI thread. That will mess up
-                // WebView2, and it is so that we can use WebView2's ExecuteJavascriptAsync
-                // that we made all these commands async to begin with.
-                // As soon as we DO have a windows.forms sync context...even if we made it ourselves,
-                // which is tricky because await won't work on a windows.forms sync context
-                // until we enter Run() and start pumping messages...we run into the problem
-                // that we need the result of the main task to return as the result of Main().
-                // We can't just call Result, because that blocks the main thread, which stops
-                // it pumping messages, which means anything that awaits on the main thread
-                // will deadlock.
-                // So, the best I can find to do is to sit here pumping messages until the
-                // main task completes.
-                // (Many of the main tasks don't actually do any awaiting and will immediately
-                // show as completed.)
-                while (!mainTask.IsCompleted)
-                {
-                    Application.DoEvents();
-                }
+                var exitCode = RunConsoleCommandLoop(() => ParseAndDispatchConsoleCommand(args));
                 WebView2Browser.CleanupWebView2UserFolders();
-                return mainTask.Result; // we're done; this is safe once there is nothing being awaited.
+                return exitCode;
             }
 
             if (!ValidateStartupVitePort(out var startupViteErrorMessage))
@@ -1100,6 +1032,158 @@ namespace Bloom
                 }
             }
             return missingOrAntique;
+        }
+
+        /// <summary>
+        /// Runs one console-mode command to completion on this thread, driving a real Windows Forms
+        /// message loop while it runs, and returns the exit code the command produced.
+        /// </summary>
+        /// <remarks>
+        /// Console mode used to wait for the command with
+        /// "while (!mainTask.IsCompleted) Application.DoEvents();". The comment there explained that Main
+        /// was deliberately left synchronous so that there would be a Windows Forms synchronization
+        /// context, and so that an await started on this thread would resume on this thread — which
+        /// WebView2 depends on. The trouble is that the wait loop defeated exactly that:
+        /// Application.DoEvents(), when it is the OUTERMOST message loop, uninstalls the
+        /// WindowsFormsSynchronizationContext and leaves a plain base SynchronizationContext, whose Post
+        /// queues to the thread pool. (Nested inside Application.Run it does not, which is why the
+        /// desktop app never had this problem.) So from the first await that actually yielded, console
+        /// work moved to MTA thread-pool threads — where a WebView2 cannot even be created, because
+        /// CoreWebView2Environment.CreateAsync needs an STA thread and throws RPC_E_CHANGED_MODE. That is
+        /// what made bulk upload fail from the second book onwards (BL-16767).
+        ///
+        /// Running a genuine loop instead makes the original intent true: the command's awaits resume on
+        /// this STA thread, which is pumping messages, so a browser created here can finish initializing
+        /// and can be used for the whole run.
+        ///
+        /// ⚠ The flip side, and the one thing to know before adding console code: because awaits now
+        /// come back to this thread, **sync-over-async on this thread can deadlock**, where under the old
+        /// DoEvents wait it could not. If a console verb blocks on a Task (<c>.Result</c>,
+        /// <c>.Wait()</c>, <c>GetAwaiter().GetResult()</c>) and that Task can only complete by running a
+        /// continuation posted back to this context, nothing will ever run it. The blocking calls on the
+        /// existing console paths were checked and are safe: they wait either on library tasks that use
+        /// <c>ConfigureAwait(false)</c> internally (the AWS SDK, HttpClient), or on work owned by another
+        /// thread (OffScreenBrowser completes its own), and <see cref="Bloom.Utils.AsyncUtil"/> pins its
+        /// work to <c>TaskScheduler.Default</c> for exactly this reason. New code that blocks on one of
+        /// Bloom's own async methods is the case to avoid — await it, or route it through AsyncUtil.
+        /// </remarks>
+        /// <param name="startCommand">
+        /// Starts the command and returns its Task. It is invoked from inside the message loop, not
+        /// before it, because an await captures whatever synchronization context is current at the moment
+        /// it suspends — starting the command any earlier would be too late for its first await.
+        /// </param>
+        internal static int RunConsoleCommandLoop(Func<Task<int>> startCommand)
+        {
+            var syncContext = new WindowsFormsSynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(syncContext);
+            // Deliberately NOT assigned to Program.MainContext. That property means "the app's UI
+            // thread", and code keyed off it (RabProjectService, CommonApi, ToastService) behaves
+            // differently when it is set; RabProjectService in particular has a null branch precisely
+            // for the case where there is no UI. Publishing this context there would silently change
+            // those paths in console mode, which is no part of what this loop is for.
+
+            var appContext = new ApplicationContext();
+            Task<int> commandTask = null;
+            Exception startupError = null;
+
+            // Post rather than call: this body runs once Application.Run below is pumping.
+            syncContext.Post(
+                _ =>
+                {
+                    try
+                    {
+                        commandTask = startCommand();
+                    }
+                    catch (Exception e)
+                    {
+                        // The command threw before it could return a Task, so nothing will ever complete
+                        // it. End the loop ourselves and rethrow below, on the caller's stack.
+                        startupError = e;
+                        appContext.ExitThread();
+                        return;
+                    }
+                    // Stop pumping as soon as the command finishes. Scheduling the continuation onto this
+                    // same context keeps ExitThread on the thread that is running the loop.
+                    commandTask.ContinueWith(
+                        _2 => appContext.ExitThread(),
+                        TaskScheduler.FromCurrentSynchronizationContext()
+                    );
+                },
+                null
+            );
+
+            Application.Run(appContext);
+
+            if (startupError != null)
+                ExceptionDispatchInfo.Capture(startupError).Throw();
+            // Normally the loop ended *because* the task completed, so reading Result below neither
+            // blocks nor deadlocks. But if something else ended the loop (a stray Application.Exit
+            // from inside a command, say), Result would block this thread forever. A console tool that
+            // hangs is the worst thing this method could do, so say what happened instead.
+            if (commandTask == null || !commandTask.IsCompleted)
+                throw new ApplicationException(
+                    "The console message loop ended before the command finished, so its exit code is"
+                        + " unavailable. Something other than the command ending stopped the loop."
+                );
+            // As before, a command that failed surfaces its exception from this line.
+            return commandTask.Result;
+        }
+
+        /// <summary>
+        /// Parses the command line and starts the matching console command, returning its Task.
+        /// Called by <see cref="RunConsoleCommandLoop"/> from inside the message loop.
+        /// </summary>
+        private static Task<int> ParseAndDispatchConsoleCommand(string[] args)
+        {
+            return CommandLine
+                .Parser.Default.ParseArguments(
+                    args,
+                    new[]
+                    {
+                        typeof(HydrateParameters),
+                        typeof(UploadParameters),
+                        typeof(DownloadBookOptions),
+                        typeof(GetUsedFontsParameters),
+                        typeof(ChangeLayoutParameters),
+                        typeof(CreateArtifactsParameters),
+                        typeof(SendFontAnalyticsParameters),
+                        typeof(SpreadsheetExportParameters),
+                        typeof(SpreadsheetImportParameters),
+                    }
+                )
+                .MapResult(
+                    (HydrateParameters opts) => HydrateBookCommand.Handle(opts),
+                    (UploadParameters opts) => HandleUpload(opts),
+                    (DownloadBookOptions opts) => DownloadBookCommand.HandleSilentDownload(opts),
+                    (GetUsedFontsParameters opts) => GetUsedFontsCommand.Handle(opts),
+                    (ChangeLayoutParameters opts) => ChangeLayoutCommand.Handle(opts),
+                    (CreateArtifactsParameters opts) => CreateArtifactsCommand.Handle(opts),
+                    (SendFontAnalyticsParameters opts) => SendFontAnalyticsCommand.Handle(opts),
+                    (SpreadsheetExportParameters opts) => SpreadsheetExportCommand.Handle(opts),
+                    // We don't have a way to get the CollectionSettings object for the Import process.
+                    // This means that if we use this CLI version, care should be taken to update the book,
+                    // so the pages get the correct "side" classes (side-left, side-right). (BL-10884)
+                    (SpreadsheetImportParameters opts) => SpreadsheetImportCommand.Handle(opts),
+                    async errors =>
+                    {
+                        var code = 0;
+                        foreach (var error in errors)
+                        {
+                            if (
+                                !(error is HelpVerbRequestedError) && !(error is HelpRequestedError)
+                            )
+                            {
+                                // All of the errors have already been reported in English text. This would just add
+                                // a cryptic class name to the output, possibly in the middle of a line in the usage
+                                // message displayed as a result of the errors.
+                                // Console.WriteLine(error.ToString());
+                                code = 1;
+                            }
+                        }
+
+                        return code;
+                    }
+                );
         }
 
         static async Task<int> HandleUpload(UploadParameters opts)

--- a/src/BloomExe/Publish/OffScreenBrowser.cs
+++ b/src/BloomExe/Publish/OffScreenBrowser.cs
@@ -151,6 +151,13 @@ namespace Bloom.Publish
             var timer = Stopwatch.StartNew();
             while (!_browser.IsReadyToNavigate)
             {
+                // Initialization failed outright, so it will never become ready. Fail now with the real
+                // cause instead of waiting out the timeout and then blaming the timeout (BL-16773).
+                if (_browser.InitializationError != null)
+                    throw new ApplicationException(
+                        "The off-screen WebView2 failed to initialize.",
+                        _browser.InitializationError
+                    );
                 if (timer.ElapsedMilliseconds > kInitTimeoutMs)
                     throw new ApplicationException(
                         "Timed out initializing the off-screen WebView2."

--- a/src/BloomExe/Spreadsheet/SpreadsheetImporter.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetImporter.cs
@@ -192,7 +192,12 @@ namespace Bloom.Spreadsheet
             {
                 if (ControlForInvoke != null && ControlForInvoke.InvokeRequired)
                 {
-                    return (Browser)
+                    // Invoke returns whatever the delegate returned, and this delegate is async, so what
+                    // comes back is the Task it returned at its first await -- not a Browser. Casting it
+                    // straight to Browser was an InvalidCastException waiting to happen, and would also
+                    // have handed back a browser that did not exist yet. Await the Task instead, the way
+                    // GetMd5Async does below. (BL-16773)
+                    return await (Task<Browser>)
                         ControlForInvoke.Invoke(new GetBrowserDelegate(GetBrowserAsync));
                 }
                 // Todo Linux: I'm choosing not to do BrowserMaker.MakeBrowser here, because
@@ -202,6 +207,15 @@ namespace Bloom.Spreadsheet
                 // about to drop. So if we want this on Linux, we'll have to test carefully there,
                 // and possibly make a new overload of NavigateAndWaitUntilDone if the wait code here
                 // is not good enough.
+                //
+                // This browser is created on whatever thread we are on, and is then used across the
+                // awaits below, so that thread has to be an STA thread with a message loop or WebView2
+                // cannot initialize at all. Two arrangements provide that, and there is no third caller:
+                // in the app, ControlForInvoke is set and the block above put us on the UI thread; in the
+                // console `spreadsheetImport` verb, ControlForInvoke is null but the command runs on the
+                // STA main thread inside Program.RunConsoleCommandLoop's message loop, and its awaits
+                // resume there. Before that loop existed, console import was exposed to exactly the
+                // failure bulk upload hit in BL-16767. See ConsoleCommandLoopTests. (BL-16773)
 #if __MonoCS__
                 _browser = new GeckoFxBrowser();
 #else

--- a/src/BloomExe/WebView2Browser.cs
+++ b/src/BloomExe/WebView2Browser.cs
@@ -32,9 +32,24 @@ namespace Bloom
         public static string AlternativeWebView2Path;
         private bool _readyToNavigate;
 
+        // Set if InitWebView failed. Since initialization is kicked off unawaited, this is the only
+        // record we have that it will never finish; without it, the browser just looks eternally
+        // not-yet-ready. See StartInitWebViewReportingAnyFailure. Volatile because it is written by
+        // that continuation (on whatever thread completes it) and read by the ready-waits below on
+        // the caller's thread, which spin on it.
+        private volatile Exception _initializationError;
+
         // Exposes whether the (async) CoreWebView2 environment initialization has finished. Lets callers
         // measure how long that init takes separately from the subsequent navigation (see BookProcessor).
         public override bool IsReadyToNavigate => _readyToNavigate;
+
+        /// <summary>
+        /// Why initialization failed, or null if it has not failed. Non-null means this browser will
+        /// never become ready to navigate, so a caller spinning on <see cref="IsReadyToNavigate"/> should
+        /// give up at once and blame this rather than its own timeout — see OffScreenBrowser, which owns
+        /// its own readiness wait and so cannot rely on the checks inside this class.
+        /// </summary>
+        internal Exception InitializationError => _initializationError;
         private PasteCommand _pasteCommand;
         private CopyCommand _copyCommand;
         private UndoCommand _undoCommand;
@@ -51,8 +66,9 @@ namespace Bloom
 
         // When set (via CreateWithInjectedEnvironment), InitWebView uses this already-created environment
         // instead of making its own. Lets OffScreenBrowser share one environment — one browser process,
-        // user-data folder, and HTTP cache — across the fresh browser it makes per page, thread-safely and
-        // without the global shared-environment batch statics.
+        // user-data folder, and HTTP cache — across the fresh browser it makes per page, thread-safely:
+        // the environment belongs to the instance that owns it, so instances on different threads never
+        // contend, and nothing global has to be set for the duration of a batch.
         private CoreWebView2Environment _injectedEnvironment;
 
         /// <summary>
@@ -70,7 +86,7 @@ namespace Bloom
             browser._injectedEnvironment = environment;
             browser.InitializeComponent();
             // Kicked off unawaited (like the default constructor); callers wait on IsReadyToNavigate.
-            _ = browser.InitWebView();
+            browser.StartInitWebViewReportingAnyFailure();
             return browser;
         }
 
@@ -119,7 +135,58 @@ namespace Bloom
             // something on that thread, it's really easy to deadlock.
             // A lot of this is because of the way that WinForms works, and when we finally get away from WinForms,
             // we may be able to get to an environment where we don't need to try so hard to avoid async.)
-            _ = InitWebView();
+            StartInitWebViewReportingAnyFailure();
+        }
+
+        /// <summary>
+        /// Starts the asynchronous WebView2 initialization without awaiting it — the constructors can't
+        /// await — but, unlike a bare "_ = InitWebView()", does not silently discard a failure.
+        /// </summary>
+        /// <remarks>
+        /// Nothing observes the Task, so an exception thrown inside InitWebView used to vanish entirely:
+        /// no log entry, no dialog, nothing. The browser was simply left with _readyToNavigate false
+        /// forever, and the first visible symptom came much later and somewhere else — a navigation
+        /// timeout, then "The instance of CoreWebView2 is uninitialized" from the next JavaScript call.
+        /// That is precisely how BL-16767 hid its own cause: bulk upload had drifted onto an MTA thread
+        /// pool thread, where CoreWebView2Environment.CreateAsync throws RPC_E_CHANGED_MODE ("Cannot
+        /// change thread mode after it is set") because WebView2 needs an STA thread. Recording the
+        /// error also lets the ready-waits below give up at once instead of spinning out their timeout.
+        /// </remarks>
+        private void StartInitWebViewReportingAnyFailure()
+        {
+            // The continuation runs on some other thread, so capture what is interesting about the
+            // creating thread now: which thread it was, and its apartment, is most of the diagnosis.
+            var creatingThreadId = Thread.CurrentThread.ManagedThreadId;
+            var creatingApartment = Thread.CurrentThread.GetApartmentState();
+            InitWebView()
+                .ContinueWith(
+                    task =>
+                    {
+                        var error = task.Exception?.GetBaseException();
+                        _initializationError =
+                            error ?? new ApplicationException("WebView2 initialization failed");
+                        if (Disposing || _inDisposeMethod || IsDisposed)
+                            return; // disposed before initialization completed. See BL-13593 and BL-11384.
+                        NonFatalProblem.Report(
+                            ModalIf.None,
+                            PassiveIf.None,
+                            "Bloom could not initialize a WebView2 browser.",
+                            "This browser will never become ready to navigate, so whatever asked for it"
+                                + " will fail later, most likely with a navigation timeout followed by"
+                                + " \"The instance of CoreWebView2 is uninitialized\". It was created on"
+                                + $" thread {creatingThreadId}, whose apartment state was"
+                                + $" {creatingApartment}."
+                                + (
+                                    creatingApartment == ApartmentState.STA
+                                        ? ""
+                                        : " WebView2 requires an STA thread with a message loop, so that"
+                                            + " by itself is enough to explain the failure; see BL-16767."
+                                ),
+                            error
+                        );
+                    },
+                    TaskContinuationOptions.OnlyOnFaulted
+                );
         }
 
         private void SetupEventHandling()
@@ -295,50 +362,6 @@ namespace Bloom
 
         static int dataFolderCounter = 0;
 
-        // When set (via BeginSharedEnvironmentBatch), all WebView2 browsers created during the batch
-        // share ONE CoreWebView2Environment — i.e. one browser process, one user-data folder, and one
-        // HTTP cache — instead of each creating its own. The first browser of the batch creates the
-        // environment; the rest reuse it. Each browser still gets its own fresh CoreWebView2 control
-        // (fresh renderer), so this does NOT reintroduce the single-control reuse-wedge. Used by
-        // BookProcessor's off-screen per-page fix-up to avoid paying environment creation per page.
-        //
-        // These statics assume the batch is UI-thread-only (which it is: all browser construction is
-        // marshalled to the UI thread, and BookProcessor drives the batch there). If another browser
-        // happens to be created during the batch (e.g. a thumbnail), it harmlessly joins the shared
-        // environment. They are NOT a mechanism for concurrent batches.
-        private static bool _useSharedEnvironment;
-        private static CoreWebView2Environment _sharedEnvironment;
-
-        public static void BeginSharedEnvironmentBatch()
-        {
-            AssertSharedEnvironmentStaticsAreUiThreadOnly();
-            _useSharedEnvironment = true;
-            _sharedEnvironment = null;
-        }
-
-        public static void EndSharedEnvironmentBatch()
-        {
-            AssertSharedEnvironmentStaticsAreUiThreadOnly();
-            _useSharedEnvironment = false;
-            // Drop our reference; the underlying browser process/profile is released once the last
-            // CoreWebView2 using this environment is disposed. (CoreWebView2Environment is not IDisposable.)
-            _sharedEnvironment = null;
-        }
-
-        // The shared-environment statics above have no synchronization; they are safe only because the
-        // batch is UI-thread-only (see the comment on _useSharedEnvironment). Assert that assumption so
-        // any future code that drives a batch off the UI thread trips here instead of silently corrupting
-        // state. Unit-test/console modes are exempt, as elsewhere in this file.
-        private static void AssertSharedEnvironmentStaticsAreUiThreadOnly()
-        {
-            Debug.Assert(
-                Program.RunningOnUiThread
-                    || Program.RunningUnitTests
-                    || Program.RunningInConsoleMode,
-                "Shared WebView2 environment batch must be driven on the UI thread (these statics are unsynchronized)"
-            );
-        }
-
         private async Task InitWebView()
         {
             // based on https://stackoverflow.com/questions/63404822/how-to-disable-cors-in-wpf-webview2
@@ -468,13 +491,11 @@ namespace Bloom
             // because EnsureCoreWebView2Async still fires this control's own InitializationCompleted, which
             // is what sets _readyToNavigate.)
             SetupEventHandling();
-            // Reuse an existing environment (and its browser process + user-data folder + HTTP cache) when we
-            // can, so we don't pay environment creation per browser:
-            //  - _injectedEnvironment: an environment handed to this instance (OffScreenBrowser shares one
-            //    environment across the fresh browser it creates per page — see CreateWithInjectedEnvironment);
-            //  - _sharedEnvironment: the legacy on-UI-thread shared-environment batch (BookProcessor's old path).
-            // Otherwise we fall through and create a fresh one.
-            var env = _injectedEnvironment ?? (_useSharedEnvironment ? _sharedEnvironment : null);
+            // Reuse an environment handed to this instance (and its browser process + user-data folder +
+            // HTTP cache) when there is one, so we don't pay environment creation per browser:
+            // OffScreenBrowser shares one environment across the fresh browser it creates per page — see
+            // CreateWithInjectedEnvironment. Otherwise we fall through and create a fresh one.
+            var env = _injectedEnvironment;
             if (env == null)
             {
                 string dataFolder;
@@ -492,8 +513,6 @@ namespace Bloom
                     userDataFolder: dataFolder,
                     options: op
                 );
-                if (_useSharedEnvironment)
-                    _sharedEnvironment = env;
             }
             await _webview.EnsureCoreWebView2Async(env);
             // Added as a footnote to BL-15466 to prevent popups generated from title
@@ -643,9 +662,28 @@ namespace Bloom
             // threw an Exception indicating it was not ready, waiting like this fixed it.
             while (!_readyToNavigate)
             {
+                // Initialization failed, so waiting can only loop forever. Fail with the real cause
+                // rather than hanging (BL-16767).
+                if (_initializationError != null)
+                    throw new ApplicationException(
+                        "This WebView2 browser failed to initialize, so it can never become ready to navigate.",
+                        _initializationError
+                    );
                 Application.DoEvents();
                 Thread.Sleep(10);
             }
+        }
+
+        /// <summary>
+        /// The exception to throw when this browser's initialization failed, so that callers see the
+        /// real cause (as the InnerException) rather than a downstream timeout or a null CoreWebView2.
+        /// </summary>
+        private ApplicationException InitializationFailedException()
+        {
+            return new ApplicationException(
+                "Browser failed to initialize, so it could not load a page.",
+                _initializationError
+            );
         }
 
         // This variation should be used by clients that use a stopwatch
@@ -655,7 +693,11 @@ namespace Bloom
         // Callers should check that _readyToNavigate is true on return.
         private void EnsureBrowserReadyToNavigate(Stopwatch navTimer, int timeLimit)
         {
-            while (!_readyToNavigate && navTimer.ElapsedMilliseconds < timeLimit)
+            while (
+                !_readyToNavigate
+                && _initializationError == null // waiting is hopeless once init has failed (BL-16767)
+                && navTimer.ElapsedMilliseconds < timeLimit
+            )
             {
                 Application.DoEvents();
                 Thread.Sleep(10);
@@ -686,6 +728,21 @@ namespace Bloom
             var navTimer = new Stopwatch();
             navTimer.Start();
             EnsureBrowserReadyToNavigate(navTimer, timeLimit);
+
+            // Initialization failed outright, so there is nothing to wait for: neither this navigation
+            // nor anything else with this browser can ever work. Give up now, naming the real cause,
+            // instead of spending the whole timeLimit waiting for a navigation we never started and
+            // then reporting it as a timeout (BL-16767).
+            if (_initializationError != null)
+            {
+                if (throwOnTimeout)
+                    throw InitializationFailedException();
+                Logger.WriteError(
+                    "Not navigating: this WebView2 browser failed to initialize.",
+                    _initializationError
+                );
+                return false;
+            }
 
             EventHandler<CoreWebView2NavigationCompletedEventArgs> navigationCompletedHandler =
                 null;
@@ -727,11 +784,17 @@ namespace Bloom
                 if (!done)
                 {
                     if (throwOnTimeout)
+                    {
+                        // Initialization can also fail after the point where it set _readyToNavigate.
+                        // Blame that rather than a timeout that never had a chance (BL-16767).
+                        if (_initializationError != null)
+                            throw InitializationFailedException();
                         throw new ApplicationException(
                             _readyToNavigate
                                 ? "Browser unexpectedly took too long to load a page"
                                 : "Browser unexpectedly took too long to initialize"
                         );
+                    }
                     else
                         return false;
                 }

--- a/src/BloomExe/web/controllers/ExternalApi.cs
+++ b/src/BloomExe/web/controllers/ExternalApi.cs
@@ -27,9 +27,11 @@ namespace Bloom.web.controllers
         // Re-entrancy guard for process-book. A process-book request is validated and dispatched on
         // the UI thread (HandleProcessBook), which sets this flag true, kicks off the heavy work on a
         // background thread (see the Task.Run in HandleProcessBook), and returns immediately. We
-        // reject a second process-book that arrives while one is still running, because the
-        // shared-environment statics in WebView2Browser (_useSharedEnvironment/_sharedEnvironment) are
-        // explicitly NOT designed for overlapping batches and would corrupt each other.
+        // reject a second process-book that arrives while one is still running. The job status this API
+        // exposes is a single most-recent-job model (see the status endpoint below), so a second
+        // overlapping run would have nowhere to report itself and would leave callers watching the
+        // wrong job; on top of that the user is blocked behind the opaque busy overlay for the whole
+        // 20-30s, so a second concurrent browser-driven pass buys nothing and just contends for CPU.
         //
         // The UI thread is the only writer of 'true', and it reads the flag (to reject overlaps) and
         // then sets it with no message pumping in between, so that check-then-set is atomic against
@@ -244,7 +246,11 @@ namespace Bloom.web.controllers
             // applies the browser-only fix-ups (image sizing, canvas-element layout, etc.) that raw
             // generated HTML is missing. The call blocks until processing is complete.
             //
-            // This must run on the UI thread because it creates and pumps an off-screen WebView2.
+            // handleOnUiThread applies to the DISPATCH only, and not because of the browser: the heavy
+            // work runs on a background thread, and the browser it drives lives on the OffScreenBrowser's
+            // own thread (see the Task.Run in HandleProcessBook). The dispatch needs the UI thread because
+            // it reads UI-owned _bookSelection/_collectionModel state, and because its check-then-set of
+            // the re-entrancy flag is only atomic while nothing pumps in between.
             //
             // requiresSync: false is essential here. The off-screen editable page this handler loads
             // makes its own /bloom/api/* calls during bootstrap (image/info to size images, bubble
@@ -324,7 +330,7 @@ namespace Bloom.web.controllers
 
             // Reject a process-book that arrives while one is already running (see field comment).
             // BloomBridge sends these sequentially so in practice this never trips, but it makes the
-            // re-entrancy contract explicit and protects the shared-environment statics if it ever does.
+            // re-entrancy contract explicit and keeps the single-job status model honest if it ever does.
             if (_processBookInProgress)
             {
                 request.Failed(

--- a/src/BloomTests/ConsoleCommandLoopTests.cs
+++ b/src/BloomTests/ConsoleCommandLoopTests.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using Bloom;
+using NUnit.Framework;
+
+namespace BloomTests
+{
+    /// <summary>
+    /// Covers Program.RunConsoleCommandLoop, which is how console-mode commands are run. The property
+    /// that matters, and that WebView2 depends on, is that an await inside a console command resumes on
+    /// the STA thread that started it. Console mode used to wait for its command with a bare
+    /// "while (!task.IsCompleted) Application.DoEvents();" loop, which silently broke that property and
+    /// is what made bulk upload fail from the second book onwards (BL-16767).
+    /// </summary>
+    [TestFixture]
+    [Apartment(ApartmentState.STA)]
+    public class ConsoleCommandLoopTests
+    {
+        /// <summary>
+        /// The core property: a console command's awaits come back to the STA thread that started it,
+        /// for the first await and every later one.
+        /// </summary>
+        [Test]
+        public void RunConsoleCommandLoop_AwaitsResumeOnTheCallingStaThread()
+        {
+            var callingThread = Thread.CurrentThread.ManagedThreadId;
+            var threadAtStart = -1;
+            var threadAfterFirstAwait = -1;
+            var threadAfterSecondAwait = -1;
+            var apartmentAfterAwait = ApartmentState.Unknown;
+
+            var exitCode = Program.RunConsoleCommandLoop(async () =>
+            {
+                threadAtStart = Thread.CurrentThread.ManagedThreadId;
+                // Task.Delay really yields, which is the case that used to lose the thread.
+                await Task.Delay(20);
+                threadAfterFirstAwait = Thread.CurrentThread.ManagedThreadId;
+                apartmentAfterAwait = Thread.CurrentThread.GetApartmentState();
+                await Task.Delay(20);
+                threadAfterSecondAwait = Thread.CurrentThread.ManagedThreadId;
+                return 42;
+            });
+
+            Assert.That(exitCode, Is.EqualTo(42), "The command's exit code should be returned.");
+            Assert.That(
+                threadAtStart,
+                Is.EqualTo(callingThread),
+                "Sanity check: the command should start on the thread that ran the loop."
+            );
+            Assert.That(
+                threadAfterFirstAwait,
+                Is.EqualTo(callingThread),
+                "After the first await the command must be back on the thread that ran the loop; "
+                    + "otherwise a WebView2 created by a console command cannot be used afterwards."
+            );
+            Assert.That(
+                threadAfterSecondAwait,
+                Is.EqualTo(callingThread),
+                "The command must stay on that thread for every later await too."
+            );
+            Assert.That(
+                apartmentAfterAwait,
+                Is.EqualTo(ApartmentState.STA),
+                "WebView2 can only be created on an STA thread, so the command must resume on one."
+            );
+        }
+
+        /// <summary>
+        /// The case BL-16767 actually failed on: a console command awaits something, and then creates and
+        /// uses a WebView2. Under the old DoEvents wait this ran on an MTA thread-pool thread, where
+        /// CoreWebView2Environment.CreateAsync throws RPC_E_CHANGED_MODE and the browser could never
+        /// become ready.
+        /// </summary>
+        [Test]
+        public void RunConsoleCommandLoop_WebView2CreatedAfterAnAwait_BecomesReady()
+        {
+            var apartmentWhereBrowserWasCreated = ApartmentState.Unknown;
+            var becameReady = false;
+
+            var exitCode = Program.RunConsoleCommandLoop(async () =>
+            {
+                await Task.Delay(20);
+                apartmentWhereBrowserWasCreated = Thread.CurrentThread.GetApartmentState();
+                using (var browser = new WebView2Browser())
+                {
+                    // Nothing parents this browser, so realize its window handle ourselves; WebView2
+                    // initialization can only complete once the control has one.
+                    browser.CreateControl();
+                    var timer = Stopwatch.StartNew();
+                    // Awaiting (rather than blocking) hands control back to the message loop, which is
+                    // what lets the browser's initialization callbacks actually run.
+                    while (!browser.IsReadyToNavigate && timer.ElapsedMilliseconds < 20000)
+                        await Task.Delay(20);
+                    becameReady = browser.IsReadyToNavigate;
+                }
+                return 0;
+            });
+
+            Assert.That(exitCode, Is.EqualTo(0));
+            Assert.That(
+                apartmentWhereBrowserWasCreated,
+                Is.EqualTo(ApartmentState.STA),
+                "Sanity check: the browser must be created on an STA thread, or it could not work at all."
+            );
+            Assert.That(
+                becameReady,
+                Is.True,
+                "A WebView2 created by a console command after an await must be able to finish "
+                    + "initializing. This is exactly what bulk upload could not do (BL-16767)."
+            );
+        }
+
+        /// <summary>
+        /// The reason RunConsoleCommandLoop exists. This is a characterization test of WinForms, not of
+        /// our code: it records that Application.DoEvents(), used as the outermost message loop, throws
+        /// away the WindowsFormsSynchronizationContext, so an await stops coming back to this thread. If
+        /// WinForms ever stops doing this, this test fails and the loop above could be reconsidered.
+        /// </summary>
+        [Test]
+        public void DoEventsAsOutermostLoop_DiscardsTheWinFormsContext_WhichIsWhyWeNeedARealLoop()
+        {
+            // Establish the starting point rather than assuming it. WinForms only auto-installs its
+            // context when there isn't already one, and Application.Run leaves a plain
+            // SynchronizationContext behind when it exits -- so whether this test's premise holds would
+            // otherwise depend on which test in this fixture ran first.
+            SynchronizationContext.SetSynchronizationContext(null);
+            using (var control = new Control())
+            {
+                control.CreateControl();
+                Assert.That(
+                    SynchronizationContext.Current,
+                    Is.TypeOf<WindowsFormsSynchronizationContext>(),
+                    "Sanity check: creating a control with a handle should install the WinForms context."
+                );
+
+                Application.DoEvents();
+
+                Assert.That(
+                    SynchronizationContext.Current,
+                    Is.Not.TypeOf<WindowsFormsSynchronizationContext>(),
+                    "One outermost DoEvents() is enough to uninstall the WinForms context. This is the "
+                        + "trap the old console wait loop fell into."
+                );
+            }
+        }
+
+        /// <summary>
+        /// A command that throws before it can return a Task leaves nothing to complete the loop, so the
+        /// loop must end itself and report the exception rather than pumping forever.
+        /// </summary>
+        [Test]
+        public void RunConsoleCommandLoop_CommandThrowsBeforeReturningATask_PropagatesIt()
+        {
+            // Nothing will ever complete the command, so the loop has to end itself and report why,
+            // rather than pumping forever.
+            var exception = Assert.Throws<InvalidOperationException>(
+                () =>
+                    Program.RunConsoleCommandLoop(() =>
+                        throw new InvalidOperationException("could not start")
+                    ),
+                "A command that throws before returning its Task should not hang the loop."
+            );
+            Assert.That(exception.Message, Is.EqualTo("could not start"));
+        }
+
+        /// <summary>
+        /// A command whose Task faults part way through still ends the loop, and its exception reaches the
+        /// caller — wrapped in an AggregateException, as it was before this loop existed.
+        /// </summary>
+        [Test]
+        public void RunConsoleCommandLoop_CommandTaskFaults_PropagatesIt()
+        {
+            var exception = Assert.Throws<AggregateException>(() =>
+                Program.RunConsoleCommandLoop(async () =>
+                {
+                    await Task.Delay(10);
+                    throw new InvalidOperationException("failed part way");
+                })
+            );
+            Assert.That(exception.InnerException, Is.TypeOf<InvalidOperationException>());
+            Assert.That(exception.InnerException.Message, Is.EqualTo("failed part way"));
+        }
+    }
+}

--- a/src/BloomTests/WebView2BrowserInitFailureTests.cs
+++ b/src/BloomTests/WebView2BrowserInitFailureTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Bloom;
+using Bloom.Api;
+using Bloom.Book;
+using NUnit.Framework;
+
+namespace BloomTests
+{
+    /// <summary>
+    /// A WebView2 can only initialize on an STA thread with a message loop. This fixture covers what
+    /// happens when it is created somewhere it cannot possibly initialize — the situation bulk upload
+    /// drifted into in BL-16767, where the code had migrated onto an MTA thread-pool thread.
+    ///
+    /// The point is not that creating a browser there should work; it can't. The point is that the
+    /// failure must be visible and immediate. Before the fix, the constructor kicked initialization
+    /// off as "_ = InitWebView()", so the exception was discarded without a trace and the browser was
+    /// simply left forever not-ready: callers spun out their whole timeout and then failed with the
+    /// baffling "The instance of CoreWebView2 is uninitialized", far from the real cause.
+    /// </summary>
+    [TestFixture]
+    public class WebView2BrowserInitFailureTests
+    {
+        /// <summary>
+        /// Runs the given action on a thread-pool thread (which is always MTA) and blocks for it.
+        /// </summary>
+        private static void RunOnThreadPoolThread(Action action)
+        {
+            Task.Run(action).GetAwaiter().GetResult();
+        }
+
+        [Test]
+        public void BrowserCreatedWhereItCannotInitialize_ReportsTheFailure()
+        {
+            NonFatalProblem.LastNonFatalProblemReported = null;
+            RunOnThreadPoolThread(() =>
+            {
+                Assert.That(
+                    Thread.CurrentThread.GetApartmentState(),
+                    Is.EqualTo(ApartmentState.MTA),
+                    "Sanity check: a thread-pool thread should be MTA, which is what WebView2 cannot initialize on."
+                );
+                var browser = new WebView2Browser();
+                try
+                {
+                    // Initialization is asynchronous, so give it a moment to fail.
+                    var timer = Stopwatch.StartNew();
+                    while (
+                        NonFatalProblem.LastNonFatalProblemReported == null
+                        && timer.ElapsedMilliseconds < 20000
+                    )
+                        Thread.Sleep(20);
+
+                    Assert.That(
+                        NonFatalProblem.LastNonFatalProblemReported,
+                        Is.Not.Null,
+                        "Initialization failed but nothing was reported, so the failure is invisible again."
+                    );
+                    Assert.That(
+                        NonFatalProblem.LastNonFatalProblemReported,
+                        Does.Contain("WebView2"),
+                        "The report should say what failed."
+                    );
+                    Assert.That(
+                        browser.IsReadyToNavigate,
+                        Is.False,
+                        "Sanity check: the browser cannot have become ready to navigate."
+                    );
+                    // Callers that run their own readiness wait (OffScreenBrowser does) can only give up
+                    // early if the failure is visible to them, so it has to be exposed, not just logged.
+                    Assert.That(
+                        browser.InitializationError,
+                        Is.Not.Null,
+                        "The failure must be readable from outside, so a caller spinning on "
+                            + "IsReadyToNavigate can stop instead of waiting out its own timeout."
+                    );
+                }
+                finally
+                {
+                    browser.Dispose();
+                }
+            });
+        }
+
+        [Test]
+        public void NavigateAndWaitTillDone_AfterInitFailure_ThrowsAtOnceWithTheRealCause()
+        {
+            RunOnThreadPoolThread(() =>
+            {
+                var browser = new WebView2Browser();
+                try
+                {
+                    const int timeLimit = 30000;
+                    var dom = new HtmlDom(
+                        "<html><body><div class='bloom-page'>hello</div></body></html>"
+                    );
+                    var timer = Stopwatch.StartNew();
+                    var exception = Assert.Throws<ApplicationException>(
+                        () =>
+                            browser.NavigateAndWaitTillDone(
+                                dom,
+                                timeLimit,
+                                InMemoryHtmlFileSource.JustCheckingPage,
+                                () => false,
+                                throwOnTimeout: true
+                            ),
+                        "A browser that failed to initialize should refuse to navigate rather than time out."
+                    );
+                    // The old code waited out the whole limit twice over (once for readiness, once for
+                    // the navigation that was never started). It must now give up as soon as it knows.
+                    Assert.That(
+                        timer.ElapsedMilliseconds,
+                        Is.LessThan(timeLimit),
+                        "It should fail as soon as initialization fails, not spin out the timeout."
+                    );
+                    Assert.That(
+                        exception.InnerException,
+                        Is.Not.Null,
+                        "The real cause of the initialization failure should be passed on, so that whoever "
+                            + "reads the log can see why the browser never came up."
+                    );
+                }
+                finally
+                {
+                    browser.Dispose();
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
**Problem.** Command-line Bloom could not reliably use a browser. Bulk upload was the visible casualty (BL-16767, fixed separately in #8246): every book after the first failed with "The instance of CoreWebView2 is uninitialized." The same trap sat under console `spreadsheetImport` of a spreadsheet carrying audio, and under anything else a console verb might want a browser for. Worse, when it sprang it said nothing useful — the real error was thrown away, and what surfaced twenty seconds later was a navigation timeout somewhere else.

**Cause.** Console mode waited for its command by spinning `Application.DoEvents()`. As the *outermost* message loop, that uninstalls the `WindowsFormsSynchronizationContext` and leaves a plain one, whose `Post` queues to the thread pool — so from the first `await` that actually yielded, console work moved onto MTA thread-pool threads. A WebView2 cannot even be created there: `CoreWebView2Environment.CreateAsync` needs an STA thread and throws `RPC_E_CHANGED_MODE`. `Program.Main`'s own comment said a synchronous `Main` was kept precisely to stop this happening; the wait loop immediately below it undid it. And because the browser constructors started initialization as `_ = InitWebView()`, nothing ever observed the resulting exception.

**Fix.**
- Console commands now run inside a real message loop (`Program.RunConsoleCommandLoop`), and are started from *inside* it, so their awaits resume on the pumping STA main thread. This is what actually fixes the class of bug, console spreadsheet import included.
- A failed WebView2 initialization is now recorded and reported — log, Sentry, and stderr in console mode — naming the creating thread and its apartment state. Every ready-wait, including `OffScreenBrowser`'s own (which runs its readiness loop on the thread it owns), now gives up at once with the real cause instead of spinning out a timeout and then blaming the timeout.
- `SpreadsheetImporter.GetBrowserAsync` no longer casts the `Task<Browser>` that `Control.Invoke` hands back to `(Browser)`.
- Removed about forty lines of dead shared-WebView2-environment machinery, and corrected two comments that had explained themselves in terms of it.

**The one new hazard, and what was done about it.** Because awaits now come back to the main thread, sync-over-async on that thread can deadlock, where under the old wait it could not. Every blocking wait reachable from a console verb was checked and is safe — each waits on a library task that uses `ConfigureAwait(false)` internally, on work owned by another thread, or through `AsyncUtil.RunSync`, which pins to `TaskScheduler.Default` for exactly this reason. `RunConsoleCommandLoop`'s doc comment records the hazard, which calls are safe and why, and that blocking on one of Bloom's own async methods is the case to avoid.

Not a behavior change for the desktop app: nested inside `Application.Run`, `DoEvents` never discarded the context, which is why only console mode was affected.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16773



Cherry-picked from #8251, which was mistakenly opened against `master`.


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8261)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8261)
<!-- Reviewable:end -->
