### PR TITLE
BL-15958 Expand full-bleed page-size support and dotImpose handoff

### DIFF
--- a/DistFiles/pageSizesLookup.json
+++ b/DistFiles/pageSizesLookup.json
@@ -1,0 +1,516 @@
+{
+    "sizes": {
+        "A5Portrait": {
+            "width": 148,
+            "height": 210
+        },
+        "A5": {
+            "width": 148,
+            "height": 210
+        },
+        "A5Landscape": {
+            "width": 210,
+            "height": 148
+        },
+        "B5Portrait": {
+            "width": 176,
+            "height": 250
+        },
+        "B5": {
+            "width": 176,
+            "height": 250
+        },
+        "A4Landscape": {
+            "width": 297,
+            "height": 210
+        },
+        "A4": {
+            "width": 210,
+            "height": 297
+        },
+        "A4Portrait": {
+            "width": 210,
+            "height": 297
+        },
+        "A3Landscape": {
+            "width": 420,
+            "height": 297
+        },
+        "A3": {
+            "width": 297,
+            "height": 420
+        },
+        "A3Portrait": {
+            "width": 297,
+            "height": 420
+        },
+        "A6Portrait": {
+            "width": 105,
+            "height": 148
+        },
+        "A6": {
+            "width": 105,
+            "height": 148
+        },
+        "A6Landscape": {
+            "width": 148,
+            "height": 105
+        },
+        "QuarterLetterPortrait": {
+            "width": 107.94999999999999,
+            "height": 139.7
+        },
+        "QuarterLetter": {
+            "width": 107.94999999999999,
+            "height": 139.7
+        },
+        "QuarterLetterLandscape": {
+            "width": 139.7,
+            "height": 107.94999999999999
+        },
+        "HalfLetterPortrait": {
+            "width": 139.7,
+            "height": 215.89999999999998
+        },
+        "HalfLetter": {
+            "width": 139.7,
+            "height": 215.89999999999998
+        },
+        "HalfLetterLandscape": {
+            "width": 215.89999999999998,
+            "height": 139.7
+        },
+        "LetterPortrait": {
+            "width": 215.89999999999998,
+            "height": 279.4
+        },
+        "Letter": {
+            "width": 215.89999999999998,
+            "height": 279.4
+        },
+        "LetterLandscape": {
+            "width": 279.4,
+            "height": 215.89999999999998
+        },
+        "HalfFolioPortrait": {
+            "width": 165.1,
+            "height": 215.89999999999998
+        },
+        "HalfFolio": {
+            "width": 165.1,
+            "height": 215.89999999999998
+        },
+        "HalfLegalPortrait": {
+            "width": 177.79999999999998,
+            "height": 215.89999999999998
+        },
+        "HalfLegal": {
+            "width": 177.79999999999998,
+            "height": 215.89999999999998
+        },
+        "HalfLegalLandscape": {
+            "width": 215.89999999999998,
+            "height": 177.79999999999998
+        },
+        "LegalPortrait": {
+            "width": 215.89999999999998,
+            "height": 355.59999999999997
+        },
+        "Legal": {
+            "width": 215.89999999999998,
+            "height": 355.59999999999997
+        },
+        "LegalLandscape": {
+            "width": 355.59999999999997,
+            "height": 215.89999999999998
+        },
+        "Cm13Landscape": {
+            "width": 130,
+            "height": 130
+        },
+        "Cm13": {
+            "width": 130,
+            "height": 130
+        },
+        "USComicPortrait": {
+            "width": 168.27499999999998,
+            "height": 260.34999999999997
+        },
+        "USComic": {
+            "width": 168.27499999999998,
+            "height": 260.34999999999997
+        },
+        "Ebook2x3Portrait": {
+            "width": 125.67708333333333,
+            "height": 185.20833333333334
+        },
+        "Ebook2x3": {
+            "width": 125.67708333333333,
+            "height": 185.20833333333334
+        },
+        "Ebook7x5Landscape": {
+            "width": 253.73541666666668,
+            "height": 182.5625
+        },
+        "Ebook7x5": {
+            "width": 253.73541666666668,
+            "height": 182.5625
+        },
+        "Size6x9Portrait": {
+            "width": 152.39999999999998,
+            "height": 228.6
+        },
+        "Size6x9": {
+            "width": 152.39999999999998,
+            "height": 228.6
+        },
+        "Size6x9Landscape": {
+            "width": 228.6,
+            "height": 152.39999999999998
+        },
+        "A0": {
+            "width": 841,
+            "height": 1189
+        },
+        "A1": {
+            "width": 594,
+            "height": 841
+        },
+        "A2": {
+            "width": 420,
+            "height": 594
+        },
+        "A7": {
+            "width": 74,
+            "height": 105
+        },
+        "A8": {
+            "width": 52,
+            "height": 74
+        },
+        "A9": {
+            "width": 37,
+            "height": 52
+        },
+        "A10": {
+            "width": 26,
+            "height": 37
+        },
+        "B0": {
+            "width": 1000,
+            "height": 1414
+        },
+        "B1": {
+            "width": 707,
+            "height": 1000
+        },
+        "B2": {
+            "width": 500,
+            "height": 707
+        },
+        "B3": {
+            "width": 353,
+            "height": 500
+        },
+        "B4": {
+            "width": 250,
+            "height": 353
+        },
+        "B6": {
+            "width": 125,
+            "height": 176
+        },
+        "B7": {
+            "width": 88,
+            "height": 125
+        },
+        "B8": {
+            "width": 62,
+            "height": 88
+        },
+        "B9": {
+            "width": 44,
+            "height": 62
+        },
+        "B10": {
+            "width": 31,
+            "height": 44
+        },
+        "Cm1": {
+            "width": 10,
+            "height": 10
+        },
+        "Cm2": {
+            "width": 20,
+            "height": 20
+        },
+        "Cm3": {
+            "width": 30,
+            "height": 30
+        },
+        "Cm4": {
+            "width": 40,
+            "height": 40
+        },
+        "Cm5": {
+            "width": 50,
+            "height": 50
+        },
+        "Cm6": {
+            "width": 60,
+            "height": 60
+        },
+        "Cm7": {
+            "width": 70,
+            "height": 70
+        },
+        "Cm8": {
+            "width": 80,
+            "height": 80
+        },
+        "Cm9": {
+            "width": 90,
+            "height": 90
+        },
+        "Cm10": {
+            "width": 100,
+            "height": 100
+        },
+        "Cm11": {
+            "width": 110,
+            "height": 110
+        },
+        "Cm12": {
+            "width": 120,
+            "height": 120
+        },
+        "Cm14": {
+            "width": 140,
+            "height": 140
+        },
+        "Cm15": {
+            "width": 150,
+            "height": 150
+        },
+        "Cm16": {
+            "width": 160,
+            "height": 160
+        },
+        "Cm17": {
+            "width": 170,
+            "height": 170
+        },
+        "Cm18": {
+            "width": 180,
+            "height": 180
+        },
+        "Cm19": {
+            "width": 190,
+            "height": 190
+        },
+        "Cm20": {
+            "width": 200,
+            "height": 200
+        },
+        "Cm21": {
+            "width": 210,
+            "height": 210
+        },
+        "Cm22": {
+            "width": 220,
+            "height": 220
+        },
+        "Cm23": {
+            "width": 230,
+            "height": 230
+        },
+        "Cm24": {
+            "width": 240,
+            "height": 240
+        },
+        "Cm25": {
+            "width": 250,
+            "height": 250
+        },
+        "Cm26": {
+            "width": 260,
+            "height": 260
+        },
+        "Cm27": {
+            "width": 270,
+            "height": 270
+        },
+        "Cm28": {
+            "width": 280,
+            "height": 280
+        },
+        "Cm29": {
+            "width": 290,
+            "height": 290
+        },
+        "Cm30": {
+            "width": 300,
+            "height": 300
+        },
+        "Cm31": {
+            "width": 310,
+            "height": 310
+        },
+        "Cm32": {
+            "width": 320,
+            "height": 320
+        },
+        "Cm33": {
+            "width": 330,
+            "height": 330
+        },
+        "Cm34": {
+            "width": 340,
+            "height": 340
+        },
+        "Cm35": {
+            "width": 350,
+            "height": 350
+        },
+        "Cm36": {
+            "width": 360,
+            "height": 360
+        },
+        "Cm37": {
+            "width": 370,
+            "height": 370
+        },
+        "Cm38": {
+            "width": 380,
+            "height": 380
+        },
+        "Cm39": {
+            "width": 390,
+            "height": 390
+        },
+        "Cm40": {
+            "width": 400,
+            "height": 400
+        },
+        "Cm41": {
+            "width": 410,
+            "height": 410
+        },
+        "Cm42": {
+            "width": 420,
+            "height": 420
+        },
+        "Cm43": {
+            "width": 430,
+            "height": 430
+        },
+        "Cm44": {
+            "width": 440,
+            "height": 440
+        },
+        "Cm45": {
+            "width": 450,
+            "height": 450
+        },
+        "Cm46": {
+            "width": 460,
+            "height": 460
+        },
+        "Cm47": {
+            "width": 470,
+            "height": 470
+        },
+        "Cm48": {
+            "width": 480,
+            "height": 480
+        },
+        "Cm49": {
+            "width": 490,
+            "height": 490
+        },
+        "Cm50": {
+            "width": 500,
+            "height": 500
+        },
+        "In1": {
+            "width": 25.4,
+            "height": 25.4
+        },
+        "In2": {
+            "width": 50.8,
+            "height": 50.8
+        },
+        "In3": {
+            "width": 76.19999999999999,
+            "height": 76.19999999999999
+        },
+        "In4": {
+            "width": 101.6,
+            "height": 101.6
+        },
+        "In5": {
+            "width": 127,
+            "height": 127
+        },
+        "In6": {
+            "width": 152.39999999999998,
+            "height": 152.39999999999998
+        },
+        "In7": {
+            "width": 177.79999999999998,
+            "height": 177.79999999999998
+        },
+        "In8": {
+            "width": 203.2,
+            "height": 203.2
+        },
+        "In9": {
+            "width": 228.6,
+            "height": 228.6
+        },
+        "In10": {
+            "width": 254,
+            "height": 254
+        },
+        "In11": {
+            "width": 279.4,
+            "height": 279.4
+        },
+        "In12": {
+            "width": 304.79999999999995,
+            "height": 304.79999999999995
+        },
+        "In13": {
+            "width": 330.2,
+            "height": 330.2
+        },
+        "In14": {
+            "width": 355.59999999999997,
+            "height": 355.59999999999997
+        },
+        "In15": {
+            "width": 381,
+            "height": 381
+        },
+        "In16": {
+            "width": 406.4,
+            "height": 406.4
+        },
+        "In17": {
+            "width": 431.79999999999995,
+            "height": 431.79999999999995
+        },
+        "In18": {
+            "width": 457.2,
+            "height": 457.2
+        },
+        "In19": {
+            "width": 482.59999999999997,
+            "height": 482.59999999999997
+        },
+        "In20": {
+            "width": 508,
+            "height": 508
+        }
+    }
+}

--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -269,7 +269,7 @@
 		<PackageReference Include="SIL.Windows.Forms.Keyboarding" Version="18.0.0-beta0028" />
 		<PackageReference Include="SIL.Windows.Forms.WritingSystems" Version="18.0.0-beta0028" />
 		<PackageReference Include="SIL.WritingSystems" Version="18.0.0-beta0028" />
-		<PackageReference Include="sillsdev.dotImpose" Version="2.6.2" />
+		<PackageReference Include="sillsdev.dotImpose" Version="2.6.7-test" />
 		<PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
 		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.2" />
 		<PackageReference Include="SQLitePCLRaw.core" Version="2.1.2" />

--- a/src/BloomExe/BloomExe.csproj
+++ b/src/BloomExe/BloomExe.csproj
@@ -269,7 +269,7 @@
 		<PackageReference Include="SIL.Windows.Forms.Keyboarding" Version="18.0.0-beta0028" />
 		<PackageReference Include="SIL.Windows.Forms.WritingSystems" Version="18.0.0-beta0028" />
 		<PackageReference Include="SIL.WritingSystems" Version="18.0.0-beta0028" />
-		<PackageReference Include="sillsdev.dotImpose" Version="2.6.7-test" />
+		<PackageReference Include="sillsdev.dotImpose" Version="2.6.8" />
 		<PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
 		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.2" />
 		<PackageReference Include="SQLitePCLRaw.core" Version="2.1.2" />

--- a/src/BloomExe/Book/SizeAndOrientation.cs
+++ b/src/BloomExe/Book/SizeAndOrientation.cs
@@ -17,6 +17,21 @@ namespace Bloom.Book
     /// </summary>
     public class SizeAndOrientation
     {
+        private static readonly Lazy<
+            Dictionary<string, (double width, double height)>
+        > s_pageSizesInMillimeters = new(LoadPageSizesInMillimeters);
+
+        private class PageSizeLookupFile
+        {
+            public Dictionary<string, PageSizeLookupItem> sizes { get; set; }
+        }
+
+        private class PageSizeLookupItem
+        {
+            public double width { get; set; }
+            public double height { get; set; }
+        }
+
         public string PageSizeName;
 
         public bool IsLandScape { get; set; }
@@ -103,6 +118,84 @@ namespace Bloom.Book
                     PageSizeName,
                     IsLandScape
                 ) != null;
+        }
+
+        public static bool TryGetSizeInMillimeters(
+            string sizeName,
+            out (double width, double height) size
+        )
+        {
+            size = default;
+            if (string.IsNullOrWhiteSpace(sizeName))
+                return false;
+
+            return s_pageSizesInMillimeters.Value.TryGetValue(sizeName, out size);
+        }
+
+        public static bool TryGetPaperLayoutInMillimeters(
+            string paperSizeName,
+            bool landscape,
+            out (double width, double height) size
+        )
+        {
+            size = default;
+            if (string.IsNullOrWhiteSpace(paperSizeName) || IsNonPaperLayout(paperSizeName))
+                return false;
+
+            var requestedOrientation = landscape ? "Landscape" : "Portrait";
+            var requestedKey = $"{paperSizeName}{requestedOrientation}";
+            if (TryGetSizeInMillimeters(requestedKey, out size))
+                return true;
+
+            var oppositeOrientation = landscape ? "Portrait" : "Landscape";
+            var oppositeKey = $"{paperSizeName}{oppositeOrientation}";
+            if (!TryGetSizeInMillimeters(oppositeKey, out var oppositeSize))
+            {
+                if (!TryGetSizeInMillimeters(paperSizeName, out size))
+                    return false;
+
+                if (landscape && size.width < size.height)
+                    size = (size.height, size.width);
+                else if (!landscape && size.width > size.height)
+                    size = (size.height, size.width);
+                return true;
+            }
+
+            size = (oppositeSize.height, oppositeSize.width);
+            return true;
+        }
+
+        private static Dictionary<
+            string,
+            (double width, double height)
+        > LoadPageSizesInMillimeters()
+        {
+            var map = new Dictionary<string, (double width, double height)>(
+                StringComparer.OrdinalIgnoreCase
+            );
+            var path = FileLocationUtilities.GetFileDistributedWithApplication(
+                "pageSizesLookup.json"
+            );
+            var json = RobustFile.ReadAllText(path);
+            var parsed = JsonConvert.DeserializeObject<PageSizeLookupFile>(json);
+            if (parsed?.sizes == null)
+                throw new ApplicationException("Could not parse pageSizesLookup.json.");
+
+            foreach (var item in parsed.sizes)
+            {
+                if (string.IsNullOrWhiteSpace(item.Key) || item.Value == null)
+                    continue;
+
+                map[item.Key] = (item.Value.width, item.Value.height);
+            }
+
+            return map;
+        }
+
+        private static bool IsNonPaperLayout(string pageSizeName)
+        {
+            return pageSizeName.StartsWith("Device", StringComparison.OrdinalIgnoreCase)
+                || pageSizeName.StartsWith("PictureStory", StringComparison.OrdinalIgnoreCase);
         }
 
         public static void AddClassesForLayout(HtmlDom dom, Layout layout)

--- a/src/BloomExe/Publish/Epub/EpubMaker.cs
+++ b/src/BloomExe/Publish/Epub/EpubMaker.cs
@@ -586,40 +586,15 @@ namespace Bloom.Publish.Epub
 
         public static void GetPageDimensions(string pageSize, out double width, out double height)
         {
-            var path = FileLocationUtilities.GetFileDistributedWithApplication("pageSizes.json");
-            var json = RobustFile.ReadAllText(path);
-            var sizes = DynamicJson.Parse(json).sizes;
-            // FirstOrDefault would be cleaner, but I can't figure out how to use it with dynamic data.
-            for (int i = 0; i < sizes.Count; i++)
+            const double pixelsPerMillimeter = 96d / 25.4d;
+            if (!SizeAndOrientation.TryGetSizeInMillimeters(pageSize, out var dimensions))
             {
-                if (sizes[i].size == pageSize)
-                {
-                    width = ConvertDimension(sizes[i].width);
-                    height = ConvertDimension(sizes[i].height);
-                    return;
-                }
+                // Unknown: use A5Portrait.
+                SizeAndOrientation.TryGetSizeInMillimeters("A5Portrait", out dimensions);
             }
-            // unknown: use first (which should be A5Portrait)
-            width = ConvertDimension(sizes[0].width);
-            height = ConvertDimension(sizes[0].height);
-        }
 
-        // Method must parse the json input in a culture invariant manner, since the computer's culture may not match
-        // the culture of the json file.
-        // Returns the dimension in pixels at 96 DPI. Supported units: "px" (already pixels),
-        // "mm", and anything else is treated as inches.
-        private static double ConvertDimension(string input)
-        {
-            string unit = input.Substring(input.Length - 2);
-            var num = Double.Parse(
-                input.Substring(0, input.Length - 2),
-                CultureInfo.InvariantCulture
-            );
-            double pixelsPerUnit =
-                unit == "px" ? 1
-                : unit == "mm" ? 96 / 25.4
-                : 96;
-            return num * pixelsPerUnit;
+            width = dimensions.width * pixelsPerMillimeter;
+            height = dimensions.height * pixelsPerMillimeter;
         }
 
         /// <summary>

--- a/src/BloomExe/Publish/PDF/MakePdfUsingExternalPdfMakerProgram.cs
+++ b/src/BloomExe/Publish/PDF/MakePdfUsingExternalPdfMakerProgram.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using Bloom.Api;
+using Bloom.Book;
 using Bloom.ToPalaso;
 using Bloom.web;
 using L10NSharp;
@@ -292,10 +293,6 @@ namespace Bloom.Publish.PDF
 
         const double inchesToMM = 25.4;
 
-        const double A4PortraitHeight = 297; // mm
-        private const double A4PortraitWidth = 210; // mm
-        private const double A3PortraitWidth = A4PortraitHeight;
-        private const double A3PortraitHeight = A4PortraitWidth * 2d;
         const double bleedWidth = 3; // mm
         private const double bleedExtra = bleedWidth * 2;
 
@@ -385,48 +382,31 @@ namespace Bloom.Publish.PDF
             bool landscape
         )
         {
-            double height;
-            double width;
-            switch (paperSizeName.ToLowerInvariant())
-            {
-                case "a5":
-                    height = A4PortraitWidth + bleedExtra;
-                    // we floor because that actually gives us the 148mm that is official
-                    width = Math.Floor(A4PortraitHeight / 2) + bleedExtra;
-                    break;
-                case "a4":
-                    height = A4PortraitHeight + bleedExtra;
-                    width = A4PortraitWidth + bleedExtra;
-                    break;
-                case "a3":
-                    height = A3PortraitHeight + bleedExtra;
-                    width = A3PortraitWidth + bleedExtra;
-                    break;
-                case "uscomic":
-                    height = USComicPortraitHeight + bleedExtra;
-                    width = USComicPortraitWidth + bleedExtra;
-                    break;
-                case "halffolio":
-                    // added for consistency, but not tested.
-                    height = HalfFolioPortraitHeight + bleedExtra;
-                    width = HalfFolioPortraitWidth + bleedExtra;
-                    break;
-                case "size6x9":
-                    height = Size6x9PortraitHeight + bleedExtra;
-                    width = Size6x9PortraitWidth + bleedExtra;
-                    break;
-                default:
-                    return null; // Page size doesn't support full bleed
-            }
+            if (!TryGetTrimPageSizeInMillimeters(paperSizeName, landscape, out var trimSize))
+                return null;
 
-            if (landscape)
-            {
-                var temp = height;
-                height = width;
-                width = temp;
-            }
+            var width = trimSize.width + bleedExtra;
+            var height = trimSize.height + bleedExtra;
 
             return (height, width);
+        }
+
+        private static bool TryGetTrimPageSizeInMillimeters(
+            string paperSizeName,
+            bool landscape,
+            out (double width, double height) trimSize
+        )
+        {
+            trimSize = default;
+
+            if (string.IsNullOrWhiteSpace(paperSizeName))
+                return false;
+
+            return SizeAndOrientation.TryGetPaperLayoutInMillimeters(
+                paperSizeName,
+                landscape,
+                out trimSize
+            );
         }
 
         private static void ConfigureFullBleedPageSize(StringBuilder bldr, PdfMakingSpecs specs)
@@ -438,7 +418,7 @@ namespace Bloom.Publish.PDF
             if (dimensions == null)
             {
                 var exception = new ArgumentException(
-                    $"Full bleed printing of paper size '{specs.PaperSizeName}' is not yet implemented. Supported sizes are: A5, A4, A3, USComic, HalfFolio, and Size6x9."
+                    $"Full bleed printing of paper size '{specs.PaperSizeName}' is not supported for this layout."
                 );
                 exception.Data["argument"] = "specs.PaperSizeName";
                 throw exception;
@@ -458,7 +438,7 @@ namespace Bloom.Publish.PDF
         public PublishModel.BookletPortions BookletPortion; // None,AllPagesNoBooklet,BookletCover,BookletPages,InnerContent
         public bool LayoutPagesForRightToLeft; // true if RTL, false if LTR layout
         public bool BookIsFullBleed; // True if the book is laid out for full-bleed printing (and Enterprise is enabled)
-        public bool PrintWithFullBleed; // True if (BookIsFullBleed and) full bleed is requested in the PdfOptions menu and we're not making a booklet
+        public bool PrintWithFullBleed; // True if BookIsFullBleed and full bleed is requested in the PdfOptions menu
         public string ColorProfile; // the name of the ICC color profile file to use, empty string if none
         public int HtmlPageCount;
 

--- a/src/BloomExe/Publish/PDF/PdfMaker.cs
+++ b/src/BloomExe/Publish/PDF/PdfMaker.cs
@@ -21,6 +21,8 @@ namespace Bloom.Publish.PDF
     /// </summary>
     public class PdfMaker
     {
+        private const double kFullBleedInsetMillimeters = 3;
+
         /// <summary>
         /// turns on crop marks and TrimBox
         /// </summary>
@@ -204,9 +206,41 @@ namespace Bloom.Publish.PDF
                     for (int i = lastEven; i > 0; i -= 2)
                         pdfDoc.Pages.RemoveAt(i);
                 }
+
+                if (specs.PrintWithFullBleed)
+                {
+                    // Ghostscript's pdfwrite pass can drop page-box metadata.
+                    // Recreate full-bleed boxes here so DotImpose gets the same trim/bleed intent
+                    // regardless of layouter choice (booklet and no-booklet).
+                    foreach (PdfPage page in pdfDoc.Pages)
+                        SetFullBleedPageBoxes(page);
+                }
+
                 pdfDoc.Save(specs.OutputPdfPath);
             }
             //Bloom.Utils.MemoryManagement.CheckMemory(true, "done checking for blank pages in full bleed PDF file", false);
+        }
+
+        private static void SetFullBleedPageBoxes(PdfPage page)
+        {
+            var bleedMargin = XUnit.FromMillimeter(kFullBleedInsetMillimeters);
+            var trimWidth = page.MediaBox.Width - (2 * bleedMargin.Point);
+            var trimHeight = page.MediaBox.Height - (2 * bleedMargin.Point);
+            if (trimWidth <= 0 || trimHeight <= 0)
+            {
+                throw new ApplicationException(
+                    $"Cannot set full-bleed page boxes for MediaBox {page.MediaBox.Width}x{page.MediaBox.Height}."
+                );
+            }
+
+            var trimBox = new PdfRectangle(
+                new XPoint(bleedMargin.Point, bleedMargin.Point),
+                new XSize(trimWidth, trimHeight)
+            );
+            page.BleedBox = page.MediaBox;
+            page.CropBox = page.MediaBox;
+            page.ArtBox = trimBox;
+            page.TrimBox = trimBox;
         }
 
         public static string GetDistributedColorProfilesFolder()
@@ -353,7 +387,9 @@ namespace Bloom.Publish.PDF
                 switch (specs.BooketLayoutMethod)
                 {
                     case PublishModel.BookletLayoutMethod.NoBooklet:
-                        method = new NullLayoutMethod(specs.PrintWithFullBleed ? 3 : 0);
+                        method = new NullLayoutMethod(
+                            GetNullLayoutBleedOffsetMm(specs.PrintWithFullBleed, ShowCropMarks)
+                        );
                         break;
                     case PublishModel.BookletLayoutMethod.SideFold:
                         // To keep the GUI simple, we assume that A6 page size for booklets
@@ -410,6 +446,12 @@ namespace Bloom.Publish.PDF
                     );
                 }
 
+                // var toDotImposePath = Path.Combine(
+                //     Path.GetTempPath(),
+                //     $"toDotImpose-{Guid.NewGuid():D}.pdf"
+                // );
+                // RobustFile.Copy(incoming.Path, toDotImposePath, true);
+
                 var pdf = XPdfForm.FromFile(incoming.Path); //REVIEW: this whole giving them the pdf and the file too... I checked once and it wasn't wasting effort...the path was only used with a NullLayout option
                 method.Layout(
                     pdf,
@@ -420,6 +462,19 @@ namespace Bloom.Publish.PDF
                     ShowCropMarks
                 );
             }
+        }
+
+        internal static double GetNullLayoutBleedOffsetMm(
+            bool printWithFullBleed,
+            bool showCropMarks
+        )
+        {
+            if (!printWithFullBleed)
+                return 0;
+
+            // Full-bleed input pages are already trim + 3mm on each edge, so we
+            // inset trim from bleed by 3mm regardless of crop mark visibility.
+            return kFullBleedInsetMillimeters;
         }
     }
 

--- a/src/BloomExe/Publish/PDF/PdfMaker.cs
+++ b/src/BloomExe/Publish/PDF/PdfMaker.cs
@@ -221,7 +221,7 @@ namespace Bloom.Publish.PDF
             //Bloom.Utils.MemoryManagement.CheckMemory(true, "done checking for blank pages in full bleed PDF file", false);
         }
 
-        private static void SetFullBleedPageBoxes(PdfPage page)
+        internal static void SetFullBleedPageBoxes(PdfPage page)
         {
             var bleedMargin = XUnit.FromMillimeter(kFullBleedInsetMillimeters);
             var trimWidth = page.MediaBox.Width - (2 * bleedMargin.Point);
@@ -387,9 +387,10 @@ namespace Bloom.Publish.PDF
                 switch (specs.BooketLayoutMethod)
                 {
                     case PublishModel.BookletLayoutMethod.NoBooklet:
-                        method = new NullLayoutMethod(
-                            GetNullLayoutBleedOffsetMm(specs.PrintWithFullBleed, ShowCropMarks)
-                        );
+                        // Full-bleed source pages carry explicit trim/bleed boxes
+                        // (see SetFullBleedPageBoxes), so NullLayoutMethod needs no
+                        // synthetic trim inset.
+                        method = new NullLayoutMethod();
                         break;
                     case PublishModel.BookletLayoutMethod.SideFold:
                         // To keep the GUI simple, we assume that A6 page size for booklets
@@ -464,18 +465,6 @@ namespace Bloom.Publish.PDF
             }
         }
 
-        internal static double GetNullLayoutBleedOffsetMm(
-            bool printWithFullBleed,
-            bool showCropMarks
-        )
-        {
-            if (!printWithFullBleed)
-                return 0;
-
-            // Full-bleed input pages are already trim + 3mm on each edge, so we
-            // inset trim from bleed by 3mm regardless of crop mark visibility.
-            return kFullBleedInsetMillimeters;
-        }
     }
 
     internal class CancellableNullProgress : NullProgress

--- a/src/BloomExe/Publish/PDF/PublishPdfApi.cs
+++ b/src/BloomExe/Publish/PDF/PublishPdfApi.cs
@@ -350,6 +350,11 @@ namespace Bloom.Publish.PDF
         // that calls PublishModel.LoadBook.
         public void MakePdf()
         {
+            // Crop marks are automatic when print bleed is enabled.
+            // This applies to both Simple and booklet outputs.
+            _publishModel.ShowCropMarks =
+                (CurrentBook?.FullBleed ?? false) && (CurrentBook?.UserPrefs.FullBleed ?? false);
+
             var message = CheckForLicenseWarning();
             if (!String.IsNullOrEmpty(message))
             {

--- a/src/BloomExe/Publish/PublishModel.cs
+++ b/src/BloomExe/Publish/PublishModel.cs
@@ -384,6 +384,8 @@ namespace Bloom.Publish
 
         private bool GetPrintingWithFullBleed()
         {
+            // Booklet layouts expect trim-sized source pages; full-bleed source pages can
+            // produce incorrect sizing in the imposed output.
             return _currentlyLoadedBook.FullBleed
                 && GetBookletLayoutMethod() == BookletLayoutMethod.NoBooklet
                 && _currentlyLoadedBook.UserPrefs.FullBleed;

--- a/src/BloomTests/Publish/PDF/MakePdfUsingExternalPdfMakerProgramTests.cs
+++ b/src/BloomTests/Publish/PDF/MakePdfUsingExternalPdfMakerProgramTests.cs
@@ -1,0 +1,67 @@
+using Bloom.Publish.PDF;
+using NUnit.Framework;
+
+namespace BloomTests.Publish.PDF
+{
+    [TestFixture]
+    public class MakePdfUsingExternalPdfMakerProgramTests
+    {
+        [TestCase("A0", false, 1195, 847)]
+        [TestCase("A6", false, 154, 111)]
+        [TestCase("B5", false, 256, 182)]
+        [TestCase("Letter", false, 285.4, 221.9)]
+        [TestCase("Legal", false, 361.6, 221.9)]
+        [TestCase("HalfLetter", false, 221.9, 145.7)]
+        [TestCase("QuarterLetter", false, 145.7, 113.95)]
+        [TestCase("USComic", false, 266.35, 174.275)]
+        [TestCase("Size6x9", false, 234.6, 158.4)]
+        [TestCase("Cm13", false, 136, 136)]
+        [TestCase("In8", false, 209, 209)]
+        public void GetFullBleedPageSize_SupportedPaperSize_ReturnsBleedDimensions(
+            string paperSize,
+            bool landscape,
+            double expectedHeightMm,
+            double expectedWidthMm
+        )
+        {
+            var dimensions = MakePdfUsingExternalPdfMakerProgram.GetFullBleedPageSize(
+                paperSize,
+                landscape
+            );
+
+            Assert.That(
+                dimensions.HasValue,
+                Is.True,
+                $"Expected {paperSize} to support full bleed"
+            );
+            Assert.That(dimensions.Value.height, Is.EqualTo(expectedHeightMm).Within(0.2));
+            Assert.That(dimensions.Value.width, Is.EqualTo(expectedWidthMm).Within(0.2));
+        }
+
+        [Test]
+        public void GetFullBleedPageSize_Landscape_SwapsDimensions()
+        {
+            var portrait = MakePdfUsingExternalPdfMakerProgram.GetFullBleedPageSize("A4", false);
+            var landscape = MakePdfUsingExternalPdfMakerProgram.GetFullBleedPageSize("A4", true);
+
+            Assert.That(portrait.HasValue, Is.True);
+            Assert.That(landscape.HasValue, Is.True);
+            Assert.That(landscape.Value.height, Is.EqualTo(portrait.Value.width).Within(0.01));
+            Assert.That(landscape.Value.width, Is.EqualTo(portrait.Value.height).Within(0.01));
+        }
+
+        [TestCase("Device16x9")]
+        [TestCase("BogusSize")]
+        [TestCase("")]
+        [TestCase(null)]
+        public void GetFullBleedPageSize_NonPaperLayout_ReturnsNull(string paperSize)
+        {
+            var dimensions = MakePdfUsingExternalPdfMakerProgram.GetFullBleedPageSize(
+                paperSize,
+                false
+            );
+
+            Assert.That(dimensions.HasValue, Is.False);
+        }
+    }
+}

--- a/src/BloomTests/Publish/PDF/PdfMakerTests.cs
+++ b/src/BloomTests/Publish/PDF/PdfMakerTests.cs
@@ -2,7 +2,12 @@
 using System.IO;
 using Bloom.Publish;
 using Bloom.Publish.PDF;
+using DotImpose.LayoutMethods;
 using NUnit.Framework;
+using PdfSharp;
+using PdfSharp.Drawing;
+using PdfSharp.Pdf;
+using PdfSharp.Pdf.IO;
 using SIL.IO;
 
 namespace BloomTests.Publish.PDF
@@ -14,6 +19,62 @@ namespace BloomTests.Publish.PDF
     [NUnit.Framework.Category("RequiresUI")]
     public class PdfMakerTests
     {
+        [Test]
+        public void GetNullLayoutBleedOffsetMm_FullBleedWithoutCropMarks_IsJustBleedInset()
+        {
+            Assert.AreEqual(3, PdfMaker.GetNullLayoutBleedOffsetMm(true, false));
+        }
+
+        [Test]
+        public void GetNullLayoutBleedOffsetMm_FullBleedWithCropMarks_IncludesCropMargin()
+        {
+            Assert.AreEqual(3, PdfMaker.GetNullLayoutBleedOffsetMm(true, true));
+        }
+
+        [Test]
+        public void GetNullLayoutBleedOffsetMm_NotFullBleed_IsZero()
+        {
+            Assert.AreEqual(0, PdfMaker.GetNullLayoutBleedOffsetMm(false, true));
+            Assert.AreEqual(0, PdfMaker.GetNullLayoutBleedOffsetMm(false, false));
+        }
+
+        [Test]
+        public void NullLayoutMethod_FullBleedWithCropMarks_KeepsTrimAtFinalPageSize()
+        {
+            using (var input = TempFile.WithExtension("pdf"))
+            using (var output = TempFile.WithExtension("pdf"))
+            {
+                CreateSinglePagePdf(input.Path, 216, 303);
+                var method = new NullLayoutMethod(PdfMaker.GetNullLayoutBleedOffsetMm(true, true));
+
+                method.Layout(
+                    XPdfForm.FromFile(input.Path),
+                    input.Path,
+                    output.Path,
+                    new PaperTarget("A4", PageSize.A4),
+                    false,
+                    true
+                );
+
+                using (var outputDoc = PdfReader.Open(output.Path, PdfDocumentOpenMode.Import))
+                {
+                    var trimBox = outputDoc.Pages[0].TrimBox.ToXRect();
+                    Assert.AreEqual(
+                        210,
+                        XUnit.FromPoint(trimBox.Width).Millimeter,
+                        0.2,
+                        "Trim width should stay at final A4 width"
+                    );
+                    Assert.AreEqual(
+                        297,
+                        XUnit.FromPoint(trimBox.Height).Millimeter,
+                        0.2,
+                        "Trim height should stay at final A4 height"
+                    );
+                }
+            }
+        }
+
         [Test]
         public void MakePdf_BookStyleIsNone_OutputsPdf()
         {
@@ -337,6 +398,17 @@ namespace BloomTests.Publish.PDF
                 null
             );
             return eventArgs.Result as System.Exception;
+        }
+
+        private static void CreateSinglePagePdf(string path, double widthMm, double heightMm)
+        {
+            using (var doc = new PdfDocument())
+            {
+                var page = doc.AddPage();
+                page.Width = XUnit.FromMillimeter(widthMm);
+                page.Height = XUnit.FromMillimeter(heightMm);
+                doc.Save(path);
+            }
         }
     }
 }

--- a/src/BloomTests/Publish/PDF/PdfMakerTests.cs
+++ b/src/BloomTests/Publish/PDF/PdfMakerTests.cs
@@ -20,32 +20,15 @@ namespace BloomTests.Publish.PDF
     public class PdfMakerTests
     {
         [Test]
-        public void GetNullLayoutBleedOffsetMm_FullBleedWithoutCropMarks_IsJustBleedInset()
-        {
-            Assert.AreEqual(3, PdfMaker.GetNullLayoutBleedOffsetMm(true, false));
-        }
-
-        [Test]
-        public void GetNullLayoutBleedOffsetMm_FullBleedWithCropMarks_IncludesCropMargin()
-        {
-            Assert.AreEqual(3, PdfMaker.GetNullLayoutBleedOffsetMm(true, true));
-        }
-
-        [Test]
-        public void GetNullLayoutBleedOffsetMm_NotFullBleed_IsZero()
-        {
-            Assert.AreEqual(0, PdfMaker.GetNullLayoutBleedOffsetMm(false, true));
-            Assert.AreEqual(0, PdfMaker.GetNullLayoutBleedOffsetMm(false, false));
-        }
-
-        [Test]
         public void NullLayoutMethod_FullBleedWithCropMarks_KeepsTrimAtFinalPageSize()
         {
             using (var input = TempFile.WithExtension("pdf"))
             using (var output = TempFile.WithExtension("pdf"))
             {
-                CreateSinglePagePdf(input.Path, 216, 303);
-                var method = new NullLayoutMethod(PdfMaker.GetNullLayoutBleedOffsetMm(true, true));
+                // Full-bleed source pages carry explicit trim/bleed boxes, exactly as
+                // PdfMaker sets them before the dotImpose handoff.
+                CreateSinglePagePdf(input.Path, 216, 303, fullBleedBoxes: true);
+                var method = new NullLayoutMethod();
 
                 method.Layout(
                     XPdfForm.FromFile(input.Path),
@@ -400,13 +383,20 @@ namespace BloomTests.Publish.PDF
             return eventArgs.Result as System.Exception;
         }
 
-        private static void CreateSinglePagePdf(string path, double widthMm, double heightMm)
+        private static void CreateSinglePagePdf(
+            string path,
+            double widthMm,
+            double heightMm,
+            bool fullBleedBoxes = false
+        )
         {
             using (var doc = new PdfDocument())
             {
                 var page = doc.AddPage();
                 page.Width = XUnit.FromMillimeter(widthMm);
                 page.Height = XUnit.FromMillimeter(heightMm);
+                if (fullBleedBoxes)
+                    PdfMaker.SetFullBleedPageBoxes(page);
                 doc.Save(path);
             }
         }

--- a/src/content/pageSizes.ts
+++ b/src/content/pageSizes.ts
@@ -1,20 +1,204 @@
 import { writeFileSync, readFileSync } from "fs";
 
 // This file implements the package.json command build:pageSizes, which creates
-// bookLayout/page-size-mixin.less from a DistFiles/pageSizes.json
+// bookLayout/page-size-mixin.less and DistFiles/pageSizesLookup.json from DistFiles/pageSizes.json.
 interface PageSize {
     size: string;
     width: string;
     height: string;
 }
 
-var input = readFileSync("../../DistFiles/pageSizes.json", "utf8");
-var sizes = JSON.parse(input);
-var data = "";
-for (var item of sizes.sizes) {
-    const pageSize: PageSize = item as PageSize;
-    data += "@" + pageSize.size + "-Height: " + pageSize.height + ";\n";
-    data += "@" + pageSize.size + "-Width: " + pageSize.width + ";\n";
+interface PageSizesFile {
+    sizes: PageSize[];
 }
 
-writeFileSync("bookLayout/page-size-mixin.less", data);
+interface PageSizeLookupEntry {
+    width: number;
+    height: number;
+}
+
+interface PageSizeLookupFile {
+    sizes: Record<string, PageSizeLookupEntry>;
+}
+
+const sourcePath = "../../DistFiles/pageSizes.json";
+const lessOutputPath = "bookLayout/page-size-mixin.less";
+const lookupOutputPath = "../../DistFiles/pageSizesLookup.json";
+const inchesToMillimeters = 25.4;
+
+/**
+ * Reads the canonical page size list from DistFiles.
+ */
+function readConfiguredPageSizes(): PageSize[] {
+    const input = readFileSync(sourcePath, "utf8");
+    const parsed = JSON.parse(input) as PageSizesFile;
+    return parsed.sizes;
+}
+
+/**
+ * Converts a CSS-style dimension string (e.g. "148mm", "8.5in", "475px") to millimeters.
+ * Pixels are CSS pixels at 96 per inch.
+ */
+function convertDimensionToMillimeters(value: string): number {
+    if (value.endsWith("mm")) {
+        return Number.parseFloat(value.substring(0, value.length - 2));
+    }
+
+    if (value.endsWith("in")) {
+        const inches = Number.parseFloat(value.substring(0, value.length - 2));
+        return inches * inchesToMillimeters;
+    }
+
+    if (value.endsWith("px")) {
+        const pixels = Number.parseFloat(value.substring(0, value.length - 2));
+        return (pixels / 96) * inchesToMillimeters;
+    }
+
+    throw new Error(`Unsupported page-size unit in '${value}'.`);
+}
+
+/**
+ * Returns true when the layout is a printable paper layout (not a device/story preset).
+ */
+function isPaperLayout(sizeName: string): boolean {
+    return (
+        !sizeName.startsWith("Device") && !sizeName.startsWith("PictureStory")
+    );
+}
+
+/**
+ * Returns the base paper name for oriented sizes (e.g. A4Portrait -> A4).
+ */
+function getBaseSizeName(sizeName: string): string | undefined {
+    for (const suffix of ["Portrait", "Landscape"]) {
+        if (sizeName.endsWith(suffix)) {
+            return sizeName.slice(0, -suffix.length);
+        }
+    }
+
+    return undefined;
+}
+
+/**
+ * Builds the less variable content consumed by the layout stylesheets.
+ * Each size produces @{size}-Height and @{size}-Width variables.
+ */
+function buildLessPageSizeVariables(configuredSizes: PageSize[]): string {
+    let data = "";
+    for (const pageSize of configuredSizes) {
+        data += `@${pageSize.size}-Height: ${pageSize.height};\n`;
+        data += `@${pageSize.size}-Width: ${pageSize.width};\n`;
+    }
+
+    return data;
+}
+
+/**
+ * Adds configured page sizes and oriented aliases (A4Portrait/A4Landscape => A4) to the lookup.
+ * If both orientations exist, Portrait is preferred for the base key (e.g. A4).
+ */
+function addConfiguredSizesToLookup(
+    configuredSizes: PageSize[],
+    lookup: Record<string, PageSizeLookupEntry>,
+): void {
+    for (const item of configuredSizes) {
+        if (!isPaperLayout(item.size)) {
+            continue;
+        }
+
+        const width = convertDimensionToMillimeters(item.width);
+        const height = convertDimensionToMillimeters(item.height);
+        lookup[item.size] = { width, height };
+
+        const baseName = getBaseSizeName(item.size);
+        if (!baseName) {
+            continue;
+        }
+
+        const shouldPreferThisAsBase =
+            item.size.endsWith("Portrait") || lookup[baseName] === undefined;
+        if (shouldPreferThisAsBase) {
+            lookup[baseName] = { width, height };
+        }
+    }
+}
+
+/**
+ * Adds ISO A/B series sizes (A0-A10, B0-B10) to the lookup.
+ */
+function addIsoSeriesSizes(lookup: Record<string, PageSizeLookupEntry>): void {
+    addIsoSeries(lookup, "A", 841, 1189);
+    addIsoSeries(lookup, "B", 1000, 1414);
+}
+
+/**
+ * Adds one ISO series by repeatedly halving the long edge and rotating.
+ */
+function addIsoSeries(
+    lookup: Record<string, PageSizeLookupEntry>,
+    series: string,
+    startWidth: number,
+    startHeight: number,
+): void {
+    let width = startWidth;
+    let height = startHeight;
+    for (let index = 0; index <= 10; index++) {
+        const key = `${series}${index}`;
+        if (lookup[key] === undefined) {
+            lookup[key] = { width, height };
+        }
+
+        const nextWidth = Math.floor(height / 2);
+        height = width;
+        width = nextWidth;
+    }
+}
+
+/**
+ * Adds common square aliases like Cm13/In8 so runtime logic can use data lookups.
+ * Covers Cm1-Cm50 and In1-In20.
+ */
+function addSquareAliases(lookup: Record<string, PageSizeLookupEntry>): void {
+    for (let centimeters = 1; centimeters <= 50; centimeters++) {
+        const key = `Cm${centimeters}`;
+        if (lookup[key] === undefined) {
+            const side = centimeters * 10;
+            lookup[key] = { width: side, height: side };
+        }
+    }
+
+    for (let inches = 1; inches <= 20; inches++) {
+        const key = `In${inches}`;
+        if (lookup[key] === undefined) {
+            const side = inches * inchesToMillimeters;
+            lookup[key] = { width: side, height: side };
+        }
+    }
+}
+
+/**
+ * Creates the mm lookup file used by C# runtime code.
+ */
+function buildLookupFile(configuredSizes: PageSize[]): PageSizeLookupFile {
+    const lookup: Record<string, PageSizeLookupEntry> = {};
+    addConfiguredSizesToLookup(configuredSizes, lookup);
+    addIsoSeriesSizes(lookup);
+    addSquareAliases(lookup);
+    return { sizes: lookup };
+}
+
+/**
+ * Generates both build artifacts derived from pageSizes.json.
+ */
+function main(): void {
+    const configuredSizes = readConfiguredPageSizes();
+
+    // Output 1: less variables used by page layout stylesheets.
+    writeFileSync(lessOutputPath, buildLessPageSizeVariables(configuredSizes));
+
+    // Output 2: mm lookup used by C# runtime page-size code.
+    const lookup = buildLookupFile(configuredSizes);
+    writeFileSync(lookupOutputPath, JSON.stringify(lookup, null, 4) + "\n");
+}
+
+main();


### PR DESCRIPTION
[Claude Fable 5 following a prompt from Hatton]

Part 2 of 3 of the updated BL-15958 work, split out of #7713.

Tracker: [BL-15958](https://issues.bloomlibrary.org/youtrack/issue/BL-15958)

## What this does

- Adds `DistFiles/pageSizesLookup.json`, generated at build time by `src/content/pageSizes.ts`, so C# code can look up trim dimensions for any layout. `SizeAndOrientation.TryGetSizeInMillimeters` reads it.
- `EpubMaker.GetPageDimensions` now uses that lookup instead of parsing `pageSizes.json` itself.
- The PDF pipeline supports full bleed for all page sizes: `MakePdfUsingExternalPdfMakerProgram` sizes full-bleed pages from the lookup, and `PdfMaker` writes explicit trim/bleed boxes before the dotImpose handoff.
- Booklet layouts keep trim-sized source pages (`PublishModel.GetPrintingWithFullBleed`).
- Updates `sillsdev.dotImpose` to 2.6.7-test, published to nuget.org from [sillsdev/dotImpose](https://github.com/sillsdev/dotImpose) master. The new library deprecates `NullLayoutMethod(insetTrimboxMillimeters)`; Bloom now uses the parameterless `NullLayoutMethod()` because the source PDF carries explicit boxes.

## Follow-up before merge

The pin is a prerelease version (`2.6.7-test`). The dotImpose publish workflow fills its default suffix "test" even when the dispatch input is empty, so a release version needs a one-line workflow fix in that repo first. Then bump the pin here.

## Relationship to the other parts

Independent of the other two PRs; based on master. The siblings are the edge-to-edge theme PR (#8262) and the edit-mode crop-marks PR (#8264).

## Verification

- The full front-end build passes and regenerates the lookup file.
- The `PdfMakerTests` and `MakePdfUsingExternalPdfMakerProgramTests` fixtures pass: 25 of 25, including the full-bleed crop-marks trim test that failed against dotImpose 2.6.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8263)
<!-- Reviewable:end -->


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8263)
