### PR TITLE
Fix BL-16772 TC message log write failure prevented collection from o…

### DIFF
--- a/src/BloomExe/TeamCollection/TeamCollectionMessageLog.cs
+++ b/src/BloomExe/TeamCollection/TeamCollectionMessageLog.cs
@@ -200,7 +200,23 @@ namespace Bloom.TeamCollection
             // Linux and Windows. But that's OK, because .NET line reading accepts either line
             // break on either platform.
             var toPersist = message.ToPersistedForm + Environment.NewLine;
-            RobustFile.AppendAllText(_logFilePath, toPersist);
+            try
+            {
+                RobustFile.AppendAllText(_logFilePath, toPersist);
+            }
+            catch (Exception ex)
+            {
+                // The message is already in Messages (so the current session still shows it) and in
+                // the Logger above; it just won't survive a restart. Not being able to write it must
+                // not take Bloom down: this very method is called while reporting a TC initialization
+                // failure, and when the underlying problem is an unwritable collection folder
+                // (e.g. read-only files, BL-16772), throwing here turned a degraded-but-working
+                // Team Collection into a collection that could not open at all.
+                SIL.Reporting.Logger.WriteError(
+                    $"Could not persist Team Collection message to {_logFilePath}",
+                    ex
+                );
+            }
         }
 
         private bool MatchParams(string p1, string p2)

--- a/src/BloomTests/TeamCollection/TeamCollectionMessageLogTests.cs
+++ b/src/BloomTests/TeamCollection/TeamCollectionMessageLogTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -557,6 +558,36 @@ namespace BloomTests.TeamCollection
                 _messageLog.TeamCollectionStatus,
                 Is.EqualTo(TeamCollectionStatus.ClobberPending)
             );
+        }
+
+        [Test]
+        public void WriteMessage_LogFileNotWritable_DoesNotThrowAndKeepsMessageInMemory()
+        {
+            // BL-16772: a user's collection folder had read-only files, and the exception from
+            // failing to persist a message escaped all the way up and prevented the collection
+            // from opening at all. The message log must survive an unwritable log file.
+            var attributes = File.GetAttributes(_logFile.Path);
+            File.SetAttributes(_logFile.Path, attributes | FileAttributes.ReadOnly);
+            try
+            {
+                // Sanity check that the file really is read-only now.
+                Assert.That(
+                    File.GetAttributes(_logFile.Path) & FileAttributes.ReadOnly,
+                    Is.EqualTo(FileAttributes.ReadOnly),
+                    "Setup failed: could not make the log file read-only"
+                );
+
+                MakeError1();
+
+                var messages = _messageLog.Messages;
+                Assert.That(messages, Has.Count.EqualTo(1));
+                AssertError1(messages, 0);
+            }
+            finally
+            {
+                // So TearDown can delete the file.
+                File.SetAttributes(_logFile.Path, attributes);
+            }
         }
 
         [Test]


### PR DESCRIPTION
…pening

https://issues.bloomlibrary.org/youtrack/issue/BL-16772

When the local collection folder is not writable (e.g. read-only files), TeamCollectionMessageLog.WriteMessage threw while the TeamCollectionManager constructor was reporting a TC initialization failure. The exception escaped the constructor and the collection failed to open entirely, instead of opening with the Team Collection in disconnected mode (the BL-16227 fallback). Now a failure to persist a message is logged and swallowed; the message is still shown in the current session.

Tests: added WriteMessage_LogFileNotWritable_DoesNotThrowAndKeepsMessageInMemory; all 203 BloomTests.TeamCollection tests pass.

[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8266)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8266)
<!-- Reviewable:end -->
