### PR TITLE
Don't expire subscriptions a day early (BL-16786)

### DIFF
--- a/src/BloomBrowserUI/collection/subscriptionCodeControl.tsx
+++ b/src/BloomBrowserUI/collection/subscriptionCodeControl.tsx
@@ -209,6 +209,18 @@ const StatusText: React.FC<{
     );
 };
 
+// Today's date in the user's own time zone, formatted so that it can be compared as a string
+// with the YYYY-MM-DD expiration date that the server sends us. Note that we deliberately do
+// not use toISOString(), which would give us the date in UTC and so could be off by a day
+// (BL-16786); the C# code that decides whether a subscription is expired uses local time.
+export function getTodayAsYYYYMMDD(): string {
+    const now = new Date();
+    const twoDigits = (n: number) => n.toString().padStart(2, "0");
+    return `${now.getFullYear()}-${twoDigits(now.getMonth() + 1)}-${twoDigits(
+        now.getDate(),
+    )}`;
+}
+
 export function getSafeLocalizedDate(dateAsYYYYMMDD: string | null) {
     const dateParts = dateAsYYYYMMDD ? dateAsYYYYMMDD.split("-") : null;
     return dateParts
@@ -252,7 +264,7 @@ function getStatusSansEditingBlorgBook(
     expiryDateStringAsYYYYMMDD: string,
     missingBrandingFiles: boolean,
 ): Status {
-    const todayAsYYYYMMDD = new Date().toISOString().slice(0, 10);
+    const todayAsYYYYMMDD = getTodayAsYYYYMMDD();
     if (subscriptionCode === "" || subscriptionCodeIntegrity === "none") {
         return "None";
     }

--- a/src/BloomBrowserUI/collectionsTab/SubscriptionStatus.tsx
+++ b/src/BloomBrowserUI/collectionsTab/SubscriptionStatus.tsx
@@ -9,7 +9,10 @@ import { BoxWithIconAndText } from "../react_components/boxes";
 import { useL10n } from "../react_components/l10nHooks";
 import { kBloomBlue } from "../bloomMaterialUITheme";
 import { Markdown } from "../react_components/markdown";
-import { getSafeLocalizedDate } from "../collection/subscriptionCodeControl";
+import {
+    getSafeLocalizedDate,
+    getTodayAsYYYYMMDD,
+} from "../collection/subscriptionCodeControl";
 import { useSubscriptionInfo } from "../collection/useSubscriptionInfo";
 import { SubscriptionTier } from "../react_components/featureStatus";
 import { useIsTeamCollection } from "../teamCollection/teamCollectionApi";
@@ -98,7 +101,7 @@ export const SubscriptionStatus: React.FunctionComponent<{
 
     // don't show anything until we have this info
     if (expiryDateStringAsYYYYMMDD === "") return null;
-    const todayAsYYYYMMDD = new Date().toISOString().slice(0, 10);
+    const todayAsYYYYMMDD = getTodayAsYYYYMMDD();
     // if the license is deprecated, we want to show the warning right away. Otherwise,
     // we only want to show it if the expiration is within 2 months (approximately 60 days).
     const kDaysBeforeWarningForNormalExpiration = 60;

--- a/src/BloomExe/SubscriptionAndFeatures/Subscription.cs
+++ b/src/BloomExe/SubscriptionAndFeatures/Subscription.cs
@@ -195,6 +195,13 @@ namespace Bloom.SubscriptionAndFeatures
             return true;
         }
 
+        /// <summary>
+        /// True if the subscription is no longer usable. A subscription remains valid through the
+        /// end of its expiration date, so it only becomes expired on the following day. (BL-16786:
+        /// ExpirationDate is midnight at the start of the expiration day, so comparing it to
+        /// DateTime.Now made us expire a day early, contradicting the Subscription tab of the
+        /// Collection Settings dialog, which compares whole dates.)
+        /// </summary>
         public bool IsExpired()
         {
             if (Code == null)
@@ -202,7 +209,7 @@ namespace Bloom.SubscriptionAndFeatures
             var date = ExpirationDate;
             if (date == DateTime.MinValue)
                 return true; // invalid code
-            return date < DateTime.Now;
+            return date.Date < DateTime.Now.Date;
         }
 
         private bool LooksIncomplete()
@@ -385,7 +392,9 @@ namespace Bloom.SubscriptionAndFeatures
 
         private SubscriptionTier CalculateTier()
         {
-            if (GetIntegrityLabel() != "ok" || ExpirationDate < DateTime.Now)
+            // Note that IsExpired() allows the subscription to work through the end of its
+            // expiration date; see the comment there.
+            if (GetIntegrityLabel() != "ok" || IsExpired())
                 return SubscriptionTier.Basic;
             var descriptor = CalculateDescriptor();
             if (string.IsNullOrWhiteSpace(descriptor) || descriptor == "Default")

--- a/src/BloomTests/SubscriptionAndFeatures/SubscriptionTests.cs
+++ b/src/BloomTests/SubscriptionAndFeatures/SubscriptionTests.cs
@@ -85,6 +85,65 @@ namespace BloomTests.SubscriptionAndFeatures
             Assert.AreEqual(expectedResult, subscription.IsExpired());
         }
 
+        // BL-16786: the expiration date is the last day the subscription works, so it does not
+        // become expired until the following day. This has to agree with the Subscription tab of
+        // the Collection Settings dialog, which compares whole dates; otherwise, on the expiration
+        // day itself, the dialog says the subscription is fine while the tools say it is not.
+        [TestCase(1, false)]
+        [TestCase(0, false)]
+        [TestCase(-1, true)]
+        public void IsExpired_AtDayBoundary_TreatsExpirationDayAsStillValid(
+            int daysFromToday,
+            bool expectedExpired
+        )
+        {
+            var dayTestStarted = DateTime.Now.Date;
+            var expiration = dayTestStarted.AddDays(daysFromToday);
+            var code = MakeCodeExpiringOn(expiration);
+            var subscription = new Subscription(code);
+            var isExpired = subscription.IsExpired();
+            var tier = subscription.Tier;
+
+            // We built the code relative to today, but Subscription reads the clock again for
+            // itself, so if midnight happened in between, the answers we just captured are about
+            // the wrong day. That is a property of the test, not a bug in Subscription.
+            if (DateTime.Now.Date != dayTestStarted)
+                Assert.Ignore("The date changed while this test was running; rerun it.");
+
+            // sanity checks: if we didn't build a well-formed code for the intended date,
+            // the assertions below would pass or fail for the wrong reason.
+            Assert.AreEqual(
+                "ok",
+                subscription.GetIntegrityLabel(),
+                $"the generated test code {code} is not well formed"
+            );
+            Assert.AreEqual(expiration, subscription.ExpirationDate);
+
+            Assert.AreEqual(expectedExpired, isExpired);
+            // The tier is what actually disables the subscription-only tools.
+            Assert.AreEqual(
+                expectedExpired ? SubscriptionTier.Basic : SubscriptionTier.Enterprise,
+                tier
+            );
+        }
+
+        /// <summary>
+        /// Build a valid subscription code that expires on the given date, using the same
+        /// arithmetic as the private code-generating spreadsheet (and, on the reading end,
+        /// Subscription.CalculateExpirationDate).
+        /// </summary>
+        private static string MakeCodeExpiringOn(DateTime expiration)
+        {
+            const string descriptor = "UnitTest-E";
+            var datePart = (int)(expiration - new DateTime(1899, 12, 30)).TotalDays - 40000;
+            var upperDescriptor = descriptor.ToUpperInvariant();
+            var descriptorSum = 0;
+            for (var i = 0; i < upperDescriptor.Length; i++)
+                descriptorSum += upperDescriptor[i] * i;
+            var checksum = ((int)Math.Floor(Math.Sqrt(datePart)) + descriptorSum) % 10000;
+            return $"{descriptor}-{datePart:D6}-{checksum:D4}";
+        }
+
         [TestCase(null, SubscriptionTier.Basic)]
         [TestCase("", SubscriptionTier.Basic)]
         [TestCase("Legacy-LC-005839-2533", SubscriptionTier.Basic)] // expired, so basic


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
## Problem

On the very day a subscription expires, Bloom contradicts itself. The **Bloom Subscription** tab of the Collection Settings dialog says the subscription is still good — green check, tier, `Expires: <today>` — plus the yellow "Your X subscription expires on <today>." warning. But subscription-gated features, such as the Canvas tool, are already switched off with a "your subscription isn't valid" message. Confirmed in 6.4.

## Cause

The two sides compare different things. The dialog compares whole dates, so a subscription is good *through the end of* its expiration day. The C# `Subscription` class compared a date to a timestamp: the stored expiration date is midnight at the **start** of the expiration day, so from 00:00 that day the code counted as expired and the subscription tier dropped to `Basic` — and it is the tier that turns the tools off.

## Fix

- A subscription is now valid through the end of its expiration date everywhere: `Subscription.IsExpired()` compares whole dates.
- The tier calculation calls `IsExpired()` instead of repeating the comparison, so there is one definition of "expired" rather than two that can drift apart.
- The Settings dialog and the collection-tab status banner computed "today" in **UTC** while the C# used local time — a smaller version of the same bug that shifts the disagreement by up to a day for users far from UTC. Both now use a shared helper that returns the local date.
- New tests pin the day boundary (expires tomorrow / today / yesterday), asserting both `IsExpired()` and the resulting tier, so a future change can't quietly move the cutoff back.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16786


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8267)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8267)
<!-- Reviewable:end -->
