### PR TITLE
Automate the Text Languages publish list (Test Case ID 169)

### DIFF
--- a/.github/skills/add-e2e-test/SKILL.md
+++ b/.github/skills/add-e2e-test/SKILL.md
@@ -104,8 +104,17 @@ carries the API mechanics.
 
 Put the file in `src/BloomE2E/tests/`, named after the behavior. Import `test` and
 `expect` from `../fixtures/bloomTest` (never from `@playwright/test` directly — that
-would give you Playwright's own browser instead of Bloom's WebView2), and name the
-collection with `test.use`:
+would give you Playwright's own browser instead of Bloom's WebView2), and say which
+collection you want with `test.use`. Ask for a new one with `collectionSpec`:
+
+```ts
+test.use({
+    collectionSpec: { name: "text-languages", languages: ["en", "de", "fr"] },
+});
+```
+
+Name a prepared one with `collectionName` only for a fixture too expensive to build at
+run time:
 
 ```ts
 import { expect, test } from "../fixtures/bloomTest";
@@ -126,14 +135,21 @@ The worker-scoped fixture launches Bloom on a temp copy of that collection and y
 
 - `page` — Playwright's `page`, overridden to be Bloom's shell document (the top bar and
   the showing tab). Most tests need nothing else.
-- `bloomApp` — `{ page, httpPort, cdpPort, bloomPid, collectionDir }`. Build book paths
-  from `collectionDir`, never from `output/testing-inputs`.
+- `bloomApp` — `{ page, httpPort, cdpPort, bloomPid, collectionDir, restart }`. Build book
+  paths from `collectionDir`, never from `output/testing-inputs`. `restart(callback)`
+  stops Bloom, runs the callback, and starts it again, which is how a test changes what
+  Bloom reads only at startup, such as the collection's languages.
 
 Helper modules:
 
 - `helpers/workspace.ts` — `switchTab`, `getTabs`, `waitForActiveTab`. Bloom hides the
   Edit and Publish tabs until a book is selected.
 - `helpers/collection.ts` — `selectBook`, `waitForCollectionReady`.
+- `helpers/bookMaking.ts` — `makeBookFromTemplate`, `addPage`, `findBookFolder`,
+  `setContentLanguages`, `getPages`, `getContentPages`, `goToPage`, `typeInGroup`. A book
+  made from a template starts with front and back matter only, so a test that needs
+  content calls `addPage`. Bloom writes a page only when the book leaves it, so `goToPage`
+  is also how a test saves what it typed.
 - `helpers/api.ts` — `apiGet`, `apiPost`, `apiGetJson`, which run `fetch` inside the page
   with a relative URL (Bloom's server rejects a `127.0.0.1` Host header; the CDP endpoint
   does not answer on `localhost`).

--- a/src/BloomBrowserUI/publish/commonPublish/LanguageSelectionSettingsGroup.tsx
+++ b/src/BloomBrowserUI/publish/commonPublish/LanguageSelectionSettingsGroup.tsx
@@ -106,7 +106,16 @@ export const LanguageSelectionSettingsGroup: React.FunctionComponent<{
     ));
 
     return (
-        <div className="publishLanguagesGroup">
+        <div
+            className="publishLanguagesGroup"
+            // The text group and the audio group are otherwise identical in the DOM, so an
+            // e2e test has no way to say which one it means. See src/BloomE2E.
+            data-testid={
+                props.forAudioLanguages
+                    ? "audio-languages-group"
+                    : "text-languages-group"
+            }
+        >
             <SettingsGroup
                 label={props.forAudioLanguages ? talkingLabel : textLabel}
             >

--- a/src/BloomE2E/AUTOMATION-DEBT.md
+++ b/src/BloomE2E/AUTOMATION-DEBT.md
@@ -26,6 +26,15 @@ force-foreground trick. Fix direction: move these surfaces to the web UI (the te
 direction anyway), or expose each dialog's WebView2 on a discoverable CDP port.
 (Promoted from PAPERCUTS 2026-07-11.)
 
+seen again 2026-09-01 (Test Case ID 169, `publish-text-languages.spec.ts`): the case
+turns on which languages the collection has, and there is no API for that either.
+`collectionSettings/changeLanguage` is not one: its only listener is the open WinForms
+`CollectionSettingsDialog` (`CollectionSettingsDialog.cs:368`), so a POST to it while
+the dialog is closed does nothing. The test therefore changes a collection language by
+stopping Bloom, rewriting the `.bloomCollection`, and starting again, which is what the
+new `bloomApp.restart(betweenStopAndStart)` fixture method is for. Each restart costs
+about six seconds and loses whatever the editor had not yet saved.
+
 ## Native OS dialogs hang automation
 
 File pickers, the Image Toolbox, and video capture open native windows Playwright
@@ -125,3 +134,40 @@ first" is itself the dangerous move; sibling scripts may share the shape. Fix
 direction: recognize `--help`/`-h` and reject unknown flags in every script that kills
 processes — and fold these helpers' jobs into the library's audited launch/teardown
 fixture over time. (Promoted from PAPERCUTS 2026-07-24.)
+
+## Adding a page needs the Add Page dialog, which offers nothing to automate against
+
+A book made from a template starts with front and back matter only, because every page
+of a template book is a template page. So almost any test that needs content has to add
+a page, and the only production route is the Add Page dialog: `edit/pageControls/addPage`
+opens it, and the thumbnails it shows are built by loading the template book's HTML in
+the dialog and reading the `.pageLabel` out of each page. Nothing in the API says which
+template pages exist or what they are called, so a test either drives that dialog or
+hard-codes a page GUID. The `e2e/templatePages` hook added for Test Case ID 169 reports
+each template page's id, label, and template book path, which is enough to call the
+production `addPage` endpoint. Fix direction: if the page chooser ever gets its list
+from C# instead of from the HTML, retire the hook and read that list.
+(Found 2026-09-01 automating Test Case ID 169.)
+
+## The Edit tab silently drops a jump to a page while it is loading
+
+`editView/jumpToPage` is the only way to move a test to a particular page, and it is
+also how a test saves what it typed, because Bloom writes a page only when the book
+leaves it. Coming back from the Publish tab, the Edit tab accepts the POST, replies
+success, and shows nothing: the page iframe stays empty until the test asks again. So
+`helpers/bookMaking.ts` asks up to three times. Two costs: a test that jumps at the
+wrong moment waits 20 seconds per attempt, and a real "this page will not load" bug
+would look like the same flake. Fix direction: have `jumpToPage` queue the request
+until the Edit tab is ready, or report that it refused it.
+(Found 2026-09-01 automating Test Case ID 169.)
+
+## Filling a text box directly leaves part of the old text behind
+
+A `.bloom-editable` is a CKEditor surface, and Playwright's `fill()` on one leaves a
+tail of what was there ("Deux" became "eux"), so `typeInGroup` clicks in, selects all,
+deletes, and types the new text one key at a time. That is closer to what a person does
+and it is reliable, but it is also slow for anything longer than a few words, and no
+test can currently clear a box by any faster route. Fix direction: understand what
+CKEditor does with a programmatic value change; a supported "set the text of this box"
+path would let long text be set at once.
+(Found 2026-09-01 automating Test Case ID 169.)

--- a/src/BloomE2E/README.md
+++ b/src/BloomE2E/README.md
@@ -27,9 +27,19 @@ test("switching workspace tabs through the real top bar", async ({ page, bloomAp
 });
 ```
 
-`test.use({ collectionName })` names a folder under `output/testing-inputs/collections`. The
-fixture copies that collection to a temp folder, launches Bloom on the copy, and attaches to the
-WebView2. One Bloom serves every test in a worker, because launching takes several seconds.
+A test says which collection it wants, in one of two ways, and never both:
+
+- `test.use({ collectionSpec: { name: "text-languages", languages: ["en", "de", "fr"] } })`
+  makes an empty collection with those languages. **This is the default choice.** The test then
+  makes the book it needs, which is journey coverage of book creation as a side effect. A test
+  that shares a prepared collection inherits somebody else's assumptions, and the next person to
+  edit that collection changes what the test means without reading it.
+- `test.use({ collectionName: "basic" })` names a folder under
+  `output/testing-inputs/collections`. Use this only for a fixture too expensive to build at run
+  time, such as a collection of 200 books.
+
+Either way the fixture launches Bloom on a temp copy and attaches to the WebView2. One Bloom
+serves every test in a worker, because launching takes several seconds.
 
 ## The fixture API
 
@@ -45,6 +55,15 @@ and whatever tab is showing. Most tests need nothing else.
 | `cdpPort`       | The port the embedded WebView2 answers CDP on.                          |
 | `bloomPid`      | The process id of the Bloom serving this collection.                    |
 | `collectionDir` | The temp copy of the collection. Build book paths from this, never from `output/testing-inputs`. |
+| `restart`       | Stop Bloom, run an optional callback, start it again on the same collection, and return the new page. |
+
+`restart(betweenStopAndStart)` is how a test changes something Bloom only reads at startup. The
+collection's languages are the case that needed it: the collection Settings dialog is a WinForms
+surface CDP cannot reach, and `collectionSettings/changeLanguage` only answers while that dialog
+is open, so the way to change a language is to stop Bloom, rewrite the `.bloomCollection` with
+`makeCollectionXml`, and start again. Bloom is killed rather than asked to quit, so leave the
+page being edited before restarting or what was typed on it is lost. Use the page `restart`
+returns; the old one is closed.
 
 Teardown kills the process tree, waits for the HTTP port to go dark, and deletes the temp copy.
 

--- a/src/BloomE2E/fixtures/bloomTest.ts
+++ b/src/BloomE2E/fixtures/bloomTest.ts
@@ -17,7 +17,11 @@ import {
     type Browser,
     type Page,
 } from "@playwright/test";
-import { launchBloom, type ILaunchedBloom } from "./launchBloom";
+import {
+    launchBloom,
+    type ILaunchedBloom,
+    type ICollectionSpec,
+} from "./launchBloom";
 import { chromium } from "@playwright/test";
 import {
     describeProblems,
@@ -25,7 +29,10 @@ import {
     type IProblemDialogWatcher,
 } from "./problemDialogWatcher";
 
-/** What a test gets about the Bloom it is driving. */
+/**
+ * What a test gets about the Bloom it is driving. Every field except collectionDir is replaced by
+ * restart(), so read them from this object each time rather than copying them into a local.
+ */
 export interface IBloomApp {
     /** Bloom's shell document in the embedded WebView2: the top bar, and whatever tab is showing. */
     page: Page;
@@ -35,14 +42,33 @@ export interface IBloomApp {
     cdpPort: number;
     /** The process id of the Bloom serving this collection. */
     bloomPid: number;
-    /** The temp copy of the collection Bloom has open. Never the inputs repository itself. */
+    /** The collection folder Bloom has open: a temp folder, never the inputs repository itself. */
     collectionDir: string;
+    /**
+     * Quit Bloom and start it again on the same collection folder, and return the new shell page.
+     *
+     * `betweenStopAndStart` runs while no Bloom holds the folder, which is the only safe moment to
+     * rewrite the .bloomCollection; use it to change collection settings, which have no API and
+     * live in a WinForms dialog CDP cannot reach.
+     *
+     * A restart invalidates the `page` fixture and the old ports. Take the page this returns, or
+     * read bloomApp.page afterwards; the old Page object throws once its target is gone.
+     */
+    restart: (
+        betweenStopAndStart?: () => void | Promise<void>,
+    ) => Promise<Page>;
 }
 
 /** Worker-scoped fixtures: one Bloom per worker. */
 interface IBloomWorkerFixtures {
-    /** Which folder under <testing-inputs>/collections to open. Set it with test.use(). */
-    collectionName: string;
+    /**
+     * Which prepared folder under <testing-inputs>/collections to open. Set it with test.use().
+     * Use it only for a fixture too expensive to build at run time; otherwise set collectionSpec,
+     * so the test owns its collection and nobody else's change can move its assumptions.
+     */
+    collectionName: string | undefined;
+    /** A collection to create for this test alone. Set it with test.use(). Preferred. */
+    collectionSpec: ICollectionSpec | undefined;
     /** The launched Bloom. Prefer the `page` fixture unless you need a port or the folder. */
     bloomApp: IBloomApp;
     problemDialogWatcher: IProblemDialogWatcher;
@@ -119,27 +145,48 @@ async function findShellPage(browser: Browser): Promise<Page> {
 }
 
 export const test = base.extend<IBloomTestFixtures, IBloomWorkerFixtures>({
-    collectionName: ["basic", { scope: "worker", option: true }],
+    collectionName: [undefined, { scope: "worker", option: true }],
+    collectionSpec: [undefined, { scope: "worker", option: true }],
 
     bloomApp: [
-        async ({ collectionName }, use) => {
+        async ({ collectionName, collectionSpec }, use) => {
             let launched: ILaunchedBloom | undefined;
+            // Reassigned by restart(), and read by the teardown below, so the connection we close
+            // is always the current one.
             let browser: Browser | undefined;
             try {
-                launched = await launchBloom({ collectionName });
+                launched = await launchBloom({
+                    collectionName,
+                    collectionSpec,
+                });
                 // CDP must go to 127.0.0.1: on Windows "localhost" resolves to ::1 first, and
                 // WebView2's debugging port does not answer there — you get an empty or wrong
                 // target list rather than an error. (Bloom's own HTTP server is the opposite: it
                 // rejects a 127.0.0.1 Host header. See helpers/api.ts.)
                 browser = await connectOverCdpWithRetry(launched.cdpPort);
-                const page = await findShellPage(browser);
-                await use({
-                    page,
+                const bloomApp: IBloomApp = {
+                    page: await findShellPage(browser),
                     httpPort: launched.httpPort,
                     cdpPort: launched.cdpPort,
                     bloomPid: launched.bloomPid,
                     collectionDir: launched.collectionDir,
-                });
+                    restart: async (betweenStopAndStart) => {
+                        // Close the old CDP connection first: it holds a socket into the process
+                        // that is about to be killed.
+                        await browser?.close();
+                        browser = undefined;
+                        await launched!.restart(betweenStopAndStart);
+                        browser = await connectOverCdpWithRetry(
+                            launched!.cdpPort,
+                        );
+                        bloomApp.page = await findShellPage(browser);
+                        bloomApp.httpPort = launched!.httpPort;
+                        bloomApp.cdpPort = launched!.cdpPort;
+                        bloomApp.bloomPid = launched!.bloomPid;
+                        return bloomApp.page;
+                    },
+                };
+                await use(bloomApp);
             } finally {
                 // Close the CDP connection first: it keeps a socket into the process we are about
                 // to kill. Then kill Bloom and delete the temp collection.
@@ -152,12 +199,15 @@ export const test = base.extend<IBloomTestFixtures, IBloomWorkerFixtures>({
 
     problemDialogWatcher: [
         async ({ bloomApp }, use) => {
-            const browser = bloomApp.page.context().browser();
-            if (!browser)
+            if (!bloomApp.page.context().browser())
                 throw new Error(
                     "The Bloom page has no browser connection, so problem dialogs cannot be watched.",
                 );
-            const watcher = startProblemDialogWatcher(browser);
+            // Read the connection through bloomApp.page each scan rather than capturing it here:
+            // restart() replaces both, and a captured connection would go quietly deaf.
+            const watcher = startProblemDialogWatcher(
+                () => bloomApp.page.context().browser() ?? undefined,
+            );
             await use(watcher);
             watcher.stop();
         },
@@ -166,6 +216,9 @@ export const test = base.extend<IBloomTestFixtures, IBloomWorkerFixtures>({
 
     // Override Playwright's own `page`, so a test that just wants to click things says `page` and
     // never launches a browser of Playwright's own.
+    //
+    // This is bound once per worker, so a test that calls bloomApp.restart() must use the page
+    // that returns (or bloomApp.page) from then on: this one points at a dead target.
     page: async ({ bloomApp }, use) => {
         await use(bloomApp.page);
     },

--- a/src/BloomE2E/fixtures/launchBloom.ts
+++ b/src/BloomE2E/fixtures/launchBloom.ts
@@ -33,12 +33,45 @@ export interface ILaunchedBloom {
     collectionDir: string;
     /** Kill the process tree, confirm the HTTP port went dark, and delete the temp copy. */
     stop: () => Promise<void>;
+    /**
+     * Shut Bloom down and start it again on the SAME collection folder, so the folder and
+     * everything in it survive. `betweenStopAndStart` runs while no Bloom holds the files, which
+     * is the only safe moment to rewrite the .bloomCollection: collection settings have no API,
+     * and their dialog is a WinForms surface CDP cannot reach (see AUTOMATION-DEBT.md).
+     *
+     * The ports change, so the caller must re-attach. This object's httpPort, cdpPort and
+     * bloomPid are updated in place; fixtures/bloomTest.ts reconnects over CDP.
+     */
+    restart: (
+        betweenStopAndStart?: () => void | Promise<void>,
+    ) => Promise<void>;
 }
 
-/** Options for launchBloom. Everything has a working default. */
+/**
+ * What languages a created collection has. Bloom fills in everything else itself the first time
+ * it opens the collection.
+ */
+export interface ICollectionSpec {
+    /** The collection's folder and file name, e.g. "text-languages". */
+    name: string;
+    /**
+     * Language tags for Language1, Language2 and Language3, in that order. Give one, two or
+     * three; two entries mean the collection has no Language3.
+     */
+    languages: string[];
+}
+
+/** Options for launchBloom. Give exactly one of collectionName and collectionSpec. */
 export interface ILaunchBloomOptions {
-    /** Name of a folder under <testing-inputs>/collections, e.g. "basic". */
-    collectionName: string;
+    /**
+     * Name of a prepared folder under <testing-inputs>/collections, e.g. "basic". Use this only
+     * for a fixture too expensive to build at run time, such as a collection of hundreds of
+     * books. A shared fixture couples every test that uses it: whoever changes it next changes
+     * the assumptions of tests they have never read. Otherwise use collectionSpec.
+     */
+    collectionName?: string;
+    /** Create a collection for this test alone. The default choice. */
+    collectionSpec?: ICollectionSpec;
     /** How long to wait for Bloom to start serving the collection. Default 120 seconds. */
     readyTimeoutMs?: number;
 }
@@ -183,6 +216,72 @@ function copyCollection(source: string, destination: string): void {
     });
 }
 
+/**
+ * Write a minimal .bloomCollection for a brand-new collection, and return its folder.
+ *
+ * Only the fields Bloom needs in order to open the collection are written; it supplies its own
+ * defaults for the rest and rewrites the file on first open.
+ */
+export function writeNewCollection(
+    parentFolder: string,
+    spec: ICollectionSpec,
+): string {
+    const collectionDir = Path.join(parentFolder, spec.name);
+    fs.mkdirSync(collectionDir, { recursive: true });
+    fs.writeFileSync(
+        Path.join(collectionDir, `${spec.name}.bloomCollection`),
+        makeCollectionXml(spec.languages),
+        "utf8",
+    );
+    return collectionDir;
+}
+
+/**
+ * The XML of a .bloomCollection with these languages. Exported because a test changes collection
+ * settings by rewriting this file between a stop and a start (see ILaunchedBloom.restart).
+ */
+export function makeCollectionXml(languages: string[]): string {
+    // Bloom treats Language2 as "same as Language1" when a collection names only one language,
+    // which is what its own new-collection code writes.
+    const [language1 = "en", language2 = languages[0] ?? "en", language3 = ""] =
+        languages;
+    const languageElements = [language1, language2, language3]
+        .map(
+            (tag, index) =>
+                `  <Language${index + 1}Name>${nameForTag(tag)}</Language${index + 1}Name>\n` +
+                `  <Language${index + 1}IsCustomName>false</Language${index + 1}IsCustomName>\n` +
+                `  <Language${index + 1}Iso639Code>${tag}</Language${index + 1}Iso639Code>\n` +
+                `  <DefaultLanguage${index + 1}FontName>Andika</DefaultLanguage${index + 1}FontName>`,
+        )
+        .join("\n");
+    return (
+        `<?xml version="1.0" encoding="utf-8"?>\n` +
+        `<Collection version="0.2">\n` +
+        languageElements +
+        `\n  <XMatterPack>Factory</XMatterPack>\n` +
+        `  <BrandingProjectName>Default</BrandingProjectName>\n` +
+        `  <AllowNewBooks>True</AllowNewBooks>\n` +
+        `  <PageNumberStyle>Decimal</PageNumberStyle>\n` +
+        `</Collection>\n`
+    );
+}
+
+/**
+ * The name Bloom should show for a language tag. Bloom knows these names itself, but the
+ * collection file wants one and a wrong name would show in the UI, so keep this to the languages
+ * the tests use and fall back to the tag.
+ */
+function nameForTag(tag: string): string {
+    const names: Record<string, string> = {
+        "": "",
+        en: "English",
+        fr: "French",
+        es: "Spanish",
+        de: "German",
+    };
+    return names[tag] ?? tag;
+}
+
 /** Find the .bloomCollection file in a collection folder. Throws if the folder has none. */
 function findCollectionFile(collectionDir: string): string {
     const file = fs
@@ -215,41 +314,32 @@ function killProcessTree(pids: number[]): void {
     }
 }
 
+/** One running Bloom process: the ports it opened and every pid worth killing. */
+interface IRunningBloom {
+    httpPort: number;
+    cdpPort: number;
+    servingPid: number;
+    pids: number[];
+}
+
+/** Type guard for the pid lists below, which hold `number | undefined`. */
+function isPid(pid: number | undefined): pid is number {
+    return typeof pid === "number";
+}
+
 /**
- * Launch a dedicated Bloom.exe on a temp copy of the named collection and wait until it is serving
- * it. The returned object carries the discovered ports and a stop() that tears everything down.
+ * Spawn Bloom.exe on an existing collection folder and wait until it is serving that folder.
+ * Both the first launch and restart() go through here, so the two cannot drift apart.
  *
  * Throws with Bloom's own captured output when the launch fails, so a broken run says WHY instead
- * of just timing out.
+ * of just timing out. Cleaning up the temp folder is the caller's job: this function does not
+ * know whether the folder is worth keeping.
  */
-export async function launchBloom(
-    options: ILaunchBloomOptions,
-): Promise<ILaunchedBloom> {
-    const sourceCollectionsRoot = getSourceCollectionsRoot();
-    const sourceCollection = Path.join(
-        sourceCollectionsRoot,
-        options.collectionName,
-    );
-    if (!fs.existsSync(sourceCollection)) {
-        const available = fs
-            .readdirSync(sourceCollectionsRoot)
-            .filter((f) =>
-                fs.statSync(Path.join(sourceCollectionsRoot, f)).isDirectory(),
-            );
-        throw new Error(
-            `There is no test-input collection named "${options.collectionName}". ` +
-                `Available collections: ${available.join(", ")}.`,
-        );
-    }
-
+async function startBloomOn(
+    collectionDir: string,
+    readyTimeoutMs: number,
+): Promise<IRunningBloom> {
     const exe = findBloomExe();
-    // Canonicalize immediately: os.tmpdir() is an 8.3 short path on Windows but Bloom reports the
-    // long form, and discovery below compares the two.
-    const tempRoot = canonicalPath(
-        fs.mkdtempSync(Path.join(os.tmpdir(), "bloom-e2e-")),
-    );
-    const collectionDir = Path.join(tempRoot, options.collectionName);
-    copyCollection(sourceCollection, collectionDir);
 
     // Everything Bloom says, kept so a failed launch can report the reason.
     let bloomOutput = "";
@@ -281,26 +371,10 @@ export async function launchBloom(
         exitStatus = { code, signal };
     });
 
-    // The pid of the Bloom actually serving our collection, read from instanceInfo once it is up.
-    // It is not always the pid we spawned; see killProcessTree.
-    let servingPid: number | undefined;
-
-    // Tear down even if the run is aborted before the fixture's teardown runs.
-    const cleanUpOnExit = () => {
-        killProcessTree(
-            [bloomProcess.pid, servingPid].filter(
-                (p): p is number => typeof p === "number",
-            ),
-        );
-        fs.rmSync(tempRoot, { recursive: true, force: true });
-    };
-    process.once("exit", cleanUpOnExit);
-
-    const readyTimeoutMs = options.readyTimeoutMs ?? 120000;
     const startTime = Date.now();
     let found: { httpPort: number; info: IInstanceInfo } | undefined;
     // When the process we spawned exits, that is USUALLY a startup crash, but Bloom can also
-    // hand off to another instance of itself (which is why servingPid can differ from the
+    // hand off to another instance of itself (which is why the serving pid can differ from the
     // spawned pid). So an exit starts a short grace window in which discovery keeps looking
     // for a successor; only when none appears do we treat the exit as a failure.
     let spawnedExitedAt: number | undefined;
@@ -308,23 +382,16 @@ export async function launchBloom(
     while (!found && Date.now() - startTime < readyTimeoutMs) {
         found = await findBloomServingCollection(collectionDir);
         if (found) break;
-        // Fail fast when Bloom died on startup, rather than waiting out the whole timeout: the
-        // exit code plus its output says it crashed, not merely that discovery could not see it.
         if (exitStatus) {
             spawnedExitedAt ??= Date.now();
-            if (Date.now() - spawnedExitedAt > handOffGraceMs) {
-                // cleanUpOnExit would also kill a successor we have not discovered yet; there is
-                // no pid to kill here beyond the one that already exited, so just delete.
-                process.removeListener("exit", cleanUpOnExit);
-                fs.rmSync(tempRoot, { recursive: true, force: true });
+            if (Date.now() - spawnedExitedAt > handOffGraceMs)
                 throw new Error(
-                    `Bloom exited before serving the temp collection, and no successor ` +
+                    `Bloom exited before serving the collection, and no successor ` +
                         `instance appeared within ${handOffGraceMs / 1000}s ` +
                         `(code ${exitStatus.code}, signal ${exitStatus.signal}).\n` +
                         `  exe: ${exe}\n  wanted: ${collectionDir}\n` +
                         formatOutput(),
                 );
-            }
         }
         await delay(1000);
     }
@@ -337,10 +404,9 @@ export async function launchBloom(
             if (info?.editableCollectionFolder)
                 seen.push(`${port} -> ${info.editableCollectionFolder}`);
         }
-        cleanUpOnExit();
-        process.removeListener("exit", cleanUpOnExit);
+        killProcessTree([bloomProcess.pid].filter(isPid));
         throw new Error(
-            `Bloom did not open the temp collection within ${readyTimeoutMs / 1000}s.\n` +
+            `Bloom did not open the collection within ${readyTimeoutMs / 1000}s.\n` +
                 `  exe: ${exe}\n  wanted: ${collectionDir}\n` +
                 `  still running: ${exitStatus ? "no (already exited)" : "yes"}\n` +
                 `  Bloom instances seen: ${seen.length ? seen.join("; ") : "none"}\n` +
@@ -348,52 +414,152 @@ export async function launchBloom(
         );
     }
 
-    servingPid = found.info.processId;
     if (!found.info.cdpPort) {
-        cleanUpOnExit();
-        process.removeListener("exit", cleanUpOnExit);
+        killProcessTree([bloomProcess.pid, found.info.processId].filter(isPid));
         throw new Error(
             `Bloom is serving ${collectionDir} on port ${found.httpPort} but reported no CDP port, ` +
                 `so tests cannot attach to its WebView2. Check that remote debugging is enabled in this build.`,
         );
     }
 
-    const httpPort = found.httpPort;
-    const stop = async () => {
-        killProcessTree(
-            [bloomProcess.pid, servingPid].filter(
-                (p): p is number => typeof p === "number",
-            ),
-        );
-        // Confirm the port really went dark before we try to delete the folder Bloom had open.
-        // taskkill has been seen to under-kill, and a survivor holds file handles.
-        const deadline = Date.now() + 15000;
-        while (Date.now() < deadline) {
-            if (!(await readInstanceInfo(httpPort))) break;
-            await delay(500);
-        }
-        if (await readInstanceInfo(httpPort))
-            throw new Error(
-                `A Bloom is still answering on port ${httpPort} after teardown. ` +
-                    `Kill pid ${servingPid ?? bloomProcess.pid} by hand before re-running.`,
-            );
-        // Bloom can release file handles slightly after it dies, so let rmSync retry.
-        fs.rmSync(tempRoot, {
-            recursive: true,
-            force: true,
-            maxRetries: 20,
-            retryDelay: 500,
-        });
-        // Only after a fully successful teardown: if anything above threw, the exit handler
-        // stays armed and still kills the survivor and deletes the temp folder at process exit.
-        process.removeListener("exit", cleanUpOnExit);
-    };
-
     return {
-        httpPort,
+        httpPort: found.httpPort,
         cdpPort: found.info.cdpPort,
-        bloomPid: servingPid ?? bloomProcess.pid!,
-        collectionDir,
-        stop,
+        servingPid: found.info.processId ?? bloomProcess.pid!,
+        pids: [bloomProcess.pid, found.info.processId].filter(isPid),
     };
+}
+
+/**
+ * Kill a running Bloom and wait until its HTTP port really goes dark. Shared by stop() and
+ * restart(): a survivor holds file handles on the collection, which breaks both the delete and
+ * the rewrite-then-relaunch.
+ */
+async function killAndWaitForPortToGoDark(
+    running: IRunningBloom,
+): Promise<void> {
+    killProcessTree(running.pids);
+    // Confirm rather than assume: taskkill has been seen to under-kill.
+    const deadline = Date.now() + 15000;
+    while (Date.now() < deadline) {
+        if (!(await readInstanceInfo(running.httpPort))) return;
+        await delay(500);
+    }
+    throw new Error(
+        `A Bloom is still answering on port ${running.httpPort} after teardown. ` +
+            `Kill pid ${running.servingPid} by hand before re-running.`,
+    );
+}
+
+/**
+ * Launch a dedicated Bloom.exe on a collection in a temp folder — one created for this test, or a
+ * copy of a prepared fixture — and wait until it is serving it. The returned object carries the
+ * discovered ports, a restart(), and a stop() that tears everything down.
+ */
+export async function launchBloom(
+    options: ILaunchBloomOptions,
+): Promise<ILaunchedBloom> {
+    if (!options.collectionName === !options.collectionSpec)
+        throw new Error(
+            "launchBloom needs exactly one of collectionName (a prepared fixture) and " +
+                "collectionSpec (a collection created for this test).",
+        );
+
+    // Canonicalize immediately: os.tmpdir() is an 8.3 short path on Windows but Bloom reports the
+    // long form, and discovery compares the two.
+    const tempRoot = canonicalPath(
+        fs.mkdtempSync(Path.join(os.tmpdir(), "bloom-e2e-")),
+    );
+
+    let collectionDir: string;
+    try {
+        collectionDir = options.collectionSpec
+            ? writeNewCollection(tempRoot, options.collectionSpec)
+            : copyPreparedCollection(tempRoot, options.collectionName!);
+    } catch (error) {
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+        throw error;
+    }
+
+    const readyTimeoutMs = options.readyTimeoutMs ?? 120000;
+
+    // The Bloom running right now. restart() replaces it, so everything that kills or reports on
+    // Bloom reads this variable rather than capturing the first launch.
+    let running: IRunningBloom | undefined;
+
+    // Tear down even if the run is aborted before the fixture's teardown runs. Armed once, and it
+    // reads `running`, so it still names the right pids after a restart.
+    const cleanUpOnExit = () => {
+        if (running) killProcessTree(running.pids);
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+    };
+    process.once("exit", cleanUpOnExit);
+
+    try {
+        running = await startBloomOn(collectionDir, readyTimeoutMs);
+    } catch (error) {
+        process.removeListener("exit", cleanUpOnExit);
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+        throw error;
+    }
+
+    const launched: ILaunchedBloom = {
+        httpPort: running.httpPort,
+        cdpPort: running.cdpPort,
+        bloomPid: running.servingPid,
+        collectionDir,
+
+        restart: async (betweenStopAndStart) => {
+            await killAndWaitForPortToGoDark(running!);
+            // Bloom releases its file handles slightly after it dies, and the caller is usually
+            // about to rewrite one of the files it had open.
+            await delay(1000);
+            if (betweenStopAndStart) await betweenStopAndStart();
+            running = await startBloomOn(collectionDir, readyTimeoutMs);
+            launched.httpPort = running.httpPort;
+            launched.cdpPort = running.cdpPort;
+            launched.bloomPid = running.servingPid;
+        },
+
+        stop: async () => {
+            await killAndWaitForPortToGoDark(running!);
+            // Bloom can release file handles slightly after it dies, so let rmSync retry.
+            fs.rmSync(tempRoot, {
+                recursive: true,
+                force: true,
+                maxRetries: 20,
+                retryDelay: 500,
+            });
+            // Only after a fully successful teardown: if anything above threw, the exit handler
+            // stays armed and still kills the survivor and deletes the temp folder at process exit.
+            process.removeListener("exit", cleanUpOnExit);
+        },
+    };
+    return launched;
+}
+
+/**
+ * Copy a prepared collection from the inputs repository into the temp folder, and return the
+ * copy. Throws, naming the collections that do exist, when the name is not one of them.
+ */
+function copyPreparedCollection(
+    tempRoot: string,
+    collectionName: string,
+): string {
+    const sourceCollectionsRoot = getSourceCollectionsRoot();
+    const sourceCollection = Path.join(sourceCollectionsRoot, collectionName);
+    if (!fs.existsSync(sourceCollection)) {
+        const available = fs
+            .readdirSync(sourceCollectionsRoot)
+            .filter((f) =>
+                fs.statSync(Path.join(sourceCollectionsRoot, f)).isDirectory(),
+            );
+        throw new Error(
+            `There is no test-input collection named "${collectionName}". ` +
+                `Available collections: ${available.join(", ")}.`,
+        );
+    }
+    const collectionDir = Path.join(tempRoot, collectionName);
+    copyCollection(sourceCollection, collectionDir);
+    return collectionDir;
 }

--- a/src/BloomE2E/fixtures/problemDialogWatcher.ts
+++ b/src/BloomE2E/fixtures/problemDialogWatcher.ts
@@ -132,12 +132,15 @@ async function closeProblemDialog(page: Page): Promise<void> {
 }
 
 /**
- * Start polling for problem dialogs on the given CDP connection. Each dialog found is recorded
+ * Start polling for problem dialogs. The connection comes from a getter rather than a Browser,
+ * because bloomApp.restart() replaces it: a watcher holding the first connection would silently
+ * stop seeing dialogs after a restart. The getter returns undefined while a restart is in flight,
+ * when there is nothing to scan. Each dialog found is recorded
  * (with its detail) and then closed, so the test can carry on far enough to fail with a message
  * that names the real exception.
  */
 export function startProblemDialogWatcher(
-    browser: Browser,
+    getBrowser: () => Browser | undefined,
     intervalMs = 750,
 ): IProblemDialogWatcher {
     const problems: IBloomProblem[] = [];
@@ -150,6 +153,8 @@ export function startProblemDialogWatcher(
     // One scan: find a dialog, record it, close it. Never throws: a failure to gather the
     // detail or to close still gets recorded as a problem, and the watcher keeps running.
     const checkOnce = async (): Promise<boolean> => {
+        const browser = getBrowser();
+        if (!browser) return false;
         const found = await findProblemDialog(browser).catch(() => undefined);
         if (!found) return false;
         if (unclosable.has(found.page)) return false;

--- a/src/BloomE2E/helpers/bookMaking.ts
+++ b/src/BloomE2E/helpers/bookMaking.ts
@@ -1,0 +1,384 @@
+// Make a book and put text in it, so a test can build the book it needs instead of shipping one.
+//
+// A test that carries its own prepared book inherits somebody else's assumptions: the next person
+// to edit that book changes what the test means, without reading it. So the default is that a test
+// creates its own collection (see ILaunchBloomOptions.collectionSpec) and makes its own book here.
+//
+// Making the book is setup, not the behavior any of these tests measures, so this takes the fast
+// reliable path through Bloom's API wherever there is one, per the UI-vs-API policy in README.md.
+// The text itself goes in through the real editor, because there is no API that writes it.
+
+import { expect, type Frame, type Page } from "@playwright/test";
+import { apiGet, apiGetJson, apiPost } from "./api";
+import { waitForCollectionReady } from "./collection";
+
+/** One book as collections/books reports it. Only the fields used here. */
+interface IBookInfo {
+    title: string;
+    folderPath: string;
+}
+
+/** One source collection as collections/list reports it. Only the fields used here. */
+interface ICollectionInfo {
+    id: string;
+    name: string;
+}
+
+/** What editView/topBar/contentLanguageUsage replies with. */
+interface IContentLanguageUsage {
+    languages: {
+        id: string;
+        label: string;
+        isUsedForContent: boolean;
+    }[];
+}
+
+/**
+ * Make a new book in the editable collection from one of Bloom's factory templates, e.g.
+ * "Basic Book", and return its folder. Bloom lands in the Edit tab, showing the new book's cover.
+ *
+ * This is the same action as selecting the template in Sources For New Books and clicking
+ * MAKE A BOOK USING THIS SOURCE.
+ */
+export async function makeBookFromTemplate(
+    page: Page,
+    templateTitle: string,
+): Promise<string> {
+    await waitForCollectionReady(page);
+    const collections = await apiGetJson<ICollectionInfo[]>(
+        page,
+        "collections/list",
+    );
+    const templates = collections.find((c) => c.name === "Templates");
+    if (!templates)
+        throw new Error(
+            `Bloom is not showing a "Templates" source collection, so there is no ` +
+                `"${templateTitle}" to make a book from. Collections: ` +
+                collections.map((c) => c.name).join(", "),
+        );
+    const books = await apiGetJson<IBookInfo[]>(
+        page,
+        `collections/books?collection-id=${encodeURIComponent(templates.id)}`,
+    );
+    const template = books.find((b) => b.title === templateTitle);
+    if (!template)
+        throw new Error(
+            `There is no factory template called "${templateTitle}". ` +
+                `Templates: ${books.map((b) => b.title).join(", ")}.`,
+        );
+
+    const before = await listEditableBooks(page);
+    await apiPost(
+        page,
+        `collections/selected-book?path=${encodeURIComponent(template.folderPath)}` +
+            `&collection-id=${encodeURIComponent(templates.id)}`,
+    );
+    await apiPost(page, "app/makeFromSelectedBook");
+
+    // Bloom makes the book, selects it, and switches to the Edit tab. Wait for the book to exist
+    // rather than for the tab, so the folder we return is real.
+    let made: IBookInfo | undefined;
+    await expect
+        .poll(
+            async () => {
+                made = (await listEditableBooks(page)).find(
+                    (b) =>
+                        !before.some((old) => old.folderPath === b.folderPath),
+                );
+                return !!made;
+            },
+            {
+                timeout: 90000,
+                message: `Bloom never added a book made from "${templateTitle}".`,
+            },
+        )
+        .toBe(true);
+    await waitForEditablePage(page);
+    return made!.folderPath;
+}
+
+/**
+ * The folder of the book with this title, in the collection Bloom has open.
+ *
+ * A test cannot hold on to the folder it got when it made the book: Bloom renames a book's folder
+ * to match its title, so the folder changes the first time the book is saved with a new title.
+ */
+export async function findBookFolder(
+    page: Page,
+    title: string,
+): Promise<string> {
+    const books = await listEditableBooks(page);
+    const book = books.find((b) => b.title === title);
+    if (!book)
+        throw new Error(
+            `The collection has no book called "${title}". It has: ` +
+                books.map((b) => `"${b.title}"`).join(", ") +
+                ".",
+        );
+    return book.folderPath;
+}
+
+/** The books in the collection Bloom has open. */
+async function listEditableBooks(page: Page): Promise<IBookInfo[]> {
+    const name = (
+        await apiGet(page, "collections/getCurrentEditableCollectionName")
+    ).body;
+    const collections = await apiGetJson<ICollectionInfo[]>(
+        page,
+        "collections/list",
+    );
+    const editable = collections.find((c) => c.name === name) ?? collections[0];
+    return apiGetJson<IBookInfo[]>(
+        page,
+        `collections/books?collection-id=${encodeURIComponent(editable.id)}`,
+    );
+}
+
+/**
+ * Set exactly which of the collection's languages the book shows, by the same route as the Edit
+ * tab's One/Two/Three Languages dropdown. Language 1 is always shown and cannot be turned off.
+ *
+ * Each change is confirmed before the next is sent. Sending two in quick succession has been seen
+ * to lose one, and a state wait is both the honest fix and faster than a fixed pause.
+ */
+export async function setContentLanguages(
+    page: Page,
+    tags: string[],
+): Promise<void> {
+    const usage = await apiGetJson<IContentLanguageUsage>(
+        page,
+        "editView/topBar/contentLanguageUsage",
+    );
+    for (const language of usage.languages) {
+        const wanted = tags.includes(language.id);
+        if (language.isUsedForContent === wanted) continue;
+        await apiPost(
+            page,
+            "editView/topBar/contentLanguageUsageChange",
+            JSON.stringify({
+                languageTag: language.id,
+                isUsedForContent: wanted,
+            }),
+            "application/json",
+        );
+        await expect
+            .poll(
+                async () =>
+                    (
+                        await apiGetJson<IContentLanguageUsage>(
+                            page,
+                            "editView/topBar/contentLanguageUsage",
+                        )
+                    ).languages.find((l) => l.id === language.id)
+                        ?.isUsedForContent,
+                {
+                    timeout: 30000,
+                    message: `Bloom never reported ${language.id} as ${wanted ? "shown" : "hidden"}.`,
+                },
+            )
+            .toBe(wanted);
+    }
+    await waitForEditablePage(page);
+}
+
+/** The Edit tab's frame holding the page being edited. Throws if the Edit tab is not showing. */
+export function editablePageFrame(page: Page): Frame {
+    const frame = page.frame({ name: "page" });
+    if (!frame)
+        throw new Error(
+            "There is no 'page' frame, so Bloom is not showing a page in the Edit tab. " +
+                `Frames: ${page
+                    .frames()
+                    .map((f) => f.name() || "(main)")
+                    .join(", ")}.`,
+        );
+    return frame;
+}
+
+/** Wait until the Edit tab is showing a page with at least one editable box in it. */
+export async function waitForEditablePage(
+    page: Page,
+    timeoutMs = 90000,
+): Promise<void> {
+    await expect
+        .poll(
+            async () => {
+                const frame = page.frame({ name: "page" });
+                if (!frame) return 0;
+                return frame
+                    .locator(".bloom-editable")
+                    .count()
+                    .catch(() => 0);
+            },
+            {
+                timeout: timeoutMs,
+                message: "The Edit tab never showed a page with editable text.",
+            },
+        )
+        .toBeGreaterThan(0);
+}
+
+/** One page of the selected book, as e2e/pages reports it. */
+export interface IBookPage {
+    /** The page's id, which is what editView/jumpToPage takes. */
+    id: string;
+    /** The page list's caption for the page: its number, or its name for front and back matter. */
+    caption: string;
+    /** False for the cover, the credits page, and the rest of the front and back matter. */
+    isContentPage: boolean;
+}
+
+/**
+ * The pages of the selected book, in order.
+ *
+ * This asks Bloom rather than reading the page-list thumbnails, because the thumbnails do not say
+ * which pages are front or back matter, and a test that guessed from their markup would break the
+ * first time that markup changed.
+ */
+export async function getPages(page: Page): Promise<IBookPage[]> {
+    return apiGetJson<IBookPage[]>(page, "e2e/pages");
+}
+
+/** The book's content pages: everything except the front and back matter. */
+export async function getContentPages(page: Page): Promise<IBookPage[]> {
+    return (await getPages(page)).filter((p) => p.isContentPage);
+}
+
+/** One template page the Add Page dialog offers, as e2e/templatePages reports it. */
+interface ITemplatePage {
+    id: string;
+    /** The label the Add Page dialog shows under the thumbnail, e.g. "Basic Text & Picture". */
+    label: string;
+    /** The template book that holds the page. The addPage API needs it as well as the id. */
+    templateBookPath: string;
+}
+
+/**
+ * Add content pages to the selected book, by the same route as the Add Page dialog: pick the
+ * template page with this label, then insert it `times` times.
+ *
+ * A book made from a template starts with front and back matter only, because every page of a
+ * template book is a template page. So a test that needs a content page adds one.
+ */
+export async function addPage(
+    page: Page,
+    templatePageLabel: string,
+    times = 1,
+): Promise<void> {
+    const templates = await apiGetJson<ITemplatePage[]>(
+        page,
+        "e2e/templatePages",
+    );
+    const template = templates.find((t) => t.label === templatePageLabel);
+    if (!template)
+        throw new Error(
+            `This book's template offers no page called "${templatePageLabel}". ` +
+                `It offers: ${templates.map((t) => t.label).join(", ")}.`,
+        );
+    const before = (await getPages(page)).length;
+    await apiPost(
+        page,
+        "addPage",
+        JSON.stringify({
+            templateBookPath: template.templateBookPath,
+            pageId: template.id,
+            numberToAdd: times,
+            // The Add Page dialog always sends these three, and the API reads all of them, so
+            // leaving one out makes it throw. See PageChooserDialog.tsx.
+            convertWholeBook: false,
+            allowDataLoss: false,
+            dataToolId: "",
+        }),
+        "application/json",
+    );
+    await expect
+        .poll(async () => (await getPages(page)).length, {
+            timeout: 60000,
+            message: `Bloom never added the "${templatePageLabel}" page(s).`,
+        })
+        .toBe(before + times);
+    await waitForEditablePage(page);
+}
+
+/**
+ * Show a page in the Edit tab. This is also how a test SAVES what it typed: Bloom writes the page
+ * it is leaving, so text typed into a box reaches the file only once the book moves off that page.
+ */
+export async function goToPage(page: Page, pageId: string): Promise<void> {
+    // The Edit tab drops a jump that arrives while it is still loading a page, so wait for it to
+    // be showing one before asking for another.
+    await waitForEditablePage(page);
+
+    // Ask up to three times. Coming back from the Publish tab, the Edit tab can still swallow a
+    // jump after it looks ready, and asking again costs a few seconds where failing costs the run.
+    const showing = async () =>
+        (await page
+            .frame({ name: "page" })
+            ?.locator(`.bloom-page[id="${pageId}"]`)
+            .count()
+            .catch(() => 0)) ?? 0;
+    for (let attempt = 1; attempt <= 3; attempt++) {
+        await apiPost(page, "editView/jumpToPage", pageId, "text/plain");
+        try {
+            await expect.poll(showing, { timeout: 20000 }).toBe(1);
+            return;
+        } catch {
+            // fall through and ask again
+        }
+    }
+    throw new Error(
+        `Bloom never showed page ${pageId} in the Edit tab, after three attempts.`,
+    );
+}
+
+/**
+ * Duplicate the page Bloom is showing, `times` times, and wait for the new pages to appear.
+ * Used to give a book more than one content page without driving the Add Page dialog.
+ */
+export async function duplicateCurrentPage(
+    page: Page,
+    times = 1,
+): Promise<void> {
+    const before = (await getPages(page)).length;
+    await apiPost(
+        page,
+        "editView/duplicatePageMany",
+        JSON.stringify({ numberOfTimes: times }),
+        "application/json",
+    );
+    await expect
+        .poll(async () => (await getPages(page)).length, {
+            timeout: 60000,
+            message: "Bloom never added the duplicated page(s).",
+        })
+        .toBe(before + times);
+    await waitForEditablePage(page);
+}
+
+/**
+ * Type text into one language's box of one translation group on the page being shown, the way a
+ * person does. `groupSelector` picks the group, e.g. ".bookTitle" for the cover title.
+ *
+ * Pass an empty string to clear the box; that is how a test makes a translation incomplete.
+ * Nothing reaches the file until the book leaves this page — see goToPage.
+ */
+export async function typeInGroup(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+    text: string,
+): Promise<void> {
+    const box = editablePageFrame(page)
+        .locator(`${groupSelector} .bloom-editable[lang="${languageTag}"]`)
+        .first();
+    await box.waitFor({ state: "visible", timeout: 30000 });
+    // Click in, select what is there, and type over it. A box here is a CKEditor surface, and
+    // filling it directly leaves part of the old text behind.
+    await box.click();
+    await box.press("Control+a");
+    await box.press("Delete");
+    if (text) await box.pressSequentially(text);
+    // Bloom's editor reacts to typing; confirm the box holds what we meant before moving on, so a
+    // later failure cannot be blamed on text that never arrived.
+    await expect(box).toHaveText(text, { timeout: 15000 });
+}

--- a/src/BloomE2E/helpers/publish.ts
+++ b/src/BloomE2E/helpers/publish.ts
@@ -1,0 +1,232 @@
+// Drive and read the Publish tab: its destination chooser, and the Text Languages check box list.
+//
+// The list is shared by the Web and BloomPUB screens, which both render PublishLanguagesGroup and
+// both write BookInfo.PublishSettings.BloomLibrary.TextLangs. So "does the other screen agree" is a
+// real question a test can ask, not a formality.
+
+import { expect, type Frame, type Locator, type Page } from "@playwright/test";
+import { apiGetJson } from "./api";
+import { switchTab } from "./workspace";
+
+/** The publish destinations, by the label each one shows in the left-hand column. */
+export type PublishDestination =
+    | "PDF & Print"
+    | "Web"
+    | "BloomPUB"
+    | "Apps"
+    | "ePUB"
+    | "Audio or Video";
+
+/**
+ * What publish/languagesInBook says about one language of the book. This is Bloom's own view of
+ * the same state the check boxes show, so a test can assert on it instead of scraping the DOM.
+ * Mirrors C#'s LanguagePublishInfo.
+ */
+export interface ILanguagePublishInfo {
+    code: string;
+    name: string;
+    /** False when at least one content-page translation group lacks this language. */
+    complete: boolean;
+    includeText: boolean;
+    containsAnyAudio: boolean;
+    includeAudio: boolean;
+    /** True when the book currently shows this language, which forces it into the publication. */
+    required: boolean;
+}
+
+/** One row of the Text Languages list, as a reader of the screen sees it. */
+export interface ITextLanguageRow {
+    /** The language's name, as the row shows it: the collection's name for it, or its autonym. */
+    name: string;
+    /** True when the row carries the "(incomplete translation)" sub-label. */
+    incomplete: boolean;
+    checked: boolean;
+    /** True for a language the book shows: it is required, so the box cannot be cleared. */
+    disabled: boolean;
+}
+
+/** Go to the Publish tab and open one of its destinations. A book must already be selected. */
+export async function openPublishDestination(
+    page: Page,
+    destination: PublishDestination,
+): Promise<void> {
+    await switchTab(page, "publish");
+    const target = page.getByRole("tab", { name: destination, exact: true });
+    await target.waitFor({ state: "visible", timeout: 30000 });
+    await target.click();
+    await textLanguagesGroup(page).waitFor({
+        state: "visible",
+        timeout: 60000,
+    });
+}
+
+/** The Text Languages group, told apart from the Talking Book group by its test id. */
+export function textLanguagesGroup(page: Page): Locator {
+    return page.getByTestId("text-languages-group");
+}
+
+/** Every row of the Text Languages list, in the order the screen shows them. */
+export async function getTextLanguageRows(
+    page: Page,
+): Promise<ITextLanguageRow[]> {
+    await textLanguagesGroup(page).waitFor({
+        state: "visible",
+        timeout: 60000,
+    });
+    return page.evaluate(() => {
+        const group = document.querySelector(
+            '[data-testid="text-languages-group"]',
+        );
+        if (!group) return [];
+        return [...group.querySelectorAll('input[type="checkbox"]')].map(
+            (input) => {
+                const box = input as HTMLInputElement;
+                const label = box.closest("label");
+                const lines = (label?.innerText ?? "")
+                    .split("\n")
+                    .map((line) => line.trim())
+                    .filter(Boolean);
+                return {
+                    name: lines[0] ?? "",
+                    incomplete: lines.some((line) =>
+                        line.includes("incomplete translation"),
+                    ),
+                    checked: box.checked,
+                    disabled: box.disabled,
+                };
+            },
+        );
+    });
+}
+
+/**
+ * Wait until the Text Languages list settles into `expected`, and return it. The list is filled
+ * from publish/languagesInBook after the screen mounts, so reading it once races that fetch.
+ */
+export async function expectTextLanguageRows(
+    page: Page,
+    expected: ITextLanguageRow[],
+    message: string,
+): Promise<void> {
+    await expect
+        .poll(async () => JSON.stringify(await getTextLanguageRows(page)), {
+            timeout: 30000,
+            message,
+        })
+        .toBe(JSON.stringify(expected));
+}
+
+/**
+ * Wait until the Text Languages list holds exactly `expected`, in any order, and return it.
+ *
+ * Use this where the position of a row is not part of the behavior being tested. Where it is,
+ * such as an incomplete language sorting last, use expectTextLanguageRows instead.
+ */
+export async function expectTextLanguageRowsInAnyOrder(
+    page: Page,
+    expected: ITextLanguageRow[],
+    message: string,
+): Promise<void> {
+    const byName = (rows: ITextLanguageRow[]) =>
+        JSON.stringify([...rows].sort((a, b) => a.name.localeCompare(b.name)));
+    await expect
+        .poll(async () => byName(await getTextLanguageRows(page)), {
+            timeout: 30000,
+            message,
+        })
+        .toBe(byName(expected));
+}
+
+/** Click one language's check box, by the name its row shows. This is the action under test. */
+export async function clickTextLanguage(
+    page: Page,
+    name: string,
+): Promise<void> {
+    const row = textLanguagesGroup(page)
+        .locator("label")
+        .filter({ hasText: name })
+        .first();
+    await row.waitFor({ state: "visible", timeout: 30000 });
+    await row.locator('input[type="checkbox"]').click();
+}
+
+/**
+ * Click PREVIEW on the BloomPUB screen and wait for bloom-player to show the book.
+ *
+ * The preview is the publication itself, so it is where a test can see whether clearing a
+ * language's check box really kept that language out.
+ */
+export async function showBloomPubPreview(page: Page): Promise<Frame> {
+    await page.locator('[aria-label="refresh preview"]').click();
+    let player: Frame | undefined;
+    await expect
+        .poll(
+            async () => {
+                player = page
+                    .frames()
+                    .find((f) => f.url().includes("bloomplayer.htm"));
+                if (!player) return 0;
+                return player
+                    .locator('[aria-label="Choose Language"]')
+                    .count()
+                    .catch(() => 0);
+            },
+            {
+                timeout: 120000,
+                message: "The BloomPUB preview never showed the book.",
+            },
+        )
+        .toBeGreaterThan(0);
+    return player!;
+}
+
+/**
+ * The languages bloom-player offers in its "Languages in this book:" menu, in the order shown.
+ * Each is the name the language calls itself, which is not the name the check box list shows.
+ *
+ * The menu is closed again, so the preview is left as it was found.
+ */
+export async function getPreviewLanguages(player: Frame): Promise<string[]> {
+    await player.locator('[aria-label="Choose Language"]').click();
+    const options = player.locator('[aria-label="languages"] label');
+    await options.first().waitFor({ state: "visible", timeout: 30000 });
+    const names = (await options.allInnerTexts()).map((t) => t.trim());
+    await player.getByRole("button", { name: "Close" }).click();
+    return names;
+}
+
+/** What Bloom itself says about the languages in the selected book. */
+export async function getLanguagesInBook(
+    page: Page,
+): Promise<ILanguagePublishInfo[]> {
+    return apiGetJson<ILanguagePublishInfo[]>(page, "publish/languagesInBook");
+}
+
+/**
+ * The tooltip text shown for one row, after hovering it the way a reader would. Bloom's tooltip
+ * needs a real pointer over the row; it is not in the DOM until then.
+ *
+ * The pointer moves off every row first, and the previous tooltip has to go, because reading the
+ * tooltip while the last one is still leaving returns the last one's words.
+ */
+export async function getTooltipForLanguage(
+    page: Page,
+    name: string,
+): Promise<string> {
+    const tooltip = page.locator('[role="tooltip"]');
+    await page.mouse.move(0, 0);
+    await expect
+        .poll(async () => tooltip.count(), {
+            timeout: 30000,
+            message: "The tooltip from the row hovered before never went away.",
+        })
+        .toBe(0);
+
+    const row = textLanguagesGroup(page)
+        .locator("label")
+        .filter({ hasText: name })
+        .first();
+    await row.hover();
+    await tooltip.first().waitFor({ state: "visible", timeout: 30000 });
+    return (await tooltip.first().innerText()).trim();
+}

--- a/src/BloomE2E/tests/publish-text-languages.spec.ts
+++ b/src/BloomE2E/tests/publish-text-languages.spec.ts
@@ -1,0 +1,490 @@
+// The Text Languages check box list on the Publish tab: which languages of a book's text a
+// publication may carry. Automates the manual test "Text Languages Publish List".
+//
+// The list appears on both the Web and the BloomPUB screens, and both write the same setting
+// (BookInfo.PublishSettings.BloomLibrary.TextLangs), so several of these tests check that the two
+// screens agree.
+//
+// THE ORDER OF THESE TESTS IS LOAD-BEARING, which is why they are serial. Bloom computes a
+// language's check state from the defaults only until something clicks its box; from then on the
+// value is Include or Exclude and is never recomputed. So every test of default behavior has to
+// run before the test that clicks a box, and the file would quietly stop testing the defaults if
+// they were reordered.
+
+import * as fs from "node:fs";
+import * as Path from "node:path";
+import { expect, test } from "../fixtures/bloomTest";
+import { makeCollectionXml } from "../fixtures/launchBloom";
+import {
+    addPage,
+    findBookFolder,
+    getContentPages,
+    getPages,
+    goToPage,
+    makeBookFromTemplate,
+    setContentLanguages,
+    typeInGroup,
+} from "../helpers/bookMaking";
+import { selectBook } from "../helpers/collection";
+import {
+    clickTextLanguage,
+    expectTextLanguageRows,
+    expectTextLanguageRowsInAnyOrder,
+    getLanguagesInBook,
+    getPreviewLanguages,
+    getTextLanguageRows,
+    getTooltipForLanguage,
+    openPublishDestination,
+    showBloomPubPreview,
+} from "../helpers/publish";
+import { switchTab } from "../helpers/workspace";
+
+// The collection starts with German as Language 2 so that the book's cover title can be typed in
+// German: the cover title box shows Language 1 and Language 2 only. Once the German title is in,
+// the test rewrites the collection as English, French and Spanish, which leaves German present in
+// the front matter and nowhere else — the state that proves a language with no content-page text
+// gets no check box at all.
+const COLLECTION_NAME = "text-languages";
+const STARTING_LANGUAGES = ["en", "de", "fr"];
+const FINAL_LANGUAGES = ["en", "fr", "es"];
+
+test.use({
+    collectionSpec: { name: COLLECTION_NAME, languages: STARTING_LANGUAGES },
+});
+
+test.describe.configure({ mode: "serial" });
+
+// The title of the book every test in this file works on.
+const BOOK_TITLE = "Text Languages Test";
+
+// The book's folder. Built once, by the first test. Bloom renames the folder to match the title,
+// so this is read back from Bloom rather than kept from when the book was made.
+let bookFolder: string;
+
+test.describe("the Text Languages publish list", () => {
+    test("builds a book with three complete languages and a German front matter title", async ({
+        page,
+        bloomApp,
+    }) => {
+        test.setTimeout(300000);
+
+        await makeBookFromTemplate(page, "Basic Book");
+
+        // The cover title, in English and in German. Nothing else in the book will be German.
+        await typeInGroup(page, ".bookTitle", "en", BOOK_TITLE);
+        await typeInGroup(page, ".bookTitle", "de", "Sprachentest");
+
+        // Two content pages, each with English and French. Two, because a language is
+        // "incomplete" when SOME content page lacks it: with one page there would be no
+        // difference between an incomplete language and an absent one.
+        await addPage(page, "Just Text", 2);
+        await setContentLanguages(page, ["en", "fr"]);
+
+        // Give each page its own words, so a later failure names the page it came from.
+        const contentPages = await getContentPages(page);
+        expect(contentPages.length).toBe(2);
+        await goToPage(page, contentPages[0].id);
+        await typeInGroup(page, ".bloom-translationGroup", "en", "One");
+        await typeInGroup(page, ".bloom-translationGroup", "fr", "Un");
+        await goToPage(page, contentPages[1].id);
+        await typeInGroup(page, ".bloom-translationGroup", "en", "Two");
+        await typeInGroup(page, ".bloom-translationGroup", "fr", "Deux");
+
+        // Leave the page before the restart. The fixture stops Bloom by killing the process, so
+        // anything typed on the page still showing is never written to the file.
+        const coverBeforeRestart = (await getPages(page)).find(
+            (p) => !p.isContentPage,
+        );
+        await goToPage(page, coverBeforeRestart!.id);
+
+        // Now swap German out for Spanish. Collection settings have no API and their dialog is a
+        // WinForms surface CDP cannot reach, so the way to change them is to quit Bloom, rewrite
+        // the .bloomCollection, and start again. See AUTOMATION-DEBT.md.
+        const newPage = await bloomApp.restart(() =>
+            fs.writeFileSync(
+                Path.join(
+                    bloomApp.collectionDir,
+                    `${COLLECTION_NAME}.bloomCollection`,
+                ),
+                makeCollectionXml(FINAL_LANGUAGES),
+                "utf8",
+            ),
+        );
+        bookFolder = await findBookFolder(newPage, BOOK_TITLE);
+        await selectBook(newPage, bookFolder);
+        await switchTab(newPage, "edit");
+
+        // Spanish on both content pages, so all three languages are complete.
+        await setContentLanguages(newPage, ["en", "fr", "es"]);
+        const pagesAfterRestart = await getContentPages(newPage);
+        await goToPage(newPage, pagesAfterRestart[0].id);
+        await typeInGroup(newPage, ".bloom-translationGroup", "es", "Uno");
+        await goToPage(newPage, pagesAfterRestart[1].id);
+        await typeInGroup(newPage, ".bloom-translationGroup", "es", "Dos");
+
+        // Back to the cover, which is what makes Bloom save the page just typed, and then back to
+        // showing one language, so English is the only required language.
+        const cover = (await getPages(newPage)).find((p) => !p.isContentPage);
+        await goToPage(newPage, cover!.id);
+        await setContentLanguages(newPage, ["en"]);
+
+        // Sanity check the book this whole file rests on, so a later failure means the list is
+        // wrong rather than that the book was never built properly. The Publish tab has to be open
+        // first: publish/languagesInBook answers for the book the Publish tab holds, and there is
+        // no such book until the tab is entered.
+        await openPublishDestination(newPage, "Web");
+        const languages = await getLanguagesInBook(newPage);
+        expect(languages.map((l) => l.code)).toEqual(["en", "fr", "es"]);
+        expect(languages.filter((l) => !l.complete).map((l) => l.code)).toEqual(
+            [],
+        );
+    });
+
+    test("shows every language of the text, and only those, checked by default [Test Case ID 169]", async ({
+        bloomApp,
+    }) => {
+        const page = bloomApp.page;
+        await openPublishDestination(page, "Web");
+
+        // German is absent because it has no text on a content page; English is disabled because
+        // the book shows it, which makes it required.
+        await expectTextLanguageRows(
+            page,
+            [
+                {
+                    name: "English",
+                    incomplete: false,
+                    checked: true,
+                    disabled: true,
+                },
+                {
+                    name: "French",
+                    incomplete: false,
+                    checked: true,
+                    disabled: false,
+                },
+                {
+                    name: "Spanish",
+                    incomplete: false,
+                    checked: true,
+                    disabled: false,
+                },
+            ],
+            "The Web screen never showed the three complete languages, all checked.",
+        );
+
+        // The BloomPUB screen shows the same list, because both screens read one setting.
+        await openPublishDestination(page, "BloomPUB");
+        await expectTextLanguageRows(
+            page,
+            [
+                {
+                    name: "English",
+                    incomplete: false,
+                    checked: true,
+                    disabled: true,
+                },
+                {
+                    name: "French",
+                    incomplete: false,
+                    checked: true,
+                    disabled: false,
+                },
+                {
+                    name: "Spanish",
+                    incomplete: false,
+                    checked: true,
+                    disabled: false,
+                },
+            ],
+            "The BloomPUB screen disagreed with the Web screen about the text languages.",
+        );
+    });
+
+    test("explains in a tooltip why a required language cannot be cleared [Test Case ID 169]", async ({
+        bloomApp,
+    }) => {
+        const page = bloomApp.page;
+        await openPublishDestination(page, "Web");
+
+        expect(await getTooltipForLanguage(page, "English")).toBe(
+            "This is disabled because this language is currently shown in the book, so it is required.",
+        );
+        expect(await getTooltipForLanguage(page, "French")).toBe(
+            "Select this if you want readers to be able to choose to read the book in this language.",
+        );
+    });
+
+    test("makes a language required while the book shows it [Test Case ID 169]", async ({
+        bloomApp,
+    }) => {
+        const page = bloomApp.page;
+
+        await switchTab(page, "edit");
+        await setContentLanguages(page, ["en", "fr"]);
+        await openPublishDestination(page, "Web");
+        expect(
+            (await getLanguagesInBook(page)).find((l) => l.code === "fr")
+                ?.required,
+        ).toBe(true);
+        await expectTextLanguageRows(
+            page,
+            [
+                {
+                    name: "English",
+                    incomplete: false,
+                    checked: true,
+                    disabled: true,
+                },
+                {
+                    name: "French",
+                    incomplete: false,
+                    checked: true,
+                    disabled: true,
+                },
+                {
+                    name: "Spanish",
+                    incomplete: false,
+                    checked: true,
+                    disabled: false,
+                },
+            ],
+            "French did not become required when the book started showing it.",
+        );
+
+        // Showing all three makes all three required.
+        await switchTab(page, "edit");
+        await setContentLanguages(page, ["en", "fr", "es"]);
+        await openPublishDestination(page, "Web");
+        expect((await getTextLanguageRows(page)).every((r) => r.disabled)).toBe(
+            true,
+        );
+
+        // Back to one language: only English stays required.
+        await switchTab(page, "edit");
+        await setContentLanguages(page, ["en"]);
+        await openPublishDestination(page, "Web");
+        await expectTextLanguageRows(
+            page,
+            [
+                {
+                    name: "English",
+                    incomplete: false,
+                    checked: true,
+                    disabled: true,
+                },
+                {
+                    name: "French",
+                    incomplete: false,
+                    checked: true,
+                    disabled: false,
+                },
+                {
+                    name: "Spanish",
+                    incomplete: false,
+                    checked: true,
+                    disabled: false,
+                },
+            ],
+            "French and Spanish stayed required after the book stopped showing them.",
+        );
+    });
+
+    test("marks a language whose translation is incomplete, and leaves it unchecked [Test Case ID 169]", async ({
+        bloomApp,
+    }) => {
+        const page = bloomApp.page;
+        test.setTimeout(180000);
+
+        // Take the French text off the second content page. French is then on one page but not
+        // the other, which is what "incomplete" means.
+        await switchTab(page, "edit");
+        await setContentLanguages(page, ["en", "fr"]);
+        const contentPages = await getContentPages(page);
+        await goToPage(page, contentPages[1].id);
+        await typeInGroup(page, ".bloom-translationGroup", "fr", "");
+        // Leave the page before anything else, so the cleared box is written to the file.
+        await goToPage(page, contentPages[0].id);
+        await setContentLanguages(page, ["en"]);
+
+        await openPublishDestination(page, "Web");
+        // An incomplete language sorts below the complete ones.
+        await expectTextLanguageRows(
+            page,
+            [
+                {
+                    name: "English",
+                    incomplete: false,
+                    checked: true,
+                    disabled: true,
+                },
+                {
+                    name: "Spanish",
+                    incomplete: false,
+                    checked: true,
+                    disabled: false,
+                },
+                {
+                    name: "French",
+                    incomplete: true,
+                    checked: false,
+                    disabled: false,
+                },
+            ],
+            "French was not marked incomplete, unchecked, and sorted last.",
+        );
+
+        // A language the book shows is required even when its translation is incomplete.
+        await switchTab(page, "edit");
+        await setContentLanguages(page, ["en", "fr"]);
+        await openPublishDestination(page, "Web");
+        const french = (await getTextLanguageRows(page)).find(
+            (r) => r.name === "French",
+        );
+        expect(french).toEqual({
+            name: "French",
+            incomplete: true,
+            checked: true,
+            disabled: true,
+        });
+
+        // Put the French text back, so the tests after this one start from a complete book.
+        await switchTab(page, "edit");
+        await goToPage(page, contentPages[1].id);
+        await typeInGroup(page, ".bloom-translationGroup", "fr", "Deux");
+        await goToPage(page, contentPages[0].id);
+        await setContentLanguages(page, ["en"]);
+    });
+
+    // KNOWN FLAKE: this test failed once in six full runs on 2026-09-01, and the cause is not
+    // known. The failure was not reproduced, and the log kept only the tail, so the assertion that
+    // failed was not captured. Whoever sees it fail again: keep the whole log. This test does not
+    // change which languages the book shows, so the earlier suspicion about quick successive
+    // calls to editView/topBar/contentLanguageUsageChange does not explain it.
+    test("keeps a language that the collection no longer has, under its own name [Test Case ID 169]", async ({
+        bloomApp,
+    }) => {
+        test.setTimeout(180000);
+
+        // Drop Spanish from the collection. The book still has Spanish text, so the language stays
+        // in the list; but the collection no longer supplies a name for it, so Bloom falls back to
+        // the name the language calls itself.
+        const withoutSpanish = await bloomApp.restart(() =>
+            fs.writeFileSync(
+                Path.join(
+                    bloomApp.collectionDir,
+                    `${COLLECTION_NAME}.bloomCollection`,
+                ),
+                makeCollectionXml(["en", "fr"]),
+                "utf8",
+            ),
+        );
+        await selectBook(withoutSpanish, bookFolder);
+        await openPublishDestination(withoutSpanish, "Web");
+        // In any order: where a language the collection no longer names sits in the list is not
+        // part of what this test is about.
+        await expectTextLanguageRowsInAnyOrder(
+            withoutSpanish,
+            [
+                {
+                    name: "English",
+                    incomplete: false,
+                    checked: true,
+                    disabled: true,
+                },
+                {
+                    name: "French",
+                    incomplete: false,
+                    checked: true,
+                    disabled: false,
+                },
+                {
+                    name: "español",
+                    incomplete: false,
+                    checked: false,
+                    disabled: false,
+                },
+            ],
+            "Spanish did not stay in the list, unchecked and under its own name.",
+        );
+
+        // Put Spanish back, for the test that follows.
+        const withSpanish = await bloomApp.restart(() =>
+            fs.writeFileSync(
+                Path.join(
+                    bloomApp.collectionDir,
+                    `${COLLECTION_NAME}.bloomCollection`,
+                ),
+                makeCollectionXml(FINAL_LANGUAGES),
+                "utf8",
+            ),
+        );
+        await selectBook(withSpanish, bookFolder);
+    });
+
+    test("keeps the choice a person makes, across screens and across a restart [Test Case ID 169]", async ({
+        bloomApp,
+    }) => {
+        test.setTimeout(180000);
+
+        // THE ACTION UNDER TEST: a real click on a real check box.
+        await openPublishDestination(bloomApp.page, "Web");
+        await clickTextLanguage(bloomApp.page, "Spanish");
+        await expect
+            .poll(
+                async () =>
+                    (await getLanguagesInBook(bloomApp.page)).find(
+                        (l) => l.code === "es",
+                    )?.includeText,
+                {
+                    message:
+                        "Clearing the Spanish box did not change the setting.",
+                },
+            )
+            .toBe(false);
+
+        // The BloomPUB screen shows the same setting, because there is only one.
+        await openPublishDestination(bloomApp.page, "BloomPUB");
+        expect(
+            (await getTextLanguageRows(bloomApp.page)).find(
+                (r) => r.name === "Spanish",
+            )?.checked,
+        ).toBe(false);
+
+        // The publication itself carries only the languages left checked.
+        const player = await showBloomPubPreview(bloomApp.page);
+        expect((await getPreviewLanguages(player)).sort()).toEqual([
+            "English",
+            "French",
+        ]);
+
+        // Put Spanish back, and the publication carries all three. bloom-player names a language
+        // the way the language names itself, so Spanish appears as "español (Spanish)".
+        await clickTextLanguage(bloomApp.page, "Spanish");
+        const playerWithSpanish = await showBloomPubPreview(bloomApp.page);
+        // Sorted, because the order bloom-player lists them in is not what this test is about.
+        expect((await getPreviewLanguages(playerWithSpanish)).sort()).toEqual(
+            ["English", "French", "español (Spanish)"].sort(),
+        );
+        await clickTextLanguage(bloomApp.page, "Spanish");
+
+        // It survives leaving the tab and coming back.
+        await switchTab(bloomApp.page, "collection");
+        await openPublishDestination(bloomApp.page, "Web");
+        expect(
+            (await getTextLanguageRows(bloomApp.page)).find(
+                (r) => r.name === "Spanish",
+            )?.checked,
+        ).toBe(false);
+
+        // And it survives quitting Bloom, because it is written into the book.
+        const afterRestart = await bloomApp.restart();
+        await selectBook(afterRestart, bookFolder);
+        await openPublishDestination(afterRestart, "Web");
+        expect(
+            (await getTextLanguageRows(afterRestart)).find(
+                (r) => r.name === "Spanish",
+            )?.checked,
+        ).toBe(false);
+    });
+});

--- a/src/BloomExe/web/controllers/E2eTestingApi.cs
+++ b/src/BloomExe/web/controllers/E2eTestingApi.cs
@@ -86,24 +86,101 @@ namespace Bloom.web.controllers
                 null, // read only
                 false // does not need the UI thread
             );
+
+            // GET returns the selected book's pages as JSON: id, caption, and whether the page is
+            // front or back matter. A test needs page ids to navigate (editView/jumpToPage takes
+            // one), and the page-list thumbnails do not expose which pages are xmatter, so without
+            // this a test has to guess from thumbnail markup.
+            apiHandler.RegisterEndpointHandler(
+                kApiUrlPart + "pages",
+                HandleGetPages,
+                false // does not need the UI thread
+            );
+
+            // GET returns the pages the Add Page dialog would offer for the selected book: the
+            // path of its template book, and the id and label of each template page. A test needs
+            // these to call the production "addPage" endpoint, and the dialog itself reads them
+            // out of the template book's HTML, so there is no other way to ask for them.
+            apiHandler.RegisterEndpointHandler(
+                kApiUrlPart + "templatePages",
+                HandleGetTemplatePages,
+                false // does not need the UI thread
+            );
         }
 
         /// <summary>
         /// True if the editable collection is loaded and its book list is available. Mirrors what
         /// selecting a book needs (see CollectionApi.GetCollectionOfRequest), so a test can wait
         /// for this before selecting. Any exception means "not ready yet", so we swallow it.
+        /// An EMPTY collection is ready: a test that creates its own collection starts with no
+        /// books and then makes one, so "has at least one book" would never come true for it.
         /// </summary>
         private bool IsCollectionReady()
         {
             try
             {
                 var editable = _collectionModel.TheOneEditableCollection;
-                return editable != null && editable.GetBookInfos().Any();
+                if (editable == null)
+                    return false;
+                // Enumerate the list rather than merely asking for it: that is the part that
+                // throws while the collection is still loading, which is what we are waiting out.
+                editable.GetBookInfos().ToList();
+                return true;
             }
             catch
             {
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Reply with the pages of the selected book, in order. `isContentPage` is false for the
+        /// front and back matter, which a test normally wants to skip over.
+        /// </summary>
+        private void HandleGetPages(ApiRequest request)
+        {
+            var book = _bookSelection.CurrentSelection;
+            if (book == null)
+            {
+                request.ReplyWithJson(new object[0]);
+                return;
+            }
+            var pages = book.GetPages()
+                .Select(page => new
+                {
+                    id = page.Id,
+                    caption = page.Caption,
+                    isContentPage = !page.IsXMatter,
+                })
+                .ToArray();
+            request.ReplyWithJson(pages);
+        }
+
+        /// <summary>
+        /// Reply with the template pages available to the selected book, each with the path of the
+        /// template book that holds it. A book made from a template starts with no content page,
+        /// because every page of a template is a template page, so a test that needs one adds it.
+        /// </summary>
+        private void HandleGetTemplatePages(ApiRequest request)
+        {
+            var book = _bookSelection.CurrentSelection;
+            var templateBook = book?.FindTemplateBook();
+            if (templateBook == null)
+            {
+                request.ReplyWithJson(new object[0]);
+                return;
+            }
+            var templateBookPath = templateBook.GetPathHtmlFile().Replace('\\', '/');
+            var pages = templateBook
+                .GetTemplatePagesIdDictionary()
+                .Select(pair => new
+                {
+                    id = pair.Key,
+                    label = pair.Value.Caption,
+                    templateBookPath,
+                })
+                .ToArray();
+            request.ReplyWithJson(pages);
         }
 
         /// <summary>


### PR DESCRIPTION
Automates the manual test [Text Languages Publish List](https://app.notion.com/p/hattonjohn/Text-Languages-Publish-List-3904bb19df128129a326e4f7852651fa) (Notion `Test Case ID` 169; its `Dokimion ID` is TC147).

`src/BloomE2E/tests/publish-text-languages.spec.ts` holds six tests carrying `[Test Case ID 169]` in their titles, plus a seventh that builds the book they share. Together they cover every step of the card:

- which languages get a check box, and that German, present only in the front matter, gets none;
- the two tooltips;
- a language the book shows becoming required, so its box is checked and cannot be cleared;
- an incomplete translation, marked and unchecked and sorted last;
- a language the collection no longer has, which stays in the list under its own name, `español`;
- the choice a person makes, holding across the Web and BloomPUB screens, in the BloomPUB preview's own language menu, and across a restart.

## Every test makes its own collection

A test that shares a prepared collection inherits assumptions the next person to edit that collection can change without reading the test. So the fixture gained two things:

- `collectionSpec: { name, languages }` makes an empty collection with those languages. This is now the default choice, and `collectionName` has no default, so a spec states one of the two.
- `bloomApp.restart(betweenStopAndStart)` stops Bloom, lets the caller rewrite the `.bloomCollection`, and starts it again. This is the only route to a collection language: `collectionSettings/changeLanguage` answers only while the WinForms Settings dialog is open, and CDP cannot reach that dialog.

## Product changes the tests needed

- `E2eTestingApi` gains `e2e/pages` and `e2e/templatePages`. A book made from a template starts with front and back matter only, because every page of a template book is a template page, so a test has to add a page. Nothing else reports which template pages exist or what they are called; the Add Page dialog reads them out of the template book's HTML.
- `IsCollectionReady` no longer demands that the collection hold a book, so it answers for a collection a test just created.
- `LanguageSelectionSettingsGroup` renders `data-testid="text-languages-group"` and `"audio-languages-group"`. The two groups were otherwise identical in the DOM.

## KNOWN FLAKE

The test "keeps a language that the collection no longer has" failed once in six full runs on 2026-09-01. The cause is not known, the failure was not reproduced, and the log kept only its tail, so the failed assertion was not captured. A comment above that test says so and tells the next person to keep the whole log. That test never changes which languages the book shows, so the suspects are the restart and the list read.

Seven of eight full runs were green, the most recent included.

## Debt recorded

`AUTOMATION-DEBT.md` gains entries for the Add Page dialog, `jumpToPage` being dropped while the Edit tab loads, and `fill()` on a CKEditor box leaving part of the old text; the WinForms entry gains a dated `seen again` line. `README.md` and `.github/skills/add-e2e-test/SKILL.md` document the new fixture options and `helpers/bookMaking.ts`.

## Running it

```bash
pnpm -C src/BloomE2E exec playwright test --reporter=list
```

Eight tests, about two minutes. It needs a built `Bloom.exe` in `output/Debug/` and, for the `workspace-tabs` test only, `node build/get-testing-inputs.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8272)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8272)
<!-- Reviewable:end -->
