### PR TITLE
Make visual-regression text rendering machine-independent

### DIFF
--- a/build/testing-inputs.pin
+++ b/build/testing-inputs.pin
@@ -18,4 +18,4 @@
 # Format: one `key=value` per line. Blank lines and lines starting with # are ignored.
 
 repo=https://github.com/BloomBooks/bloom-testing-inputs.git
-commit=cd0df0a7310312ff1e014716d89c39e00ef0615d
+commit=ffdd2e4d935f63c53da803983377005e18227f97

--- a/src/BloomVisualRegressionTests/index.spec.ts
+++ b/src/BloomVisualRegressionTests/index.spec.ts
@@ -204,7 +204,20 @@ describe("All books", () => {
 
     beforeAll(async () => {
         await launchDedicatedBloom();
-        browser = await chromium.launch();
+        // Text must rasterize the same way on every machine, or the reference images are only
+        // valid on whichever machine made them. By default Chrome anti-aliases text with LCD
+        // sub-pixel rendering, using the host's DirectWrite gamma/contrast settings, so the same
+        // glyphs come out with different colored fringes on a developer machine than on the CI
+        // runner. --disable-lcd-text forces grayscale anti-aliasing instead;
+        // --font-render-hinting=none removes the other host-dependent step; --force-color-profile
+        // pins the color space the result is converted through.
+        browser = await chromium.launch({
+            args: [
+                "--disable-lcd-text",
+                "--font-render-hinting=none",
+                "--force-color-profile=srgb",
+            ],
+        });
         context = await browser.newContext();
         page = await context.newPage();
         playerPage = await context.newPage();


### PR DESCRIPTION
[Claude Opus from Hatton's machine, delegated by Claude Fable 5]

## The problem

The visual-regression suite's reference screenshots were only valid on the machine that produced them.

Chromium anti-aliases text with LCD sub-pixel rendering by default, and that path reads the host's DirectWrite gamma and contrast settings. The same glyphs therefore come out with different coloured fringes on a developer machine than on the `windows-latest` CI runner that generated the baselines.

The result: **all 12 bloom-player pages failed on a developer machine** while the identical commit matched on CI. Each failure was around 2000 differing pixels with a maximum channel delta of 44, and glyph positions identical to within 0.04 px, so the differences were purely anti-aliasing. The old baselines contained 1601 colour-fringed pixels, which is the signature of sub-pixel anti-aliasing having been active when they were made.

The player captures were the visible casualty because `pageElement.screenshot(...)` targets an element inside a fractionally-scaled composited CSS-transform layer, where Chrome's rasterization is most sensitive to these settings. The book-preview captures happened to agree across machines, but nothing guaranteed that they would.

## The fix

Launch Chromium with three flags:

```ts
args: [
    "--disable-lcd-text",
    "--font-render-hinting=none",
    "--force-color-profile=srgb",
]
```

`--disable-lcd-text` forces grayscale anti-aliasing instead of sub-pixel. The other two remove the remaining host-dependent steps: font hinting, and the colour profile the result is converted through.

## The regeneration

These flags change how Chrome rasterizes text everywhere, not only inside the transformed player layer, so **all 84 baselines are regenerated**, the 12 book-preview ones included. Confirmed by running the suite with and without the flags: without them the preview comparisons pass and the player ones fail; with them both change.

The new baselines are in bloom-testing-inputs at **ffdd2e4d935f63c53da803983377005e18227f97**, and `build/testing-inputs.pin` advances to that commit in this PR.

Colour fringing (pixels whose R, G and B channels differ by more than 8) on the text-only player pages went from 2282 and 11944 to **zero**. On pages carrying illustrations the remaining count is the artwork, which is genuinely coloured.

## Verification

The suite was run green three times against the regenerated baselines: twice against the authoring checkout via `BLOOM_TESTING_INPUTS_DIR`, and once against `output/testing-inputs` at the new pin. No image comparison failed in any run after regeneration.

## Caveat

Grayscale anti-aliasing carries slightly less sub-pixel detail than LCD anti-aliasing, so a very small genuine shift in text rendering is marginally less likely to surface as differing pixels. That is worth accepting in exchange for baselines that mean the same thing on every machine, since the alternative is baselines that fail for everyone who is not the CI runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8273)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8273)
<!-- Reviewable:end -->
