### PR TITLE
Make add-e2e-test carry a test through to a PR that is ready to merge

### DIFF
--- a/.github/skills/add-e2e-test/SKILL.md
+++ b/.github/skills/add-e2e-test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-e2e-test
-description: How to add a new edge-to-edge (e2e) test that drives the real Bloom.exe through its UI, using a collection from the bloom-testing-inputs repo. Use when asked to automate a manual test, add an e2e test, add a journey test, or extend the nightly e2e suite.
+description: How to add a new edge-to-edge (e2e) test that drives the real Bloom.exe through its UI, from writing the test to a PR that is ready to merge, with a Devin review whenever Bloom production code changes, and a short closing summary. Use when asked to automate a manual test, add an e2e test, add a journey test, or extend the nightly e2e suite.
 ---
 
 # Add an edge-to-edge test
@@ -16,6 +16,37 @@ Test code lives in BloomDesktop (`src/BloomE2E/`), versioned with the product co
 Test input collections live in https://github.com/BloomBooks/bloom-testing-inputs,
 pinned by `build/testing-inputs.pin` and fetched to `output/testing-inputs/` by
 `node build/get-testing-inputs.mjs`.
+
+## Build Bloom whenever it helps; the usual rules are suspended here
+
+The repo's guidance for agents says not to build Bloom: use the `agent-dotnet` wrapper, never
+run `pnpm build`, let the dev server push front-end edits into the developer's running Bloom.
+Those rules protect a Bloom the developer is running from this worktree. **They do not apply
+while you follow this skill.** The suite launches its own `Bloom.exe` from `output/Debug/` (or
+`output/Release/`), with `--e2e --automation`, on a temp copy of a collection, and that instance
+runs alongside whatever Bloom the developer has open. Developing a test does not disturb them.
+The Bloom you launch is also not the one the dev server feeds: it reads the front end from
+`output/browser` and the C# from the built exe. So a test sees a change to Bloom only after a
+build, and you build whenever it helps, without asking.
+
+- **A fresh worktree:** `./init.sh` (dependencies, `pnpm install`, and the full front-end build),
+  then `pnpm install` in `src/BloomE2E`, `node build/get-testing-inputs.mjs`, and the C# build
+  below.
+- **C# changed** (an `E2eTestingApi` hook, anything under `src/BloomExe/`), or no `Bloom.exe` is
+  built yet: `dotnet build src/BloomExe/BloomExe.csproj`. Plain `dotnet`, not the
+  `build/agent-dotnet` wrapper: the wrapper builds into a private tree and builds no `Bloom.exe`
+  apphost, so the suite would never find its output.
+- **Front end changed** (a `data-testid` in a `.tsx` file): `pnpm build:ui` in
+  `src/BloomBrowserUI` rebuilds the bundles in `output/browser`, manifest included. Run the full
+  `pnpm build` there when the change also touches pug, LESS, markdown, or content.
+- **Before you trust a failure, ask whether the build is current.** A `data-testid` that is in the
+  source but not in `output/browser`, or a hook that is in `E2eTestingApi.cs` but not in the exe,
+  fails exactly like a bug in the test.
+
+The one collision left is the build lock: `dotnet build` fails with **MSB3027** ("being used by
+another process") while a Bloom launched from this worktree's `output/Debug/` is running. If that
+Bloom is one a test run left behind, kill it. If it is the developer's, tell them and let them
+choose. Never kill a Bloom you did not start.
 
 ## The UI-vs-API policy (applies to every test)
 
@@ -37,7 +68,9 @@ automation (no stable selector, a native dialog, a WinForms surface):
    workaround or a decision.
 2. Prefer fixing Bloom: add a `data-testid` in the React code, or add a hook to
    `src/BloomExe/web/controllers/E2eTestingApi.cs` (registered only under `--e2e`).
-   Ship that fix in the same PR as the test.
+   Ship that fix in the same PR as the test. That is a change to Bloom's production code,
+   and "Ship" below says what it brings with it: a Devin review, and its own heading in the
+   PR description and the closing summary.
 3. If you cannot fix it now, record it in `AUTOMATION-DEBT.md` and mark the test
    accordingly, so the investment is visible and schedulable.
 
@@ -273,13 +306,115 @@ pnpm exec playwright test -g "switching workspace tabs"  # one test by title
 ```
 
 A run opens a real Bloom window; that is expected. It needs a built `Bloom.exe` under
-`output/{Debug,Release}/{x64,AnyCPU,}/` and the inputs at `output/testing-inputs`. Point
+`output/{Debug,Release}/{x64,AnyCPU,}/` (build it yourself; see "Build Bloom whenever it
+helps") and the inputs at `output/testing-inputs`. Point
 `BLOOM_TESTING_INPUTS_DIR` at a bloom-testing-inputs checkout to use your own in-progress
 collections instead of the pinned ones.
 
 `.github/workflows/nightly.yml` does not run this suite yet. The step it will need is the
 same `pnpm test` in that folder, after the Release build and the testing-inputs fetch that
 the visual-regression job already does.
+
+## Ship: a PR that is ready to merge
+
+The job is not done when the test is green. It is done when a PR is open, every reviewer has
+spoken, and the developer can merge it, or can read one short message to see what is left.
+
+**Invoking this skill is the authorization for these writes**, without stopping to confirm:
+commit and push the branch; create the PR and later mark it ready for review; reply to bot
+review threads and resolve them; the `devin-review` skill's own writes; and the Notion card's
+`Automation` and `Automation Notes` properties. It does not authorize merging the PR, requesting
+a reviewer, or dismissing a human's comment. If the auto-mode classifier denies a `gh` write, do
+not route around it: report that step as pending in the summary.
+
+**Base branch: `master`.** `src/BloomE2E` exists only there; this is the exception to the "new
+work targets Version6.5" rule in `AGENTS.md`. A caller that owns the PR lifecycle (for example
+the `improve-test-automation-coverage` worker brief, which ships through `preflight`) says so,
+and its instructions replace steps 2 to 5 below.
+
+### 1. Gate
+
+- The new test passes **three times in a row**, launched with no Bloom of yours running, and no
+  `Bloom.exe` you started survives the run. A test that passes two of three is not done.
+- Every test that calls a helper you changed passes.
+- `pnpm typecheck` in `src/BloomE2E`.
+- If you changed the front end: `pnpm lint` and `pnpm typecheck` in `src/BloomBrowserUI`, and the
+  bundle you built for the test compiled. If you changed C#: it builds, and the unit tests for the
+  classes you touched pass (`build/agent-dotnet.ps1 test ... --filter ...`).
+
+### 2. Commit, integrate, push, open the PR
+
+- Commit everything with a descriptive message and the repo's commit trailer; let the hooks run.
+- `git fetch origin`, then merge `origin/master`. Re-run the gate if the merge touched anything
+  you touched. Abort a merge with a semantic conflict and hand it to the developer in the summary.
+- Push, then open a **draft** PR against `master`:
+  `gh pr create --draft --base master --title "<what the test covers> (Notion test case <id>)" --body-file <file>`.
+  Always `--body-file`; an inline body does not expand newlines in PowerShell.
+- The PR body is the same text as the closing summary (step 6), minus the run-specific details
+  under "Problems" that belong only in chat. It always contains the line
+  `Automates Notion test case <id> (<title>): <card url>` and the **Bloom production code
+  changes** heading, even when that section says "None".
+- Set the Notion card to `PR Pending` with the PR URL and the covered and not-covered steps in
+  `Automation Notes` (see "Tie the test to the Notion test inventory").
+
+### 3. Decide whether production code changed
+
+**Production code is anything that ships in Bloom or builds it:** `src/BloomExe/**`,
+`src/BloomBrowserUI/**`, `src/content/**`, `DistFiles/**`, `build/**`, and any `*.csproj`,
+`*.sln`, or `package.json` outside `src/BloomE2E`. Not production code: `src/BloomE2E/**`,
+`.github/**`, and Markdown. Decide from `git diff --name-only origin/master...HEAD`, not from
+memory. A `data-testid` and an `E2eTestingApi` hook are small, but they are production code.
+
+**Test code inside those folders does not count.** Unit tests live beside or near the code they
+test: `src/BloomTests/**` (C#), and in `src/BloomBrowserUI` the `*.test.ts(x)` and `*.spec.ts(x)`
+files, `__tests__` folders, and the `canvas-e2e-tests` folder. Changing one of them, which is
+rare while building an e2e test, means the affected unit tests must run and pass in the gate,
+but it does not by itself trigger Devin or the **Bloom production code changes** heading.
+
+### 4. Reviewers
+
+- **CI, always.** `gh pr checks <n>` until every check is terminal. A failure is yours to fix
+  unless it is clearly unrelated to the diff, in which case the summary names it.
+- **Devin, when production code changed.** Run the `devin-review` skill on the PR through to its
+  terminal result (BloomDesktop's `pr-automation.yml` triggers Devin on every push; the skill
+  waits, gathers, and mirrors the findings). Treat each finding as `preflight` does:
+  - clear, correct, and confined to the test hook: fix it, push, reply "Fixed in `<sha>`", and
+    resolve the thread. A new push restarts Devin, so run the skill again; cap this at four
+    rounds;
+  - mistaken: reply with the reason and resolve;
+  - anything else, such as a finding that would change what a user sees or how Bloom behaves
+    outside `--e2e`, or one you cannot settle from the code: leave the thread **open** and defer
+    it to the developer in the summary, with Devin's text, your assessment, and a recommendation.
+
+  Devin still analyzing is not "clean". If it has not finished after 30 minutes, record "timed
+  out after 30 min" and say so in the summary.
+- **Any other bot** that posts on its own (Greptile and the like) gets the same fix, refute, or
+  defer treatment whether or not production code changed: its comments are on the PR either way.
+- A test-only PR does not need Devin. Say so in the summary in one line.
+
+### 5. Mark it ready
+
+When CI is green, every bot thread has a documented outcome, and nothing is deferred to the
+developer: `gh pr ready <n>`. The PR is now ready to merge, and the developer does the merging.
+If anything is deferred, leave the PR a draft and let the summary say why. Never merge, and never
+request a reviewer.
+
+### 6. Close with the summary
+
+The last message of the run is short (about 200 words) and stands on its own. In this order:
+
+1. **Bloom production code changes**, only when there are any, and then at the very top so
+   nobody misses it: every file outside `src/BloomE2E`, what changed and why, and Devin's
+   outcome for it. When there are none, one line at the end instead: "No Bloom production code
+   changed; Devin not run."
+2. **Purpose**: the behavior the test protects, and the Notion card (`Test Case ID` and title).
+3. **Steps**: what the test does, as a few bullets in the order it does them.
+4. **How it verifies the result**: what state it reads (an API, the page list, a file on disk)
+   and what it expects; how many green runs you saw; that no Bloom survived.
+5. **PR**: URL, draft or ready, CI state, and each reviewer's terminal state.
+6. **Problems**: steps that stay manual and why, `AUTOMATION-DEBT.md` entries you added,
+   anything deferred to the developer with your recommendation, and anything the environment
+   made hard (a build that would not go, a flaky run you had to chase). If none, say "None".
 
 ## Checklist before you call it done
 
@@ -294,3 +429,10 @@ the visual-regression job already does.
 - [ ] No Bloom.exe process survives the run.
 - [ ] New inputs: PR merged in bloom-testing-inputs, pin advanced here, both green.
 - [ ] Anything you could not automate cleanly is recorded in `AUTOMATION-DEBT.md`.
+- [ ] The PR is open against `master`, CI is green, and it is marked ready unless something is
+      deferred to the developer.
+- [ ] If production code changed, Devin ran to a terminal state and every finding has an
+      outcome on its thread or in the summary.
+- [ ] The Notion card is `PR Pending` with the PR URL.
+- [ ] The closing summary was delivered, with production code changes at the top when there
+      are any.

--- a/.github/skills/improve-test-automation-coverage/worker-brief.md
+++ b/.github/skills/improve-test-automation-coverage/worker-brief.md
@@ -34,9 +34,10 @@ again.
   not start.
 - Keep the Orca card current: `orca worktree set --worktree active --comment "<state>" --json`
   after each checkpoint (feasibility decided, test written, test green, review round, PR open).
-- Follow the repo rules in `AGENTS.md`: never `pnpm build`; build C# through
-  `build/agent-dotnet.ps1`, with the one exception in step 0 (the wrapper builds no
-  `Bloom.exe`); never commit or push except inside the `preflight` skill in step 6.
+- Build Bloom whenever it helps, as the add-e2e-test skill's build section says: nobody runs
+  Bloom from your worktree, so nothing collides. Never commit or push except inside the
+  `preflight` skill in step 6. That step, not the skill's own "Ship" section, is how your PR
+  gets opened; the controller owns the PR's state, so leave it a draft.
 
 ## Steps
 
@@ -116,7 +117,7 @@ fixes, re-run step 4, and ask again. Repeat until the answer is `ship`. If the a
 resume it with `orca orchestration ask --resume <message_id> --timeout-ms 3600000 --json`; do not
 proceed without a `ship`.
 
-### 6. Ship
+### 6. Ship (this replaces the "Ship" section of add-e2e-test)
 
 1. Run the `preflight` skill (`Skill` tool, name `preflight`). It commits, pushes, opens a draft
    PR against `master`, and waits for the bots. Preflight looks for a `BL-` ticket in the branch
@@ -127,7 +128,9 @@ proceed without a `ship`.
    Automates Notion test case {{TEST_CASE_ID}} ({{CARD_TITLE}}): {{CARD_URL}}
    ```
 
-   Also say which Test Steps the test covers and which it does not.
+   Also say which Test Steps the test covers and which it does not, and give any change
+   outside `src/BloomE2E` its own **Bloom production code changes** heading, as the add-e2e-test
+   summary does.
 2. Set the card to `PR Pending` with the PR URL in the note. If the test covers only part of the
    steps, say which part in the same note:
 


### PR DESCRIPTION
**Problem.** The add-e2e-test skill stopped at a green test. Opening the PR, getting a review, and reporting what was done were left to whoever invoked it, and the repo's no-build rules for agents got in the way of a suite that only sees a change to Bloom after a build.

**Fix.** The skill now carries the work through to a PR that is ready to merge, and says what it did.

- A new **Ship** section: gate (three green runs, typecheck, lint), commit, merge master, draft PR whose body mirrors the closing summary, Notion card to PR Pending, wait for CI, then mark the PR ready when nothing is deferred to the developer. It never merges or requests a reviewer.
- **Devin runs only when Bloom production code changed.** The section defines production code (anything that ships in Bloom or builds it) and says unit test files inside those folders do not count, though the affected unit tests must still run. Findings are fixed, refuted, or deferred the way preflight does.
- **Every run ends with a short summary**: purpose, steps, how the test verifies its result, PR state, problems. Any production code change goes at the very top.
- A new **Build Bloom whenever it helps** section suspends the repo's no-build rules for this skill, explains why that is safe (the suite launches its own Bloom from the built output and reads `output/browser`, alongside whatever the developer is running), gives the command for each case, and names the one remaining collision (MSB3027 while a Bloom from this worktree runs).
- The improve-test-automation-coverage worker brief is reconciled: workers may build freely, and its preflight step replaces the skill's Ship section, with the PR left a draft for the controller.

Targets `master` because `src/BloomE2E` and these skills exist only there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8278)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8278)
<!-- Reviewable:end -->
