### PR TITLE
Add an e2e test for the items a book needs before upload (Notion test case 606)

### DIFF
--- a/src/BloomBrowserUI/publish/LibraryPublish/LibraryPublishSteps.tsx
+++ b/src/BloomBrowserUI/publish/LibraryPublish/LibraryPublishSteps.tsx
@@ -478,6 +478,7 @@ export const LibraryPublishSteps: React.FunctionComponent<{
                 <MissingInfo
                     text="Missing Title"
                     l10nKey={"PublishTab.Upload.Missing.Title"}
+                    testId="missing-title"
                     onClick={() => post("libraryPublish/goToEditBookTitle")}
                 />
             );
@@ -495,7 +496,12 @@ export const LibraryPublishSteps: React.FunctionComponent<{
 
     return (
         <React.Fragment>
-            <BloomStepper orientation="vertical">
+            {/* The test id tells the e2e tests that the upload steps have arrived; the screen
+                has nothing else that is always there and never on another publish screen. */}
+            <BloomStepper
+                data-testid="publish-to-web-steps"
+                orientation="vertical"
+            >
                 <Step
                     active={true}
                     completed={isReadyForAgreements()}
@@ -524,6 +530,7 @@ export const LibraryPublishSteps: React.FunctionComponent<{
                                             l10nKey={
                                                 "PublishTab.Upload.Missing.Copyright"
                                             }
+                                            testId="missing-copyright"
                                             onClick={
                                                 showCopyrightAndLicenseInfoOrDialog
                                             }
@@ -609,6 +616,7 @@ export const LibraryPublishSteps: React.FunctionComponent<{
                         {serverErrorBox}
                         {bookshelfErrorBox}
                         <div
+                            data-testid="upload-buttons"
                             css={css`
                                 display: flex;
                                 justify-content: space-between;
@@ -852,7 +860,8 @@ const AgreementCheckbox: React.FunctionComponent<{
         props.onChange(isChecked);
     }
     return (
-        <div>
+        // The test id marks one agreement for the e2e tests; the Agreements step shows three.
+        <div data-testid="upload-agreement">
             <BloomCheckbox
                 label={props.label}
                 checked={isChecked}
@@ -884,6 +893,9 @@ const WarningMessage: React.FunctionComponent<{
 const MissingInfo: React.FunctionComponent<{
     text: string;
     l10nKey: string;
+    // Marks this warning for the e2e tests, which have to tell the two apart and click the
+    // right "Click to fix". See src/BloomE2E/helpers/libraryPublish.ts.
+    testId: string;
     onClick: () => void;
 }> = (props) => {
     const selectedBookContext = React.useContext(SelectedBookContext);
@@ -893,7 +905,7 @@ const MissingInfo: React.FunctionComponent<{
                 max-width: 550px;
             `}
         >
-            <div>
+            <div data-testid={props.testId}>
                 <Div
                     css={css`
                         font-style: italic;

--- a/src/BloomE2E/AUTOMATION-DEBT.md
+++ b/src/BloomE2E/AUTOMATION-DEBT.md
@@ -67,6 +67,25 @@ video have none: the Talking Book tool records from a real microphone, and a vid
 through the Sign Language tool's native file picker or camera, so those two sections of the
 manual test stay manual.
 
+## The Bloom Library login cannot be done for real in a test
+
+Bloom's login state lives in machine-wide settings (`Settings.Default.WebUserId`), which an e2e
+Bloom shares with the developer's own Bloom, and signing in goes out to an external browser with
+real credentials. So a test can drive neither half of it: posting `account/logout` would sign the
+developer out of their own Bloom, and `account/login` would sit waiting for a human. The e2e hook
+`e2e/loginState` therefore makes Bloom *report* a login state without touching the real one, which
+is enough for the gate the upload screen enforces (Upload is offered only to a signed-in user) but
+covers neither the real sign-in and sign-out buttons nor anything that needs a real account —
+which is every manual case that uploads for real (#204, #205, #211-#213, #215, #217, #218, #220),
+so none of those can be automated either. Fix direction: a test account plus a per-instance login
+store (a login the `--e2e` instance keeps to itself), so a run can sign in for real and upload to
+dev.bloomlibrary.org without touching the developer's settings. The per-instance half of that is
+the same fix "Every Bloom of one build shares one user.config" asks for, below; the test account
+is the rest. Note that the pretense changes only what Bloom reports, so Bloom under `--e2e` now
+refuses to upload at all rather than let an automated click publish under the developer's real
+account.
+(Found 2026-09-02 automating Test Case ID 606, `upload-required-items.spec.ts`.)
+
 ## Visual-regression cases stop at the first failed comparison
 
 Each case in `src/BloomVisualRegressionTests/index.spec.ts` throws on the first

--- a/src/BloomE2E/helpers/bookMaking.ts
+++ b/src/BloomE2E/helpers/bookMaking.ts
@@ -471,6 +471,22 @@ export async function addPage(
 }
 
 /**
+ * The id of the page the Edit tab is showing, or undefined when it is not showing one. A test uses
+ * this to check where Bloom took it, e.g. that "Click to fix" on a missing title opened the cover.
+ */
+export async function getShownPageId(page: Page): Promise<string | undefined> {
+    const frame = page.frame({ name: "page" });
+    if (!frame) return undefined;
+    return (
+        (await frame
+            .locator(".bloom-page")
+            .first()
+            .getAttribute("id")
+            .catch(() => null)) ?? undefined
+    );
+}
+
+/**
  * Show a page in the Edit tab. This is also how a test SAVES what it typed: Bloom writes the page
  * it is leaving, so text typed into a box reaches the file only once the book moves off that page.
  */

--- a/src/BloomE2E/helpers/copyrightAndLicense.ts
+++ b/src/BloomE2E/helpers/copyrightAndLicense.ts
@@ -1,0 +1,45 @@
+// Drive the Copyright and License dialog.
+//
+// The dialog is reached from more than one place (the Edit tab's copyright button, and the
+// "Click to fix" link on the Missing Copyright warning in Publish: Web), and it is a React
+// dialog rendered into whichever page opened it, so a test drives it on the page it is already
+// holding.
+
+import { expect, type Locator, type Page } from "@playwright/test";
+
+/** The open dialog, whichever page opened it. */
+function dialog(page: Page): Locator {
+    return page
+        .getByRole("dialog")
+        .filter({ hasText: "Copyright and License" });
+}
+
+/** Wait until the Copyright and License dialog is open and ready to type in. */
+export async function waitForCopyrightDialog(page: Page): Promise<void> {
+    await dialog(page)
+        .getByLabel("Copyright Holder")
+        .waitFor({ state: "visible", timeout: 60000 });
+}
+
+/**
+ * Give the book a copyright holder in the open Copyright and License dialog, and click OK.
+ *
+ * The year is left as the dialog offers it (this year), because that is what a user accepts. OK
+ * stays disabled until both fields are valid, so this waits for it rather than clicking blind.
+ * Returns once the dialog has closed; whoever opened it decides what to check next.
+ */
+export async function setCopyrightHolder(
+    page: Page,
+    holder: string,
+): Promise<void> {
+    await waitForCopyrightDialog(page);
+    const holderField = dialog(page).getByLabel("Copyright Holder");
+    await holderField.click();
+    await holderField.fill(holder);
+    await expect(holderField).toHaveValue(holder, { timeout: 15000 });
+
+    const ok = dialog(page).getByRole("button", { name: "OK", exact: true });
+    await expect(ok).toBeEnabled({ timeout: 15000 });
+    await ok.click();
+    await expect(dialog(page)).toHaveCount(0, { timeout: 30000 });
+}

--- a/src/BloomE2E/helpers/libraryPublish.ts
+++ b/src/BloomE2E/helpers/libraryPublish.ts
@@ -1,0 +1,284 @@
+// Drive and read Publish: Web — the stepper that decides whether a book may go to
+// BloomLibrary.org: the Confirm Metadata step with its "Missing Title"/"Missing Copyright"
+// warnings, the Agreements step, and the Upload step's buttons.
+//
+// The screen is a MUI vertical stepper, so a step that is not active shows no content at all.
+// That is why "have the Agreements appeared?" is a real question with a real answer here, and why
+// several of these helpers poll: what the screen shows follows libraryPublish/getBookInfo, which
+// is fetched after the screen mounts and re-fetched whenever the copyright is saved.
+
+import { expect, type Locator, type Page } from "@playwright/test";
+import { apiPost } from "./api";
+import { selectPublishDestination } from "./publish";
+
+/** The two things a book must have before Bloom will let it be uploaded. */
+export type UploadRequirement = "Title" | "Copyright";
+
+// Each warning box carries its own test id, because the two look alike and a test has to click
+// the right one's "Click to fix". See LibraryPublishSteps.tsx.
+const WARNING_TEST_ID: Record<UploadRequirement, string> = {
+    Title: "missing-title",
+    Copyright: "missing-copyright",
+};
+
+/** Whether a button of the Upload step is there at all, and if so whether it can be clicked. */
+export type ButtonState = "absent" | "enabled" | "disabled";
+
+/** The buttons the Upload step offers. Which ones exist is itself the login gate under test. */
+export interface IUploadStepButtons {
+    /** "Sign in or sign up to BloomLibrary.org". Shown only while nobody is signed in. */
+    signIn: ButtonState;
+    /** "Upload Book". Shown only to a signed-in user, which is the gate this screen enforces. */
+    uploadBook: ButtonState;
+    /** "Sign out (email)". Shown only while somebody is signed in. */
+    signOut: ButtonState;
+}
+
+/**
+ * Go to the Publish tab, open its Web screen, and wait for the upload steps to be showing. A book
+ * must already be selected.
+ */
+export async function openPublishToWeb(page: Page): Promise<void> {
+    await selectPublishDestination(page, "Web");
+    await page
+        .getByTestId("publish-to-web-steps")
+        .waitFor({ state: "visible", timeout: 60000 });
+}
+
+/**
+ * Which required items the screen is currently complaining about, always Title before Copyright.
+ * An empty array means the book's metadata is complete enough to upload.
+ */
+export async function getMissingRequirements(
+    page: Page,
+): Promise<UploadRequirement[]> {
+    const shown = await Promise.all(
+        (Object.keys(WARNING_TEST_ID) as UploadRequirement[]).map(
+            async (requirement) =>
+                (await page.getByTestId(WARNING_TEST_ID[requirement]).count()) >
+                0
+                    ? requirement
+                    : undefined,
+        ),
+    );
+    return shown.filter((r): r is UploadRequirement => !!r);
+}
+
+/**
+ * Wait until the screen is complaining about exactly these requirements, and no others.
+ *
+ * Poll rather than read once: the warnings appear only after libraryPublish/getBookInfo answers,
+ * and they go away only after the same call is repeated when the copyright is saved, so reading
+ * the moment after an action races Bloom.
+ */
+export async function expectMissingRequirements(
+    page: Page,
+    expected: UploadRequirement[],
+    message: string,
+): Promise<void> {
+    await expect
+        .poll(async () => (await getMissingRequirements(page)).join(", "), {
+            timeout: 30000,
+            message,
+        })
+        .toBe(expected.join(", "));
+}
+
+/**
+ * Click the "Click to fix" link of one warning, the way a user does. For Copyright this opens the
+ * Copyright and License dialog (see helpers/copyrightAndLicense.ts); for Title it takes Bloom to
+ * the Edit tab, showing the front cover, where the title is typed.
+ *
+ * This does not wait for what the click leads to, because the two lead somewhere different; the
+ * caller waits for its own destination.
+ */
+export async function clickToFixMissingItem(
+    page: Page,
+    requirement: UploadRequirement,
+): Promise<void> {
+    const warning = page.getByTestId(WARNING_TEST_ID[requirement]);
+    await warning.waitFor({ state: "visible", timeout: 30000 });
+    await warning.getByRole("link").click();
+}
+
+/**
+ * Whether the Agreements step is showing its three check boxes. The stepper collapses the content
+ * of a step that is not active, so this is false until the book has both a title and a copyright.
+ */
+export async function areAgreementsShowing(page: Page): Promise<boolean> {
+    return (await page.getByTestId("upload-agreement").count()) > 0;
+}
+
+/** Wait until the Agreements step has appeared (or, with false, until it has gone away). */
+export async function expectAgreementsShowing(
+    page: Page,
+    showing: boolean,
+    message: string,
+): Promise<void> {
+    await expect
+        .poll(async () => areAgreementsShowing(page), {
+            timeout: 30000,
+            message,
+        })
+        .toBe(showing);
+}
+
+/**
+ * Tick every agreement check box, which is what the user does before uploading. Returns when all
+ * three are ticked.
+ */
+export async function acceptAllAgreements(page: Page): Promise<void> {
+    const agreements = page.getByTestId("upload-agreement");
+    await agreements.first().waitFor({ state: "visible", timeout: 30000 });
+    const count = await agreements.count();
+    if (count !== 3)
+        throw new Error(
+            `The Agreements step showed ${count} agreements; Bloom's upload screen has three.`,
+        );
+    for (let i = 0; i < count; i++) {
+        const box = agreements.nth(i).locator('input[type="checkbox"]');
+        if (!(await box.isChecked())) await box.click();
+        await expect(box).toBeChecked({ timeout: 15000 });
+    }
+}
+
+/**
+ * What the Upload step is offering right now. A test reads this rather than looking for one
+ * button, because "which buttons are there" is the answer to both "can I upload?" and "does it
+ * want me to sign in first?".
+ */
+export async function getUploadStepButtons(
+    page: Page,
+): Promise<IUploadStepButtons> {
+    const buttons = await page
+        .getByTestId("upload-buttons")
+        .locator("button")
+        .evaluateAll((elements) =>
+            elements.map((element) => ({
+                text: (element.textContent ?? "").trim(),
+                disabled: (element as HTMLButtonElement).disabled,
+            })),
+        );
+    // The labels are English, as everywhere else in this suite (see AUTOMATION-DEBT.md on the
+    // top bar). Each is matched by its start, because the sign-out button carries the user's
+    // email and the upload button says which server it will upload to.
+    const stateOf = (startsWith: string): ButtonState => {
+        const button = buttons.find((b) => b.text.startsWith(startsWith));
+        if (!button) return "absent";
+        return button.disabled ? "disabled" : "enabled";
+    };
+    return {
+        signIn: stateOf("Sign in"),
+        uploadBook: stateOf("Upload Book"),
+        signOut: stateOf("Sign out"),
+    };
+}
+
+/**
+ * The three button states as one comparable line, in a fixed order, so that comparing two of them
+ * cannot depend on the order a caller happened to write the fields in.
+ */
+function describeUploadStepButtons(buttons: IUploadStepButtons): string {
+    return (
+        `signIn: ${buttons.signIn}, uploadBook: ${buttons.uploadBook}, ` +
+        `signOut: ${buttons.signOut}`
+    );
+}
+
+/** Wait until the Upload step is offering exactly these buttons in these states. */
+export async function expectUploadStepButtons(
+    page: Page,
+    expected: IUploadStepButtons,
+    message: string,
+): Promise<void> {
+    await expect
+        .poll(
+            async () =>
+                describeUploadStepButtons(await getUploadStepButtons(page)),
+            { timeout: 30000, message },
+        )
+        .toBe(describeUploadStepButtons(expected));
+}
+
+/**
+ * Click the Upload Book button. Bloom refuses to upload at all under --e2e (see
+ * LibraryPublishApi.RefuseUploadWhileRunningE2eTests), so this cannot publish anything; what a
+ * test can see is what the screen does before that point, such as the template warning below.
+ */
+export async function clickUploadBook(page: Page): Promise<void> {
+    await page
+        .getByTestId("upload-buttons")
+        .getByRole("button", { name: /^Upload Book/ })
+        .click();
+}
+
+/**
+ * Wait for the warning Bloom shows when the book being uploaded is a template — templates are the
+ * exception to the copyright rule, so Bloom lets them through but checks that the user meant it —
+ * and return what it says.
+ */
+export async function waitForTemplateUploadWarning(
+    page: Page,
+): Promise<string> {
+    const warning = templateUploadWarning(page);
+    await warning.waitFor({ state: "visible", timeout: 60000 });
+    return (await warning.innerText()).trim();
+}
+
+/**
+ * Answer No to the template warning. There is deliberately no helper for Yes: Bloom refuses to
+ * upload under --e2e, so answering Yes would prove nothing beyond that refusal, and what the
+ * manual test is really checking — that a template is allowed through the copyright rule — is
+ * already settled by the warning appearing at all.
+ */
+export async function declineTemplateUploadWarning(page: Page): Promise<void> {
+    await templateUploadWarning(page)
+        .getByRole("button", { name: "No", exact: true })
+        .click();
+    await expect(templateUploadWarning(page)).toHaveCount(0, {
+        timeout: 30000,
+    });
+}
+
+/** The template warning dialog, told apart from any other dialog by what it says. */
+function templateUploadWarning(page: Page): Locator {
+    return page
+        .getByRole("dialog")
+        .filter({ hasText: "seems to be a template" });
+}
+
+/**
+ * Make Bloom report that this email is signed in to Bloom Library, or — with the empty string —
+ * that nobody is, without touching the real login. Undo it with stopPretendingAboutLogin.
+ *
+ * A test cannot use the real thing in either direction: signing in opens an external browser and
+ * needs real credentials, and signing out would sign the developer's own Bloom out, because the
+ * login lives in machine-wide settings. So the e2e hook e2e/loginState pretends, which is enough
+ * to test the gate — the upload screen offers Upload only to a signed-in user — while an actual
+ * upload would still need a real login. See AUTOMATION-DEBT.md.
+ */
+export async function pretendLoginState(
+    page: Page,
+    email: string,
+): Promise<void> {
+    await postLoginState(page, email);
+}
+
+/**
+ * Stop pretending: Bloom reports the real login state again. A test that pretended should end
+ * this way, because the Bloom it is driving reads the developer's own machine-wide login, and the
+ * top bar's account control shows whatever this reports.
+ */
+export async function stopPretendingAboutLogin(page: Page): Promise<void> {
+    await postLoginState(page, null);
+}
+
+/** Post one of the hook's three states: an email, "" for signed out, or null for "stop pretending". */
+async function postLoginState(page: Page, email: string | null): Promise<void> {
+    await apiPost(
+        page,
+        "e2e/loginState",
+        JSON.stringify({ email }),
+        "application/json",
+    );
+}

--- a/src/BloomE2E/helpers/publish.ts
+++ b/src/BloomE2E/helpers/publish.ts
@@ -45,8 +45,12 @@ export interface ITextLanguageRow {
     disabled: boolean;
 }
 
-/** Go to the Publish tab and open one of its destinations. A book must already be selected. */
-export async function openPublishDestination(
+/**
+ * Go to the Publish tab and click one of its destinations, without waiting for what that screen
+ * shows. Each screen's own module waits for its own content; they do not all show the same things
+ * (the Web screen, for one, shows no Text Languages list for a book that has no text).
+ */
+export async function selectPublishDestination(
     page: Page,
     destination: PublishDestination,
 ): Promise<void> {
@@ -54,6 +58,18 @@ export async function openPublishDestination(
     const target = page.getByRole("tab", { name: destination, exact: true });
     await target.waitFor({ state: "visible", timeout: 30000 });
     await target.click();
+}
+
+/**
+ * Go to the Publish tab, open one of its destinations, and wait for its Text Languages list. A
+ * book must already be selected. Use this for the screens whose subject is that list; the Web
+ * screen has its own opener in helpers/libraryPublish.ts.
+ */
+export async function openPublishDestination(
+    page: Page,
+    destination: PublishDestination,
+): Promise<void> {
+    await selectPublishDestination(page, destination);
     await textLanguagesGroup(page).waitFor({
         state: "visible",
         timeout: 60000,

--- a/src/BloomE2E/tests/upload-required-items.spec.ts
+++ b/src/BloomE2E/tests/upload-required-items.spec.ts
@@ -1,0 +1,275 @@
+// What a book must have before Bloom will upload it to BloomLibrary.org: a title, a copyright,
+// the agreements, and a signed-in user. Automates the manual test "Required Items Before Upload"
+// (Test Case ID 606).
+//
+// Every step of the card is covered. The one thing that is not real is the login: the test tells
+// Bloom what login state to report, because the real one lives in machine-wide settings shared
+// with the developer's own Bloom — a test signing out would sign the developer out, and signing in
+// needs an external browser and real credentials. So this proves the gate (a signed-out user is
+// offered Sign in, never Upload), not that a real account can upload; the cards that upload for
+// real (#204, #205, #211-#213, #215, #217, #218, #220) cover that. See AUTOMATION-DEBT.md.
+//
+// The tests are serial: each one starts from the book the one before it left behind, which is how
+// the manual test reads too.
+
+import * as Path from "node:path";
+import { fileURLToPath } from "node:url";
+import { type Page } from "@playwright/test";
+import { expect, test } from "../fixtures/bloomTest";
+import {
+    addPage,
+    getContentPages,
+    getPages,
+    getShownPageId,
+    goToPage,
+    makeBookFromTemplate,
+    typeInGroup,
+} from "../helpers/bookMaking";
+import { setCopyrightHolder } from "../helpers/copyrightAndLicense";
+import { chooseImageFile } from "../helpers/images";
+import {
+    acceptAllAgreements,
+    clickToFixMissingItem,
+    clickUploadBook,
+    declineTemplateUploadWarning,
+    expectAgreementsShowing,
+    expectMissingRequirements,
+    expectUploadStepButtons,
+    openPublishToWeb,
+    pretendLoginState,
+    stopPretendingAboutLogin,
+    waitForTemplateUploadWarning,
+} from "../helpers/libraryPublish";
+import { switchTab, waitForActiveTab } from "../helpers/workspace";
+
+test.use({
+    collectionSpec: { name: "upload-required-items", languages: ["en"] },
+});
+
+test.describe.configure({ mode: "serial" });
+
+// The picture the picture-only book gets. Shipped with the suite, so the test needs nothing from
+// outside this folder.
+const IMAGE_FILE = Path.resolve(
+    Path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "fixtures",
+    "images",
+    "bird.png",
+);
+
+const TITLE = "A Book With A Title";
+const COPYRIGHT_HOLDER = "Test Publisher";
+const SIGNED_IN_EMAIL = "e2e-tester@example.com";
+
+/**
+ * Make a book that has neither a title nor a copyright, which is what a book made from a template
+ * starts as, and give it one content page of the kind asked for. Leaves the book selected and the
+ * Edit tab showing it.
+ */
+async function makeBookWithNothingRequired(
+    page: Page,
+    kind: "text-less" | "picture-only",
+): Promise<void> {
+    await switchTab(page, "collection");
+    await makeBookFromTemplate(page, "Basic Book");
+    if (kind === "text-less") {
+        // A "Just Text" page, with nothing typed in it: the book has no text anywhere.
+        await addPage(page, "Just Text");
+    } else {
+        await addPage(page, "Just an Image");
+        const [contentPage] = await getContentPages(page);
+        await goToPage(page, contentPage.id);
+        await chooseImageFile(page, IMAGE_FILE);
+    }
+}
+
+test.describe("the items a book needs before it can be uploaded", () => {
+    test("a text-less book with no title and no copyright is refused [Test Case ID 606]", async ({
+        page,
+    }) => {
+        test.setTimeout(300000);
+        await makeBookWithNothingRequired(page, "text-less");
+        await openPublishToWeb(page);
+
+        await expectMissingRequirements(
+            page,
+            ["Title", "Copyright"],
+            "Publish: Web did not warn that a book with no title and no copyright is missing both.",
+        );
+        await expectAgreementsShowing(
+            page,
+            false,
+            "The Agreements appeared even though the book was missing its title and copyright.",
+        );
+        await expectUploadStepButtons(
+            page,
+            { signIn: "absent", uploadBook: "absent", signOut: "absent" },
+            "The Upload step offered a button even though the book was missing its title and copyright.",
+        );
+    });
+
+    test("a picture-only book with no title and no copyright is refused too [Test Case ID 606]", async ({
+        page,
+    }) => {
+        test.setTimeout(300000);
+        await makeBookWithNothingRequired(page, "picture-only");
+        await openPublishToWeb(page);
+
+        await expectMissingRequirements(
+            page,
+            ["Title", "Copyright"],
+            "Publish: Web did not warn that a picture-only book with no title and no copyright is missing both.",
+        );
+        await expectAgreementsShowing(
+            page,
+            false,
+            "The Agreements appeared even though the picture-only book was missing its title and copyright.",
+        );
+    });
+
+    test("Click to fix on the copyright takes that warning away [Test Case ID 606]", async ({
+        page,
+    }) => {
+        // THE ACTION UNDER TEST: the "Click to fix" link, and the dialog it opens.
+        await clickToFixMissingItem(page, "Copyright");
+        await setCopyrightHolder(page, COPYRIGHT_HOLDER);
+
+        await expectMissingRequirements(
+            page,
+            ["Title"],
+            "The Missing Copyright warning did not go away after a copyright was added.",
+        );
+        await expectAgreementsShowing(
+            page,
+            false,
+            "The Agreements appeared while the book still had no title.",
+        );
+    });
+
+    test("Click to fix on the title opens the front cover, and the warning stays until a title is typed [Test Case ID 606]", async ({
+        page,
+    }) => {
+        test.setTimeout(300000);
+        // THE ACTION UNDER TEST: the "Click to fix" link of the Missing Title warning.
+        await clickToFixMissingItem(page, "Title");
+
+        await waitForActiveTab(page, "edit");
+        const frontCover = (await getPages(page))[0];
+        expect(frontCover.caption).toBe("Front Cover");
+        await expect
+            .poll(async () => getShownPageId(page), {
+                timeout: 60000,
+                message:
+                    "Click to fix on the title did not open the book at its front cover.",
+            })
+            .toBe(frontCover.id);
+
+        // Go back without typing a title: Bloom should still be asking for one.
+        await openPublishToWeb(page);
+        await expectMissingRequirements(
+            page,
+            ["Title"],
+            "The Missing Title warning went away even though no title was typed.",
+        );
+    });
+
+    test("adding a title clears the last warning and brings up the Agreements [Test Case ID 606]", async ({
+        page,
+    }) => {
+        test.setTimeout(300000);
+        await switchTab(page, "edit");
+        const frontCover = (await getPages(page))[0];
+        await goToPage(page, frontCover.id);
+        await typeInGroup(page, ".bookTitle", "en", TITLE);
+        // Bloom writes a page only when the book leaves it, so move off the cover to save it.
+        const [contentPage] = await getContentPages(page);
+        await goToPage(page, contentPage.id);
+
+        await openPublishToWeb(page);
+        await expectMissingRequirements(
+            page,
+            [],
+            "Publish: Web was still asking for something after the book had both a title and a copyright.",
+        );
+        await expectAgreementsShowing(
+            page,
+            true,
+            "The Agreements did not appear once the book had a title and a copyright.",
+        );
+    });
+
+    test("uploading is offered only to a signed-in user [Test Case ID 606]", async ({
+        page,
+    }) => {
+        // Nobody signed in. Until the agreements are ticked the Upload step is not even open, so
+        // there is nothing to upload with and nothing to sign in with.
+        await pretendLoginState(page, "");
+        await expectUploadStepButtons(
+            page,
+            { signIn: "absent", uploadBook: "absent", signOut: "absent" },
+            "The Upload step offered a button while the agreements were still unticked.",
+        );
+
+        // THE ACTION UNDER TEST for this step: ticking the three agreements, which opens the
+        // Upload step — and it asks the user to sign in rather than offering to upload.
+        await acceptAllAgreements(page);
+        await expectUploadStepButtons(
+            page,
+            { signIn: "enabled", uploadBook: "absent", signOut: "absent" },
+            "With the agreements ticked and nobody signed in, the Upload step should offer Sign in and still no way to upload.",
+        );
+
+        // Signed in, everything else being ready: now, and only now, the book can be uploaded.
+        await pretendLoginState(page, SIGNED_IN_EMAIL);
+        await expectUploadStepButtons(
+            page,
+            { signIn: "absent", uploadBook: "enabled", signOut: "enabled" },
+            "A signed-in user with the agreements ticked was not offered the Upload Book button.",
+        );
+
+        // Stop pretending, so the rest of this Bloom sees the machine's real login state again.
+        await stopPretendingAboutLogin(page);
+    });
+
+    test("a template is let through without a copyright, after a warning [Test Case ID 606]", async ({
+        page,
+    }) => {
+        test.setTimeout(300000);
+        // A book made from Template Starter is a template, and Bloom titles it for us, so this one
+        // is short of a copyright and nothing else.
+        await switchTab(page, "collection");
+        await makeBookFromTemplate(page, "Template Starter");
+        await openPublishToWeb(page);
+
+        await expectMissingRequirements(
+            page,
+            [],
+            "Publish: Web asked a template for something, but a template needs no copyright.",
+        );
+        await expectAgreementsShowing(
+            page,
+            true,
+            "The Agreements did not appear for a template with no copyright.",
+        );
+
+        await acceptAllAgreements(page);
+        await pretendLoginState(page, SIGNED_IN_EMAIL);
+        await expectUploadStepButtons(
+            page,
+            { signIn: "absent", uploadBook: "enabled", signOut: "enabled" },
+            "A template with no copyright was not offered the Upload Book button.",
+        );
+
+        // THE ACTION UNDER TEST: clicking Upload on a template. Bloom lets it through, but warns
+        // first, in case the book is a template by accident.
+        await clickUploadBook(page);
+        const warning = await waitForTemplateUploadWarning(page);
+        expect(warning).toContain("Do you want to go ahead?");
+
+        // Answering Yes would upload to a real server, so this is where an automated run stops:
+        // being offered the choice IS the "upload is allowed" the manual test looks for.
+        await declineTemplateUploadWarning(page);
+        await stopPretendingAboutLogin(page);
+    });
+});

--- a/src/BloomExe/web/controllers/AccountApi.cs
+++ b/src/BloomExe/web/controllers/AccountApi.cs
@@ -26,6 +26,11 @@ namespace Bloom.web.controllers
         private readonly AvatarCache _avatarCache;
         private readonly ITeamCollectionManager _tcManager;
 
+        // What an e2e test has told us to report as the login state, or null to report the real
+        // one. See SetLoginStateForE2eTests. Volatile because the endpoint that sets it and the
+        // one that reads it run on different server threads.
+        private volatile string _e2eLoginOverride;
+
         // Whether we still owe the user the "please sign in" invitation described in
         // HandleSignInInvitationNeeded. It is used up once the front end reports having shown the
         // dialog, so we invite the user at most once per Bloom run.
@@ -178,7 +183,26 @@ namespace Bloom.web.controllers
         }
 
         // The email of the logged-in user, or empty when not logged in.
-        private string CurrentEmail => _client.LoggedIn ? Settings.Default.WebUserId : "";
+        private string CurrentEmail =>
+            _e2eLoginOverride ?? (_client.LoggedIn ? Settings.Default.WebUserId : "");
+
+        /// <summary>
+        /// Make Bloom report a pretended login state without touching the real Bloom Library
+        /// login: an email to report as signed in, the empty string to report as signed out, or
+        /// null to stop pretending and report the real state again. Called only by the e2e test
+        /// hook (e2e/loginState), which exists only in e2e test mode.
+        ///
+        /// A test needs this because the real login lives in machine-wide settings shared with the
+        /// developer's own Bloom: signing out for real would sign the developer out, and signing in
+        /// needs an external browser and real credentials. So the upload screen's login gate is
+        /// tested against a pretended state instead. Everything downstream of the actual upload
+        /// still uses the real client, so nothing can be uploaded with a pretended login.
+        /// </summary>
+        internal void SetLoginStateForE2eTests(string emailOrNullToStopPretending)
+        {
+            _e2eLoginOverride = emailOrNullToStopPretending;
+            BroadcastLoginState();
+        }
 
         /// <summary>
         /// Called once at startup (from ProjectContext, after this API's endpoints are registered) to

--- a/src/BloomExe/web/controllers/E2eTestingApi.cs
+++ b/src/BloomExe/web/controllers/E2eTestingApi.cs
@@ -29,6 +29,7 @@ namespace Bloom.web.controllers
         private readonly PageTemplatesApi _pageTemplatesApi;
         private readonly SourceCollectionsList _sourceCollectionsList;
         private readonly EditingModel _editingModel;
+        private readonly AccountApi _accountApi;
 
         public E2eTestingApi(
             CollectionSettings collectionSettings,
@@ -37,7 +38,8 @@ namespace Bloom.web.controllers
             CollectionModel collectionModel,
             PageTemplatesApi pageTemplatesApi,
             SourceCollectionsList sourceCollectionsList,
-            EditingModel editingModel
+            EditingModel editingModel,
+            AccountApi accountApi
         )
         {
             _collectionSettings = collectionSettings;
@@ -47,6 +49,7 @@ namespace Bloom.web.controllers
             _pageTemplatesApi = pageTemplatesApi;
             _sourceCollectionsList = sourceCollectionsList;
             _editingModel = editingModel;
+            _accountApi = accountApi;
         }
 
         /// <summary>
@@ -129,6 +132,40 @@ namespace Bloom.web.controllers
                 HandleGetTemplatePages,
                 false // does not need the UI thread
             );
+
+            // POST {"email": ...}: which Bloom Library login state Bloom should REPORT. A test
+            // needs this because the real login lives in machine-wide settings shared with the
+            // developer's own Bloom: signing out for real would sign the developer out, and
+            // signing in needs an external browser and real credentials. Only the report changes,
+            // so a test can check that the upload screen offers Upload only to a signed-in user;
+            // an actual upload still needs a real login. It runs off the UI thread like the rest
+            // of the login state's plumbing (see AccountApi's own broadcasts).
+            apiHandler.RegisterEndpointHandler(
+                kApiUrlPart + "loginState",
+                HandleSetLoginState,
+                false // does not need the UI thread
+            );
+        }
+
+        /// <summary>
+        /// What POST e2e/loginState takes: the email to report as signed in, the empty string to
+        /// report as signed out, or null (an absent member) to stop pretending altogether and
+        /// report the real login again. The three have to be distinguishable, so this is JSON
+        /// rather than a bare string, in which "signed out" and "no pretense" would both be empty.
+        /// </summary>
+        private class E2eLoginState
+        {
+            public string Email;
+        }
+
+        /// <summary>
+        /// POST e2e/loginState: report a pretended Bloom Library login state instead of the real
+        /// one. See AccountApi.SetLoginStateForE2eTests.
+        /// </summary>
+        private void HandleSetLoginState(ApiRequest request)
+        {
+            _accountApi.SetLoginStateForE2eTests(request.RequiredPostObject<E2eLoginState>().Email);
+            request.PostSucceeded();
         }
 
         /// <summary>

--- a/src/BloomExe/web/controllers/LibraryPublishApi.cs
+++ b/src/BloomExe/web/controllers/LibraryPublishApi.cs
@@ -200,8 +200,29 @@ namespace Bloom.web.controllers
             request.PostSucceeded();
         }
 
+        /// <summary>
+        /// Uploading is refused while Bloom is running e2e tests (the --e2e flag). A test can ask
+        /// Bloom to REPORT a Bloom Library login (the e2e/loginState hook) so it can check what the
+        /// upload screen offers a signed-in user; that pretense does not touch the real
+        /// credentials, so without this an automated click on Upload would publish a real book to
+        /// a real server under whatever account the developer happens to be signed in as.
+        /// The refusal goes to the progress box, which is where this screen shows upload trouble.
+        /// </summary>
+        private bool RefuseUploadWhileRunningE2eTests()
+        {
+            if (!Program.RunningE2eTests)
+                return false;
+            _webSocketProgress.MessageWithoutLocalizing(
+                "Uploading is disabled while Bloom is running e2e tests (--e2e).",
+                ProgressKind.Error
+            );
+            return true;
+        }
+
         private async Task UploadBookAsync()
         {
+            if (RefuseUploadWhileRunningE2eTests())
+                return;
             _webSocketProgress.Message("Common.Starting", "Starting...");
             SetParentControlsState(false); // Disable UI
 
@@ -334,6 +355,11 @@ namespace Bloom.web.controllers
 
         private void HandleUploadCollection(ApiRequest request)
         {
+            if (RefuseUploadWhileRunningE2eTests())
+            {
+                request.PostSucceeded();
+                return;
+            }
             if (!ValidateBookshelfBeforeBulkUpload())
             {
                 request.PostSucceeded();
@@ -346,6 +372,11 @@ namespace Bloom.web.controllers
 
         private void HandleUploadFolderOfCollections(ApiRequest request)
         {
+            if (RefuseUploadWhileRunningE2eTests())
+            {
+                request.PostSucceeded();
+                return;
+            }
             if (!ValidateBookshelfBeforeBulkUpload())
             {
                 request.PostSucceeded();
@@ -436,6 +467,13 @@ namespace Bloom.web.controllers
 
         private async Task HandleUploadAfterChangingBookId(ApiRequest request)
         {
+            // Before ChangeBookInstanceId, not after: refusing later would still have given the
+            // book a new identity it never needed.
+            if (RefuseUploadWhileRunningE2eTests())
+            {
+                request.PostSucceeded();
+                return;
+            }
             if (!Model.ChangeBookInstanceId(_progress))
             {
                 request.Failed("Can't fix ID because in TC");


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
Automates Notion test case 606 (Required Items Before Upload): https://app.notion.com/p/Required-Items-Before-Upload-3904bb19df12811cb1d1fd489941988a

## Bloom production code changes

- **`publish/LibraryPublish/LibraryPublishSteps.tsx`** — `data-testid`s on the two missing-item warnings, on each agreement check box, on the Upload step's row of buttons, and on the stepper. Markup only; nothing a user sees changes.
- **`web/controllers/AccountApi.cs` + `web/controllers/E2eTestingApi.cs`** — a new `e2e/loginState` endpoint that makes Bloom *report* a Bloom Library login state (an email, `""` for signed out, or nothing to stop pretending) without touching the real one. Like every `e2e/*` endpoint it is registered only under `--e2e`.
- **`web/controllers/LibraryPublishApi.cs`** — under `--e2e`, Bloom now refuses to upload at all, on every path (single book, both bulk ones, and the change-the-id one, where it refuses before the id changes). The login pretense above changes only what Bloom *reports*, so without this an automated click on Upload would have published a real book under whatever account the developer was signed in as.

## Problem

Publish: Web is the gate on a book reaching BloomLibrary.org. It refuses a book with no title or no copyright, names which is missing, offers a "Click to fix" route to each, keeps the Agreements closed until the metadata is complete, offers Upload only to a signed-in user — and lets a template through without a copyright, after a warning. All of it was checked only by hand (Notion test case 606, which has since absorbed #203, #221, #607, #608, #609 and #610).

## What this PR does

- Adds `src/BloomE2E/tests/upload-required-items.spec.ts`: seven tests that build their own books and drive the real screen — both warnings on a text-less book and again on a picture-only one, "Click to fix" on the copyright through the real Copyright and License dialog, "Click to fix" on the title opening the front cover with the warning surviving a return trip, the Agreements appearing once the book has both, Upload appearing only once the agreements are ticked and somebody is signed in, and a template being let through without a copyright after Bloom's warning.
- Adds two helper modules for the surfaces it drives: `helpers/libraryPublish.ts` (the Publish: Web stepper) and `helpers/copyrightAndLicense.ts` (the dialog).
- Ships the Bloom changes above that make all this drivable, and safe to drive.
- Records the new automation debt: the Bloom Library login cannot be done for real in a test, which is also what keeps the cards that upload for real out of reach.

## Test steps covered

**Every step of the card.** Its upload steps were removed from the card itself while this test was written — a real upload is exercised by #204, #211, #215, #217 and #218 — so 606 is now only about the gate.

The one thing that is not real is the login: the test tells Bloom what login state to report, because the real one lives in machine-wide settings shared with the developer's own Bloom. So this proves that a signed-out user is offered Sign in and never Upload, not that a real account can upload. See the entry in `src/BloomE2E/AUTOMATION-DEBT.md`.
<!-- preflight-narrative:end -->

---
[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8279)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8279)
<!-- Reviewable:end -->
