### PR TITLE
E2E test: Format dialog opens next to the gear and on screen (Notion test case 356)

### DIFF
--- a/.github/skills/add-e2e-test/SKILL.md
+++ b/.github/skills/add-e2e-test/SKILL.md
@@ -234,11 +234,12 @@ Dependencies point down only:
    header and the CDP endpoint does not answer on `localhost`) and `helpers/realClick.ts`
    (`realClick`, `realClickAt`). Tests do not import these; surface modules wrap them.
 2. **One module per Bloom surface**, named after the surface:
-   - `helpers/workspace.ts` — `switchTab`, `getTabs`, `waitForActiveTab`. Bloom hides the
-     Edit and Publish tabs until a book is selected.
+   - `helpers/workspace.ts` — `switchTab`, `getTabs`, `waitForActiveTab`, and the zoom
+     control's `getZoom`, `setZoom`. Bloom hides the Edit and Publish tabs until a book is
+     selected.
    - `helpers/collection.ts` — `selectBook`, `waitForCollectionReady`.
    - `helpers/bookMaking.ts` — `makeBookFromTemplate`, `addPage`, `findBookFolder`,
-     `setContentLanguages`, `getPages`, `getContentPages`, `goToPage`, `typeInGroup`,
+     `setContentLanguages`, `getPages`, `getContentPages`, `goToPage`, `clickInGroup`, `typeInGroup`,
      `waitForEditablePage`, `editablePageFrame`. A book made from a template starts with
      front and back matter only, so a test that needs content calls `addPage`. Bloom writes
      a page only when the book leaves it, so `goToPage` is also how a test saves what it
@@ -247,6 +248,10 @@ Dependencies point down only:
      `movePageToSlotOf`, and the API route `duplicateCurrentPage` for setup.
    - `helpers/images.ts` — `chooseImageFile` (setup, no picker), `cropImage`,
      `getImagePlacement`.
+   - `helpers/formatDialog.ts` — the format gear and the Format dialog it opens:
+     `openFormatDialog`, `clickOutsideFormatDialog`, `dragFormatDialog`,
+     `getFormatDialogPlacement`, `scrollFormatGearIntoView`, `scrollFormatGearPartlyIntoView`,
+     `zoomUntilFormatGearIsOutOfView`.
    - `helpers/publish.ts` — `openPublishDestination`, `getTextLanguageRows`,
      `expectTextLanguageRows`, `clickTextLanguage`, `showBloomPubPreview`,
      `getPreviewLanguages`, `getLanguagesInBook`, `getTooltipForLanguage`.

--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -19,6 +19,16 @@ House rules:
 
 ---
 
+## 2026-09-02 — notion_automation.py needs Python, which not every dev machine has
+
+- **Cut:** `.github/skills/improve-test-automation-coverage/notion_automation.py` is the only way the
+  add-e2e-test flow reads or updates a Notion test card, and both it and the skill text assume `py`.
+  On a machine with no Python (only the Windows Store stub) every `show`/`set` fails, and an agent
+  ends up hand-porting the script to Node before it can read the card.
+- **Idea:** Rewrite it as `notion_automation.mjs`: the repo already requires Node and the script is
+  stdlib-only (`urllib` → `fetch`), so nothing else changes; update the skill text and worker brief.
+- **Context:** Hit while automating Test Case ID 356 on a machine with no Python.
+
 ## 2026-09-01 — VR suite: a slow first preview load fails its case via Playwright's default 30s goto timeout
 
 - **Cut:** The first case after Bloom starts pays for the first book-preview load (~33s observed

--- a/src/BloomE2E/AUTOMATION-DEBT.md
+++ b/src/BloomE2E/AUTOMATION-DEBT.md
@@ -186,3 +186,20 @@ test can currently clear a box by any faster route. Fix direction: understand wh
 CKEditor does with a programmatic value change; a supported "set the text of this box"
 path would let long text be set at once.
 (Found 2026-09-01 automating Test Case ID 169.)
+
+## Every Bloom of one build shares one user.config, so a run inherits another Bloom's settings
+
+Bloom keeps its user settings (UI language, page zoom, and the rest of `Settings.Default`) in
+`%LOCALAPPDATA%\SIL\Bloom\<version>\user.config`, one file per build version, and `--e2e` does
+nothing to change that. So the Bloom a test launches starts from whatever the last Bloom of the
+same version saved, and saves its own changes for the next one. The e2e lock keeps suites from
+running at once, but a developer's own Bloom from a worktree of the same version is outside the
+lock and shares the file all the same, and so does the previous run of any suite.
+
+Seen 2026-09-02 (Test Case ID 356, `format-gear-positioning.spec.ts`): two runs found every
+factory template named in Turkish, then in French, and failed in `makeBookFromTemplate`, which
+matches the English title; a Bloom nobody in the suite had started was running at the time, and
+the file said `en` again a moment later. The same test has to restore the zoom it changes, because
+that setting is shared too. Fix direction: under `--e2e`, point the settings provider at a
+per-instance folder (a sibling of the temp collection would do), so a test's Bloom starts from
+defaults and its changes die with it.

--- a/src/BloomE2E/README.md
+++ b/src/BloomE2E/README.md
@@ -87,8 +87,12 @@ real bug in the code under test; read the message and fix it rather than working
 
 ## Helpers
 
-- `helpers/workspace.ts` — `switchTab`, `getTabs`, `waitForActiveTab`. Note that Bloom hides the
-  Edit and Publish tabs until a book is selected.
+- `helpers/workspace.ts` — `switchTab`, `getTabs`, `waitForActiveTab`, and the zoom control's
+  `getZoom`, `setZoom`. Note that Bloom hides the Edit and Publish tabs until a book is selected.
+- `helpers/formatDialog.ts` — the format gear beside the text box being edited, and the Format
+  dialog it opens: `openFormatDialog`, `clickOutsideFormatDialog`, `dragFormatDialog`,
+  `getFormatDialogPlacement`, and the scrolling and zooming that put the gear at the edge of the
+  screen.
 - `helpers/collection.ts` — `selectBook`, `waitForCollectionReady`.
 - `helpers/api.ts` — `apiGet`, `apiPost`, `apiGetJson`. These run `fetch` inside the page with a
   relative URL, which is not a style choice: Bloom's server rejects a `127.0.0.1` Host header, and

--- a/src/BloomE2E/helpers/bookMaking.ts
+++ b/src/BloomE2E/helpers/bookMaking.ts
@@ -8,7 +8,7 @@
 // reliable path through Bloom's API wherever there is one, per the UI-vs-API policy in README.md.
 // The text itself goes in through the real editor, because there is no API that writes it.
 
-import { expect, type Frame, type Page } from "@playwright/test";
+import { expect, type Frame, type Locator, type Page } from "@playwright/test";
 import { apiGet, apiGetJson, apiPost } from "./api";
 import { waitForCollectionReady } from "./collection";
 
@@ -348,6 +348,30 @@ export async function goToPage(page: Page, pageId: string): Promise<void> {
 }
 
 /**
+ * Click in one language's box of one translation group on the page being shown, so that it has the
+ * focus, the way a person starts editing it. `groupSelector` picks the group, e.g. ".bookTitle" for
+ * the cover title. Waits until the box has the focus, and returns it.
+ *
+ * Focusing a box is also what makes Bloom show the box's format gear (see helpers/formatDialog.ts).
+ */
+export async function clickInGroup(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+): Promise<Locator> {
+    const box = editablePageFrame(page)
+        .locator(`${groupSelector} .bloom-editable[lang="${languageTag}"]`)
+        .first();
+    await box.waitFor({ state: "visible", timeout: 30000 });
+    await box.click();
+    await expect(
+        box,
+        `Clicking in the "${languageTag}" box of "${groupSelector}" did not give it the focus.`,
+    ).toBeFocused({ timeout: 15000 });
+    return box;
+}
+
+/**
  * Type text into one language's box of one translation group on the page being shown, the way a
  * person does. `groupSelector` picks the group, e.g. ".bookTitle" for the cover title.
  *
@@ -360,13 +384,9 @@ export async function typeInGroup(
     languageTag: string,
     text: string,
 ): Promise<void> {
-    const box = editablePageFrame(page)
-        .locator(`${groupSelector} .bloom-editable[lang="${languageTag}"]`)
-        .first();
-    await box.waitFor({ state: "visible", timeout: 30000 });
     // Click in, select what is there, and type over it. A box here is a CKEditor surface, and
     // filling it directly leaves part of the old text behind.
-    await box.click();
+    const box = await clickInGroup(page, groupSelector, languageTag);
     await box.press("Control+a");
     await box.press("Delete");
     if (text) await box.pressSequentially(text);

--- a/src/BloomE2E/helpers/formatDialog.ts
+++ b/src/BloomE2E/helpers/formatDialog.ts
@@ -1,0 +1,375 @@
+// The Format dialog: the gear Bloom shows at the corner of the text box being edited, and the
+// dialog the gear opens, where the box's style, font, and paragraph settings are changed.
+//
+// Both live in the Edit tab's page frame. The gear sits inside the zoomed page, next to its box.
+// The dialog is appended to the frame's body, outside the zoom, and Bloom places it just to the
+// right of the gear, then moves it only as far as needed to keep it wholly inside the frame's
+// viewport (StyleEditor.runFormatDialog and EditableDivUtils.positionDialogAndSetDraggable). So
+// that viewport is the "screen" the dialog has to stay on, and every measurement here is in the
+// page frame's client coordinates.
+//
+// The gear is clicked at a point, not with Playwright's own click, because Playwright scrolls its
+// target into view first, and the case the manual test cares about most is a gear that is only
+// partly in view.
+
+import { expect, type Page } from "@playwright/test";
+import { editablePageFrame } from "./bookMaking";
+import { realClickAt } from "./realClick";
+import { getZoom, setZoom } from "./workspace";
+
+/** The gear Bloom adds beside the text box that has the focus. */
+const GEAR = "#formatButton";
+/** The dialog itself. Bloom creates it when the gear is clicked and removes it when it closes. */
+const DIALOG = "#format-toolbar";
+/** The dialog's title bar, which is what a person drags it by. */
+const DIALOG_TITLE_BAR = `${DIALOG} .bloomDialogTitleBar`;
+
+/** A rectangle in the page frame's client coordinates. */
+export interface IRect {
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
+    width: number;
+    height: number;
+}
+
+/** Where the format gear and the Format dialog are, relative to the page frame's viewport. */
+export interface IFormatDialogPlacement {
+    /** The Format dialog, or undefined while it is not open. */
+    dialog: IRect | undefined;
+    /** The format gear, or undefined while no text box has the focus. */
+    gear: IRect | undefined;
+    /** The page frame's viewport: the area in which the page, the gear and the dialog can be seen. */
+    viewport: { width: number; height: number };
+}
+
+/**
+ * Where the gear and the dialog are, and how big the viewport is, measured together inside the
+ * page frame so that the three agree with each other.
+ */
+export async function getFormatDialogPlacement(
+    page: Page,
+): Promise<IFormatDialogPlacement> {
+    return editablePageFrame(page).evaluate(
+        ({ gearSelector, dialogSelector }) => {
+            const rectOf = (selector: string): IRect | undefined => {
+                const element = document.querySelector(selector);
+                if (!element) return undefined;
+                const r = element.getBoundingClientRect();
+                return {
+                    left: r.left,
+                    top: r.top,
+                    right: r.right,
+                    bottom: r.bottom,
+                    width: r.width,
+                    height: r.height,
+                };
+            };
+            return {
+                dialog: rectOf(dialogSelector),
+                gear: rectOf(gearSelector),
+                // clientWidth/clientHeight leave out the scrollbars, which hide whatever is
+                // under them.
+                viewport: {
+                    width: document.documentElement.clientWidth,
+                    height: document.documentElement.clientHeight,
+                },
+            };
+        },
+        { gearSelector: GEAR, dialogSelector: DIALOG },
+    );
+}
+
+/** A rectangle described for an error message. */
+const describeRect = (r: IRect) =>
+    `left ${Math.round(r.left)}, top ${Math.round(r.top)}, ${Math.round(r.width)}x${Math.round(r.height)}`;
+
+/**
+ * Wait until the text box with the focus is showing its format gear, and return where the gear is.
+ * Bloom adds the gear when a box gets the focus, once CKEditor is ready, which can be a moment
+ * after clickInGroup returns.
+ */
+export async function waitForFormatGear(page: Page): Promise<IRect> {
+    let gear: IRect | undefined;
+    await expect
+        .poll(
+            async () => {
+                gear = (await getFormatDialogPlacement(page)).gear;
+                return !!gear && gear.width > 0;
+            },
+            {
+                timeout: 30000,
+                message:
+                    "No text box is showing its format gear. A box has to have the focus for its gear to appear (see clickInGroup).",
+            },
+        )
+        .toBe(true);
+    return gear!;
+}
+
+/**
+ * The point in the shell page's coordinates that the page frame's client origin (0, 0) maps to,
+ * so a point measured inside the frame can be clicked with the mouse.
+ */
+async function pageFrameOrigin(page: Page): Promise<{ x: number; y: number }> {
+    const iframe = await editablePageFrame(page).frameElement();
+    const box = await iframe.boundingBox();
+    if (!box)
+        throw new Error(
+            "The page frame has no on-screen box, so nothing in it can be clicked.",
+        );
+    // A border on the iframe would shift its content relative to its box.
+    const border = await iframe.evaluate((element) => ({
+        left: (element as HTMLElement).clientLeft,
+        top: (element as HTMLElement).clientTop,
+    }));
+    return { x: box.x + border.left, y: box.y + border.top };
+}
+
+/** Click, with a real mouse press and release, at a point given in the page frame's coordinates. */
+async function clickInPageFrameAt(
+    page: Page,
+    x: number,
+    y: number,
+): Promise<void> {
+    const origin = await pageFrameOrigin(page);
+    await realClickAt(page, origin.x + x, origin.y + y);
+}
+
+/**
+ * Click the format gear, the way a person does, and wait for the Format dialog to open.
+ *
+ * The click lands on the middle of whatever part of the gear is in view, and nothing is scrolled
+ * first: a gear that is half off the bottom of the frame is clicked on its visible half, which is
+ * how the manual test checks where the dialog lands for a gear at the edge of the screen. Throws
+ * when no part of the gear is in view; see scrollFormatGearIntoView.
+ */
+export async function openFormatDialog(page: Page): Promise<void> {
+    await waitForFormatGear(page);
+    const { gear, viewport } = await getFormatDialogPlacement(page);
+    const visible = {
+        left: Math.max(gear!.left, 0),
+        top: Math.max(gear!.top, 0),
+        right: Math.min(gear!.right, viewport.width),
+        bottom: Math.min(gear!.bottom, viewport.height),
+    };
+    if (visible.right - visible.left < 2 || visible.bottom - visible.top < 2)
+        throw new Error(
+            `The format gear is out of view (it is at ${describeRect(gear!)} in a ` +
+                `${viewport.width}x${viewport.height} viewport), so it cannot be clicked. ` +
+                `Scroll it into view first.`,
+        );
+    await clickInPageFrameAt(
+        page,
+        (visible.left + visible.right) / 2,
+        (visible.top + visible.bottom) / 2,
+    );
+    await expect(
+        editablePageFrame(page).locator(DIALOG),
+        "Clicking the format gear did not open the Format dialog.",
+    ).toBeVisible({ timeout: 30000 });
+}
+
+/** True while the Format dialog is open. */
+export async function isFormatDialogOpen(page: Page): Promise<boolean> {
+    return editablePageFrame(page).locator(DIALOG).isVisible();
+}
+
+/**
+ * Click on the page outside the Format dialog, the way a person dismisses it, and wait for the
+ * dialog to go away.
+ *
+ * The click lands near the corner of the frame's viewport farthest from the dialog, which is the
+ * spot least likely to be on the dialog or on anything that reacts to a click of its own.
+ */
+export async function clickOutsideFormatDialog(page: Page): Promise<void> {
+    const { dialog, viewport } = await getFormatDialogPlacement(page);
+    if (!dialog)
+        throw new Error(
+            "The Format dialog is not open, so there is nothing to click outside of.",
+        );
+    const inset = 8;
+    const corners = [
+        { x: inset, y: inset },
+        { x: viewport.width - inset, y: inset },
+        { x: inset, y: viewport.height - inset },
+        { x: viewport.width - inset, y: viewport.height - inset },
+    ];
+    const centre = {
+        x: (dialog.left + dialog.right) / 2,
+        y: (dialog.top + dialog.bottom) / 2,
+    };
+    const distance = (p: { x: number; y: number }) =>
+        Math.hypot(p.x - centre.x, p.y - centre.y);
+    const target = corners.sort((a, b) => distance(b) - distance(a))[0];
+    await clickInPageFrameAt(page, target.x, target.y);
+    await expect(
+        editablePageFrame(page).locator(DIALOG),
+        "The Format dialog stayed open after a click outside it.",
+    ).toBeHidden({ timeout: 30000 });
+}
+
+/**
+ * Drag the Format dialog by its title bar, `dx` pixels to the right and `dy` down, with a real
+ * press, move and release, and wait until the dialog has moved.
+ */
+export async function dragFormatDialog(
+    page: Page,
+    dx: number,
+    dy: number,
+): Promise<void> {
+    const titleBar = editablePageFrame(page).locator(DIALOG_TITLE_BAR);
+    await titleBar.waitFor({ state: "visible", timeout: 30000 });
+    const before = (await getFormatDialogPlacement(page)).dialog!;
+    const box = (await titleBar.boundingBox())!;
+    // Grab the bar left of its middle: the language code sits at its right end.
+    const x = box.x + box.width / 4;
+    const y = box.y + box.height / 2;
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+    // The dialog only starts to follow the pointer once it has travelled some way, so travel in
+    // steps rather than jumping.
+    await page.mouse.move(x + dx, y + dy, { steps: 10 });
+    await page.mouse.up();
+    await expect
+        .poll(
+            async () => {
+                const dialog = (await getFormatDialogPlacement(page)).dialog;
+                return dialog
+                    ? Math.hypot(
+                          dialog.left - before.left,
+                          dialog.top - before.top,
+                      )
+                    : 0;
+            },
+            {
+                timeout: 30000,
+                message: `Dragging the Format dialog's title bar by (${dx}, ${dy}) did not move the dialog.`,
+            },
+        )
+        .toBeGreaterThan(Math.hypot(dx, dy) / 2);
+}
+
+/**
+ * Scroll the page frame so that the format gear is where `wantedTop` and `wantedLeft` put it,
+ * and wait until it is there according to `isPlaced`.
+ */
+async function scrollFormatGearTo(
+    page: Page,
+    wanted: (
+        gear: IRect,
+        viewport: { width: number; height: number },
+    ) => {
+        left: number;
+        top: number;
+    },
+    isPlaced: (
+        gear: IRect,
+        viewport: { width: number; height: number },
+    ) => boolean,
+    description: string,
+): Promise<void> {
+    await waitForFormatGear(page);
+    const placement = await getFormatDialogPlacement(page);
+    const target = wanted(placement.gear!, placement.viewport);
+    await editablePageFrame(page).evaluate(
+        ({ selector, left, top }) => {
+            const gear = document
+                .querySelector(selector)!
+                .getBoundingClientRect();
+            window.scrollBy(gear.left - left, gear.top - top);
+        },
+        { selector: GEAR, left: target.left, top: target.top },
+    );
+    await expect
+        .poll(
+            async () => {
+                const { gear, viewport } = await getFormatDialogPlacement(page);
+                return !!gear && isPlaced(gear, viewport);
+            },
+            {
+                timeout: 30000,
+                message: `The format gear never came to be ${description}.`,
+            },
+        )
+        .toBe(true);
+}
+
+/** Room to leave between the gear and the left edge of the viewport when scrolling to it. */
+const GEAR_MARGIN_PX = 40;
+
+/**
+ * Scroll the page frame so that the whole format gear is in view, with a little room around it.
+ * Setup for clicking the gear when the page is bigger than the frame.
+ */
+export async function scrollFormatGearIntoView(page: Page): Promise<void> {
+    await scrollFormatGearTo(
+        page,
+        (gear, viewport) => ({
+            left: Math.min(gear.left, GEAR_MARGIN_PX),
+            top: Math.min(
+                gear.top,
+                viewport.height - gear.height - GEAR_MARGIN_PX,
+            ),
+        }),
+        (gear, viewport) =>
+            gear.left >= 0 &&
+            gear.top >= 0 &&
+            gear.right <= viewport.width &&
+            gear.bottom <= viewport.height,
+        "wholly in view",
+    );
+}
+
+/**
+ * Scroll the page frame so that the format gear straddles the bottom edge of the viewport: its
+ * top half in view, its bottom half below the edge. Setup for checking where the Format dialog
+ * lands when the gear is at the edge of the screen.
+ */
+export async function scrollFormatGearPartlyIntoView(
+    page: Page,
+): Promise<void> {
+    await scrollFormatGearTo(
+        page,
+        (gear, viewport) => ({
+            left: Math.min(gear.left, GEAR_MARGIN_PX),
+            top: viewport.height - gear.height / 2,
+        }),
+        (gear, viewport) =>
+            gear.left >= 0 &&
+            gear.right <= viewport.width &&
+            gear.top < viewport.height &&
+            gear.bottom > viewport.height,
+        "half off the bottom edge of the viewport",
+    );
+}
+
+/**
+ * Zoom the page in, one notch at a time as the top bar's + button does, until the format gear has
+ * scrolled out of view below the bottom of the frame, and return the zoom that did it. This is
+ * the manual tester's "increase zoom until the format gear is scrolled out of view": the smallest
+ * zoom at which the box at the bottom of the page no longer fits, which is a zoom people use.
+ *
+ * Throws if the gear is still in view at Bloom's largest zoom.
+ */
+export async function zoomUntilFormatGearIsOutOfView(
+    page: Page,
+): Promise<number> {
+    await waitForFormatGear(page);
+    const isOutOfView = async () => {
+        const { gear, viewport } = await getFormatDialogPlacement(page);
+        return !!gear && gear.top >= viewport.height;
+    };
+    let { zoom, maxZoom } = await getZoom(page);
+    while (!(await isOutOfView())) {
+        if (zoom >= maxZoom)
+            throw new Error(
+                `The format gear is still in view at Bloom's largest zoom, ${maxZoom}%, so it ` +
+                    `cannot be scrolled out of view by zooming. Is the text box near the bottom of the page?`,
+            );
+        zoom = Math.min(zoom + 10, maxZoom);
+        await setZoom(page, zoom);
+    }
+    return zoom;
+}

--- a/src/BloomE2E/helpers/workspace.ts
+++ b/src/BloomE2E/helpers/workspace.ts
@@ -1,4 +1,4 @@
-// Drive and read Bloom's top-bar workspace tabs.
+// Drive and read Bloom's top bar: the workspace tabs, and the zoom control at its right end.
 //
 // The WinForms shell, not the React top bar, owns which tab is active. So a test clicks the real
 // button (switchTab) but asks Bloom's own workspace/tabs API what happened (getTabs,
@@ -7,7 +7,8 @@
 // finished the switch rather than merely started it.
 
 import { expect, type Page } from "@playwright/test";
-import { apiGetJson } from "./api";
+import { apiGetJson, apiPost } from "./api";
+import { editablePageFrame } from "./bookMaking";
 
 /** The three workspace tabs, named as Bloom's API names them. */
 export type WorkspaceTabId = "collection" | "edit" | "publish";
@@ -69,4 +70,70 @@ export async function switchTab(
     await target.waitFor({ state: "visible", timeout: timeoutMs });
     await target.click();
     await waitForActiveTab(page, tab, timeoutMs);
+}
+
+/** What GET workspace/topRight/zoom replies with: the Edit tab's zoom, as a percentage. */
+export interface IZoomInfo {
+    zoom: number;
+    minZoom: number;
+    maxZoom: number;
+    /** False outside the Edit tab, where the top bar hides the zoom control. */
+    zoomEnabled: boolean;
+}
+
+/** Ask Bloom what the Edit tab's zoom is, and the range it allows. */
+export async function getZoom(page: Page): Promise<IZoomInfo> {
+    return apiGetJson<IZoomInfo>(page, "workspace/topRight/zoom");
+}
+
+/**
+ * Set the Edit tab's zoom to `percent`, by the same route as the top bar's + and − buttons post.
+ * This is the SETUP route for a test that needs the page drawn large or small; a test whose subject
+ * is the zoom control clicks the buttons instead.
+ *
+ * Returns once Bloom reports the new zoom and the page being edited is drawn at it. Bloom saves the
+ * zoom as a user setting, so a test that changes it should put it back when it is done.
+ */
+export async function setZoom(page: Page, percent: number): Promise<void> {
+    const info = await getZoom(page);
+    if (!info.zoomEnabled)
+        throw new Error(
+            "Bloom is not showing the Edit tab, so there is no page to zoom.",
+        );
+    if (percent < info.minZoom || percent > info.maxZoom)
+        throw new Error(
+            `Bloom's zoom goes from ${info.minZoom}% to ${info.maxZoom}%, so it cannot be set to ${percent}%.`,
+        );
+    await apiPost(
+        page,
+        "workspace/topRight/zoom",
+        JSON.stringify({ zoom: percent }),
+        "application/json",
+    );
+    await expect
+        .poll(async () => (await getZoom(page)).zoom, {
+            timeout: 30000,
+            message: `Bloom never reported the zoom as ${percent}%.`,
+        })
+        .toBe(percent);
+    // Bloom draws the zoom by scaling a container it wraps around the page (see SetupPageZoom in
+    // EditingModel.cs and setZoom in workspaceRoot.ts). Wait for that to show the new zoom, or a
+    // measurement taken right after this returns would see the old size.
+    await expect
+        .poll(
+            async () =>
+                editablePageFrame(page)
+                    .locator("#page-scaling-container")
+                    .evaluate((container) => {
+                        const match = /scale\(([\d.]+)\)/.exec(
+                            (container as HTMLElement).style.transform,
+                        );
+                        return match ? Math.round(Number(match[1]) * 100) : 0;
+                    }),
+            {
+                timeout: 30000,
+                message: `The page being edited was never drawn at ${percent}%.`,
+            },
+        )
+        .toBe(percent);
 }

--- a/src/BloomE2E/tests/format-gear-positioning.spec.ts
+++ b/src/BloomE2E/tests/format-gear-positioning.spec.ts
@@ -1,0 +1,168 @@
+// Where the Format dialog appears when the format gear is clicked: close to the gear, and wholly
+// on the screen even when the gear is at the very edge of it; that a click outside the dialog
+// closes it; and that it can be dragged. Automates the manual test "Format Gear Positioning"
+// (Test Case ID 356).
+//
+// The page frame's viewport is the screen here. Bloom keeps the dialog inside that viewport, and
+// the gear can only ever be scrolled off the edge of it, so every position is measured against it
+// (see helpers/formatDialog.ts).
+//
+// The tests are serial: each starts from the state the one before it left behind.
+
+import { expect, test } from "../fixtures/bloomTest";
+import {
+    addPage,
+    clickInGroup,
+    getContentPages,
+    goToPage,
+    makeBookFromTemplate,
+} from "../helpers/bookMaking";
+import {
+    clickOutsideFormatDialog,
+    dragFormatDialog,
+    getFormatDialogPlacement,
+    isFormatDialogOpen,
+    openFormatDialog,
+    scrollFormatGearIntoView,
+    scrollFormatGearPartlyIntoView,
+    zoomUntilFormatGearIsOutOfView,
+    type IFormatDialogPlacement,
+    type IRect,
+} from "../helpers/formatDialog";
+import { getZoom, setZoom } from "../helpers/workspace";
+
+test.use({
+    collectionSpec: { name: "format-gear-positioning", languages: ["en"] },
+});
+
+test.describe.configure({ mode: "serial" });
+
+/** The one text box on the page this file builds: the box under the picture. */
+const TEXT_BOX = ".bloom-translationGroup";
+const LANGUAGE = "en";
+
+/**
+ * How far, in pixels, the dialog may be from the gear and still count as close to it. Bloom places
+ * the dialog 30px to the right of the gear and level with it, so the gap is normally about 30;
+ * this leaves room for the nudge that keeps the dialog on the screen.
+ */
+const NEAR_PX = 50;
+
+/** How far the drag test moves the dialog, and how far off that the dialog may land. */
+const DRAG = { dx: -120, dy: -80 };
+const DRAG_TOLERANCE_PX = 15;
+
+/** The zoom Bloom started with, put back at the end so the setting does not leak out of the run. */
+let startingZoom: number;
+
+/** The gap between two rectangles along each axis: zero where they overlap on that axis. */
+const gapBetween = (a: IRect, b: IRect) => ({
+    x: Math.max(0, a.left - b.right, b.left - a.right),
+    y: Math.max(0, a.top - b.bottom, b.top - a.bottom),
+});
+
+/** Assert that the Format dialog is open and close to the format gear. */
+const expectDialogCloseToGear = (placement: IFormatDialogPlacement) => {
+    expect(placement.dialog, "The Format dialog is not open.").toBeDefined();
+    expect(
+        placement.gear,
+        "No text box is showing its format gear.",
+    ).toBeDefined();
+    const gap = gapBetween(placement.dialog!, placement.gear!);
+    expect(
+        gap.x,
+        `The dialog is ${Math.round(gap.x)}px to the side of the gear.`,
+    ).toBeLessThanOrEqual(NEAR_PX);
+    expect(
+        gap.y,
+        `The dialog is ${Math.round(gap.y)}px above or below the gear.`,
+    ).toBeLessThanOrEqual(NEAR_PX);
+};
+
+/** Assert that the Format dialog is open and wholly on the screen. */
+const expectDialogEntirelyOnScreen = (placement: IFormatDialogPlacement) => {
+    expect(placement.dialog, "The Format dialog is not open.").toBeDefined();
+    const { dialog, viewport } = placement;
+    expect(
+        dialog!.left,
+        "The dialog runs off the left edge.",
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+        dialog!.top,
+        "The dialog runs off the top edge.",
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+        dialog!.right,
+        "The dialog runs off the right edge.",
+    ).toBeLessThanOrEqual(viewport.width);
+    expect(
+        dialog!.bottom,
+        "The dialog runs off the bottom edge.",
+    ).toBeLessThanOrEqual(viewport.height);
+};
+
+test.describe("Format gear positioning", () => {
+    test.afterAll(async ({ page }) => {
+        if (startingZoom !== undefined) await setZoom(page, startingZoom);
+    });
+
+    test("builds a book with a text box at the bottom of a page", async ({
+        page,
+    }) => {
+        test.setTimeout(300000);
+        await makeBookFromTemplate(page, "Basic Book");
+        await addPage(page, "Basic Text & Image");
+        const [textPage] = await getContentPages(page);
+        await goToPage(page, textPage.id);
+        startingZoom = (await getZoom(page)).zoom;
+
+        await clickInGroup(page, TEXT_BOX, LANGUAGE);
+        await scrollFormatGearIntoView(page);
+        // Sanity check the page the rest of the file rests on: the gear, and so the box it belongs
+        // to, is in the lower half of the view.
+        const { gear, viewport } = await getFormatDialogPlacement(page);
+        expect(gear!.top).toBeGreaterThan(viewport.height / 2);
+    });
+
+    test("the Format dialog opens close to the gear [Test Case ID 356]", async ({
+        page,
+    }) => {
+        await openFormatDialog(page);
+        const placement = await getFormatDialogPlacement(page);
+        expectDialogCloseToGear(placement);
+        expectDialogEntirelyOnScreen(placement);
+    });
+
+    test("a click outside the Format dialog closes it [Test Case ID 356]", async ({
+        page,
+    }) => {
+        expect(await isFormatDialogOpen(page)).toBe(true);
+        await clickOutsideFormatDialog(page);
+        expect(await isFormatDialogOpen(page)).toBe(false);
+    });
+
+    test("with the gear half off the screen, the dialog opens close to it and wholly on the screen [Test Case ID 356]", async ({
+        page,
+    }) => {
+        await zoomUntilFormatGearIsOutOfView(page);
+        await scrollFormatGearPartlyIntoView(page);
+        await openFormatDialog(page);
+        const placement = await getFormatDialogPlacement(page);
+        expectDialogCloseToGear(placement);
+        expectDialogEntirelyOnScreen(placement);
+    });
+
+    test("the Format dialog can be dragged [Test Case ID 356]", async ({
+        page,
+    }) => {
+        const before = (await getFormatDialogPlacement(page)).dialog!;
+        await dragFormatDialog(page, DRAG.dx, DRAG.dy);
+        const after = (await getFormatDialogPlacement(page)).dialog!;
+        expect(
+            Math.abs(after.left - before.left - DRAG.dx),
+        ).toBeLessThanOrEqual(DRAG_TOLERANCE_PX);
+        expect(Math.abs(after.top - before.top - DRAG.dy)).toBeLessThanOrEqual(
+            DRAG_TOLERANCE_PX,
+        );
+    });
+});

--- a/src/BloomE2E/tests/format-gear-positioning.spec.ts
+++ b/src/BloomE2E/tests/format-gear-positioning.spec.ts
@@ -102,8 +102,11 @@ const expectDialogEntirelyOnScreen = (placement: IFormatDialogPlacement) => {
 };
 
 test.describe("Format gear positioning", () => {
-    test.afterAll(async ({ page }) => {
-        if (startingZoom !== undefined) await setZoom(page, startingZoom);
+    // A suite hook takes the worker-scoped bloomApp rather than the test-scoped page: bloomApp is
+    // what a hook is meant to use, and its page is the live one even after a restart.
+    test.afterAll(async ({ bloomApp }) => {
+        if (startingZoom !== undefined)
+            await setZoom(bloomApp.page, startingZoom);
     });
 
     test("builds a book with a text box at the bottom of a page", async ({


### PR DESCRIPTION
Automates Notion test case 356 (Format Gear Positioning): https://app.notion.com/p/Format-Gear-Positioning-3904bb19df128188b2fbe4b52790f27b

## Purpose

Protects where the Format dialog appears when the format gear of a text box is clicked: close to the gear, and wholly on the screen even when the gear has been scrolled half off the bottom edge of the page frame. Also that a click outside the dialog closes it, and that the dialog can be dragged. All four Test Steps of the card are covered; none stay manual.

## Steps

New spec `src/BloomE2E/tests/format-gear-positioning.spec.ts`, five serial tests on a collection the test creates:

- Make a Basic Book, add a "Basic Text & Image" page (text box at the bottom), click in the box so its gear appears, and scroll the gear into view.
- Click the gear; the dialog opens close to the gear and entirely within the page frame's viewport.
- Click the far corner of the page, outside the dialog; the dialog goes away.
- Zoom in one notch at a time until the gear scrolls out of view (150% on the dev screen), scroll so the gear straddles the bottom edge, click its visible half; the dialog is again close to the gear and entirely on the screen (Bloom nudges it up to fit).
- Drag the dialog by its title bar by (−120, −80); it lands within 15px of that.

The starting zoom is restored in `afterAll`, since Bloom saves zoom as a user setting.

## How it verifies the result

Gear, dialog and viewport rectangles are read together inside the page frame (`getFormatDialogPlacement`). "Close" means a gap of at most 50px on each axis (Bloom places the dialog 30px right of the gear). "On the screen" means all four dialog edges inside the frame's client area. Zoom is confirmed both through `workspace/topRight/zoom` and the page's scaling container.

Locally: the spec passed 5 runs in a row before the merge and 3 after; the whole BloomE2E suite (19 tests) passed once, covering the two existing specs that use the changed `typeInGroup`. No `Bloom.exe` survived any run.

## Helpers

- New `helpers/formatDialog.ts`: `openFormatDialog` (clicks the visible part of the gear without scrolling), `clickOutsideFormatDialog`, `dragFormatDialog`, `getFormatDialogPlacement`, `scrollFormatGearIntoView`, `scrollFormatGearPartlyIntoView`, `zoomUntilFormatGearIsOutOfView`.
- `helpers/workspace.ts`: `getZoom`, `setZoom` (the route the top bar's +/− buttons post; setup only).
- `helpers/bookMaking.ts`: `clickInGroup`, which `typeInGroup` now reuses.
- The skill's helper map and the README list the new module. A papercut notes that `notion_automation.py` needs Python, which not every dev machine has.

## Bloom production code changes

None. Devin not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8281)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8281)
<!-- Reviewable:end -->
