### PR TITLE
Visual regression: warn when Andika is installed, and say so on player-page mismatches

### DIFF
--- a/src/BloomVisualRegressionTests/index.spec.ts
+++ b/src/BloomVisualRegressionTests/index.spec.ts
@@ -219,6 +219,10 @@ describe("All books", () => {
             ],
         });
         context = await browser.newContext();
+        andikaIsInstalled = await isFontInstalled(context, "Andika");
+        if (andikaIsInstalled) {
+            console.warn(chalk.black.bgYellow(ANDIKA_INSTALLED_WARNING));
+        }
         page = await context.newPage();
         playerPage = await context.newPage();
         await playerPage.setViewportSize({ width: 900, height: 1200 });
@@ -332,10 +336,13 @@ describe("All books", () => {
     // `screenshotsDir` is always in the SOURCE inputs tree (output/testing-inputs, or whatever
     // BLOOM_TESTING_INPUTS_DIR names), never in the temp copy, so that an accepted new baseline is
     // a file a developer can commit to the inputs repository. See readme.md.
+    // `isPlayerCapture` marks a bloom-player screenshot, whose text comes from whatever Andika the
+    // machine has (see andikaIsInstalled), as opposed to a book-preview one, which does not.
     async function captureOrCompare(
         label: string,
         screenshotsDir: string,
         shoot: (imagePath: string) => Promise<void>,
+        isPlayerCapture = false,
     ) {
         const referencePath = Path.join(
             screenshotsDir,
@@ -354,6 +361,9 @@ describe("All books", () => {
             referencePath,
             currentPath,
             Path.join(screenshotsDir, `${label}-diff.png`),
+            isPlayerCapture && andikaIsInstalled
+                ? ANDIKA_INSTALLED_WARNING
+                : undefined,
         );
     }
 
@@ -508,6 +518,52 @@ describe("All books", () => {
         return result.text();
     }
 
+    // The bloom-player captures must not depend on which fonts this machine has installed. When Bloom
+    // stages a BloomPUB it strips the book's own @font-face rules (BL-12594) and leaves the font to
+    // bloom-player, which declares Andika as `local("Andika")` first and the Bloom-served woff2 only
+    // as a fallback. So a machine with Andika installed renders every player page with its own copy of
+    // the font, and its glyphs differ from the reference images (which come from a machine without it,
+    // like the CI runner) by tens to hundreds of pixels per page. That has twice led someone to "fix"
+    // the suite by regenerating the baselines on their own machine, which just moved the failure to
+    // CI. The book-preview captures are unaffected: the staged book's own @font-face points at the
+    // served copy. So we don't refuse to run; we warn once up front, and when a player page then
+    // mismatches we say in the failure itself that the font is the likely cause, so nobody reads it
+    // as a regression or accepts it as a new baseline.
+    let andikaIsInstalled = false;
+    const ANDIKA_INSTALLED_WARNING =
+        `Andika is installed on this machine. bloom-player prefers an installed Andika over the copy ` +
+        `Bloom serves, so the bloom-player screenshots will be rendered with this machine's Andika and ` +
+        `will probably differ from the reference images (which are rendered without it, as on CI). ` +
+        `Player-page differences on this machine are probably that, not a regression, and must not be ` +
+        `accepted as new baselines. Uninstall Andika to make these comparisons meaningful; Bloom ` +
+        `does not need it installed.`;
+
+    // The probe is a @font-face whose only source is local(<family>): it loads if and only if the
+    // font is installed. Chrome may either resolve with no faces or reject when it is not.
+    async function isFontInstalled(
+        context: BrowserContext,
+        family: string,
+    ): Promise<boolean> {
+        const probe = await context.newPage();
+        try {
+            await probe.setContent(
+                `<style>@font-face { font-family: "bloom-vr-probe"; src: local("${family}"); }</style>`,
+            );
+            return await probe.evaluate(async () => {
+                try {
+                    const faces = await (globalThis as any).document.fonts.load(
+                        '16px "bloom-vr-probe"',
+                    );
+                    return faces.some((f: any) => f.status === "loaded");
+                } catch {
+                    return false;
+                }
+            });
+        } finally {
+            await probe.close();
+        }
+    }
+
     // Build the bloom-player URL for the staged book at a specific page (0-based). Mirrors what the
     // desktop app does (see RecordVideoWindow): the staged URL is already single-encoded, and
     // URLSearchParams encodes it again so it survives as a query parameter (see BL-11319).
@@ -628,14 +684,18 @@ describe("All books", () => {
                 async (imagePath) => {
                     await pageElement.screenshot({ path: imagePath });
                 },
+                true,
             );
         }
     }
 
+    // `likelyCause`, when given, is an explanation to attach to a mismatch (see andikaIsInstalled):
+    // something we know about this machine that makes the difference expected rather than a regression.
     async function comparePreviewImage(
         referencePath: string,
         testPath: string,
         diffPath: string,
+        likelyCause?: string,
     ) {
         const referenceImage = PNG.sync.read(fs.readFileSync(referencePath));
         const testImage = PNG.sync.read(fs.readFileSync(testPath));
@@ -665,7 +725,14 @@ describe("All books", () => {
                         `If the new version is correct, replace ${referencePath} with ${testPath}`,
                 ),
             );
-            expect(numberOfDifferentPixels).toBe(0);
+            // A thrown Error rather than expect(...).toBe(0), so the failure itself carries the
+            // diff path and, when we know one, the likely cause; the console lines above are lost in
+            // a long run's output.
+            throw new Error(
+                `${testPath} differed from the reference by ${numberOfDifferentPixels} pixels. ` +
+                    `The diff image is at ${diffPath}.` +
+                    (likelyCause ? `\n\n${likelyCause}` : ""),
+            );
         }
     }
 });

--- a/src/BloomVisualRegressionTests/readme.md
+++ b/src/BloomVisualRegressionTests/readme.md
@@ -15,6 +15,17 @@ over HTTP, and shuts it down and deletes the temp folder afterward. Because it l
 `--automation`, it can run alongside a Bloom you already have open. Because it operates on a temp
 copy, a run never modifies the books it renders.
 
+# If Andika is installed on your machine
+
+bloom-player prefers an installed Andika (`local("Andika")`) over the copy Bloom serves, so with
+Andika installed the bloom-player screenshots come out with your machine's version of the font and
+differ from the reference images, which are rendered without it (as on the CI runner). The book
+previews are not affected. The suite detects this: it warns at the start of the run, and any
+player-page mismatch on such a machine says so in its failure message. Treat those failures as the
+font, not a regression, and do **not** fix them by regenerating the baselines on a machine that has
+Andika — that makes them wrong on CI and on everyone else's machine. To make the player comparisons
+meaningful, uninstall Andika; Bloom itself does not need it installed.
+
 # Where the test inputs come from
 
 The books and their reference screenshots are **not in this repository**. They live in
@@ -26,11 +37,11 @@ inputs and so that changing a test book does not churn BloomDesktop's history.
 (gitignored). Because it is one exact commit, a run is reproducible: the same BloomDesktop commit
 always renders the same books against the same reference images.
 
--   `node build/get-testing-inputs.mjs --check` reports whether `output/testing-inputs/` matches
-    the pin, and exits non-zero if it does not. Useful when a run renders something you did not
-    expect.
--   If the suite cannot find the inputs, it fails immediately and tells you to run
-    `node build/get-testing-inputs.mjs`.
+- `node build/get-testing-inputs.mjs --check` reports whether `output/testing-inputs/` matches
+  the pin, and exits non-zero if it does not. Useful when a run renders something you did not
+  expect.
+- If the suite cannot find the inputs, it fails immediately and tells you to run
+  `node build/get-testing-inputs.mjs`.
 
 ## Using your own checkout of the inputs
 
@@ -38,8 +49,8 @@ Set **`BLOOM_TESTING_INPUTS_DIR`** to the folder that contains `collections/` in
 bloom-testing-inputs. The suite then renders (and writes screenshots into) that checkout instead of
 `output/testing-inputs/`. This is how you edit a test book or accept a new baseline.
 
--   bash: `BLOOM_TESTING_INPUTS_DIR=/d/bloom-testing-inputs pnpm test`
--   PowerShell: `$env:BLOOM_TESTING_INPUTS_DIR="D:/bloom-testing-inputs"; pnpm test`
+- bash: `BLOOM_TESTING_INPUTS_DIR=/d/bloom-testing-inputs pnpm test`
+- PowerShell: `$env:BLOOM_TESTING_INPUTS_DIR="D:/bloom-testing-inputs"; pnpm test`
 
 # Test failures
 
@@ -85,5 +96,5 @@ Bloom on a different one; set branding/theme in the tests instead.
 
 # TODO
 
--   The diffs are fairly low-resolution.
--   Could test different XMatters.
+- The diffs are fairly low-resolution.
+- Could test different XMatters.


### PR DESCRIPTION
Follow-up to the nightly visual-regression failure after #8273.

bloom-player declares Andika as `local("Andika")` before the Bloom-served copy, so on a machine with Andika installed every bloom-player capture renders with that machine's font and mismatches the references, which are rendered without it (as on CI). That twice led to baselines being regenerated on such a machine, which moved the failure to CI. (The baselines themselves were fixed by advancing the pin directly on master, c526d49d4.)

- Probe for an installed Andika at startup with a `local()`-only `@font-face`. If present, warn once and keep running; book previews are unaffected.
- Attach the explanation to any player-page mismatch on such a machine, so it reads as the font rather than a regression and is not accepted as a new baseline.
- Mismatches now throw an Error carrying the diff path and the cause, since Playwright's `expect()` does not take a custom message.
- readme updated.

Verified locally by probing for Arial (installed) with one player reference swapped: warning at startup, 11 passed, the induced failure carried the explanation. With no font installed the probe is silent and the suite was green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8282)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8282)
<!-- Reviewable:end -->
