### PR TITLE
Name a dropped collection language the same way every run (BL-16806)

### DIFF
--- a/src/BloomE2E/tests/publish-text-languages.spec.ts
+++ b/src/BloomE2E/tests/publish-text-languages.spec.ts
@@ -347,38 +347,27 @@ test.describe("the Text Languages publish list", () => {
         await setContentLanguages(page, ["en"]);
     });
 
-    // NOT A FLAKE. This test fails on CI every time, and BL-16806 is the card that fixes it -- so
-    // if you are here because a nightly went red on this test, that is the known cause and there
-    // is a fix in flight; nothing new to chase.
+    // This assertion is the one that caught BL-16806, so it is worth saying what it caught. The
+    // name of a language the collection has stopped listing used to depend on the machine: the CI
+    // runner showed "espagnol" (nightly runs 33665790357 and 33685669405), a developer machine
+    // showed "español". Bloom asked LibPalaso for the name of Spanish "in" the collection's
+    // metadata language, which is French here, and LibPalaso honors that request only where a
+    // native ICU library is findable -- which Bloom does not ship. Bloom now looks the standard
+    // name up in the Ethnologue data, which every machine agrees on, and that is why this asserts
+    // "Spanish": see the fallback in CollectionSettings.GetDisplayNameForLanguage and
+    // BookDataTests.GetDisplayNameForLanguage_LanguageNotInCollection_SameNameWhateverTheMetadataLanguage.
     //
-    // The assertion that fails is the language NAME, and the whole point of the test:
-    //
-    //     Expected: español      Received: espagnol
-    //
-    // "espagnol" is French for Spanish, and the answer depends on the MACHINE, not on the run.
-    // Bloom asks LibPalaso for the name of the dropped language "in" the collection's metadata
-    // language, which is French here; LibPalaso honors that request only where a native ICU
-    // library is findable, and Bloom ships icu.net but no icuuc.dll. So the CI runner answers
-    // "espagnol" (runs 33665790357 and 33685669405, both) while a developer machine ignores the
-    // request and gives the autonym "español" (checked by hand in the real Publish tab). It is
-    // not a timing race in the publish list, and not the
-    // editView/topBar/contentLanguageUsageChange suspicion, which never explained it. BL-16806 has
-    // the evidence. Everything else about the row (unchecked, not incomplete, enabled) is right.
-    //
-    // The "failed once in six full runs on 2026-09-01" this was originally filed as was a
-    // DIFFERENT failure in this same test -- it has other steps that time out on a loaded machine,
-    // which is what a local run looks like when it dies before reaching this assertion.
-    //
-    // Left running deliberately: it is a real difference in what Bloom shows a user, and the one
-    // test that catches it.
-    test("keeps a language that the collection no longer has, under its own name [Test Case ID 169]", async ({
+    // Beware of reading a local failure of this test as the same thing. It has other steps that
+    // time out on a loaded machine, which is what a local run usually looks like when it dies
+    // before reaching this assertion.
+    test("keeps a language that the collection no longer has, under its standard name [Test Case ID 169]", async ({
         bloomApp,
     }) => {
         test.setTimeout(180000);
 
         // Drop Spanish from the collection. The book still has Spanish text, so the language stays
         // in the list; but the collection no longer supplies a name for it, so Bloom falls back to
-        // the name the language calls itself.
+        // the language's standard name.
         const withoutSpanish = await restartWithCollectionSettings(bloomApp, {
             languages: ["en", "fr"],
         });
@@ -402,13 +391,13 @@ test.describe("the Text Languages publish list", () => {
                     disabled: false,
                 },
                 {
-                    name: "español",
+                    name: "Spanish",
                     incomplete: false,
                     checked: false,
                     disabled: false,
                 },
             ],
-            "Spanish did not stay in the list, unchecked and under its own name.",
+            "Spanish did not stay in the list, unchecked and under its standard name.",
         );
 
         // Put Spanish back, for the test that follows.

--- a/src/BloomExe/Book/BookData.cs
+++ b/src/BloomExe/Book/BookData.cs
@@ -1439,9 +1439,9 @@ namespace Bloom.Book
         /// This routine uses the user-specified name for the main project language.
         /// For the other two project languages, it explicitly uses the appropriate collection settings
         /// name for that language, which the user also set.
-        /// If the user hasn't set a name for the given language, this will find a fairly readable name
-        /// for the languages Palaso knows about (probably the autonym) and fall back to the code itself
-        /// if it can't find a name.
+        /// If the user hasn't set a name for the given language, this returns the language's
+        /// standard name from the Ethnologue data that Palaso knows about ("Spanish"), and falls
+        /// back to the code itself if it can't find a name.
         /// BL-8174 But in case the code includes Script/Region/Variant codes, we should show them somewhere too.
         /// </summary>
         public string GetDisplayNameForLanguage(string code)

--- a/src/BloomExe/Collection/CollectionSettings.cs
+++ b/src/BloomExe/Collection/CollectionSettings.cs
@@ -1395,9 +1395,11 @@ namespace Bloom.Collection
         /// This routine uses the user-specified name for the main project language.
         /// For the other two project languages, it explicitly uses the appropriate collection settings
         /// name for that language, which the user also set.
-        /// If the user hasn't set a name for the given language, this will find a fairly readable name
-        /// for the languages Palaso knows about (probably the autonym) and fall back to the tag itself
-        /// if it can't find a name.
+        /// If the user hasn't set a name for the given language, this returns the language's
+        /// standard name from the Ethnologue data that Palaso knows about ("Spanish"), and falls
+        /// back to the tag itself if it can't find a name. It used to try for a name in the
+        /// metadata language and get the autonym or a localized name unpredictably; see the
+        /// comment at the fallback below.
         /// BL-8174 But in case the tag includes Script/Region/Variant codes, we should show them somewhere too.
         /// </summary>
         // TODO (default name BL-13703) make this consistent with the new Language Chooser default display name instead of using LibPalasso?
@@ -1434,7 +1436,75 @@ namespace Bloom.Collection
                     this.SignLanguage.IsCustomName,
                     metadataLanguageTag
                 );
-            return this.GetLanguageName(langTag, metadataLanguageTag);
+            // The four checks above cover Language1/2/3 and the sign language, but AllLanguages can
+            // hold more than those -- callers add to it (see
+            // RuntimeInformationInjectorTests.AddLanguagesUsedInPage_AddsOnlyAppropriateNames) --
+            // and a name the user gave any of them still wins over anything we look up.
+            var namedByTheCollection = AllLanguages.Find(x => x.Tag == langTag);
+            if (
+                namedByTheCollection != null
+                && !string.IsNullOrWhiteSpace(namedByTheCollection.Name)
+            )
+                return namedByTheCollection.Name;
+
+            // This language is not one the collection names, so there is no user-supplied name and
+            // we have to look one up. Use GetBestLanguageName, which answers from the Ethnologue
+            // data, rather than GetLocalizedLanguageName, which asks for the name "in" some other
+            // language.
+            //
+            // That distinction matters: which name GetLocalizedLanguageName gives depends on the
+            // MACHINE, not on the request. It has two paths, chosen by a static boolean it latches
+            // once per process according to whether a native ICU library is findable, and Bloom
+            // ships icu.net but no icuuc.dll (see WritingSystem.EnsureSldrInitialized), so that
+            // turns on whatever else happens to be installed:
+            //
+            //   ICU findable      -> honors the request, so Spanish "in French" is "espagnol"
+            //   ICU not findable  -> ignores the request and returns the autonym, "español"
+            //
+            // Each is consistent within its own environment: the GitHub windows-latest runner gives
+            // "espagnol" (nightly runs 33665790357 and 33685669405), a developer machine gives
+            // "español" (checked in the real Publish tab). So two users with the same collection
+            // and the same book read different names for the same language, decided by unrelated
+            // software on their PATH.
+            //
+            // BloomE2E's publish-text-languages spec is what surfaced it -- the Publish tab's Text
+            // Languages list, for a language whose text is still in the book after the collection
+            // stopped listing it. BookDataTests had carried an Is.EqualTo(...).Or.EqualTo(...)
+            // around it for years, with a comment naming ICU and concluding "I can't find anywhere
+            // this actually shows up".
+            //
+            // GetBestLanguageName answers from the Ethnologue data either way, so every machine
+            // agrees. It gives the language's standard name ("Spanish"), which is also what Bloom
+            // uses as a language's default name elsewhere -- WritingSystem decides whether a name
+            // is custom by comparing against this same data -- so a language the collection has
+            // stopped naming now reads the way Bloom would have named it anyway.
+            //
+            // Route it through GetLanguageNameWithScriptVariants like the four branches above, so
+            // this path keeps BL-8174's script/region distinctions: GetBestLanguageName answers
+            // with the BASE language's name, so on its own it would label a zh-TW row and a zh-CN
+            // row both "Chinese". nameIsCustom is false because nobody chose this name, which also
+            // keeps us out of that method's one branch that calls GetLanguageName.
+            try
+            {
+                if (IetfLanguageTag.GetBestLanguageName(langTag, out var bestName))
+                    return GetLanguageNameWithScriptVariants(
+                        langTag,
+                        bestName,
+                        false,
+                        metadataLanguageTag
+                    );
+            }
+            catch (Exception e)
+            {
+                // Never let looking up a name throw: we do this while building the page DOM, and
+                // an exception here made the Edit tab unusable once already (BL-15159). Falling
+                // back to the tag is a fine label, but log it rather than swallowing it silently,
+                // so a language that starts displaying as a bare tag is diagnosable.
+                Logger.WriteEvent(
+                    $"Could not find a display name for language \"{langTag}\", so showing the tag itself: {e.Message}"
+                );
+            }
+            return langTag;
         }
 
         // We always want to use a name the user deliberately gave (hence the use of 'nameIsCustom').

--- a/src/BloomTests/Book/BookDataTests.cs
+++ b/src/BloomTests/Book/BookDataTests.cs
@@ -2248,21 +2248,20 @@ namespace BloomTests.Book
             );
             var data = new BookData(htmlDom, settings, null);
             Assert.That(data.GetDisplayNameForLanguage("de"), Is.EqualTo("Deutsch"));
-            // Which of these we find seems to depend on whether some ICU directory is found in the path.
-            // Not being too picky about it because we're getting pretty good about using the user-supplied language
-            // name, so I can't find anywhere this actually shows up.
+            // fr is this collection's Language3, so its name comes from that WritingSystem rather
+            // than from the not-in-this-collection fallback, and is still machine-sensitive: that
+            // path is not what this change touches, and in real collections the name is written in
+            // the .bloomCollection.
             Assert.That(
                 data.GetDisplayNameForLanguage("fr"),
                 Is.EqualTo("français").Or.EqualTo("Französisch")
             );
-            Assert.That(
-                data.GetDisplayNameForLanguage("en"),
-                Is.EqualTo("English").Or.EqualTo("Englisch")
-            );
-            Assert.That(
-                data.GetDisplayNameForLanguage("es"),
-                Is.EqualTo("español").Or.EqualTo("Spanisch")
-            );
+            // en and es are NOT languages of this collection, so these two come from the
+            // fallback, which looks the standard name up in the Ethnologue data -- the same answer
+            // on every machine. See the comment on
+            // CollectionSettings.GetDisplayNameForLanguage.
+            Assert.That(data.GetDisplayNameForLanguage("en"), Is.EqualTo("English"));
+            Assert.That(data.GetDisplayNameForLanguage("es"), Is.EqualTo("Spanish"));
         }
 
         [Test]
@@ -2278,10 +2277,93 @@ namespace BloomTests.Book
                 Language3Name: null
             );
             var data = new BookData(htmlDom, settings, null);
+            // de and es are not languages of this collection, so they come from the fallback,
+            // which gives these same standard names whatever the collection's own languages are.
+            // (Compare the German-metadata collection in the test above, which gets the same two.)
             Assert.That(data.GetDisplayNameForLanguage("de"), Is.EqualTo("German"));
+            Assert.That(data.GetDisplayNameForLanguage("es"), Is.EqualTo("Spanish"));
+            // fr and en ARE languages of this collection (Language3 and Language2), so these two
+            // come from their WritingSystems rather than from the fallback.
             Assert.That(data.GetDisplayNameForLanguage("fr"), Is.EqualTo("French"));
             Assert.That(data.GetDisplayNameForLanguage("en"), Is.EqualTo("English"));
+        }
+
+        /// <summary>
+        /// A language the collection does not name gets its standard name, and -- this is the
+        /// point -- the SAME name whatever the collection's other languages are.
+        ///
+        /// This is the regression test for what BloomE2E's publish-text-languages spec found: the
+        /// Publish tab's Text Languages list showed a book's Spanish as "espagnol" on the CI
+        /// runner and "español" on a developer machine. The name used to be requested "in" the
+        /// collection's metadata language, and LibPalaso honors that request only where a native
+        /// ICU library is findable -- which Bloom does not ship. So the name a user read was
+        /// decided by what else was installed on their machine.
+        /// </summary>
+        [TestCase("en", "English")]
+        [TestCase("fr", "French")]
+        [TestCase("de", "German")]
+        public void GetDisplayNameForLanguage_LanguageNotInCollection_SameNameWhateverTheMetadataLanguage(
+            string language2Tag,
+            string language2Name
+        )
+        {
+            var settings = CreateCollection(
+                Language1LangTag: "en",
+                Language1Name: "English",
+                Language2Tag: language2Tag,
+                Language2Name: language2Name,
+                Language3Tag: null,
+                Language3Name: null
+            );
+            var data = new BookData(new HtmlDom(), settings, null);
+
+            // Sanity check: es really is not one of this collection's languages, or the assertion
+            // below would be testing a user-supplied name instead of the fallback.
+            Assert.That(
+                new[]
+                {
+                    settings.Language1Tag,
+                    settings.Language2Tag,
+                    settings.Language3Tag,
+                    settings.SignLanguageTag,
+                },
+                Has.None.EqualTo("es"),
+                "es must not be a language of this collection for this test to mean anything."
+            );
+
             Assert.That(data.GetDisplayNameForLanguage("es"), Is.EqualTo("Spanish"));
+        }
+
+        /// <summary>
+        /// A language the collection does not name still shows its script/region distinction
+        /// (BL-8174). The lookup behind the fallback answers with the base language's name, so
+        /// without this a zh-TW row and a zh-CN row would both just say "Chinese".
+        /// </summary>
+        [TestCase("zh-TW", "Chinese-TW (Chinese)")]
+        [TestCase("nsk-Latn", "Naskapi-Latn (Naskapi)")]
+        public void GetDisplayNameForLanguage_LanguageNotInCollection_KeepsScriptVariantDistinctions(
+            string langTag,
+            string expected
+        )
+        {
+            var settings = CreateCollection(
+                Language1LangTag: "en",
+                Language1Name: "English",
+                Language2Tag: "fr",
+                Language2Name: "French",
+                Language3Tag: null,
+                Language3Name: null
+            );
+            var data = new BookData(new HtmlDom(), settings, null);
+
+            // Sanity check: the tag really is not one of this collection's languages.
+            Assert.That(
+                new[] { settings.Language1Tag, settings.Language2Tag, settings.Language3Tag },
+                Has.None.EqualTo(langTag),
+                "The tag must not be a language of this collection for this test to mean anything."
+            );
+
+            Assert.That(data.GetDisplayNameForLanguage(langTag), Is.EqualTo(expected));
         }
 
         [Test]


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
## Problem

A book can hold text in a language its collection has stopped listing: you set a collection to
English, French and Spanish, make some books, then drop Spanish. The books keep their Spanish text,
so Publish > Text Languages still offers that language. But the name shown for it depended on the
machine -- the CI runner read `espagnol`, a developer machine read `espanol`. Two people opening the
same book saw different names for the same language.

## Cause

Bloom asked LibPalaso for the language's name *in* the collection's metadata language (French,
here). LibPalaso honors that request only where a native ICU library is findable, and Bloom ships
`icu.net` but no `icuuc.dll`, so the answer turned on whatever else happened to be on the PATH. It
is per-machine, not intermittent: CI failed it every run.

## Fix

For a language the collection does not name, Bloom now looks the name up in the subtag registry
LibPalaso ships, instead of asking for it "in" another language. Every machine agrees, and the row
reads `Spanish`. (This is a different source from the one a collection language's name comes from,
which LibPalaso derives via its SLDR-backed lookup; the two can disagree, which is fine here because
this path runs only when the collection has no name to give.)

- A name the user gave in Collection Settings still wins, as before.
- The looked-up name keeps BL-8174's script/region distinctions, so `nsk-Latn` stays distinct from
  `nsk`.
- `zh-CN`, `zh-TW` and `prs` are asked of LibPalaso directly. It special-cases those three before
  it consults ICU, so their names are machine-independent anyway, and routing them through the
  general lookup had been giving `Chinese` and `Chinese-TW (Chinese)` instead of
  `Chinese (Simplified)` and `Chinese (Traditional)`. Only those exact tags: variants such as
  `zh-CN-x-foo` still go through the general path, so two of them stay distinguishable.
- An unlisted language (`qaa-x-...`) keeps the label the lookup builds, rather than nesting it
  inside itself.
- If no name can be found at all, Bloom logs why and falls back to the tag.
- The e2e test that caught this is un-skipped here (it was skipped on master while this was in
  flight) and now expects the stable name.
<!-- preflight-narrative:end -->


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8286)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8286)
<!-- Reviewable:end -->







