### PR TITLE
Add e2e test for the font chooser's marks (Notion test case 358)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -153,6 +153,17 @@ jobs:
               shell: bash
               run: node build/get-testing-inputs.mjs
 
+            # The font chooser test (src/BloomE2E/tests/font-chooser.spec.ts) needs one installed
+            # font of each verdict Bloom gives, and a clean windows-latest runner has only
+            # Microsoft fonts: nothing Bloom calls "unknown", and nothing non-Microsoft it calls
+            # "unsuitable". bloom-testing-inputs carries the missing fonts under fonts/ (its
+            # fonts/README.md says which and why); this installs them for the runner's user. The
+            # script fails if GDI+ does not list them afterwards, which is what Bloom reads.
+            - name: Install test fonts
+              if: ${{ env.RUN_E2E_TESTS == 'true' }}
+              shell: powershell
+              run: ./src/BloomE2E/scripts/install-test-fonts.ps1
+
             - name: pnpm install
               shell: bash
               run: |

--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -19,6 +19,18 @@ House rules:
 
 ---
 
+## 2026-09-03 — The e2e fixture launches a stale Bloom.exe when output/Debug/x64 is older than AnyCPU
+
+- **Cut:** `findBloomExe` in `src/BloomE2E/fixtures/launchBloom.ts` tries `Debug/x64` before
+  `Debug/AnyCPU` in a fixed order. `dotnet build src/BloomExe/BloomExe.csproj` writes to `AnyCPU`, so
+  a leftover `x64` folder from an earlier build wins, and the suite runs an old exe against the
+  freshly built `output/browser`. It looked like a broken test: a blank Collections tab,
+  `e2e/isCollectionReady` never true, and `BLOOM_AUTOMATION_MONITOR` ignored (the exe predated it).
+  Nothing in the run says which exe was launched; `common/instanceInfo` does.
+- **Idea:** pick the newest `Bloom.exe` among the candidates (or the one matching the newest
+  `output/browser`), and log the chosen path once at launch so a stale exe is visible in the output.
+- **Context:** Test Case ID 358, PR #8289; cost about 20 minutes of misdiagnosis.
+
 ## 2026-09-02 — notion_automation.py needs Python, which not every dev machine has
 
 - **Cut:** `.github/skills/improve-test-automation-coverage/notion_automation.py` is the only way the
@@ -28,6 +40,9 @@ House rules:
 - **Idea:** Rewrite it as `notion_automation.mjs`: the repo already requires Node and the script is
   stdlib-only (`urllib` → `fetch`), so nothing else changes; update the skill text and worker brief.
 - **Context:** Hit while automating Test Case ID 356 on a machine with no Python.
+- seen again 2026-09-03 (Test Case ID 358): ported to Node once more, this time with the card
+  split (`[Automated portion]` / `[Manual portion]`, related both ways) that `add-e2e-test` asks
+  for and the Python script has no command for either.
 
 ## 2026-09-01 — VR suite: a slow first preview load fails its case via Playwright's default 30s goto timeout
 

--- a/build/testing-inputs.pin
+++ b/build/testing-inputs.pin
@@ -18,4 +18,4 @@
 # Format: one `key=value` per line. Blank lines and lines starting with # are ignored.
 
 repo=https://github.com/BloomBooks/bloom-testing-inputs.git
-commit=9b58f6be71491201b121debd184bb38ec14aa43f
+commit=099bb445491ba576a468ab18cc13ca68beb6fea1

--- a/src/BloomE2E/AUTOMATION-DEBT.md
+++ b/src/BloomE2E/AUTOMATION-DEBT.md
@@ -69,6 +69,13 @@ journey of picking a pack in Settings stays untested. Story Producer is worse of
 not in the dialog's list at all, only forced by its branding, so the test sets the branding
 through the `e2e/setBranding` hook.
 
+seen again 2026-09-03 (Test Case ID 358, `font-chooser.spec.ts`): the manual test reaches the
+font chooser through Settings, on the Book Making tab ("Default Font for English"), which is
+the same WinForms dialog. The chooser is the same React component there as in the Edit tab's
+Format dialog, so the test drives it in the Format dialog (`helpers/fontChooser.ts`) and the
+Settings route stays manual. `settings/setFontForLanguage` is not a way round it: like the other
+settings endpoints it only records a pending change on the open dialog.
+
 ## Native OS dialogs hang automation
 
 File pickers, the Image Toolbox, and video capture open native windows Playwright

--- a/src/BloomE2E/README.md
+++ b/src/BloomE2E/README.md
@@ -250,6 +250,16 @@ BLOOM_TESTING_INPUTS_DIR=D:/bloom-testing-inputs pnpm test
 Either way the fixture copies the collection before Bloom opens it, so a run never modifies your
 inputs.
 
+The same repository carries, under `fonts/`, fonts a test needs installed: `font-chooser.spec.ts`
+wants one font of each verdict Bloom gives, and a clean Windows machine has none that Bloom
+calls "unknown" and none outside Microsoft's that it calls "unsuitable". The nightly workflow
+installs them for its user with `scripts/install-test-fonts.ps1`; if that test tells you your
+machine lacks a kind of font, run the same script:
+
+```powershell
+powershell src/BloomE2E/scripts/install-test-fonts.ps1
+```
+
 ## Testing a front-end change
 
 The launched Bloom serves its React UI from the built `output/browser`, so an edit to a `.tsx`

--- a/src/BloomE2E/helpers/bookMaking.ts
+++ b/src/BloomE2E/helpers/bookMaking.ts
@@ -597,6 +597,29 @@ export async function typeInGroup(
     await expect(box).toHaveText(text, { timeout: 15000 });
 }
 
+/**
+ * The font one language's box of one translation group is shown in: the first family of its computed
+ * font-family, without quotes, e.g. "Andika". This is how a test checks that a font chosen in the
+ * Format dialog reached the text.
+ */
+export async function getFontFamilyInGroup(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+): Promise<string> {
+    const box = editablePageFrame(page)
+        .locator(`${groupSelector} .bloom-editable[lang="${languageTag}"]`)
+        .first();
+    await box.waitFor({ state: "visible", timeout: 30000 });
+    const family = await box.evaluate(
+        (element) => getComputedStyle(element).fontFamily,
+    );
+    return family
+        .split(",")[0]
+        .trim()
+        .replace(/^["']|["']$/g, "");
+}
+
 /** One front or back matter page, as the Edit tab showed it. */
 export interface IShownXmatterPage {
     /** The page list's caption for the page, e.g. "Front Cover". */

--- a/src/BloomE2E/helpers/fontChooser.ts
+++ b/src/BloomE2E/helpers/fontChooser.ts
@@ -153,9 +153,11 @@ export async function getFontMetadata(
 }
 
 /**
- * The name of a font of the given kind, from the fonts Bloom offers on this machine: `preferred` if
- * it is there and is of that kind, otherwise the first such font. Which fonts a machine has varies,
- * so a test names the font it would like and takes what it gets.
+ * The name of a font of the given kind, from the fonts Bloom offers on this machine: the first of
+ * `preferred` that is there and is of that kind, otherwise the first such font. Which fonts a
+ * machine has varies, so a test names the fonts it would like, in order, and takes what it gets.
+ * The nightly runner has the fonts bloom-testing-inputs ships under fonts/ (installed by
+ * scripts/install-test-fonts.ps1), so a test names those first to behave the same everywhere.
  *
  * Throws when the machine has no font of the kind, listing how many of each kind it does have: a
  * test of the mark for that kind cannot run on such a machine, and the failure should say so.
@@ -163,12 +165,14 @@ export async function getFontMetadata(
 export async function pickFont(
     page: Page,
     kind: FontKind,
-    preferred?: string,
+    preferred: string[] = [],
 ): Promise<string> {
     const fonts = await getFontsMetadata(page);
     const candidates = fonts.filter((f) => f.name && isKind(f, kind));
     const chosen =
-        candidates.find((f) => f.name === preferred) ?? candidates[0];
+        preferred
+            .map((name) => candidates.find((f) => f.name === name))
+            .find((f) => f) ?? candidates[0];
     if (!chosen) {
         const kinds: FontKind[] = [
             "usable",
@@ -350,10 +354,15 @@ export async function readFontInformationPane(
             name:
                 element.querySelector(selectors.name)?.textContent?.trim() ??
                 "",
-            links: Array.from(element.querySelectorAll("a[href]")).map((a) => ({
-                text: a.textContent?.trim() ?? "",
-                href: a.getAttribute("href") ?? "",
-            })),
+            // A font with no manufacturer at all still gets a manufacturer link, with an empty
+            // href (FontInformationPane renders the link when neither name nor URL is there).
+            // That is not a link a person can follow, so leave it out.
+            links: Array.from(element.querySelectorAll("a[href]"))
+                .filter((a) => a.getAttribute("href"))
+                .map((a) => ({
+                    text: a.textContent?.trim() ?? "",
+                    href: a.getAttribute("href") ?? "",
+                })),
             hasDetailsIcon: !!element.querySelector(selectors.detailsIcon),
             text: element.textContent ?? "",
         }),

--- a/src/BloomE2E/helpers/fontChooser.ts
+++ b/src/BloomE2E/helpers/fontChooser.ts
@@ -1,0 +1,430 @@
+// The font chooser: the dropdown of installed fonts that shows, beside each font, whether Bloom may
+// use it in a published book (a check mark), may not (an exclamation mark), or cannot tell (a
+// question mark), and the information pane that hovering one of those marks opens. In the source
+// it is FontSelectComponent, with FontDisplayBar for each row and FontInformationPane for the pane.
+//
+// The chooser appears in two places: the Format dialog in the Edit tab (see formatDialog.ts), which
+// is where these helpers drive it, and the Book Making tab of the collection Settings dialog, a
+// WinForms surface CDP cannot reach (see AUTOMATION-DEBT.md). The component is the same in both.
+//
+// Everything here lives in the Edit tab's page frame, where the Format dialog is: the chooser sits
+// in the dialog, and its list and its information pane are portals in that frame's body. Bloom
+// marks the font it may not use as dimmed in the list but still lets it be chosen, and the mark of
+// the chosen font in the closed chooser is coloured (red, gold, or Bloom blue) where the same mark
+// in the list is grey.
+
+import { expect, type Frame, type Locator, type Page } from "@playwright/test";
+import { apiGetJson } from "./api";
+import { editablePageFrame } from "./bookMaking";
+
+/** The container the Format dialog renders the chooser into (StyleEditor.pug). */
+const CHOOSER_CONTAINER = "#fontSelectComponent";
+/** The closed chooser: the control showing the chosen font and its mark. */
+const CHOOSER = `${CHOOSER_CONTAINER} .MuiSelect-select`;
+/** The dropdown list, which MUI portals into the frame's body while it is open. */
+const LIST = ".MuiMenu-root [role='listbox']";
+/** One font in the list. Its data-value is the font's name. */
+const LIST_ITEM = "[role='option']";
+/** The information pane's popover: the one MUI popover in the frame that is not the list's menu. */
+const PANE = ".MuiPopover-root:not(.MuiMenu-root) .MuiPaper-root";
+/** The information icon in the pane, which shows the font's raw metadata. Not shown for a usable font. */
+const PANE_DETAILS_ICON = "svg[data-testid='InfoOutlinedIcon']";
+/** The pane's close button (the X). Clicking anywhere on the pane closes it; this is the visible way. */
+const PANE_CLOSE_BUTTON = "button";
+/** The pane's main message, the first paragraph. */
+const PANE_MESSAGE = ".MuiTypography-body2";
+/** The font's name in the pane, set in bold. */
+const PANE_FONT_NAME = ".MuiTypography-subtitle2";
+
+/** What the mark beside a font says: usable, not usable, or Bloom cannot tell. */
+export type FontMark = "check" | "exclamation" | "question";
+
+/** The colours Bloom draws a mark or a font name in, named as the theme names them. */
+export type FontChooserColor = "bloom-blue" | "gold" | "red" | "grey" | "black";
+
+/** One font's metadata as GET fonts/metadata reports it (FontMetadata.cs). Only the fields tests use. */
+export interface IFontMetadata {
+    name: string;
+    version?: string;
+    license?: string;
+    licenseURL?: string;
+    designer?: string;
+    designerURL?: string;
+    manufacturer?: string;
+    manufacturerURL?: string;
+    variants?: string[];
+    determinedSuitability: "ok" | "unknown" | "unsuitable" | "invalid";
+    determinedSuitabilityNotes?: string;
+}
+
+/** One row of the font list, or the closed chooser, as shown. */
+export interface IFontMarkDisplay {
+    name: string;
+    mark: FontMark;
+    markColor: FontChooserColor;
+    /** The colour of the font's name: black for a usable font, grey for a dimmed one. */
+    textColor: FontChooserColor;
+    /** False when the row is disabled and cannot be chosen. Bloom dims rows but never disables them. */
+    enabled: boolean;
+}
+
+/** What the information pane shows for one font. */
+export interface IFontInformation {
+    /** The verdict at the top of the pane, e.g. that the font is legal for all Bloom purposes. */
+    message: string;
+    /** The font's name, set in bold. */
+    name: string;
+    /** Every link in the pane's summary: the designer, the manufacturer, the license. */
+    links: { text: string; href: string }[];
+    /** True when the pane offers the information icon that shows the font's raw metadata. */
+    hasDetailsIcon: boolean;
+    /** The whole pane as text, for checks on the summary block (styles, version). */
+    text: string;
+}
+
+/** Which kind of font a test wants, by what the chooser says about it. */
+export type FontKind = "usable" | "microsoft" | "not-embeddable" | "unknown";
+
+/** How the four kinds are recognised in the metadata. */
+const MICROSOFT_LICENSE_URL =
+    "https://learn.microsoft.com/en-us/typography/fonts/font-faq";
+const isKind = (font: IFontMetadata, kind: FontKind): boolean => {
+    switch (kind) {
+        case "usable":
+            return font.determinedSuitability === "ok";
+        case "microsoft":
+            return (
+                font.determinedSuitability === "unsuitable" &&
+                font.licenseURL === MICROSOFT_LICENSE_URL
+            );
+        case "not-embeddable":
+            return (
+                font.determinedSuitability === "unsuitable" &&
+                font.licenseURL !== MICROSOFT_LICENSE_URL
+            );
+        case "unknown":
+            return font.determinedSuitability === "unknown";
+    }
+};
+
+/** The computed colours Bloom's theme constants come out as (bloomMaterialUITheme.ts). */
+const COLOR_NAMES: Record<string, FontChooserColor> = {
+    "rgb(29, 148, 164)": "bloom-blue", // kBloomBlue #1d94a4
+    "rgb(243, 170, 24)": "gold", // kBloomGold #f3aa18
+    "rgb(255, 0, 0)": "red", // kErrorColor
+    "rgb(187, 187, 187)": "grey", // kDisabledControlGray #bbb
+    "rgb(0, 0, 0)": "black",
+};
+
+/** The MUI icon each mark is drawn with (FontDisplayBar.tsx). MUI stamps the icon's name on the svg. */
+const MARK_BY_ICON: Record<string, FontMark> = {
+    CheckCircleIcon: "check",
+    ErrorIcon: "exclamation",
+    HelpIcon: "question",
+};
+
+/** Name a computed colour, or throw so that a new theme colour is noticed rather than misread. */
+const nameColor = (computed: string, what: string): FontChooserColor => {
+    const name = COLOR_NAMES[computed];
+    if (!name)
+        throw new Error(
+            `${what} is drawn in ${computed}, which is not a colour the font chooser is known to use.`,
+        );
+    return name;
+};
+
+/** Every font Bloom offers, with its metadata, as fonts/metadata reports them. */
+export async function getFontsMetadata(page: Page): Promise<IFontMetadata[]> {
+    return apiGetJson<IFontMetadata[]>(page, "fonts/metadata");
+}
+
+/** The metadata of one font by name. Throws, naming the fonts there are, when Bloom has no such font. */
+export async function getFontMetadata(
+    page: Page,
+    fontName: string,
+): Promise<IFontMetadata> {
+    const fonts = await getFontsMetadata(page);
+    const font = fonts.find((f) => f.name === fontName);
+    if (!font)
+        throw new Error(
+            `Bloom offers no font called "${fontName}". It offers: ${fonts.map((f) => f.name).join(", ")}.`,
+        );
+    return font;
+}
+
+/**
+ * The name of a font of the given kind, from the fonts Bloom offers on this machine: `preferred` if
+ * it is there and is of that kind, otherwise the first such font. Which fonts a machine has varies,
+ * so a test names the font it would like and takes what it gets.
+ *
+ * Throws when the machine has no font of the kind, listing how many of each kind it does have: a
+ * test of the mark for that kind cannot run on such a machine, and the failure should say so.
+ */
+export async function pickFont(
+    page: Page,
+    kind: FontKind,
+    preferred?: string,
+): Promise<string> {
+    const fonts = await getFontsMetadata(page);
+    const candidates = fonts.filter((f) => f.name && isKind(f, kind));
+    const chosen =
+        candidates.find((f) => f.name === preferred) ?? candidates[0];
+    if (!chosen) {
+        const kinds: FontKind[] = [
+            "usable",
+            "microsoft",
+            "not-embeddable",
+            "unknown",
+        ];
+        throw new Error(
+            `This machine has no ${kind} font for the test to use. Of its ${fonts.length} fonts, ` +
+                kinds
+                    .map(
+                        (k) =>
+                            `${fonts.filter((f) => isKind(f, k)).length} are ${k}`,
+                    )
+                    .join(", ") +
+                ".",
+        );
+    }
+    return chosen.name;
+}
+
+/** What is read off one font display bar in the page, before the colours and icon are named. */
+interface IRawMarkDisplay {
+    name: string;
+    icon: string;
+    markColor: string;
+    textColor: string;
+    enabled: boolean;
+}
+
+/**
+ * Read font display bars (list rows, or the closed chooser) in the page, in one round trip. This
+ * is the page function for Locator.evaluateAll, so it runs in the browser and can refer to nothing
+ * outside itself. A row's name is its data-value when it has one, else the text shown.
+ */
+const readRawMarkDisplays = (elements: Element[]): IRawMarkDisplay[] =>
+    elements.map((element) => {
+        const svg = element.querySelector("svg");
+        const text = element.querySelector(".MuiTypography-root");
+        if (!svg || !text)
+            throw new Error(
+                "The font row has no mark or no name; is this a font display bar?",
+            );
+        return {
+            name:
+                element.getAttribute("data-value") ??
+                text.textContent?.trim() ??
+                "",
+            icon: svg.getAttribute("data-testid") ?? "",
+            markColor: getComputedStyle(svg).color,
+            textColor: getComputedStyle(text).color,
+            enabled: element.getAttribute("aria-disabled") !== "true",
+        };
+    });
+
+/** Name the icon and colours of a raw reading, throwing on anything the chooser is not known to draw. */
+const nameMarkDisplay = (raw: IRawMarkDisplay): IFontMarkDisplay => {
+    const mark = MARK_BY_ICON[raw.icon];
+    if (!mark)
+        throw new Error(
+            `The mark beside "${raw.name}" is a ${raw.icon || "(unnamed icon)"}, which is not one of the font chooser's marks.`,
+        );
+    return {
+        name: raw.name,
+        mark,
+        markColor: nameColor(raw.markColor, `The mark beside "${raw.name}"`),
+        textColor: nameColor(raw.textColor, `The name "${raw.name}"`),
+        enabled: raw.enabled,
+    };
+};
+
+/** The frame the Format dialog, and so the chooser, is in. */
+const chooserFrame = (page: Page): Frame => editablePageFrame(page);
+
+/**
+ * Pull down the font list in the Format dialog, the way a person does, and wait until it is showing
+ * its fonts. The Format dialog must be open (see openFormatDialog).
+ */
+export async function openFontList(page: Page): Promise<void> {
+    const frame = chooserFrame(page);
+    await frame.locator(CHOOSER).click({ timeout: 30000 });
+    await expect(
+        frame.locator(LIST),
+        "Clicking the font chooser did not open its list.",
+    ).toBeVisible({ timeout: 30000 });
+    await expect
+        .poll(() => frame.locator(`${LIST} ${LIST_ITEM}`).count(), {
+            timeout: 30000,
+            message: "The font list opened but never listed a font.",
+        })
+        .toBeGreaterThan(0);
+}
+
+/** True while the font list is pulled down. */
+export async function isFontListOpen(page: Page): Promise<boolean> {
+    return chooserFrame(page).locator(LIST).isVisible();
+}
+
+/** Every font in the pulled-down list, in its order, with the mark and colours each is shown with. */
+export async function getFontListItems(
+    page: Page,
+): Promise<IFontMarkDisplay[]> {
+    const rows = chooserFrame(page).locator(`${LIST} ${LIST_ITEM}`);
+    if ((await rows.count()) === 0)
+        throw new Error(
+            "The font list is not open, or lists no font. Open it with openFontList first.",
+        );
+    // One round trip for the whole list: a machine has hundreds of fonts.
+    return (await rows.evaluateAll(readRawMarkDisplays)).map(nameMarkDisplay);
+}
+
+/** The list row for one font. */
+const listRow = (page: Page, fontName: string): Locator =>
+    chooserFrame(page).locator(
+        `${LIST} ${LIST_ITEM}[data-value="${fontName}"]`,
+    );
+
+/** Wait for the information pane to open, then read it. */
+const waitForPane = async (
+    page: Page,
+    what: string,
+): Promise<IFontInformation> => {
+    const pane = chooserFrame(page).locator(PANE);
+    await expect(
+        pane,
+        `Hovering ${what} did not open the font information pane.`,
+    ).toBeVisible({ timeout: 30000 });
+    return readFontInformationPane(page);
+};
+
+/**
+ * Hover the mark beside one font in the pulled-down list, the way a person asks what the mark means,
+ * and wait for the information pane to open. Returns what the pane says.
+ *
+ * Bloom opens the pane a moment after the pointer arrives (a 700ms debounce in FontDisplayBar), and
+ * the pane is modal: close it with closeFontInformationPane before hovering or clicking anything
+ * else in the list.
+ */
+export async function hoverFontMarkInList(
+    page: Page,
+    fontName: string,
+): Promise<IFontInformation> {
+    const row = listRow(page, fontName);
+    await expect(
+        row,
+        `The font list has no row for "${fontName}".`,
+    ).toHaveCount(1, { timeout: 30000 });
+    await row.locator("svg").hover({ timeout: 30000 });
+    return waitForPane(page, `the mark beside "${fontName}" in the list`);
+}
+
+/**
+ * Hover the mark in the closed chooser, beside the name of the chosen font, and wait for the
+ * information pane to open. Returns what the pane says. Close it with closeFontInformationPane.
+ */
+export async function hoverChosenFontMark(
+    page: Page,
+): Promise<IFontInformation> {
+    await chooserFrame(page)
+        .locator(`${CHOOSER} svg`)
+        .hover({ timeout: 30000 });
+    return waitForPane(page, "the mark in the font chooser");
+}
+
+/** Read the open information pane. Throws when no pane is open. */
+export async function readFontInformationPane(
+    page: Page,
+): Promise<IFontInformation> {
+    const pane = chooserFrame(page).locator(PANE);
+    if (!(await pane.isVisible()))
+        throw new Error(
+            "The font information pane is not open, so there is nothing to read.",
+        );
+    return pane.evaluate(
+        (element, selectors) => ({
+            message:
+                element.querySelector(selectors.message)?.textContent?.trim() ??
+                "",
+            name:
+                element.querySelector(selectors.name)?.textContent?.trim() ??
+                "",
+            links: Array.from(element.querySelectorAll("a[href]")).map((a) => ({
+                text: a.textContent?.trim() ?? "",
+                href: a.getAttribute("href") ?? "",
+            })),
+            hasDetailsIcon: !!element.querySelector(selectors.detailsIcon),
+            text: element.textContent ?? "",
+        }),
+        {
+            message: PANE_MESSAGE,
+            name: PANE_FONT_NAME,
+            detailsIcon: PANE_DETAILS_ICON,
+        },
+    );
+}
+
+/** Close the information pane with its X button, and wait for it to go. */
+export async function closeFontInformationPane(page: Page): Promise<void> {
+    const pane = chooserFrame(page).locator(PANE);
+    await pane.locator(PANE_CLOSE_BUTTON).click({ timeout: 30000 });
+    await expect(
+        pane,
+        "The font information pane stayed open after its close button was clicked.",
+    ).toBeHidden({ timeout: 30000 });
+}
+
+/**
+ * Click the information icon in the open pane, which shows the font's raw metadata in a message box,
+ * and return that message. The box is the browser's own alert; this accepts it, so nothing is left
+ * open. Only a font Bloom may not use, or cannot judge, offers the icon.
+ */
+export async function showFontDetails(page: Page): Promise<string> {
+    const icon = chooserFrame(page).locator(`${PANE} ${PANE_DETAILS_ICON}`);
+    await expect(
+        icon,
+        "The open font information pane offers no information icon.",
+    ).toBeVisible({ timeout: 30000 });
+    // Listen before clicking: Playwright dismisses a dialog nobody is listening for.
+    const message = new Promise<string>((resolve) => {
+        page.once("dialog", async (dialog) => {
+            const text = dialog.message();
+            await dialog.accept();
+            resolve(text);
+        });
+    });
+    await icon.click({ timeout: 30000 });
+    return message;
+}
+
+/**
+ * Choose a font from the pulled-down list, the way a person does, and wait until the chooser shows
+ * it. The list closes. What the choice does to the text box is the caller's to check (see
+ * getFontFamilyInGroup in bookMaking.ts).
+ */
+export async function chooseFont(page: Page, fontName: string): Promise<void> {
+    const row = listRow(page, fontName);
+    await expect(
+        row,
+        `The font list has no row for "${fontName}".`,
+    ).toHaveCount(1, { timeout: 30000 });
+    await row.click({ timeout: 30000 });
+    const frame = chooserFrame(page);
+    await expect(
+        frame.locator(LIST),
+        `The font list stayed open after "${fontName}" was chosen.`,
+    ).toBeHidden({ timeout: 30000 });
+    await expect(
+        frame.locator(CHOOSER),
+        `The font chooser does not show "${fontName}" after it was chosen.`,
+    ).toContainText(fontName, { timeout: 30000 });
+}
+
+/** The font the closed chooser shows, with the mark and colours beside its name. */
+export async function getChosenFont(page: Page): Promise<IFontMarkDisplay> {
+    const chooser = chooserFrame(page).locator(CHOOSER);
+    await chooser.waitFor({ state: "visible", timeout: 30000 });
+    const [raw] = await chooser.evaluateAll(readRawMarkDisplays);
+    return nameMarkDisplay(raw);
+}

--- a/src/BloomE2E/helpers/formatDialog.ts
+++ b/src/BloomE2E/helpers/formatDialog.ts
@@ -176,6 +176,65 @@ export async function isFormatDialogOpen(page: Page): Promise<boolean> {
     return editablePageFrame(page).locator(DIALOG).isVisible();
 }
 
+/** The Format dialog's tabs, named as the dialog labels them. Not every box offers every tab. */
+export type FormatDialogTab =
+    | "styleName"
+    | "characters"
+    | "paragraph"
+    | "highlighting"
+    | "canvasText";
+
+/**
+ * A control that lives on each tab's page, which is how a page is told apart: the dialog's tab
+ * plugin (lib/tabpane.js) gives the pages no ids of their own, moves each page's heading into a
+ * tab row in page order, and Bloom removes the pages a box does not need before that happens.
+ */
+const TAB_PAGE_CONTENT: Record<FormatDialogTab, string> = {
+    styleName: "#styleSelect",
+    characters: "#fontSelectComponent",
+    paragraph: "#para-spacing-select",
+    highlighting: "#audioHilitePage",
+    canvasText: "#canvasFormatPage",
+};
+/** The pages of the dialog's tab control, in the order their tabs appear. */
+const TAB_PAGES = `${DIALOG} #tabRoot > .tab-page`;
+/** The tabs themselves, in the same order. */
+const TABS = `${DIALOG} .tab-row .tab`;
+
+/**
+ * Click one of the Format dialog's tabs and wait for its page to show. The dialog opens on the
+ * Style Name tab (or on the tab it was last on: the plugin remembers it in a session cookie).
+ * Throws, naming the tabs the dialog does have, when it has no such tab for this box.
+ */
+export async function showFormatDialogTab(
+    page: Page,
+    tab: FormatDialogTab,
+): Promise<void> {
+    const frame = editablePageFrame(page);
+    const pages = frame.locator(TAB_PAGES);
+    await expect(
+        pages.first(),
+        "The Format dialog is not open, or has no tabs.",
+    ).toBeAttached({ timeout: 30000 });
+    const count = await pages.count();
+    let index = -1;
+    for (let i = 0; i < count && index < 0; i++) {
+        if ((await pages.nth(i).locator(TAB_PAGE_CONTENT[tab]).count()) > 0)
+            index = i;
+    }
+    if (index < 0) {
+        const tabs = await frame.locator(TABS).allTextContents();
+        throw new Error(
+            `The Format dialog has no "${tab}" tab for this box. Its tabs: ${tabs.map((t) => t.trim()).join(", ")}.`,
+        );
+    }
+    await frame.locator(TABS).nth(index).click({ timeout: 30000 });
+    await expect(
+        pages.nth(index),
+        `Clicking the Format dialog's "${tab}" tab did not show its page.`,
+    ).toBeVisible({ timeout: 30000 });
+}
+
 /**
  * Click on the page outside the Format dialog, the way a person dismisses it, and wait for the
  * dialog to go away.

--- a/src/BloomE2E/scripts/install-test-fonts.ps1
+++ b/src/BloomE2E/scripts/install-test-fonts.ps1
@@ -47,17 +47,30 @@ public static extern int AddFontResourceW(string lpFileName);
 public static extern bool PostMessage(System.IntPtr hWnd, uint Msg, System.IntPtr wParam, System.IntPtr lParam);
 '@
 
-# The registry value name Windows uses is the font's full name plus the format in brackets,
-# e.g. "Alef Regular (TrueType)". GDI+ does not read the name, only the file, but matching
-# Windows keeps Settings > Fonts happy about the entry.
-Add-Type -AssemblyName PresentationCore
-function Get-FontFullName([string] $path) {
-    $face = New-Object System.Windows.Media.GlyphTypeface ([Uri] $path)
-    $name = $face.Win32FamilyNames["en-us"]
-    if (-not $name) { $name = ($face.Win32FamilyNames.Values | Select-Object -First 1) }
-    $style = $face.Win32FaceNames["en-us"]
-    if (-not $style) { $style = ($face.Win32FaceNames.Values | Select-Object -First 1) }
-    return "$name $style".Trim()
+# The font's family name, read with GDI+ (the same library Bloom lists fonts with). Not WPF's
+# GlyphTypeface: its constructor fails intermittently in a non-interactive runner session.
+Add-Type -AssemblyName System.Drawing
+function Get-FontFamilyName([string] $path) {
+    $collection = New-Object System.Drawing.Text.PrivateFontCollection
+    try {
+        $collection.AddFontFile($path)
+        if ($collection.Families.Count -eq 0) { throw "GDI+ reads no font family from $path" }
+        return $collection.Families[0].Name
+    } finally {
+        $collection.Dispose()
+    }
+}
+
+# The registry value name Windows writes for an installed font is its full name plus the format
+# in brackets, e.g. "Alef Bold (TrueType)". GDI+ does not read the name, only the file path, so
+# the style part need only keep the names of a family's files apart: it is taken from the file
+# name after the hyphen ("Alef-Bold" -> "Bold"), or "Regular".
+function Get-RegistryValueName([System.IO.FileInfo] $file) {
+    $family = Get-FontFamilyName $file.FullName
+    $base = $file.BaseName
+    $style = if ($base.Contains("-")) { $base.Substring($base.IndexOf("-") + 1) } else { "Regular" }
+    $format = if ($file.Extension -ieq ".otf") { "OpenType" } else { "TrueType" }
+    return "$family $style ($format)"
 }
 
 $files = Get-ChildItem -Path $FontsDir -Recurse -File -Include *.ttf, *.otf
@@ -70,8 +83,7 @@ foreach ($file in $files) {
         Write-Host "already installed: $($file.Name)"
     } else {
         Copy-Item $file.FullName $target
-        $format = if ($file.Extension -ieq ".otf") { "OpenType" } else { "TrueType" }
-        $valueName = "$(Get-FontFullName $target) ($format)"
+        $valueName = Get-RegistryValueName $file
         New-ItemProperty -Path $registryKey -Name $valueName -Value $target -PropertyType String -Force | Out-Null
         $installed++
         Write-Host "installed: $($file.Name) as '$valueName'"
@@ -87,11 +99,10 @@ $WM_FONTCHANGE = 0x001D
 [TestFonts.Native]::PostMessage($HWND_BROADCAST, $WM_FONTCHANGE, [IntPtr]::Zero, [IntPtr]::Zero) | Out-Null
 
 # Prove it the way Bloom will see it: GDI+'s installed-font families.
-Add-Type -AssemblyName System.Drawing
 $families = (New-Object System.Drawing.Text.InstalledFontCollection).Families | ForEach-Object { $_.Name }
 $missing = @()
 foreach ($file in $files) {
-    $family = (New-Object System.Windows.Media.GlyphTypeface ([Uri] $file.FullName)).Win32FamilyNames.Values | Select-Object -First 1
+    $family = Get-FontFamilyName $file.FullName
     if ($families -notcontains $family) { $missing += "$family ($($file.Name))" }
 }
 if ($missing.Count -gt 0) {

--- a/src/BloomE2E/scripts/install-test-fonts.ps1
+++ b/src/BloomE2E/scripts/install-test-fonts.ps1
@@ -1,0 +1,100 @@
+<#
+.SYNOPSIS
+Installs, for the current user, every font under a folder, so that Bloom lists it.
+
+.DESCRIPTION
+The e2e suite needs some fonts a clean machine does not have: font-chooser.spec.ts wants one
+installed font of each verdict Bloom gives (usable, unsuitable, unknown), and a GitHub Actions
+windows-latest runner has only Microsoft fonts. The bloom-testing-inputs repository carries the
+missing ones under fonts/ (see its fonts/README.md); the nightly workflow runs this script on
+that folder before the suite, and a developer can run it on the same folder.
+
+Bloom finds a font two ways, and both have to be satisfied. Its font list comes from GDI+
+(InstalledFontCollection), which knows a font once it is registered with the session
+(AddFontResource) and, to survive a logoff, listed in the registry. Its font *files* come from
+FontFileFinder, which on Windows reads C:\Windows\Fonts and the per-user
+%LOCALAPPDATA%\Microsoft\Windows\Fonts. So this copies each file to the per-user folder, writes
+the per-user registry entry Windows itself writes for a per-user install, and registers the
+file with the session. No administrator rights are needed.
+
+Idempotent: a font already installed (same file name in the per-user folder) is skipped.
+
+.PARAMETER FontsDir
+The folder to search, recursively, for .ttf and .otf files. Default: the bloom-testing-inputs
+fonts folder that build/get-testing-inputs.mjs fetches, output/testing-inputs/fonts.
+
+.EXAMPLE
+pwsh src/BloomE2E/scripts/install-test-fonts.ps1
+#>
+param(
+    [string] $FontsDir = (Join-Path $PSScriptRoot "..\..\..\output\testing-inputs\fonts")
+)
+
+$ErrorActionPreference = "Stop"
+
+$FontsDir = (Resolve-Path $FontsDir).Path
+$userFontsDir = Join-Path $env:LOCALAPPDATA "Microsoft\Windows\Fonts"
+$registryKey = "HKCU:\Software\Microsoft\Windows NT\CurrentVersion\Fonts"
+New-Item -ItemType Directory -Force $userFontsDir | Out-Null
+if (-not (Test-Path $registryKey)) { New-Item -Path $registryKey -Force | Out-Null }
+
+# AddFontResourceW tells the session about a font file at once; WM_FONTCHANGE tells running
+# programs the font table changed. Without the first, only a new logon would pick the font up.
+Add-Type -Namespace TestFonts -Name Native -MemberDefinition @'
+[System.Runtime.InteropServices.DllImport("gdi32.dll", CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
+public static extern int AddFontResourceW(string lpFileName);
+[System.Runtime.InteropServices.DllImport("user32.dll")]
+public static extern bool PostMessage(System.IntPtr hWnd, uint Msg, System.IntPtr wParam, System.IntPtr lParam);
+'@
+
+# The registry value name Windows uses is the font's full name plus the format in brackets,
+# e.g. "Alef Regular (TrueType)". GDI+ does not read the name, only the file, but matching
+# Windows keeps Settings > Fonts happy about the entry.
+Add-Type -AssemblyName PresentationCore
+function Get-FontFullName([string] $path) {
+    $face = New-Object System.Windows.Media.GlyphTypeface ([Uri] $path)
+    $name = $face.Win32FamilyNames["en-us"]
+    if (-not $name) { $name = ($face.Win32FamilyNames.Values | Select-Object -First 1) }
+    $style = $face.Win32FaceNames["en-us"]
+    if (-not $style) { $style = ($face.Win32FaceNames.Values | Select-Object -First 1) }
+    return "$name $style".Trim()
+}
+
+$files = Get-ChildItem -Path $FontsDir -Recurse -File -Include *.ttf, *.otf
+if ($files.Count -eq 0) { throw "No .ttf or .otf files under $FontsDir" }
+
+$installed = 0
+foreach ($file in $files) {
+    $target = Join-Path $userFontsDir $file.Name
+    if (Test-Path $target) {
+        Write-Host "already installed: $($file.Name)"
+    } else {
+        Copy-Item $file.FullName $target
+        $format = if ($file.Extension -ieq ".otf") { "OpenType" } else { "TrueType" }
+        $valueName = "$(Get-FontFullName $target) ($format)"
+        New-ItemProperty -Path $registryKey -Name $valueName -Value $target -PropertyType String -Force | Out-Null
+        $installed++
+        Write-Host "installed: $($file.Name) as '$valueName'"
+    }
+    if ([TestFonts.Native]::AddFontResourceW($target) -eq 0) {
+        throw "AddFontResource rejected $target"
+    }
+}
+# PostMessage, not SendMessage: a broadcast SendMessage waits for every top-level window to
+# answer, and one hung window (there is usually one) stalls this script for good.
+$HWND_BROADCAST = [IntPtr] 0xffff
+$WM_FONTCHANGE = 0x001D
+[TestFonts.Native]::PostMessage($HWND_BROADCAST, $WM_FONTCHANGE, [IntPtr]::Zero, [IntPtr]::Zero) | Out-Null
+
+# Prove it the way Bloom will see it: GDI+'s installed-font families.
+Add-Type -AssemblyName System.Drawing
+$families = (New-Object System.Drawing.Text.InstalledFontCollection).Families | ForEach-Object { $_.Name }
+$missing = @()
+foreach ($file in $files) {
+    $family = (New-Object System.Windows.Media.GlyphTypeface ([Uri] $file.FullName)).Win32FamilyNames.Values | Select-Object -First 1
+    if ($families -notcontains $family) { $missing += "$family ($($file.Name))" }
+}
+if ($missing.Count -gt 0) {
+    throw "Installed the files, but GDI+ does not list: $($missing -join ', '). Bloom will not offer them."
+}
+Write-Host "$installed font file(s) newly installed; all $($files.Count) are listed by GDI+."

--- a/src/BloomE2E/tests/font-chooser.spec.ts
+++ b/src/BloomE2E/tests/font-chooser.spec.ts
@@ -1,0 +1,297 @@
+// The font chooser's marks: beside each font, whether Bloom may use it in a published book. Fonts
+// Bloom may use get a check mark and stay enabled; the others are dimmed, with a grey exclamation
+// mark (the metadata forbids embedding, or Microsoft supplied the font for this computer alone) or a
+// grey question mark (Bloom cannot tell), yet can still be chosen. Hovering a mark opens a pane that
+// says why, summarizes the font, and, for a font Bloom may not use or cannot judge, offers an icon
+// that shows the raw metadata. The chosen font's mark shows in the closed chooser too, in colour.
+// Automates the manual test "New Font Chooser" (Test Case ID 358).
+//
+// The chooser is the same component in the Format dialog and in the collection Settings dialog's
+// Book Making tab. This file drives it in the Format dialog; the Settings dialog is a WinForms
+// surface CDP cannot reach (AUTOMATION-DEBT.md), so the card's Settings route is on its manual
+// portion.
+//
+// Which fonts a machine has varies, so the file asks Bloom for a font of each kind at run time,
+// preferring the ones the manual test names, and fails plainly when a kind is missing.
+//
+// The tests are serial: each starts from the state the one before it left behind.
+
+import { expect, test } from "../fixtures/bloomTest";
+import {
+    addPage,
+    clickInGroup,
+    getContentPages,
+    getFontFamilyInGroup,
+    goToPage,
+    makeBookFromTemplate,
+} from "../helpers/bookMaking";
+import {
+    chooseFont,
+    closeFontInformationPane,
+    getChosenFont,
+    getFontListItems,
+    getFontMetadata,
+    hoverChosenFontMark,
+    hoverFontMarkInList,
+    isFontListOpen,
+    openFontList,
+    pickFont,
+    showFontDetails,
+    type FontChooserColor,
+    type FontMark,
+    type IFontInformation,
+    type IFontMetadata,
+} from "../helpers/fontChooser";
+import {
+    openFormatDialog,
+    scrollFormatGearIntoView,
+    showFormatDialogTab,
+} from "../helpers/formatDialog";
+
+test.use({
+    collectionSpec: { name: "font-chooser", languages: ["en"] },
+});
+
+test.describe.configure({ mode: "serial" });
+
+/** The one text box on the page this file builds: the box under the picture. */
+const TEXT_BOX = ".bloom-translationGroup";
+const LANGUAGE = "en";
+
+/** What the pane says at the top for each kind of font (FontInformationPane.tsx, in English). */
+const MESSAGE = {
+    usable: "The metadata inside this font indicates that it is legal to use for all Bloom purposes.",
+    microsoft:
+        "This is a font supplied by Microsoft for use on your computer alone. Microsoft does not allow its fonts to be used freely on the web or distributed in eBooks. Please use a different font.",
+    notEmbeddable:
+        "The metadata inside this font tells us that it may not be embedded for free in ebooks and the web. Please use a different font.",
+    unknown:
+        "Bloom cannot determine what rules govern the use of this font. Please read the license and make sure it allows embedding in ebooks and the web. Before publishing to bloomlibrary.org, you will probably have to make a special request to the Bloom team to investigate this font so that we can make sure we won't get in trouble for hosting it.",
+};
+
+/** The fonts this run uses, one of each kind, chosen from what the machine has. */
+let usableFont: string;
+let microsoftFont: string;
+let notEmbeddableFont: string;
+let unknownFont: string;
+
+/**
+ * Assert that the pane summarizes the font the way its metadata says: its name, its styles and
+ * version when it has them, and a link for every URL the metadata carries.
+ */
+const expectPaneToSummarize = (pane: IFontInformation, font: IFontMetadata) => {
+    expect(pane.name).toBe(font.name);
+    if (font.variants?.length)
+        expect(pane.text).toContain(font.variants.join(", "));
+    if (font.version) expect(pane.text).toContain(font.version);
+    const expectedHrefs = [
+        font.designerURL,
+        font.manufacturerURL,
+        font.licenseURL,
+    ].filter((url): url is string => !!url);
+    expect(pane.links.map((l) => l.href).sort()).toEqual(
+        [...expectedHrefs].sort(),
+    );
+};
+
+/**
+ * Choose a font from the list and assert that it reached the text box, that the closed chooser shows
+ * it with the given mark in the given colour, and that hovering that mark shows the given message.
+ */
+const chooseFontAndExpectItsMark = async (
+    page: Parameters<typeof chooseFont>[0],
+    fontName: string,
+    mark: FontMark,
+    markColor: FontChooserColor,
+    message: string,
+) => {
+    if (!(await isFontListOpen(page))) await openFontList(page);
+    await chooseFont(page, fontName);
+    expect(await getFontFamilyInGroup(page, TEXT_BOX, LANGUAGE)).toBe(fontName);
+    const chosen = await getChosenFont(page);
+    expect(chosen.name).toBe(fontName);
+    expect(chosen.mark).toBe(mark);
+    expect(chosen.markColor).toBe(markColor);
+    const pane = await hoverChosenFontMark(page);
+    expect(pane.message).toBe(message);
+    expectPaneToSummarize(pane, await getFontMetadata(page, fontName));
+    await closeFontInformationPane(page);
+};
+
+test.describe("Font chooser", () => {
+    test("builds a book, opens the Format dialog for a text box, and finds a font of each kind", async ({
+        page,
+    }) => {
+        test.setTimeout(300000);
+        await makeBookFromTemplate(page, "Basic Book");
+        await addPage(page, "Basic Text & Image");
+        const [textPage] = await getContentPages(page);
+        await goToPage(page, textPage.id);
+
+        // The manual test names Andika, Times New Roman, Baskerville Old Face and Euclid; take
+        // those when the machine has them, and another font of the same kind when it does not.
+        usableFont = await pickFont(page, "usable", "Andika");
+        microsoftFont = await pickFont(page, "microsoft", "Times New Roman");
+        notEmbeddableFont = await pickFont(
+            page,
+            "not-embeddable",
+            "Baskerville Old Face",
+        );
+        unknownFont = await pickFont(page, "unknown", "Euclid");
+
+        await clickInGroup(page, TEXT_BOX, LANGUAGE);
+        await scrollFormatGearIntoView(page);
+        await openFormatDialog(page);
+        // The font chooser is on the Characters tab; the dialog opens on Style Name.
+        await showFormatDialogTab(page, "characters");
+    });
+
+    test("fonts Bloom may use have a check mark and are enabled [Test Case ID 358]", async ({
+        page,
+    }) => {
+        await openFontList(page);
+        const items = await getFontListItems(page);
+        const checked = items.filter((i) => i.mark === "check");
+        expect(
+            checked.length,
+            "No font in the list has a check mark.",
+        ).toBeGreaterThan(0);
+        for (const item of checked) {
+            expect(item.markColor, `${item.name}'s check mark`).toBe(
+                "bloom-blue",
+            );
+            expect(item.textColor, `${item.name} looks dimmed`).toBe("black");
+            expect(item.enabled, `${item.name} is disabled`).toBe(true);
+        }
+        expect(items.find((i) => i.name === usableFont)?.mark).toBe("check");
+    });
+
+    test("fonts Bloom may not use, or cannot judge, are dimmed with a grey mark but stay enabled [Test Case ID 358]", async ({
+        page,
+    }) => {
+        const chosen = (await getChosenFont(page)).name;
+        const items = await getFontListItems(page);
+        const byName = (name: string) => {
+            const item = items.find((i) => i.name === name);
+            expect(item, `The list has no row for ${name}.`).toBeDefined();
+            return item!;
+        };
+        expect(byName(microsoftFont).mark).toBe("exclamation");
+        expect(byName(notEmbeddableFont).mark).toBe("exclamation");
+        expect(byName(unknownFont).mark).toBe("question");
+        // Every unmarked font is dimmed, except the chosen one, whose row is drawn as the chooser
+        // draws it.
+        for (const item of items.filter(
+            (i) => i.mark !== "check" && i.name !== chosen,
+        )) {
+            expect(item.markColor, `${item.name}'s mark`).toBe("grey");
+            expect(item.textColor, `${item.name}'s name`).toBe("grey");
+            expect(item.enabled, `${item.name} is disabled`).toBe(true);
+        }
+    });
+
+    test("hovering a check mark says the font is legal for all Bloom purposes, with a summary and links [Test Case ID 358]", async ({
+        page,
+    }) => {
+        const pane = await hoverFontMarkInList(page, usableFont);
+        expect(pane.message).toBe(MESSAGE.usable);
+        expect(pane.hasDetailsIcon).toBe(false);
+        expectPaneToSummarize(pane, await getFontMetadata(page, usableFont));
+        expect(pane.links.length, "The summary has no link.").toBeGreaterThan(
+            0,
+        );
+        for (const link of pane.links)
+            expect(link.href, `${link.text} links to ${link.href}`).toMatch(
+                /^https?:\/\/[^/]+\.[^/]+/,
+            );
+        await closeFontInformationPane(page);
+    });
+
+    test("hovering a Microsoft font's mark says it may be used on this computer alone [Test Case ID 358]", async ({
+        page,
+    }) => {
+        const pane = await hoverFontMarkInList(page, microsoftFont);
+        expect(pane.message).toBe(MESSAGE.microsoft);
+        expect(pane.hasDetailsIcon).toBe(true);
+        expectPaneToSummarize(pane, await getFontMetadata(page, microsoftFont));
+        await closeFontInformationPane(page);
+    });
+
+    test("hovering the mark of a font whose metadata forbids embedding says so [Test Case ID 358]", async ({
+        page,
+    }) => {
+        const pane = await hoverFontMarkInList(page, notEmbeddableFont);
+        expect(pane.message).toBe(MESSAGE.notEmbeddable);
+        expect(pane.hasDetailsIcon).toBe(true);
+        expectPaneToSummarize(
+            pane,
+            await getFontMetadata(page, notEmbeddableFont),
+        );
+        await closeFontInformationPane(page);
+    });
+
+    test("hovering a question mark says Bloom cannot determine the font's rules [Test Case ID 358]", async ({
+        page,
+    }) => {
+        const pane = await hoverFontMarkInList(page, unknownFont);
+        expect(pane.message).toBe(MESSAGE.unknown);
+        expect(pane.hasDetailsIcon).toBe(true);
+        expectPaneToSummarize(pane, await getFontMetadata(page, unknownFont));
+        // The pane stays open for the next test, which uses its information icon.
+    });
+
+    test("the information icon shows the font's raw metadata [Test Case ID 358]", async ({
+        page,
+    }) => {
+        const details = await showFontDetails(page);
+        const font = await getFontMetadata(page, unknownFont);
+        expect(details).toContain(`name: ${font.name}`);
+        expect(details).toContain(`license: ${font.license}`);
+        expect(details).toContain(`licenseURL: ${font.licenseURL}`);
+        expect(details).toContain(`copyright:`);
+        expect(details).toContain(`fsType:`);
+        expect(details).toContain(
+            `determinedSuitability: ${font.determinedSuitability}`,
+        );
+        expect(details).toContain(
+            `determinedSuitabilityNotes: ${font.determinedSuitabilityNotes}`,
+        );
+        await closeFontInformationPane(page);
+    });
+
+    test("a dimmed Microsoft font can still be chosen, and the chooser then shows a red exclamation mark [Test Case ID 358]", async ({
+        page,
+    }) => {
+        await chooseFontAndExpectItsMark(
+            page,
+            microsoftFont,
+            "exclamation",
+            "red",
+            MESSAGE.microsoft,
+        );
+    });
+
+    test("a font Bloom cannot judge can be chosen, and the chooser then shows a gold question mark [Test Case ID 358]", async ({
+        page,
+    }) => {
+        await chooseFontAndExpectItsMark(
+            page,
+            unknownFont,
+            "question",
+            "gold",
+            MESSAGE.unknown,
+        );
+    });
+
+    test("a font Bloom may use, once chosen, shows its check mark in the chooser [Test Case ID 358]", async ({
+        page,
+    }) => {
+        await chooseFontAndExpectItsMark(
+            page,
+            usableFont,
+            "check",
+            "bloom-blue",
+            MESSAGE.usable,
+        );
+    });
+});

--- a/src/BloomE2E/tests/font-chooser.spec.ts
+++ b/src/BloomE2E/tests/font-chooser.spec.ts
@@ -128,16 +128,17 @@ test.describe("Font chooser", () => {
         const [textPage] = await getContentPages(page);
         await goToPage(page, textPage.id);
 
-        // The manual test names Andika, Times New Roman, Baskerville Old Face and Euclid; take
-        // those when the machine has them, and another font of the same kind when it does not.
-        usableFont = await pickFont(page, "usable", "Andika");
-        microsoftFont = await pickFont(page, "microsoft", "Times New Roman");
-        notEmbeddableFont = await pickFont(
-            page,
-            "not-embeddable",
+        // The manual test names Andika, Times New Roman, Baskerville Old Face and Euclid. A clean
+        // Windows machine has neither of the last two, so bloom-testing-inputs ships Alef (which
+        // Bloom calls unsuitable) and Luciole (unknown) for the nightly runner to install; prefer
+        // those, then the card's fonts, then any font of the kind.
+        usableFont = await pickFont(page, "usable", ["Andika"]);
+        microsoftFont = await pickFont(page, "microsoft", ["Times New Roman"]);
+        notEmbeddableFont = await pickFont(page, "not-embeddable", [
+            "Alef",
             "Baskerville Old Face",
-        );
-        unknownFont = await pickFont(page, "unknown", "Euclid");
+        ]);
+        unknownFont = await pickFont(page, "unknown", ["Luciole", "Euclid"]);
 
         await clickInGroup(page, TEXT_BOX, LANGUAGE);
         await scrollFormatGearIntoView(page);


### PR DESCRIPTION
Automates Notion test case 358 (New Font Chooser): https://app.notion.com/p/New-Font-Chooser-3904bb19df12811dab13eb2df088c16d

## Bloom production code changes

None in Bloom itself. Outside `src/BloomE2E` the PR touches `.github/workflows/nightly.yml` (a step that installs the test fonts before the e2e suite) and `build/testing-inputs.pin` (advanced to the bloom-testing-inputs commit that carries the fonts, BloomBooks/bloom-testing-inputs#3). Nothing that ships in Bloom or builds it changes.

## Fonts for the nightly runner

A `windows-latest` runner has 66 fonts: 5 Bloom calls usable, 51 Microsoft, and none it calls unknown or non-Microsoft unsuitable, so the first dispatch of the nightly e2e suite on this branch could not find a font of each kind. bloom-testing-inputs now carries, under `fonts/`, two genuinely free fonts whose internal metadata lands them in exactly those verdicts: **Alef** (SIL OFL; metadata says only "All rights reserved", so *unsuitable*) and **Luciole** (CC BY 4.0, stated in a form Bloom's heuristics do not read, so *unknown*). `src/BloomE2E/scripts/install-test-fonts.ps1` installs everything under that folder for the current user and fails unless GDI+, which is what Bloom's font list reads, lists them afterwards; the workflow runs it after fetching the inputs. The test prefers Alef and Luciole, then the fonts the card names, then any font of the kind, so it behaves the same on a developer machine that has them and on the runner.

**Merge order:** BloomBooks/bloom-testing-inputs#3 first, then this PR. The pin already names that branch's commit, which stays reachable after the merge.

## Purpose

Protects what the font chooser tells a user about each installed font: fonts Bloom may embed in a published book get a check mark and stay enabled; fonts it may not use (a Microsoft font, or one whose metadata forbids embedding) get an exclamation mark, and fonts it cannot judge a question mark, dimmed in the list yet still choosable. Hovering a mark opens the information pane with the right verdict, a summary of the font with its links, and, for anything but a usable font, the information icon that shows the raw metadata. The chosen font's mark shows in the closed chooser in colour (red, gold, Bloom blue) with the same pane.

The chooser is the same React component in the Format dialog and in the Settings dialog's Book Making tab. The test drives it in the Format dialog. The Settings dialog is a WinForms surface CDP cannot reach, so the card is split: the original keeps its id as `New Font Chooser [Automated portion]`, and the Settings route is `New Font Chooser [Manual portion]` (Test Case ID 811), linked both ways.

## Steps

- Makes a Basic Book in a new one-language collection, adds a Basic Text & Image page, and asks `fonts/metadata` for a font of each kind, preferring the ones the card names (Andika, Times New Roman, Baskerville Old Face, Euclid) and taking another of the same kind when the machine lacks one. A machine with no font of a kind fails plainly, as the card asks.
- Clicks in the text box, opens the Format dialog, and switches to its Characters tab (new helper `showFormatDialogTab`).
- Pulls down the font list and reads every row: mark, mark colour, name colour, enabled.
- Hovers the mark of each of the four fonts and reads the pane; clicks the information icon for the unknown font and captures the alert it raises.
- Chooses the Microsoft font, the unknown font, then the usable font, checking the text box's computed font, the closed chooser's mark and colour, and the pane behind that mark.

## How it verifies the result

Reads the DOM of the list, the pane and the chooser (MUI's icon `data-testid`s name the marks; computed colours are mapped to the theme's named colours), the box's computed `font-family`, and `fonts/metadata` as the oracle for the pane's summary (name, styles, version, and exactly the links whose URLs the metadata carries). Eleven serial tests in one Bloom; three green runs in a row locally, no Bloom.exe left behind.

## New helpers

- `helpers/fontChooser.ts`: `pickFont`, `getFontsMetadata`, `getFontMetadata`, `openFontList`, `isFontListOpen`, `getFontListItems`, `hoverFontMarkInList`, `hoverChosenFontMark`, `readFontInformationPane`, `closeFontInformationPane`, `showFontDetails`, `chooseFont`, `getChosenFont`.
- `helpers/formatDialog.ts`: `showFormatDialogTab`.
- `helpers/bookMaking.ts`: `getFontFamilyInGroup`.

## Problems

- The Settings dialog route stays manual (WinForms; `AUTOMATION-DEBT.md` "WinForms surfaces are invisible to CDP" has a new seen-again line).
- The card says the check mark is in a "green circle"; the product draws it in Bloom blue (`kBloomBlue`), and the test asserts the product's colour.
- The card asks that the summary's links go to real websites. The test checks that every link is one the font's metadata carries and, for the usable font, that it is an absolute http(s) URL; it does not fetch them.
- The CI runner had no unknown or non-Microsoft unsuitable font; see "Fonts for the nightly runner" above for how the PR supplies them. A machine that still lacks a kind fails with a message listing how many of each kind it has.
- Bloom's information pane renders a manufacturer link with an empty `href` for a font whose metadata has no manufacturer at all (Luciole). The pane reader ignores it; it is a small product oddity, not a test problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8289)
<!-- Reviewable:end -->


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8289)
