### PR TITLE
Make the bloom-automation scripts safe to ask for help (BL-16799)

### DIFF
--- a/.github/skills/bloom-automation/bloomProcessCommon.mjs
+++ b/.github/skills/bloom-automation/bloomProcessCommon.mjs
@@ -42,9 +42,40 @@ export const requireTcpPortOption = (optionName, value) => {
     return port;
 };
 
+/**
+ * A process id given on the command line, as a positive integer.
+ *
+ * This throws rather than returning undefined, because the caller that wants a process id wants
+ * to act on exactly that process. A killer script that read a malformed id as "no id given" would
+ * fall through to whatever its no-target default is, and killBloomProcess.mjs's default is to kill
+ * every Bloom the worktree owns.
+ */
+export const requireProcessIdOption = (optionName, value) => {
+    const normalized = value === undefined ? "" : String(value).trim();
+    const processId = /^\d+$/.test(normalized)
+        ? toPositiveInteger(normalized)
+        : undefined;
+    if (!processId) {
+        throw new Error(
+            `${optionName} must be a positive integer process id. Received: ${value}`,
+        );
+    }
+
+    return processId;
+};
+
+// Whether the caller asked for the usage, wherever the request sits on the command line. Every
+// script checks this before it parses anything else: `--repo-root -h` used to store "-h" as
+// the path, name no target, and reach the default that kills every Bloom on the machine.
+export const asksForHelp = (args) =>
+    args.some((arg) => arg === "--help" || arg === "-h");
+
 export const requireOptionValue = (args, index, optionName) => {
     const value = args[index + 1];
-    if (!value || value.startsWith("--")) {
+    // A leading "-" of any length means the next flag, not this option's value. Every value
+    // these scripts take is a path, a TCP port or a process id, and none of those starts
+    // with "-", so there is nothing legitimate to reject here.
+    if (!value || value.startsWith("-")) {
         throw new Error(`${optionName} requires a value.`);
     }
 

--- a/.github/skills/bloom-automation/bloomProcessStatus.mjs
+++ b/.github/skills/bloom-automation/bloomProcessStatus.mjs
@@ -1,4 +1,5 @@
 import {
+    asksForHelp,
     buildProcessChain,
     classifyProcesses,
     fetchBloomInstanceInfo,
@@ -13,8 +14,24 @@ import {
     toWorkspaceTabsEndpoint,
 } from "./bloomProcessCommon.mjs";
 
+const usage = `Report the Bloom and launcher processes this machine is running.
+
+  node bloomProcessStatus.mjs [options]
+
+  --help, -h            Print this and exit.
+  --json                Report as JSON.
+  --running-bloom       Also probe each running Bloom's own HTTP server.
+  --repo-root <path>    The worktree to judge instances against (default: this checkout).
+  --http-port <port>    Report the instance whose server answers on this port.
+
+This script only reads; it never kills anything.`;
+
 const parseArgs = () => {
     const args = process.argv.slice(2);
+    if (asksForHelp(args)) {
+        console.log(usage);
+        process.exit(0);
+    }
     const options = {
         json: false,
         runningBloom: false,
@@ -24,6 +41,11 @@ const parseArgs = () => {
 
     for (let i = 0; i < args.length; i++) {
         const arg = args[i];
+
+        if (arg === "--help" || arg === "-h") {
+            console.log(usage);
+            process.exit(0);
+        }
 
         if (arg === "--json") {
             options.json = true;
@@ -36,7 +58,11 @@ const parseArgs = () => {
         }
 
         if (arg === "--repo-root") {
-            options.repoRoot = args[i + 1] || options.repoRoot;
+            // A required value, checked the same way as every other option's. Taking
+            // `args[i + 1]` and falling back to the default would swallow the next flag as
+            // this option's value. killBloomProcess.mjs has the same parser, where that
+            // mistake is destructive.
+            options.repoRoot = requireOptionValue(args, i, "--repo-root");
             i++;
             continue;
         }
@@ -57,6 +83,10 @@ const parseArgs = () => {
             );
             continue;
         }
+
+        // An unknown flag is a mistake, and silently ignoring it hides it.
+        console.error(`Unknown option ${arg}.\n\n${usage}`);
+        process.exit(2);
     }
 
     return options;

--- a/.github/skills/bloom-automation/dismissProblemDialog.mjs
+++ b/.github/skills/bloom-automation/dismissProblemDialog.mjs
@@ -23,6 +23,7 @@
 import { createRequire } from "node:module";
 import path from "node:path";
 import {
+    asksForHelp,
     fetchBloomInstanceInfo,
     getDefaultRepoRoot,
     normalizeBloomInstanceInfo,
@@ -32,8 +33,15 @@ import {
     toLocalOrigin,
 } from "./bloomProcessCommon.mjs";
 
+const usage =
+    "Usage: node .github/skills/bloom-automation/dismissProblemDialog.mjs --http-port <port> [--wait] [--timeout-ms <ms>] [--json]";
+
 const parseArgs = () => {
     const args = process.argv.slice(2);
+    if (asksForHelp(args)) {
+        console.log(usage);
+        process.exit(0);
+    }
     const options = {
         httpPort: undefined,
         wait: false,
@@ -79,12 +87,12 @@ const parseArgs = () => {
             continue;
         }
 
-        if (arg === "--help") {
-            console.log(
-                "Usage: node .github/skills/bloom-automation/dismissProblemDialog.mjs --http-port <port> [--wait] [--timeout-ms <ms>] [--json]",
-            );
-            process.exit(0);
-        }
+        // A typo must not be ignored: an option this script does not know is a request it
+        // cannot carry out, so say so rather than do something else.
+        console.error(`Unknown option ${arg}.
+
+${usage}`);
+        process.exit(2);
     }
 
     if (!options.httpPort) {

--- a/.github/skills/bloom-automation/driveAiImageEditor.mjs
+++ b/.github/skills/bloom-automation/driveAiImageEditor.mjs
@@ -35,6 +35,29 @@ const { chromium } = createRequire(path.join(componentTester, "package.json"))(
 );
 
 const args = process.argv.slice(2);
+
+const usage = `Drive the "Edit with AI…" image editor of a running Bloom over CDP.
+
+  node driveAiImageEditor.mjs [options] [command]
+
+  frames                  List every frame of the Edit tab (the default command).
+  images                  Report the images of the current page.
+  credits                 Report each book image's credits, read from the file metadata.
+  dummy-edit              Open the editor, edit with the Local Dummy model, and commit.
+
+  --help, -h              Print this and exit.
+  --http-port <port>      The Bloom whose server answers on this port (default: 8092).
+  --cdp-port <port>       The debugging port to attach to (default: --http-port plus 2).
+  --match <text>          Part of the src of the image to edit (default: ai-image).
+  --shot <path>           Where to write the screenshot of a dummy-edit run.`;
+
+// The usage counts wherever the request sits, and this script attaches to a running Bloom, so
+// answer it before anything reaches that Bloom.
+if (args.some((arg) => arg === "--help" || arg === "-h")) {
+    console.log(usage);
+    process.exit(0);
+}
+
 const opt = (name, def) => {
     const i = args.indexOf(name);
     return i >= 0 && args[i + 1] ? args[i + 1] : def;
@@ -44,8 +67,16 @@ const valueFlags = new Set(["--http-port", "--cdp-port", "--match", "--shot"]);
 const positional = [];
 for (let i = 0; i < args.length; i++) {
     if (args[i].startsWith("--")) {
-        if (valueFlags.has(args[i])) i++; // skip its value
-        continue;
+        if (valueFlags.has(args[i])) {
+            i++; // skip its value
+            continue;
+        }
+        // A typo must not be ignored: this script attaches to a running Bloom and does things
+        // to the book being edited, so an option it does not know stops the run.
+        console.error(`Unknown option ${args[i]}.
+
+${usage}`);
+        process.exit(2);
     }
     positional.push(args[i]);
 }

--- a/.github/skills/bloom-automation/killBloomProcess.mjs
+++ b/.github/skills/bloom-automation/killBloomProcess.mjs
@@ -6,12 +6,42 @@ import {
     getWindowsProcessSnapshot,
     killProcessIds,
     normalizeBloomInstanceInfo,
+    asksForHelp,
     requireOptionValue,
+    requireProcessIdOption,
     requireTcpPortOption,
 } from "./bloomProcessCommon.mjs";
 
+const usage = `Kill the Bloom.exe (and dotnet.exe BloomExe.csproj) processes of this worktree.
+
+  node killBloomProcess.mjs [options]
+
+  --help, -h              Print this and exit without killing anything.
+  --json                  Report what was killed as JSON.
+  --only-mismatched       Kill only instances whose repo root is not this worktree.
+  --repo-root <path>      The worktree to judge instances against (default: this checkout).
+  --http-port <port>      Kill the instance whose server answers on this port.
+  --pid <pid>             Kill this process and the Bloom processes in its chain.
+  --watch-pid <pid>       Kill this launcher/watch process and its Bloom processes.
+
+With no --http-port, --pid or --watch-pid, this kills EVERY Bloom this worktree owns.`;
+
+// Print the usage and exit 0 without killing anything, or reject an unknown flag with a non-zero
+// exit. Reading the usage first must never be the dangerous move: this script used to ignore
+// --help and go straight to its destructive default (AUTOMATION-DEBT.md, "Automation helper
+// scripts run destructive defaults on unknown flags").
+const exitWithUsage = (unknownArgument) => {
+    if (unknownArgument) {
+        console.error(`Unknown option ${unknownArgument}.\n\n${usage}`);
+        process.exit(2);
+    }
+    console.log(usage);
+    process.exit(0);
+};
+
 const parseArgs = () => {
     const args = process.argv.slice(2);
+    if (asksForHelp(args)) exitWithUsage();
     const options = {
         json: false,
         onlyMismatched: false,
@@ -24,6 +54,10 @@ const parseArgs = () => {
     for (let i = 0; i < args.length; i++) {
         const arg = args[i];
 
+        if (arg === "--help" || arg === "-h") {
+            exitWithUsage();
+        }
+
         if (arg === "--json") {
             options.json = true;
             continue;
@@ -35,7 +69,11 @@ const parseArgs = () => {
         }
 
         if (arg === "--repo-root") {
-            options.repoRoot = args[i + 1] || options.repoRoot;
+            // A required value, checked the same way as every other option's. Taking
+            // `args[i + 1]` and falling back to the default would swallow the NEXT FLAG as
+            // this option's value, so `--repo-root --pid 123` would name no target at all and
+            // reach the default that kills every Bloom this worktree owns.
+            options.repoRoot = requireOptionValue(args, i, "--repo-root");
             i++;
             continue;
         }
@@ -58,25 +96,40 @@ const parseArgs = () => {
         }
 
         if (arg === "--pid") {
-            options.pid = Number(args[i + 1]);
+            options.pid = requireProcessIdOption(
+                "--pid",
+                requireOptionValue(args, i, "--pid"),
+            );
             i++;
             continue;
         }
 
         if (arg.startsWith("--pid=")) {
-            options.pid = Number(arg.slice("--pid=".length));
+            options.pid = requireProcessIdOption(
+                "--pid",
+                arg.slice("--pid=".length),
+            );
             continue;
         }
 
         if (arg === "--watch-pid") {
-            options.watchPid = Number(args[i + 1]);
+            options.watchPid = requireProcessIdOption(
+                "--watch-pid",
+                requireOptionValue(args, i, "--watch-pid"),
+            );
             i++;
             continue;
         }
 
         if (arg.startsWith("--watch-pid=")) {
-            options.watchPid = Number(arg.slice("--watch-pid=".length));
+            options.watchPid = requireProcessIdOption(
+                "--watch-pid",
+                arg.slice("--watch-pid=".length),
+            );
+            continue;
         }
+
+        exitWithUsage(arg);
     }
 
     return options;
@@ -85,8 +138,14 @@ const parseArgs = () => {
 const options = parseArgs();
 const processState = classifyProcesses(options.repoRoot);
 const processIds = new Set();
+// Whether the caller named a target, not whether the value we parsed from it is usable. The
+// two are the same now that every target option is validated at parse time, and this says the
+// intended thing: a caller who asked for one process must never reach the default that kills
+// every Bloom this worktree owns.
 const exactTargetRequested =
-    !!options.httpPort || !!options.pid || !!options.watchPid;
+    options.httpPort !== undefined ||
+    options.pid !== undefined ||
+    options.watchPid !== undefined;
 let targetedInstance;
 let exactTargetResolutionError;
 

--- a/.github/skills/bloom-automation/launcherControl.mjs
+++ b/.github/skills/bloom-automation/launcherControl.mjs
@@ -26,6 +26,7 @@ import {
 } from "node:fs";
 import path from "node:path";
 import {
+    asksForHelp,
     getDefaultRepoRoot,
     requireOptionValue,
 } from "./bloomProcessCommon.mjs";
@@ -43,8 +44,25 @@ const actionNames = [
     "--ensure-running",
 ];
 
+const usage = `Command the go.sh launcher for this worktree.
+
+  node launcherControl.mjs <action> [options]
+
+  actions: ${actionNames.join(", ")}
+  options: --json, --wait-ready, --repo-root <path>, --timeout-ms <n>
+           --help, -h   Print this and exit without commanding anything.
+
+  --restart rebuilds and relaunches; --quit-bloom stops Bloom and leaves the launcher;
+  --shutdown stops Bloom, the launcher, and Vite.`;
+
 const parseArgs = () => {
     const args = process.argv.slice(2);
+    // Asking a destructive script how to use it must never be the destructive move, and the
+    // request counts wherever it sits: see asksForHelp.
+    if (asksForHelp(args)) {
+        console.log(usage);
+        process.exit(0);
+    }
     const options = {
         action: undefined,
         json: false,
@@ -55,6 +73,13 @@ const parseArgs = () => {
 
     for (let i = 0; i < args.length; i++) {
         const arg = args[i];
+
+        // Print the usage and stop, before any action can run. Asking a destructive script how to
+        // use it must never be the destructive move.
+        if (arg === "--help" || arg === "-h") {
+            console.log(usage);
+            process.exit(0);
+        }
 
         if (actionNames.includes(arg)) {
             if (options.action) {

--- a/.github/skills/bloom-automation/switchWorkspaceTab.mjs
+++ b/.github/skills/bloom-automation/switchWorkspaceTab.mjs
@@ -1,6 +1,7 @@
 import { createRequire } from "node:module";
 import path from "node:path";
 import {
+    asksForHelp,
     fetchBloomInstanceInfo,
     findRunningStandardBloomInstance,
     getDefaultRepoRoot,
@@ -11,8 +12,15 @@ import {
     toWorkspaceTabsEndpoint,
 } from "./bloomProcessCommon.mjs";
 
+const usage =
+    "Usage: node .github/skills/bloom-automation/switchWorkspaceTab.mjs (--running-bloom | --http-port <port>) --tab <collection|edit|publish> [--json] [--timeout-ms <ms>]";
+
 const parseArgs = () => {
     const args = process.argv.slice(2);
+    if (asksForHelp(args)) {
+        printHelp();
+        process.exit(0);
+    }
     const options = {
         runningBloom: false,
         httpPort: undefined,
@@ -68,19 +76,19 @@ const parseArgs = () => {
             continue;
         }
 
-        if (arg === "--help") {
-            printHelp();
-            process.exit(0);
-        }
+        // A typo must not be ignored: an option this script does not know is a request it
+        // cannot carry out, so say so rather than do something else.
+        console.error(`Unknown option ${arg}.
+
+${usage}`);
+        process.exit(2);
     }
 
     return options;
 };
 
 const printHelp = () => {
-    console.log(
-        "Usage: node .github/skills/bloom-automation/switchWorkspaceTab.mjs (--running-bloom | --http-port <port>) --tab <collection|edit|publish> [--json] [--timeout-ms <ms>]",
-    );
+    console.log(usage);
 };
 
 const normalizeTab = (tab) => {

--- a/.github/skills/bloom-automation/webview2Targets.mjs
+++ b/.github/skills/bloom-automation/webview2Targets.mjs
@@ -1,4 +1,5 @@
 import {
+    asksForHelp,
     fetchBloomInstanceInfo,
     findRunningStandardBloomInstance,
     normalizeBloomInstanceInfo,
@@ -7,8 +8,26 @@ import {
     toLocalOrigin,
 } from "./bloomProcessCommon.mjs";
 
+const usage = `List the WebView2 debugging targets of a running Bloom.
+
+  node webview2Targets.mjs [options]
+
+  --help, -h              Print this and exit.
+  --json                  Report the targets as JSON.
+  --all                   List every target, not only Bloom's own documents.
+  --running-bloom         Find the Bloom that is running, rather than naming a port.
+  --http-port <port>      The Bloom whose server answers on this port.
+  --host <name>           The host to ask for targets (default: localhost).
+  --port <port>           The CDP port to ask directly.
+  --wait                  Wait for a target to appear.
+  --timeout-ms <ms>       How long to wait (default: 15000).`;
+
 const parseArgs = () => {
     const args = process.argv.slice(2);
+    if (asksForHelp(args)) {
+        console.log(usage);
+        process.exit(0);
+    }
     const options = {
         host: "localhost",
         port: undefined,
@@ -85,7 +104,15 @@ const parseArgs = () => {
         if (arg === "--timeout-ms") {
             options.timeoutMs = Number(args[i + 1] || options.timeoutMs);
             i++;
+            continue;
         }
+
+        // A typo must not be ignored: an option this script does not know is a request it
+        // cannot carry out, so say so rather than do something else.
+        console.error(`Unknown option ${arg}.
+
+${usage}`);
+        process.exit(2);
     }
 
     return options;

--- a/src/BloomE2E/AUTOMATION-DEBT.md
+++ b/src/BloomE2E/AUTOMATION-DEBT.md
@@ -21,7 +21,6 @@ the identity here. Before you start on a marked entry, ask the owner of its bran
 
 | Branch | What it pays down |
 | --- | --- |
-| `BL-16799-automation-scripts` | The `bloom-automation` scripts answer `--help` without killing anything, and reject an unknown flag or a malformed process id. |
 | `BL-16799-vr-collect-failures` | A visual-regression case collects every failed comparison and fails once at the end. |
 | `BL-16799-component-tests-in-ci` | The component-tester Playwright suites get a nightly job. |
 | `BL-16799-vite-port` | `BLOOM_E2E_VITE_PORT` makes a run test the working tree's front end. Adds a new entry for what remains. |
@@ -216,18 +215,6 @@ run of the suite cannot go green, which makes local verification and baseline
 authoring painful. Fix direction: a small per-comparison pixel tolerance, or
 machine-profile baselines, or render fonts only from Bloom's own WOFF2 set in --e2e
 mode. (Found 2026-09-01 while verifying the bloom-testing-inputs rewire.)
-
-## Automation helper scripts run destructive defaults on unknown flags
-
-`node .github/skills/bloom-automation/killBloomProcess.mjs --help` killed the running
-Bloom: unknown flags are ignored and the destructive default runs, so "read the usage
-first" is itself the dangerous move; sibling scripts may share the shape. Fix
-direction: recognize `--help`/`-h` and reject unknown flags in every script that kills
-processes — and fold these helpers' jobs into the library's audited launch/teardown
-fixture over time. (Promoted from PAPERCUTS 2026-07-24.)
-
-being fixed on `BL-16799-automation-scripts`, for the `--help`, unknown-flag and
-malformed-process-id part. Folding the helpers into the fixture is not part of it.
 
 ## Adding a page needs the Add Page dialog, which offers nothing to automate against
 


### PR DESCRIPTION
`node killBloomProcess.mjs --help` killed the running Bloom. Unknown flags were
ignored, so the destructive default ran, which made "read the usage first" the
dangerous move. The sibling scripts shared the shape.

Every script in .github/skills/bloom-automation now recognizes --help and -h,
prints its usage, and exits without killing anything. An unknown option is
rejected with the usage rather than ignored, and a --pid or --watch-pid that is
not a positive integer is rejected instead of being passed to the kill code,
where a NaN would have meant "every Bloom this worktree owns".

Retires the AUTOMATION-DEBT.md entry "Automation helper scripts run destructive
defaults on unknown flags". Folding these helpers into the launch fixture, the
other half of that entry's fix direction, is not part of this.

## This is one of eleven stacked pull requests (BL-16799)

Each one pays down one entry of `src/BloomE2E/AUTOMATION-DEBT.md`, and each branches off the one before it. **Base: `master`.** Review only this pull request's own commit; the ones below it are reviewed in their own pull requests. The first six change test and tooling code only; the last five also change product code.

1. `BL-16799-automation-scripts` — Make the bloom-automation scripts safe to ask for help
2. `BL-16799-vr-collect-failures` — Report every failed image comparison in a visual-regression case, not the first
3. `BL-16799-component-tests-in-ci` — Run the component-tester Playwright suites nightly
4. `BL-16799-vite-port` — Let an e2e run test the working tree's front end
5. `BL-16799-type-in-one-call` — Type into a text box in one call, not one key press per character
6. `BL-16799-page-screenshot` — Capture a whole book page from a test
7. `BL-16799-toolbox-registration` — Register the toolbox tools from one list both callers share
8. `BL-16799-shell-document` — Stop a test attaching to a shell document Bloom does not drive
9. `BL-16799-tab-test-ids` — Click a workspace tab by a test id, not by its localized label
10. `BL-16799-page-change` — Refuse a page change the Edit tab cannot do, and wait before asking
11. `BL-16799-collection-languages` — Set a collection's languages through an e2e hook, not by writing XML

Replaces #8276, which did all of this in one pull request.

Verification of the whole stack, at its tip: the C# suite passes (3338 passed, 13 skipped), the front-end vitest suite passes (781 passed, 5 skipped), and the `src/BloomE2E` suite passes against a Vite dev server on the working tree (36 passed, 0 skipped, 8.2 minutes). Each pull request also has its own type check and lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8290)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8290)
<!-- Reviewable:end -->
