### PR TITLE
Report every failed image comparison in a visual-regression case, not the first (BL-16799)

### DIFF
--- a/src/BloomE2E/AUTOMATION-DEBT.md
+++ b/src/BloomE2E/AUTOMATION-DEBT.md
@@ -21,7 +21,6 @@ the identity here. Before you start on a marked entry, ask the owner of its bran
 
 | Branch | What it pays down |
 | --- | --- |
-| `BL-16799-vr-collect-failures` | A visual-regression case collects every failed comparison and fails once at the end. |
 | `BL-16799-component-tests-in-ci` | The component-tester Playwright suites get a nightly job. |
 | `BL-16799-vite-port` | `BLOOM_E2E_VITE_PORT` makes a run test the working tree's front end. Adds a new entry for what remains. |
 | `BL-16799-type-in-one-call` | Typing in a text box is one insertion, not one key press per character. Adds a new entry: typing now raises no key events. |
@@ -111,17 +110,6 @@ is the rest. Note that the pretense changes only what Bloom reports, so Bloom un
 refuses to upload at all rather than let an automated click publish under the developer's real
 account.
 (Found 2026-09-02 automating Test Case ID 606, `upload-required-items.spec.ts`.)
-
-## Visual-regression cases stop at the first failed comparison
-
-Each case in `src/BloomVisualRegressionTests/index.spec.ts` throws on the first
-mismatch, so later comparisons never capture their images; stale baselines surface one
-layer per ~3-minute run (BL-16638 took three accept-and-rerun rounds). Fix direction:
-accumulate per-comparison failures and fail once at the end — proven during BL-16638
-(~20–30 lines, confined to the spec). Loop at `index.spec.ts:426`, assertion at
-`index.spec.ts:486` (pre-rewire line numbers). (Promoted from PAPERCUTS 2026-07-30.)
-
-being fixed on `BL-16799-vr-collect-failures`.
 
 ## The top bar has no stable test ids, so tests match on localized text
 

--- a/src/BloomVisualRegressionTests/index.spec.ts
+++ b/src/BloomVisualRegressionTests/index.spec.ts
@@ -208,6 +208,12 @@ describe("All books", () => {
     let playerPage: Page;
     let browser: Browser;
     let context: BrowserContext;
+    // Every image comparison the CURRENT case has failed. A case compares one book-preview image
+    // and one image per bloom-player page, and a stale baseline usually affects several of them.
+    // Throwing on the first mismatch meant the later comparisons never even captured their
+    // images, so accepting a real layout change took one ~3-minute run per image (BL-16638 took
+    // three rounds). So collect them all and fail once, at the end of the case.
+    let comparisonFailures: string[] = [];
 
     beforeAll(async () => {
         await launchDedicatedBloom();
@@ -297,6 +303,7 @@ describe("All books", () => {
     });
 
     test.each(cases)("$title", async (testCase) => {
+        comparisonFailures = [];
         // Park the capture pages before we mutate this book. Otherwise the previous case's still-open
         // book-preview / bloom-player page keeps requesting book and staged-BloomPUB files while this
         // case rewrites them, which caused mid-run "file is being used by another process" and
@@ -334,6 +341,14 @@ describe("All books", () => {
         await selectTab("publish");
         const stagedUrl = await makeBloomPubPreview();
         await capturePlayerPages(stagedUrl, testCase.label, screenshotsDir);
+
+        // One failure for the whole case, listing every image that did not match, so a single run
+        // shows all the baselines that need looking at.
+        if (comparisonFailures.length > 0)
+            throw new Error(
+                `${comparisonFailures.length} of this case's images did not match their ` +
+                    `reference:\n  ${comparisonFailures.join("\n  ")}`,
+            );
     });
 
     // Create the reference image if it does not exist yet; otherwise capture a current image and
@@ -694,9 +709,35 @@ describe("All books", () => {
         }
     }
 
+    // Compare one captured image against its reference. This does NOT throw on a mismatch: it
+    // appends a description to comparisonFailures, and the test body fails the case once it has
+    // compared every image. Anything thrown while comparing (notably Pixelmatch's "Image sizes do
+    // not match", which is itself a real failure) is recorded the same way.
+    //
     // `likelyCause`, when given, is an explanation to attach to a mismatch (see andikaIsInstalled):
     // something we know about this machine that makes the difference expected rather than a regression.
     async function comparePreviewImage(
+        referencePath: string,
+        testPath: string,
+        diffPath: string,
+        likelyCause?: string,
+    ) {
+        try {
+            await compareOrThrow(
+                referencePath,
+                testPath,
+                diffPath,
+                likelyCause,
+            );
+        } catch (error) {
+            comparisonFailures.push(
+                `${testPath}: ${error instanceof Error ? error.message : String(error)}`,
+            );
+        }
+    }
+
+    // The comparison itself: write a diff image and throw when the two images differ at all.
+    async function compareOrThrow(
         referencePath: string,
         testPath: string,
         diffPath: string,
@@ -732,9 +773,9 @@ describe("All books", () => {
             );
             // A thrown Error rather than expect(...).toBe(0), so the failure itself carries the
             // diff path and, when we know one, the likely cause; the console lines above are lost in
-            // a long run's output.
+            // a long run's output. comparePreviewImage catches this and records it.
             throw new Error(
-                `${testPath} differed from the reference by ${numberOfDifferentPixels} pixels. ` +
+                `${testPath} differed from ${referencePath} by ${numberOfDifferentPixels} pixels. ` +
                     `The diff image is at ${diffPath}.` +
                     (likelyCause ? `\n\n${likelyCause}` : ""),
             );


### PR DESCRIPTION
Each case in src/BloomVisualRegressionTests/index.spec.ts threw on its first
mismatch, so the comparisons after it never captured their images. A stale
baseline therefore surfaced one image per run, and each run takes about three
minutes: BL-16638 needed three accept-and-rerun rounds to get through one
layout change.

comparePreviewImage now records a mismatch in a per-case list instead of
throwing, and the case body throws once at the end, naming every image that did
not match. Anything thrown while comparing, such as Pixelmatch's "Image sizes
do not match", is recorded the same way, so it is still a failure and it no
longer hides the comparisons behind it. The list resets at the start of each
case.

Retires the AUTOMATION-DEBT.md entry "Visual-regression cases stop at the first
failed comparison".

Verified by type check only. This suite's baselines match the CI runner rather
than a developer machine, so it cannot go green here.

## This is one of eleven stacked pull requests (BL-16799)

Each one pays down one entry of `src/BloomE2E/AUTOMATION-DEBT.md`, and each branches off the one before it. **Base: `BL-16799-automation-scripts`.** Review only this pull request's own commit; the ones below it are reviewed in their own pull requests. The first six change test and tooling code only; the last five also change product code.

1. `BL-16799-automation-scripts` — Make the bloom-automation scripts safe to ask for help
2. `BL-16799-vr-collect-failures` — Report every failed image comparison in a visual-regression case, not the first
3. `BL-16799-component-tests-in-ci` — Run the component-tester Playwright suites nightly
4. `BL-16799-vite-port` — Let an e2e run test the working tree's front end
5. `BL-16799-type-in-one-call` — Type into a text box in one call, not one key press per character
6. `BL-16799-page-screenshot` — Capture a whole book page from a test
7. `BL-16799-toolbox-registration` — Register the toolbox tools from one list both callers share
8. `BL-16799-shell-document` — Stop a test attaching to a shell document Bloom does not drive
9. `BL-16799-tab-test-ids` — Click a workspace tab by a test id, not by its localized label
10. `BL-16799-page-change` — Refuse a page change the Edit tab cannot do, and wait before asking
11. `BL-16799-collection-languages` — Set a collection's languages through an e2e hook, not by writing XML

Replaces #8276, which did all of this in one pull request.

Verification of the whole stack, at its tip: the C# suite passes (3338 passed, 13 skipped), the front-end vitest suite passes (781 passed, 5 skipped), and the `src/BloomE2E` suite passes against a Vite dev server on the working tree (36 passed, 0 skipped, 8.2 minutes). Each pull request also has its own type check and lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8291)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8291)
<!-- Reviewable:end -->
