### PR TITLE
Type into a text box in one call, not one key press per character (BL-16799)

### DIFF
--- a/src/BloomE2E/AUTOMATION-DEBT.md
+++ b/src/BloomE2E/AUTOMATION-DEBT.md
@@ -21,7 +21,6 @@ the identity here. Before you start on a marked entry, ask the owner of its bran
 
 | Branch | What it pays down |
 | --- | --- |
-| `BL-16799-type-in-one-call` | Typing in a text box is one insertion, not one key press per character. Adds a new entry: typing now raises no key events. |
 | `BL-16799-page-screenshot` | A helper captures a whole book page, which absorbs the `captureBeyondViewport` footgun. |
 | `BL-16799-toolbox-registration` | One `registerAllToolboxTools()` that both the bootstrap and the test harness call. |
 | `BL-16799-shell-document` | A test can no longer attach to a shell document Bloom does not drive: one WebView2 environment per run, plus the `e2e/shellUrl` hook. |
@@ -269,16 +268,16 @@ dropped.
 
 A `.bloom-editable` is a CKEditor surface, and Playwright's `fill()` on one leaves a
 tail of what was there ("Deux" became "eux"), so `typeInGroup` clicks in, selects all,
-deletes, and types the new text one key at a time. That is closer to what a person does
-and it is reliable, but it is also slow for anything longer than a few words, and no
-test can currently clear a box by any faster route. Fix direction: understand what
-CKEditor does with a programmatic value change; a supported "set the text of this box"
-path would let long text be set at once.
-(Found 2026-09-01 automating Test Case ID 169.)
+deletes, and then puts the new text in.
 
-being fixed on `BL-16799-type-in-one-call`, for the typing half only: one insertion
-instead of a key press per character. Clearing a box still needs Control+A and Delete, and
-that branch adds an entry saying that typing now raises no key events.
+Partly fixed 2026-09-01: the typing half is no longer a key press per character.
+`typeInGroup` now inserts the whole string in one call (`keyboard.insertText`), which
+CKEditor and Bloom's markup code both handle through the input event it raises, so the
+cost of typing no longer grows with the length of the text. What remains is clearing a
+box: that still needs a click, Control+A and Delete, because neither `fill()` nor
+setting the value leaves CKEditor in a state Bloom then saves correctly. Fix direction:
+an `e2e/` hook, or a supported CKEditor path, that sets the text of one box outright.
+(Found 2026-09-01 automating Test Case ID 169.)
 
 ## The page menu offers commands that silently do nothing while a page is loading
 
@@ -450,3 +449,20 @@ So both halves say the same thing: **serve the dev server on 5173 and set
 shell gets it, so `--vite-port` means what it says; and give Bloom an option that means "ignore
 any dev server", so a run can state which front end it is testing rather than inherit it from
 the machine. (Found 2026-09-02.)
+
+## Typing in a text box raises no key events
+
+`typeInGroup` puts the whole string in with `keyboard.insertText`, which raises `input`
+and nothing else. So no test that types exercises anything in Bloom that listens for
+`keydown`, `keypress` or `keyup`, and the `toHaveText` check that follows cannot tell the
+difference: the text arrives either way. The pieces of Bloom that watch for a particular
+key, rather than for a change to the text, are therefore not covered by any test that
+types.
+
+This is a deliberate trade for speed, taken because a key press per character made every
+test that fills a book slower in proportion to how much it typed. Fix direction: a helper
+that presses one named key in a box, for the tests whose subject is the key press itself
+(Enter splitting a paragraph, Tab moving between boxes, a shortcut), and a note in that
+helper that `typeInGroup` is not the way to test those. (Found 2026-09-02, during the
+review of the headless work.)
+

--- a/src/BloomE2E/helpers/bookMaking.ts
+++ b/src/BloomE2E/helpers/bookMaking.ts
@@ -560,7 +560,16 @@ export async function typeInGroup(
     const box = await clickInGroup(page, groupSelector, languageTag);
     await box.press("Control+a");
     await box.press("Delete");
-    if (text) await box.pressSequentially(text);
+    // One insertion rather than a key press per character: the box has focus, and CKEditor and
+    // Bloom's own markup code both work from the input event this raises, so the result is the
+    // same and the cost does not grow with the length of the text.
+    //
+    // What this does NOT do is raise keydown, keypress or keyup. So a test that types here does
+    // not exercise anything in Bloom that listens for a key rather than for input, and the
+    // assertion below cannot tell the difference. A test whose subject IS a key press needs a
+    // helper of its own that presses that key. (AUTOMATION-DEBT.md: "Typing in a text box raises
+    // no key events".)
+    if (text) await page.keyboard.insertText(text);
     // Bloom's editor reacts to typing; confirm the box holds what we meant before moving on, so a
     // later failure cannot be blamed on text that never arrived.
     await expect(box).toHaveText(text, { timeout: 15000 });


### PR DESCRIPTION
typeInGroup pressed a key per character, so the cost of typing grew with the
length of the text, and every test that fills a book paid it. It now clicks in,
selects all, deletes, and inserts the whole string with keyboard.insertText.
CKEditor and Bloom's own markup code both work from the input event that
raises, so the text arrives the same way, and the toHaveText check after it
still proves so.

The AUTOMATION-DEBT.md entry "Filling a text box directly leaves part of the
old text behind" stays open for the half that is not fixed: clearing a box
still needs Control+A and Delete, because neither fill() nor setting the value
leaves CKEditor in a state Bloom saves correctly.

Adds the entry "Typing in a text box raises no key events", for what this
trades away: insertText raises input and nothing else, so no test that types
covers the parts of Bloom that listen for a particular key, and the assertion
cannot tell the difference. A test whose subject is a key press needs a helper
of its own.

## This is one of eleven stacked pull requests (BL-16799)

Each one pays down one entry of `src/BloomE2E/AUTOMATION-DEBT.md`, and each branches off the one before it. **Base: `BL-16799-vite-port`.** Review only this pull request's own commit; the ones below it are reviewed in their own pull requests. The first six change test and tooling code only; the last five also change product code.

1. `BL-16799-automation-scripts` — Make the bloom-automation scripts safe to ask for help
2. `BL-16799-vr-collect-failures` — Report every failed image comparison in a visual-regression case, not the first
3. `BL-16799-component-tests-in-ci` — Run the component-tester Playwright suites nightly
4. `BL-16799-vite-port` — Let an e2e run test the working tree's front end
5. `BL-16799-type-in-one-call` — Type into a text box in one call, not one key press per character
6. `BL-16799-page-screenshot` — Capture a whole book page from a test
7. `BL-16799-toolbox-registration` — Register the toolbox tools from one list both callers share
8. `BL-16799-shell-document` — Stop a test attaching to a shell document Bloom does not drive
9. `BL-16799-tab-test-ids` — Click a workspace tab by a test id, not by its localized label
10. `BL-16799-page-change` — Refuse a page change the Edit tab cannot do, and wait before asking
11. `BL-16799-collection-languages` — Set a collection's languages through an e2e hook, not by writing XML

Replaces #8276, which did all of this in one pull request.

Verification of the whole stack, at its tip: the C# suite passes (3338 passed, 13 skipped), the front-end vitest suite passes (781 passed, 5 skipped), and the `src/BloomE2E` suite passes against a Vite dev server on the working tree (36 passed, 0 skipped, 8.2 minutes). Each pull request also has its own type check and lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8294)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8294)
<!-- Reviewable:end -->
