### PR TITLE
Capture a whole book page from a test (BL-16799)

### DIFF
--- a/src/BloomE2E/AUTOMATION-DEBT.md
+++ b/src/BloomE2E/AUTOMATION-DEBT.md
@@ -21,7 +21,6 @@ the identity here. Before you start on a marked entry, ask the owner of its bran
 
 | Branch | What it pays down |
 | --- | --- |
-| `BL-16799-page-screenshot` | A helper captures a whole book page, which absorbs the `captureBeyondViewport` footgun. |
 | `BL-16799-toolbox-registration` | One `registerAllToolboxTools()` that both the bootstrap and the test harness call. |
 | `BL-16799-shell-document` | A test can no longer attach to a shell document Bloom does not drive: one WebView2 environment per run, plus the `e2e/shellUrl` hook. |
 | `BL-16799-tab-test-ids` | `data-testid` on the workspace tabs, so no test matches a localized label. |
@@ -177,6 +176,17 @@ being fixed on `BL-16799-toolbox-registration`, which extracts
 `bookEdit/toolbox/registerAllToolboxTools.ts`. The `test.fixme` half is not fixed there; it
 stays as an entry of its own.
 
+## One test's tab is the next test's starting state
+
+`fixtures/bloomTest.ts` launches one Bloom per worker, and Playwright gives every test with the
+same fixture options that same worker. So a test that ends on the Edit tab makes the next one
+start there, and `tests/workspace-tabs.spec.ts` fails its opening sanity check with
+`collection: "enabled"` rather than for any reason to do with tabs. `tests/capture-book-page.spec.ts`
+switches back to the collection tab at its end to avoid exactly this, which is a convention no
+helper enforces and nothing reminds a new test about. Fix direction: reset the workspace in the
+fixture's per-test setup, so the tab a test starts on is not a matter of file order.
+(Found 2026-09-01, when adding capture-book-page.spec.ts broke workspace-tabs.spec.ts.)
+
 ## AI-image-editor selectors are an untested cross-repo contract
 
 `driveAiImageEditor.mjs` drives the `bloom-ai-image-tools` overlay by role/text
@@ -187,23 +197,19 @@ did NOT drift. Fix direction: stable `data-testid`s on tool tiles and category h
 in the editor repo, or have it publish its host-harness selectors for import.
 (Promoted from PAPERCUTS 2026-07-30, BL-16603.)
 
-## Driver-level CDP footguns that the automation library must absorb
+## Driver-level CDP footguns the helper layer does not cover yet
 
-Known WebView2/CDP behaviors that every ad-hoc script rediscovers the hard way; the
-`src/BloomE2E` helper layer should encode them once:
+Known WebView2/CDP behaviors that every ad-hoc script rediscovers the hard way. The screenshot
+one is now absorbed by `helpers/screenshot.ts` (enlarge the window, clip, clear the override,
+and time out every CDP request); these two are not, because they are about the scripts around a
+capture rather than the capture itself:
 
-- `Page.captureScreenshot` with `captureBeyondViewport:true` hangs (no response, no
-  error). Working pattern: `Emulation.setDeviceMetricsOverride` large enough for the
-  whole `.bloom-page`, screenshot with a `clip`, then `clearDeviceMetricsOverride`;
-  give every CDP request a timeout.
-  being fixed on `BL-16799-page-screenshot`, which absorbs this into
-  `helpers/screenshot.ts`. The other two items in this list stay.
 - Never `taskkill //IM node.exe //F` to clean up a hung capture — it kills the go.sh
   vite/dotnet-watch flow and takes Bloom's server down. Kill only the script's own PID.
 - Reopening a book re-stamps it with freshly compiled xmatter CSS from `output/`, so
   "before" captures taken after a restart already show the new layout.
 
-(Promoted from PAPERCUTS 2026-07-22.)
+(Promoted from PAPERCUTS 2026-07-22; the screenshot item removed 2026-09-01.)
 
 ## Visual-regression baselines only match the CI runner
 

--- a/src/BloomE2E/README.md
+++ b/src/BloomE2E/README.md
@@ -104,6 +104,10 @@ real bug in the code under test; read the message and fix it rather than working
 - `helpers/realClick.ts` — `realClick`, `realClickAt`. Book tiles, Settings, and PREVIEW ignore a
   synthetic `element.click()`. Never hand-roll `Input.dispatchMouseEvent` in a test; add the
   gesture here.
+- `helpers/screenshot.ts` — `captureCurrentBookPage`, `captureElement`, `readPngSize`. Captures an
+  element taller than the window. `Page.captureScreenshot` with `captureBeyondViewport` hangs in
+  WebView2, so this enlarges the window, clips, clears the override, and times out every CDP
+  request. Never open a CDP session in a test; add the capture here.
 
 Two things a test must never do: trigger a native OS dialog (file pickers, the WinForms Image
 Toolbox, video capture), because Playwright cannot dismiss one and the run hangs; and wait on a

--- a/src/BloomE2E/helpers/screenshot.ts
+++ b/src/BloomE2E/helpers/screenshot.ts
@@ -1,0 +1,306 @@
+// Capture an image of one element in Bloom's WebView2, including an element taller than the
+// window.
+//
+// A book page is the case that forces this. A `.bloom-page` in the Edit tab is usually taller than
+// the WebView2's window, and the obvious route, `Page.captureScreenshot` with
+// `captureBeyondViewport: true`, hangs in WebView2: no response, no error, and the run dies on a
+// timeout with nothing to read. The pattern that works, and the one this module encodes, is:
+//
+//   1. Enlarge the window with Emulation.setDeviceMetricsOverride, big enough for the whole
+//      element.
+//   2. Measure the element only after that, because enlarging the window re-lays out the page.
+//   3. Screenshot with a `clip` for the element's box.
+//   4. Emulation.clearDeviceMetricsOverride, always, even when the capture failed. A left-over
+//      override leaves the rest of the run driving a Bloom of the wrong size.
+//
+// Every CDP request also gets a timeout, because a WebView2 CDP call that never answers otherwise
+// stops the run rather than failing it. (AUTOMATION-DEBT.md: "Driver-level CDP footguns that the
+// automation library must absorb".)
+//
+// Tests do not open CDP sessions of their own. If you need a capture this file does not do, add it
+// here.
+
+import type { CDPSession, Locator, Page } from "@playwright/test";
+import { editablePageFrame, waitForEditablePage } from "./bookMaking";
+
+/** An element's image, and the size of that image in pixels. */
+export interface IElementImage {
+    /** The PNG bytes. */
+    png: Buffer;
+    /** The image's width in pixels, read from the PNG itself. */
+    width: number;
+    /** The image's height in pixels, read from the PNG itself. */
+    height: number;
+    /**
+     * The element's own box, in CSS pixels, at the moment we captured it. The image should be this
+     * size (to within the rounding CDP does), so a caller can check that it captured the element
+     * rather than the window.
+     */
+    elementWidth: number;
+    /** The element's own height in CSS pixels at the moment we captured it. */
+    elementHeight: number;
+}
+
+/** The CDP method names Playwright's session accepts. */
+type CdpMethod = Parameters<CDPSession["send"]>[0];
+
+/** How long any one CDP request may take before we call the driver stuck. */
+const CDP_TIMEOUT_MS = 30000;
+
+// The largest window we will pretend to have. A book page cannot legitimately need more than this,
+// and an absurd number here would make WebView2 try to allocate an absurd surface.
+const MAX_OVERRIDE_PIXELS = 8000;
+
+/**
+ * Capture the `.bloom-page` the Edit tab is showing.
+ *
+ * This waits for the Edit tab to have a page with editable text in it first, so a caller does not
+ * have to; call goToPage (helpers/bookMaking.ts) first to choose which page.
+ */
+export async function captureCurrentBookPage(
+    page: Page,
+    timeoutMs = 90000,
+): Promise<IElementImage> {
+    await waitForEditablePage(page, timeoutMs);
+    const bloomPage = editablePageFrame(page).locator(".bloom-page").first();
+    return captureElement(bloomPage, timeoutMs);
+}
+
+/**
+ * Capture one element as a PNG, whatever its size, and return the bytes with the image's real
+ * dimensions.
+ *
+ * The element may be inside an iframe: the box is measured in the top document's coordinates,
+ * which is what CDP's clip wants. Fails with a message naming the locator when the element has no
+ * on-screen box, which is what a collapsed or zero-size container looks like from here.
+ */
+export async function captureElement(
+    locator: Locator,
+    timeoutMs = 30000,
+): Promise<IElementImage> {
+    const page = locator.page();
+    await locator.waitFor({ state: "visible", timeout: timeoutMs });
+
+    const session = await page.context().newCDPSession(page);
+    // The capture's own failure, kept so that a cleanup failure on top of it can carry it as a
+    // cause instead of hiding it.
+    let captureError: unknown;
+    try {
+        // How big the window has to be for the whole element to be laid out at once. Ask for the
+        // element's own scroll size, plus where it sits, rather than the document's size: the
+        // document includes page-list thumbnails and other chrome we are not capturing.
+        const wanted = await elementExtent(locator, timeoutMs);
+        // An element bigger than the cap would be clipped to its full box against a window that
+        // was never made large enough, so the image would be a truncated element rather than a
+        // failure, and nothing downstream could tell: the box we measure afterwards is measured
+        // inside the too-small window, so it agrees with the truncated image. Say so instead.
+        if (
+            wanted.right > MAX_OVERRIDE_PIXELS ||
+            wanted.bottom > MAX_OVERRIDE_PIXELS
+        ) {
+            throw new Error(
+                `captureElement cannot capture this element: laying all of it out needs a window ` +
+                    `${Math.ceil(wanted.right)}x${Math.ceil(wanted.bottom)} pixels, and the ` +
+                    `largest this helper will ask WebView2 for is ${MAX_OVERRIDE_PIXELS}. ` +
+                    `Capture a smaller part of it, or raise MAX_OVERRIDE_PIXELS if WebView2 can ` +
+                    `still allocate that.`,
+            );
+        }
+        const viewport = page.viewportSize();
+        const overrideWidth = clampOverride(
+            Math.max(wanted.right, viewport?.width ?? 0),
+        );
+        const overrideHeight = clampOverride(
+            Math.max(wanted.bottom, viewport?.height ?? 0),
+        );
+
+        await sendWithTimeout(session, "Emulation.setDeviceMetricsOverride", {
+            width: overrideWidth,
+            height: overrideHeight,
+            deviceScaleFactor: 1,
+            mobile: false,
+        });
+
+        // Measure only now. Enlarging the window re-lays out the page, and on a book page it
+        // genuinely moves things: the Edit tab centres the page in the space it has.
+        const box = await documentBox(locator, timeoutMs);
+
+        const result = (await sendWithTimeout(
+            session,
+            "Page.captureScreenshot",
+            {
+                format: "png",
+                // No captureBeyondViewport: it hangs in WebView2. The override above is what makes
+                // the whole element fit inside the window instead.
+                clip: {
+                    x: box.x,
+                    y: box.y,
+                    width: box.width,
+                    height: box.height,
+                    scale: 1,
+                },
+            },
+        )) as { data: string };
+
+        const png = Buffer.from(result.data, "base64");
+        const size = readPngSize(png);
+        return {
+            png,
+            width: size.width,
+            height: size.height,
+            elementWidth: box.width,
+            elementHeight: box.height,
+        };
+    } catch (error) {
+        captureError = error;
+        throw error;
+    } finally {
+        // Always, including after a failed capture: the next test in this worker drives the same
+        // Bloom, and an emulated 8000-pixel window would make everything it sees wrong.
+        let clearError: unknown;
+        await sendWithTimeout(
+            session,
+            "Emulation.clearDeviceMetricsOverride",
+            {},
+        ).catch((error) => {
+            clearError = error;
+        });
+        await session.detach().catch(() => undefined);
+
+        if (clearError !== undefined) {
+            // The window is still the size we made it, and the rest of this worker's tests would
+            // measure that Bloom rather than the real one. Fail rather than warn, whether or not
+            // the capture itself got that far: a warning on standard error is easy to miss in a
+            // long run, and every later test in this worker is then wrong.
+            //
+            // When the capture failed too, that error is the one the test author needs to read,
+            // so hand it on as the cause rather than let this one replace it.
+            throw new Error(
+                `captureElement could not clear the window size override, so the rest of this worker's tests would drive a Bloom of the wrong size: ${clearError}`,
+                captureError === undefined
+                    ? undefined
+                    : { cause: captureError },
+            );
+        }
+    }
+}
+
+/**
+ * Keep an override within what WebView2 can reasonably allocate, and never ask for zero.
+ *
+ * The caller checks the element against MAX_OVERRIDE_PIXELS before calling this, so the cap here
+ * only ever applies to the viewport's own size. A silently capped element would be captured
+ * truncated rather than reported.
+ */
+function clampOverride(pixels: number): number {
+    return Math.max(1, Math.min(MAX_OVERRIDE_PIXELS, Math.ceil(pixels)));
+}
+
+/**
+ * How far right and down the element reaches in the top document, counting its own scrollable
+ * content. This is what the window has to be enlarged to before the element is fully laid out.
+ */
+async function elementExtent(
+    locator: Locator,
+    timeoutMs: number,
+): Promise<{ right: number; bottom: number }> {
+    const box = await requireBoundingBox(locator, timeoutMs);
+    const scroll = await locator.evaluate((element) => ({
+        width: element.scrollWidth,
+        height: element.scrollHeight,
+    }));
+    return {
+        right: box.x + Math.max(box.width, scroll.width),
+        bottom: box.y + Math.max(box.height, scroll.height),
+    };
+}
+
+/**
+ * The element's box in the TOP document's coordinates, which is the space CDP's clip is in.
+ * Playwright reports a box relative to the top document's window, so add that window's scroll.
+ */
+async function documentBox(
+    locator: Locator,
+    timeoutMs: number,
+): Promise<{ x: number; y: number; width: number; height: number }> {
+    const box = await requireBoundingBox(locator, timeoutMs);
+    const scroll = await locator.page().evaluate(() => ({
+        x: window.scrollX,
+        y: window.scrollY,
+    }));
+    return {
+        x: box.x + scroll.x,
+        y: box.y + scroll.y,
+        width: box.width,
+        height: box.height,
+    };
+}
+
+/** The element's on-screen box, or an error saying which element had none. */
+async function requireBoundingBox(
+    locator: Locator,
+    timeoutMs: number,
+): Promise<{ x: number; y: number; width: number; height: number }> {
+    const box = await locator.boundingBox({ timeout: timeoutMs });
+    if (!box)
+        throw new Error(
+            `${locator} is visible but has no bounding box, so there is nothing to capture. ` +
+                `It may be inside a collapsed or zero-size container.`,
+        );
+    if (box.width < 1 || box.height < 1)
+        throw new Error(
+            `${locator} measures ${box.width}x${box.height}, which is too small to capture.`,
+        );
+    return box;
+}
+
+/**
+ * Send one CDP request, and fail rather than hang when WebView2 never answers. A CDP call with no
+ * reply is the failure mode this whole module exists to absorb, so it gets its own deadline here
+ * instead of relying on Playwright's test timeout to notice.
+ */
+async function sendWithTimeout<TMethod extends CdpMethod>(
+    session: CDPSession,
+    method: TMethod,
+    params: object,
+): Promise<unknown> {
+    let timer: NodeJS.Timeout | undefined;
+    const expired = new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+            () =>
+                reject(
+                    new Error(
+                        `The CDP request ${method} got no reply within ${CDP_TIMEOUT_MS / 1000}s. ` +
+                            `WebView2 stops answering rather than failing, so treat this as the ` +
+                            `driver being stuck.`,
+                    ),
+                ),
+            CDP_TIMEOUT_MS,
+        );
+    });
+    try {
+        // `as never` only because the two arguments are typed as one pair per method, and this
+        // wrapper is deliberately method-agnostic; the method name itself is still checked.
+        return await Promise.race([
+            session.send(method, params as never),
+            expired,
+        ]);
+    } finally {
+        if (timer) clearTimeout(timer);
+    }
+}
+
+/**
+ * Read a PNG's pixel dimensions out of its header, so a caller can assert on the size of what it
+ * captured without this package depending on an image library.
+ */
+export function readPngSize(png: Buffer): { width: number; height: number } {
+    // 8-byte signature, then a 4-byte length and the "IHDR" tag, then width and height as 32-bit
+    // big-endian integers.
+    const signature = "89504e470d0a1a0a";
+    if (png.length < 24 || png.subarray(0, 8).toString("hex") !== signature)
+        throw new Error(
+            `That is not a PNG: ${png.length} bytes starting ${png.subarray(0, 8).toString("hex")}.`,
+        );
+    return { width: png.readUInt32BE(16), height: png.readUInt32BE(20) };
+}

--- a/src/BloomE2E/tests/capture-book-page.spec.ts
+++ b/src/BloomE2E/tests/capture-book-page.spec.ts
@@ -1,0 +1,53 @@
+// Proves the capture helper works against a real WebView2, on a page taller than the window.
+//
+// This is the test for helpers/screenshot.ts rather than a test of a Bloom behavior. It exists
+// because the driver-level footgun it absorbs is invisible from the outside: the obvious CDP route
+// to this image (captureBeyondViewport) hangs with no error, and nothing else in the suite would
+// notice if the safe pattern stopped working. See AUTOMATION-DEBT.md, "Driver-level CDP footguns
+// that the automation library must absorb".
+//
+// This test has no "[Test Case ID N]" tag because it covers the automation library, not a case in
+// the Notion test inventory.
+
+import * as Path from "node:path";
+import { expect, test } from "../fixtures/bloomTest";
+import { selectBook } from "../helpers/collection";
+import { getPages } from "../helpers/bookMaking";
+import { captureCurrentBookPage } from "../helpers/screenshot";
+import { switchTab } from "../helpers/workspace";
+
+test.use({ collectionName: "basic" });
+
+test("capturing the cover page gives a PNG the size of the page", async ({
+    page,
+    bloomApp,
+}) => {
+    await selectBook(page, Path.join(bloomApp.collectionDir, "A5 Portrait"));
+    await switchTab(page, "edit");
+
+    // Sanity check: the Edit tab opens on the cover, so there is a page to capture and it is the
+    // one this test says it captures.
+    const pages = await getPages(page);
+    expect(pages.length).toBeGreaterThan(0);
+
+    const image = await captureCurrentBookPage(page);
+
+    // Non-empty, and a PNG: readPngSize inside the helper already rejects anything else, so a
+    // plausible byte count is what is left to check.
+    expect(image.png.length).toBeGreaterThan(1000);
+
+    // The image is the page, not the window: its pixels match the element's own box. CDP rounds
+    // the clip, so allow a pixel either way.
+    expect(image.width).toBeGreaterThan(100);
+    expect(image.height).toBeGreaterThan(100);
+    expect(Math.abs(image.width - image.elementWidth)).toBeLessThanOrEqual(1);
+    expect(Math.abs(image.height - image.elementHeight)).toBeLessThanOrEqual(1);
+
+    // A5 Portrait is taller than it is wide, which is the case that needs the window override.
+    expect(image.height).toBeGreaterThan(image.width);
+
+    // Put the workspace back on the collection tab. The launched Bloom is worker-scoped, so every
+    // test with these same options shares it: a test that ends on the Edit tab makes the next one
+    // start there. See AUTOMATION-DEBT.md, "One test's tab is the next test's starting state".
+    await switchTab(page, "collection");
+});

--- a/src/BloomE2E/tests/workspace-tabs.spec.ts
+++ b/src/BloomE2E/tests/workspace-tabs.spec.ts
@@ -22,7 +22,9 @@ test("switching workspace tabs through the real top bar", async ({
     bloomApp,
 }) => {
     // Sanity check the start state, so a failure below means a click failed rather than that we
-    // were already on the tab we were about to click.
+    // were already on the tab we were about to click. This reads the state once rather than waiting
+    // for it: a Bloom that is not on the collection tab here has been left that way by an earlier
+    // test sharing this worker's Bloom, and waiting would only turn that into a slow failure.
     expect((await getTabs(page)).tabStates.collection).toBe("active");
 
     // Setup, not the behavior under test: Bloom hides the Edit and Publish tabs until a book is


### PR DESCRIPTION
Nothing in the suite could produce an image of a book page, and the obvious CDP
route to one is a trap: Page.captureScreenshot with captureBeyondViewport hangs
in WebView2 with no response and no error, so every ad-hoc script rediscovered
that the hard way.

helpers/screenshot.ts now holds the working pattern once:
Emulation.setDeviceMetricsOverride large enough for the whole element, a
screenshot with a clip, then clearDeviceMetricsOverride, with a timeout on
every CDP request. captureCurrentBookPage does the page in the Edit tab,
captureElement does any element, and readPngSize reads the size back out of the
PNG bytes.

tests/capture-book-page.spec.ts is the test for the helper rather than for a
Bloom behavior: it captures the A5 Portrait cover, which is taller than the
window, and checks the image is a PNG the size of the page. Without it, the
pattern could stop working and nothing would notice. It has no Notion test case
id, because it covers the automation library.

Trims the AUTOMATION-DEBT.md entry "Driver-level CDP footguns that the
automation library must absorb" to the two items that are still not absorbed,
and renames it to say so.

Adds the entry "One test's tab is the next test's starting state": the launched
Bloom is worker-scoped, so this new test leaving the Edit tab open broke
workspace-tabs.spec.ts on its opening sanity check. This test switches back to
the collection tab at its end, and workspace-tabs.spec.ts now says in a comment
why it reads the tab state rather than waiting for it. Neither is enforced by
anything, which is what the entry asks for.

## This is one of eleven stacked pull requests (BL-16799)

Each one pays down one entry of `src/BloomE2E/AUTOMATION-DEBT.md`, and each branches off the one before it. **Base: `BL-16799-type-in-one-call`.** Review only this pull request's own commit; the ones below it are reviewed in their own pull requests. The first six change test and tooling code only; the last five also change product code.

1. `BL-16799-automation-scripts` — Make the bloom-automation scripts safe to ask for help
2. `BL-16799-vr-collect-failures` — Report every failed image comparison in a visual-regression case, not the first
3. `BL-16799-component-tests-in-ci` — Run the component-tester Playwright suites nightly
4. `BL-16799-vite-port` — Let an e2e run test the working tree's front end
5. `BL-16799-type-in-one-call` — Type into a text box in one call, not one key press per character
6. `BL-16799-page-screenshot` — Capture a whole book page from a test
7. `BL-16799-toolbox-registration` — Register the toolbox tools from one list both callers share
8. `BL-16799-shell-document` — Stop a test attaching to a shell document Bloom does not drive
9. `BL-16799-tab-test-ids` — Click a workspace tab by a test id, not by its localized label
10. `BL-16799-page-change` — Refuse a page change the Edit tab cannot do, and wait before asking
11. `BL-16799-collection-languages` — Set a collection's languages through an e2e hook, not by writing XML

Replaces #8276, which did all of this in one pull request.

Verification of the whole stack, at its tip: the C# suite passes (3338 passed, 13 skipped), the front-end vitest suite passes (781 passed, 5 skipped), and the `src/BloomE2E` suite passes against a Vite dev server on the working tree (36 passed, 0 skipped, 8.2 minutes). Each pull request also has its own type check and lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8295)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8295)
<!-- Reviewable:end -->
