### PR TITLE
Register the toolbox tools from one list both callers share (BL-16799)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/registerAllToolboxTools.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/registerAllToolboxTools.ts
@@ -1,0 +1,89 @@
+// The one list of the tools that belong in the Edit tab's toolbox.
+//
+// ToolboxRoot renders a section only for a tool that is in the master tool list, and a tool gets
+// there by being registered. In the running app that used to happen as a side effect of loading
+// toolboxBootstrap.ts, which also renders its own toolbox root and assigns window.toolboxBundle.
+// A test harness cannot afford those side effects, so it duplicated the list with a "keep in
+// sync" comment. This module is the list, and nothing else: importing it registers nothing, and
+// both toolboxBootstrap.ts and react_components/ToolboxRootTestHarness call the function below.
+// (AUTOMATION-DEBT.md: "Toolbox tool registration is a side effect of toolboxBootstrap".)
+
+import { ITool, ToolBox, getMasterToolList } from "./toolbox";
+import {
+    kCanvasToolId,
+    kGameToolId,
+    kMotionToolId,
+    kMusicToolId,
+} from "./toolIds";
+import { DecodableReaderTool } from "./readers/decodableReader/decodableReaderTool";
+import { LeveledReaderTool } from "./readers/leveledReader/leveledReaderTool";
+import { MusicToolAdaptor } from "./music/musicToolControls";
+import { ImpairmentVisualizerAdaptor } from "./impairmentVisualizer/impairmentVisualizer";
+import { MotionTool } from "./motion/motionTool";
+import TalkingBookTool from "./talkingBook/talkingBookTool";
+import { SignLanguageTool } from "./signLanguage/signLanguageTool";
+import { ImageDescriptionAdapter } from "./imageDescription/imageDescription";
+import { CanvasTool } from "./canvas/canvasTool";
+import { GameTool } from "./games/GameTool";
+import { SettingsTool } from "./settings/settingsTool";
+
+/**
+ * Make the one instance of each toolbox class and register it with the master toolbox. The
+ * imports above also serve to ensure that each tool's code is part of the bundle.
+ *
+ * Calling this twice registers nothing the second time, and makes no second instance either. See
+ * registerOnce for both.
+ */
+export function registerAllToolboxTools(): void {
+    registerOnce("decodableReader", () => new DecodableReaderTool());
+    registerOnce("leveledReader", () => new LeveledReaderTool());
+    registerOnce(kMusicToolId, () => new MusicToolAdaptor());
+    registerOnce(
+        "impairmentVisualizer",
+        () => new ImpairmentVisualizerAdaptor(),
+    );
+    registerOnce(kMotionToolId, () => new MotionTool());
+    registerOnce("talkingBook", () => new TalkingBookTool());
+    registerOnce("signLanguage", () => new SignLanguageTool());
+    registerOnce(
+        ImageDescriptionAdapter.kToolID,
+        () => new ImageDescriptionAdapter(),
+    );
+    registerOnce(kCanvasToolId, () => new CanvasTool());
+    registerOnce(kGameToolId, () => new GameTool());
+    registerOnce("settings", () => new SettingsTool());
+}
+
+/**
+ * Register one tool, unless the master list already has a tool of that id.
+ *
+ * ToolBox.registerTool is a bare push with no check for duplicates, so something has to do the
+ * check. It reads the shared master list rather than a flag in this module because a caller that
+ * is a React-Refresh boundary re-executes its own module during `pnpm dev` while masterToolList,
+ * which lives in toolbox.ts, keeps its entries. A flag here would reset and we would get eleven
+ * duplicate tools and duplicate accordion sections.
+ *
+ * The check is per tool, not "is the list empty": a list holding some other tool is not evidence
+ * that these eleven are registered, and skipping all of them on that evidence would leave the
+ * toolbox missing every section.
+ *
+ * The caller passes the id and a factory rather than a tool, so that a tool the list already has
+ * is never constructed. CanvasTool and GameTool each point a static field at the instance being
+ * constructed (CanvasTool.theOneCanvasTool, GameTool.theOneDragActivityTool), so constructing one
+ * only to discard it as a duplicate leaves every reader of that field holding a tool the toolbox
+ * does not know about, and a canvas refresh or a game's state then goes nowhere.
+ */
+function registerOnce(id: string, makeTool: () => ITool): void {
+    if (getMasterToolList().some((registered) => registered.id() === id))
+        return;
+    const tool = makeTool();
+    // The id above has to be the tool's own, or the duplicate check reads the wrong entry and a
+    // second call registers the tool again. Some of these tools name their id in a constant and
+    // some in a string literal, so nothing but this check ties the two together.
+    if (tool.id() !== id)
+        throw new Error(
+            `registerAllToolboxTools names the tool "${id}", but the tool calls itself ` +
+                `"${tool.id()}".`,
+        );
+    ToolBox.registerTool(tool);
+}

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolboxBootstrap.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolboxBootstrap.ts
@@ -10,18 +10,10 @@ import {
 import { simulateBlurOnPageFrameMouseDown } from "../../utils/menuCloseOnBlur";
 import { getTheOneReaderToolsModel } from "./readers/readerToolsModel";
 import { ToolBox } from "./toolbox";
-import { DecodableReaderTool } from "./readers/decodableReader/decodableReaderTool";
-import { LeveledReaderTool } from "./readers/leveledReader/leveledReaderTool";
-import { MusicToolAdaptor } from "./music/musicToolControls";
-import { ImpairmentVisualizerAdaptor } from "./impairmentVisualizer/impairmentVisualizer";
-import { MotionTool } from "./motion/motionTool";
 import TalkingBookTool from "./talkingBook/talkingBookTool";
-import { SignLanguageTool } from "./signLanguage/signLanguageTool";
-import { ImageDescriptionAdapter } from "./imageDescription/imageDescription";
 import "errorHandler";
-import { CanvasTool } from "./canvas/canvasTool";
-import { GameTool, setActiveDragActivityTab } from "./games/GameTool";
-import { SettingsTool } from "./settings/settingsTool";
+import { setActiveDragActivityTab } from "./games/GameTool";
+import { registerAllToolboxTools } from "./registerAllToolboxTools";
 // Explicit imports needed so that these symbols are in local scope for the window.toolboxBundle object
 import {
     addWordListChangedListener,
@@ -120,20 +112,10 @@ $(document).ready(() => {
     getTheOneToolbox().initialize();
 });
 
-// Make the one instance of each Toolbox class and register it with the master toolbox.
-// The imports we need to make these calls possible also serve to ensure that each
-// toolbox's code is made part of the bundle.
-ToolBox.registerTool(new DecodableReaderTool());
-ToolBox.registerTool(new LeveledReaderTool());
-ToolBox.registerTool(new MusicToolAdaptor());
-ToolBox.registerTool(new ImpairmentVisualizerAdaptor());
-ToolBox.registerTool(new MotionTool());
-ToolBox.registerTool(new TalkingBookTool());
-ToolBox.registerTool(new SignLanguageTool());
-ToolBox.registerTool(new ImageDescriptionAdapter());
-ToolBox.registerTool(new CanvasTool());
-ToolBox.registerTool(new GameTool());
-ToolBox.registerTool(new SettingsTool());
+// Make the one instance of each Toolbox class and register it with the master toolbox. The list
+// lives in registerAllToolboxTools.ts, which the test harness imports as well, so there is only
+// one list to keep right.
+registerAllToolboxTools();
 
 const toolboxBundle: ToolboxBundleApi = {
     getTheOneToolbox,

--- a/src/BloomBrowserUI/react_components/ToolboxRootTestHarness/ToolboxRootTestHarness.tsx
+++ b/src/BloomBrowserUI/react_components/ToolboxRootTestHarness/ToolboxRootTestHarness.tsx
@@ -1,47 +1,15 @@
 import * as React from "react";
 import { ToolboxRoot } from "../../bookEdit/toolbox/ToolboxRoot";
-import { ToolBox, getMasterToolList } from "../../bookEdit/toolbox/toolbox";
-import { DecodableReaderTool } from "../../bookEdit/toolbox/readers/decodableReader/decodableReaderTool";
-import { LeveledReaderTool } from "../../bookEdit/toolbox/readers/leveledReader/leveledReaderTool";
-import { MusicToolAdaptor } from "../../bookEdit/toolbox/music/musicToolControls";
-import { ImpairmentVisualizerAdaptor } from "../../bookEdit/toolbox/impairmentVisualizer/impairmentVisualizer";
-import { MotionTool } from "../../bookEdit/toolbox/motion/motionTool";
-import TalkingBookTool from "../../bookEdit/toolbox/talkingBook/talkingBookTool";
-import { SignLanguageTool } from "../../bookEdit/toolbox/signLanguage/signLanguageTool";
-import { ImageDescriptionAdapter } from "../../bookEdit/toolbox/imageDescription/imageDescription";
-import { CanvasTool } from "../../bookEdit/toolbox/canvas/canvasTool";
-import { GameTool } from "../../bookEdit/toolbox/games/GameTool";
-import { SettingsTool } from "../../bookEdit/toolbox/settings/settingsTool";
+import { registerAllToolboxTools } from "../../bookEdit/toolbox/registerAllToolboxTools";
 
 // ToolboxRoot only renders a section for a tool that is in the master tool list, and tools
-// put themselves there by being registered. In the running app that happens as a side effect
-// of loading toolboxBootstrap. We deliberately do NOT import that module here: besides
-// registering tools it also renders its own toolbox root on $(document).ready and assigns
-// window.toolboxBundle, which would both duplicate the root this harness renders and
-// overwrite the toolboxBundle stub some tests install. So we register the same set of tools
-// ourselves. Keep this list in sync with toolboxBootstrap.ts.
-// The guard keys off the shared master list rather than a module-local flag on purpose.
-// This file is a valid React-Refresh boundary (its only export is a component), so editing
-// it during `pnpm dev` re-executes this module without reloading the page. A module-local
-// flag would reset to false while masterToolList — which lives in toolbox.ts and is not
-// invalidated — kept its entries, and ToolBox.registerTool is a bare push with no dedupe,
-// so we would end up with 11 duplicate tools and duplicate accordion sections.
-function registerToolsOnce() {
-    if (getMasterToolList().length > 0) return;
-    ToolBox.registerTool(new DecodableReaderTool());
-    ToolBox.registerTool(new LeveledReaderTool());
-    ToolBox.registerTool(new MusicToolAdaptor());
-    ToolBox.registerTool(new ImpairmentVisualizerAdaptor());
-    ToolBox.registerTool(new MotionTool());
-    ToolBox.registerTool(new TalkingBookTool());
-    ToolBox.registerTool(new SignLanguageTool());
-    ToolBox.registerTool(new ImageDescriptionAdapter());
-    ToolBox.registerTool(new CanvasTool());
-    ToolBox.registerTool(new GameTool());
-    ToolBox.registerTool(new SettingsTool());
-}
-
-registerToolsOnce();
+// put themselves there by being registered. In the running app that happens when
+// toolboxBootstrap.ts calls registerAllToolboxTools. We deliberately do NOT import
+// toolboxBootstrap here: besides registering tools it also renders its own toolbox root on
+// $(document).ready and assigns window.toolboxBundle, which would both duplicate the root this
+// harness renders and overwrite the toolboxBundle stub some tests install. So we call the shared
+// registration function, which is side-effect-free to import and safe to call twice.
+registerAllToolboxTools();
 
 export const ToolboxRootTestHarness: React.FunctionComponent = () => {
     return <ToolboxRoot />;

--- a/src/BloomE2E/AUTOMATION-DEBT.md
+++ b/src/BloomE2E/AUTOMATION-DEBT.md
@@ -21,7 +21,6 @@ the identity here. Before you start on a marked entry, ask the owner of its bran
 
 | Branch | What it pays down |
 | --- | --- |
-| `BL-16799-toolbox-registration` | One `registerAllToolboxTools()` that both the bootstrap and the test harness call. |
 | `BL-16799-shell-document` | A test can no longer attach to a shell document Bloom does not drive: one WebView2 environment per run, plus the `e2e/shellUrl` hook. |
 | `BL-16799-tab-test-ids` | `data-testid` on the workspace tabs, so no test matches a localized label. |
 | `BL-16799-page-change` | `editView/jumpToPage` refuses a jump it cannot do, and every page-changing helper waits for the Edit tab to settle. |
@@ -160,21 +159,16 @@ inline), so `src/BloomE2E/helpers/pageThumbnails.ts` has to find "Copy Page" and
 by their English labels, exactly as the top bar does. Same fix: a `data-testid` per command,
 taken from the `commandId` the menu already has.
 
-## Toolbox tool registration is a side effect of toolboxBootstrap
+## One toolbox harness test asserts on classes that do not exist
 
-`ToolboxRoot` only renders tools registered via importing `toolboxBootstrap.ts`, which
-also renders and clobbers globals, so the test harness duplicates the 11
-`ToolBox.registerTool(...)` calls with a "keep in sync" comment. Fix direction: extract
-a side-effect-free `registerAllToolboxTools()` both import — probably folded into the
-toolbox React refactor (BL-16608 / PR #8109). Related: one harness test is `test.fixme`
-because it asserts on `.subscription-badge` (legacy-toolbox-only) and
-`.toolbox-react-header-icon` (never existed); re-enabling it needs a decision on whether
-the React header renders badges/icons and what classes to expose.
-(Promoted from PAPERCUTS 2026-07-27.)
-
-being fixed on `BL-16799-toolbox-registration`, which extracts
-`bookEdit/toolbox/registerAllToolboxTools.ts`. The `test.fixme` half is not fixed there; it
-stays as an entry of its own.
+`react_components/ToolboxRootTestHarness`'s suite has one `test.fixme` because it asserts on
+`.subscription-badge` (which only the legacy toolbox has) and `.toolbox-react-header-icon` (which
+never existed). Re-enabling it needs a decision on whether the React toolbox header renders
+badges and icons at all, and what classes to expose for them. Fix direction: make that decision
+as part of the toolbox React refactor (BL-16608 / PR #8109), then rewrite the assertions against
+what the header really renders.
+(Was part of a larger entry about toolbox registration, whose other half was fixed 2026-09-01 by
+extracting `bookEdit/toolbox/registerAllToolboxTools.ts`.)
 
 ## One test's tab is the next test's starting state
 


### PR DESCRIPTION
ToolboxRoot renders a section only for a tool that is in the master tool list,
and a tool gets there by being registered. That happened as a side effect of
loading toolboxBootstrap.ts, which also renders its own toolbox root and
assigns window.toolboxBundle. A test harness cannot afford those side effects,
so react_components/ToolboxRootTestHarness duplicated all eleven
ToolBox.registerTool calls with a "keep this in sync" comment.

bookEdit/toolbox/registerAllToolboxTools.ts is now that list and nothing else:
importing it registers nothing, and both toolboxBootstrap.ts and the harness
call registerAllToolboxTools().

Calling it twice registers nothing the second time. The check is per tool
rather than "is the list empty", because a list holding some other tool is no
evidence that these eleven are registered, and skipping them all on that
evidence would leave the toolbox with no sections at all. It reads the shared
master list rather than a flag in the module, because a caller that is a
React-Refresh boundary re-executes its own module during pnpm dev while
masterToolList keeps its entries.

The caller passes an id and a factory rather than a tool, so a tool the list
already has is never constructed: CanvasTool and GameTool each point a static
field at the instance being constructed, so building one only to discard it as
a duplicate would leave every reader of that field holding a tool the toolbox
does not know about.

Each id is checked against the tool's own id() at registration, because some of
these tools name their id in a constant and some in a string literal, and
nothing else ties the two together. That check earns its keep: it caught
SignLanguageTool.kToolID, which does not exist, the static belonging to
SignLanguageToolControls.

The AUTOMATION-DEBT.md entry becomes "One toolbox harness test asserts on
classes that do not exist", which is the half of it this does not fix.

Verified: the ToolboxRootTestHarness Playwright suite passes, 7 passed and 1
skipped, which is the test.fixme in that entry. Type check and lint clean.

## This is one of eleven stacked pull requests (BL-16799)

Each one pays down one entry of `src/BloomE2E/AUTOMATION-DEBT.md`, and each branches off the one before it. **Base: `BL-16799-page-screenshot`.** Review only this pull request's own commit; the ones below it are reviewed in their own pull requests. The first six change test and tooling code only; the last five also change product code.

1. `BL-16799-automation-scripts` — Make the bloom-automation scripts safe to ask for help
2. `BL-16799-vr-collect-failures` — Report every failed image comparison in a visual-regression case, not the first
3. `BL-16799-component-tests-in-ci` — Run the component-tester Playwright suites nightly
4. `BL-16799-vite-port` — Let an e2e run test the working tree's front end
5. `BL-16799-type-in-one-call` — Type into a text box in one call, not one key press per character
6. `BL-16799-page-screenshot` — Capture a whole book page from a test
7. `BL-16799-toolbox-registration` — Register the toolbox tools from one list both callers share
8. `BL-16799-shell-document` — Stop a test attaching to a shell document Bloom does not drive
9. `BL-16799-tab-test-ids` — Click a workspace tab by a test id, not by its localized label
10. `BL-16799-page-change` — Refuse a page change the Edit tab cannot do, and wait before asking
11. `BL-16799-collection-languages` — Set a collection's languages through an e2e hook, not by writing XML

Replaces #8276, which did all of this in one pull request.

Verification of the whole stack, at its tip: the C# suite passes (3338 passed, 13 skipped), the front-end vitest suite passes (781 passed, 5 skipped), and the `src/BloomE2E` suite passes against a Vite dev server on the working tree (36 passed, 0 skipped, 8.2 minutes). Each pull request also has its own type check and lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8296)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8296)
<!-- Reviewable:end -->
