### PR TITLE
Stop a test attaching to a shell document Bloom does not drive (BL-16799)

### DIFF
--- a/src/BloomBrowserUI/react_components/TopBar/TopBar.tsx
+++ b/src/BloomBrowserUI/react_components/TopBar/TopBar.tsx
@@ -130,6 +130,10 @@ export const TopBar: React.FunctionComponent = () => {
         <ScopedCssBaseline>
             <div
                 ref={topBarRef}
+                // How automation recognizes Bloom's shell document among the WebView2's CDP
+                // targets, and the one stable marker on the top bar as a whole. See
+                // src/BloomE2E/fixtures/bloomTest.ts (SHELL_MARKER).
+                data-testid="workspace-top-bar"
                 css={css`
                     background-color: ${getColorForTab(activeTab)};
                     padding-top: 2px;

--- a/src/BloomE2E/AUTOMATION-DEBT.md
+++ b/src/BloomE2E/AUTOMATION-DEBT.md
@@ -21,7 +21,6 @@ the identity here. Before you start on a marked entry, ask the owner of its bran
 
 | Branch | What it pays down |
 | --- | --- |
-| `BL-16799-shell-document` | A test can no longer attach to a shell document Bloom does not drive: one WebView2 environment per run, plus the `e2e/shellUrl` hook. |
 | `BL-16799-tab-test-ids` | `data-testid` on the workspace tabs, so no test matches a localized label. |
 | `BL-16799-page-change` | `editView/jumpToPage` refuses a jump it cannot do, and every page-changing helper waits for the Edit tab to settle. |
 | `BL-16799-collection-languages` | The `e2e/setCollectionLanguages` hook, so no test composes `.bloomCollection` XML. |
@@ -143,15 +142,14 @@ nowhere in the source, so `bloom-exe-tabs.uitest.ts` cannot have worked for some
 (it needs a developer's Bloom already running, and nothing runs it in CI — see the entry
 below); and `src/BloomE2E/helpers/workspace.ts` has to map tab ids to the English labels
 "Collections"/"Edit"/"Publish", so the suite silently only works in an English UI —
-which rules out automating the UI-language cases. The same gap makes the fixture
-identify Bloom's shell document among the CDP page targets by `[role="tablist"]`, the
-only stable marker available. Fix direction: `data-testid="workspace-tab-collection"`
-(etc.) on each tab and one on the shell root, and drop the label matching.
+which rules out automating the UI-language cases. Fix direction:
+`data-testid="workspace-tab-collection"` (etc.) on each tab, and drop the label matching.
+The shell root has its own test id as of 2026-09-01, so the fixture no longer identifies
+Bloom's shell document by `[role="tablist"]`.
 (Found 2026-09-01 while scaffolding src/BloomE2E.)
 
-being fixed on two branches: `BL-16799-shell-document` puts a test id on the top bar and
-stops the fixture identifying the shell document by `[role="tablist"]`, and
-`BL-16799-tab-test-ids` puts one on each tab and drops the label matching.
+being fixed on `BL-16799-tab-test-ids`, which puts a test id on each tab and drops the
+label matching.
 
 seen again 2026-09-01, in the Edit tab's page thumbnail menu: the items
 `pageThumbnailList.tsx` renders carry no id, class or `data-testid` (all their styling is
@@ -465,4 +463,33 @@ that presses one named key in a box, for the tests whose subject is the key pres
 (Enter splitting a paragraph, Tab moving between boxes, a shortcut), and a note in that
 helper that `typeInGroup` is not the way to test those. (Found 2026-09-02, during the
 review of the headless work.)
+
+
+## A test can attach to a shell document Bloom does not drive
+
+More than one document in a run carries the workspace root's markup, and therefore the
+top bar's `data-testid`, so `fixtures/bloomTest.ts findShellPage` returns whichever the
+debugging protocol lists first. When that is not the document Bloom drives, the test is
+silently broken rather than failing: its own clicking and typing work, `expect` on what
+it typed passes, and every page Bloom loads goes into the document it cannot see. The
+symptom is a 60-second wait in `goToPage` for a page Bloom's own log says it showed.
+This is why `publish-text-languages.spec.ts` fails perhaps one run in three.
+
+Fixed for tests, 2026-09-01. `e2e/shellUrl` reports the URL of the document Bloom drives,
+and `findShellPage` now takes the page whose URL has the same file name (Bloom and the
+debugging protocol escape the rest of the URL differently), re-resolving after
+`bloomApp.restart`. It falls back to the first page carrying the marker only when the
+endpoint never answers, which is what an old `Bloom.exe` in `output/Debug` does, and says
+so. `goToPage`'s failure message names both URLs. Also, under `--e2e` every browser built
+on the UI thread shares one CoreWebView2Environment, so those documents live in one
+browser process with one debugging listener; before that, each environment was given the
+same port number and only the first process to start could listen on it. That sharing is
+deliberately limited to the UI thread: an environment belongs to the thread that created
+it, and handing it to a browser built on the thread serving an API call hangs that thread.
+Publishing a BloomPUB does exactly that, and its preview never appeared.
+
+What remains: nobody knows why a run has a second workspace root document at all. Bloom
+creates one `_workspaceReactControl`. Worth finding, because the duplicate is what makes
+the test-side check necessary.
+(Found 2026-09-01 while making `jumpToPage` queue a jump.)
 

--- a/src/BloomE2E/fixtures/bloomTest.ts
+++ b/src/BloomE2E/fixtures/bloomTest.ts
@@ -86,8 +86,27 @@ const SHELL_READY_TIMEOUT_MS = 90000;
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-// How we recognize Bloom's shell document: it is the page holding the top bar's tab strip.
-const SHELL_MARKER = '[role="tablist"]';
+// How we recognize a candidate for Bloom's shell document: it is a page holding the top bar, which
+// carries this test id (react_components/TopBar/TopBar.tsx).
+const SHELL_MARKER = '[data-testid="workspace-top-bar"]';
+
+// Bloom's own answer to "which document are you driving?". The endpoint exists only under --e2e,
+// and reports the URL of the shell browser the C# side sends its commands to
+// (E2eTestingApi.HandleGetShellUrl).
+const SHELL_URL_ENDPOINT = "e2e/shellUrl";
+
+/**
+ * The file name part of a shell URL, e.g. "bloom45mgnfsl.htm" from
+ * "http://localhost:8095/bloom/C$3A/.../bloom45mgnfsl.htm?x=1". Bloom names each shell document
+ * after a temp file, so the file name identifies the document while the query string does not:
+ * the workspace rewrites its own query as the user moves around (updateWorkspaceUrlParam).
+ */
+function shellDocumentName(url: string): string {
+    const withoutQuery = url.split(/[?#]/)[0];
+    return withoutQuery
+        .substring(withoutQuery.lastIndexOf("/") + 1)
+        .toLowerCase();
+}
 
 /**
  * Connect to the WebView2's CDP endpoint, retrying while it comes up. Bloom's HTTP API reports
@@ -113,34 +132,90 @@ async function connectOverCdpWithRetry(cdpPort: number): Promise<Browser> {
 }
 
 /**
- * Find Bloom's shell document among the CDP page targets. We identify it by the top bar's tab
- * strip rather than by URL, which also excludes the separately-hosted problem dialog and any
- * DevTools target. Polling matters: the WebView2 target exists, as about:blank, for a second or
- * two before Bloom navigates it to the shell, and the React top bar mounts later still.
+ * Find the shell document Bloom is actually driving, among the CDP page targets.
+ *
+ * Two tests are applied, and both are needed. The top bar's test id finds the candidates, which
+ * also excludes the separately-hosted problem dialog and any DevTools target; then Bloom itself is
+ * asked which document it drives, and only that one is returned. The marker alone is not enough:
+ * a run can expose more than one workspace-root document, and attaching to an undriven one costs
+ * an hour, because the test's own clicks work while nothing Bloom loads ever appears (see
+ * AUTOMATION-DEBT.md). The hook alone is not enough either: it answers "" until the workspace
+ * view has built its browser, and an older Bloom.exe in output/Debug does not have the endpoint at
+ * all, so the marker match stays as the fallback for a hook that never answers.
+ *
+ * Polling matters: the WebView2 target exists, as about:blank, for a second or two before Bloom
+ * navigates it to the shell, and the React top bar mounts later still.
  */
-async function findShellPage(browser: Browser): Promise<Page> {
+async function findShellPage(
+    browser: Browser,
+    httpPort: number,
+): Promise<Page> {
     const deadline = Date.now() + SHELL_READY_TIMEOUT_MS;
     let lastUrls: string[] = [];
+    let markerOnlyMatch: Page | undefined;
+    let hookEverAnswered = false;
     while (Date.now() < deadline) {
         const pages = browser
             .contexts()
             .flatMap((context) => context.pages())
-            .filter((page) => !page.url().startsWith("devtools://"));
+            .filter((page) => !page.url().startsWith("devtools://"))
+            // Keep only this Bloom's own documents. Another Bloom (another worktree, or the
+            // developer's) can answer on this CDP port, and its pages carry the same marker and
+            // answer the same hook, so a page from a different HTTP port must not win.
+            .filter(
+                (page) =>
+                    !page.url().startsWith("http") ||
+                    page.url().includes(`:${httpPort}/`),
+            );
         lastUrls = pages.map((page) => page.url());
         for (const page of pages) {
-            const hasTabs = await page
+            const hasTopBar = await page
                 .evaluate(
                     (marker) => !!document.querySelector(marker),
                     SHELL_MARKER,
                 )
                 .catch(() => false);
-            if (hasTabs) return page;
+            if (!hasTopBar) continue;
+            if (!markerOnlyMatch) markerOnlyMatch = page;
+            const drivenUrl = await page
+                .evaluate(async (endpoint) => {
+                    const response = await fetch(`/bloom/api/${endpoint}`);
+                    return response.ok ? await response.text() : "";
+                }, SHELL_URL_ENDPOINT)
+                .catch(() => "");
+            if (!drivenUrl) continue;
+            hookEverAnswered = true;
+            if (shellDocumentName(drivenUrl) === shellDocumentName(page.url()))
+                return page;
         }
         await delay(500);
     }
+    // Re-check it before handing it back. It was found on some earlier turn of the loop, possibly
+    // ninety seconds ago, and Bloom navigates the shell target while it starts up, so by now the
+    // page may be gone.
+    if (markerOnlyMatch) {
+        const stillThere = await markerOnlyMatch
+            .evaluate(
+                (marker) => !!document.querySelector(marker),
+                SHELL_MARKER,
+            )
+            .catch(() => false);
+        if (!stillThere) markerOnlyMatch = undefined;
+    }
+    if (markerOnlyMatch && !hookEverAnswered) {
+        console.warn(
+            `Bloom never answered ${SHELL_URL_ENDPOINT}, so the shell document was chosen by ` +
+                `${SHELL_MARKER} alone. If this test fails oddly, check that output/Debug holds a ` +
+                `Bloom.exe new enough to have that endpoint.`,
+        );
+        return markerOnlyMatch;
+    }
     throw new Error(
-        `Bloom's WebView2 never exposed a page containing ${SHELL_MARKER} within ` +
-            `${SHELL_READY_TIMEOUT_MS / 1000}s. Targets seen: ${lastUrls.join(", ") || "none"}.`,
+        `Bloom's WebView2 never exposed the shell document it is driving within ` +
+            `${SHELL_READY_TIMEOUT_MS / 1000}s. Pages carrying ${SHELL_MARKER} were ` +
+            `${markerOnlyMatch ? "found" : "not found"}; ${SHELL_URL_ENDPOINT} ` +
+            `${hookEverAnswered ? "answered, but named a different document" : "never answered"}. ` +
+            `Targets seen: ${lastUrls.join(", ") || "none"}.`,
     );
 }
 
@@ -165,7 +240,7 @@ export const test = base.extend<IBloomTestFixtures, IBloomWorkerFixtures>({
                 // rejects a 127.0.0.1 Host header. See helpers/api.ts.)
                 browser = await connectOverCdpWithRetry(launched.cdpPort);
                 const bloomApp: IBloomApp = {
-                    page: await findShellPage(browser),
+                    page: await findShellPage(browser, launched.httpPort),
                     httpPort: launched.httpPort,
                     cdpPort: launched.cdpPort,
                     bloomPid: launched.bloomPid,
@@ -179,7 +254,12 @@ export const test = base.extend<IBloomTestFixtures, IBloomWorkerFixtures>({
                         browser = await connectOverCdpWithRetry(
                             launched!.cdpPort,
                         );
-                        bloomApp.page = await findShellPage(browser);
+                        // Resolve the shell again: the restarted Bloom has a new shell document,
+                        // and the old page object points at a dead target.
+                        bloomApp.page = await findShellPage(
+                            browser,
+                            launched!.httpPort,
+                        );
                         bloomApp.httpPort = launched!.httpPort;
                         bloomApp.cdpPort = launched!.cdpPort;
                         bloomApp.bloomPid = launched!.bloomPid;

--- a/src/BloomExe/WebView2Browser.cs
+++ b/src/BloomExe/WebView2Browser.cs
@@ -309,6 +309,12 @@ namespace Bloom
         private static bool _useSharedEnvironment;
         private static CoreWebView2Environment _sharedEnvironment;
 
+        // The one environment every browser of an e2e run shares, so the run has a single browser
+        // process and therefore a single remote-debugging listener. See where it is used in
+        // InitWebView. Like the statics above it is unsynchronized, which is safe for the same
+        // reason: browser construction is marshalled to the UI thread.
+        private static CoreWebView2Environment _environmentForE2eTests;
+
         public static void BeginSharedEnvironmentBatch()
         {
             AssertSharedEnvironmentStaticsAreUiThreadOnly();
@@ -484,6 +490,21 @@ namespace Bloom
             //  - _sharedEnvironment: the legacy on-UI-thread shared-environment batch (BookProcessor's old path).
             // Otherwise we fall through and create a fresh one.
             var env = _injectedEnvironment ?? (_useSharedEnvironment ? _sharedEnvironment : null);
+            // An e2e run attaches a test to ONE of these browser processes over the remote debugging
+            // port, and every environment we create is given that same port number, so only the
+            // process that starts first can listen on it. Which one that is depends on startup
+            // timing, so a test could attach to a browser Bloom is not driving: its scripts appeared
+            // to run (ExecuteScriptAsync reported success against the browser Bloom does drive)
+            // while the document the test was watching never changed. One environment for the whole
+            // run means one browser process, one listener, and every document visible to the test.
+            //
+            // Only for browsers built on the UI thread, which is every browser a test can see. A
+            // CoreWebView2Environment belongs to the thread that created it, so handing this one to
+            // a browser built on a server thread hangs that thread: publishing a BloomPUB, which
+            // makes its browsers on the thread serving the API call, waited forever and the preview
+            // never appeared.
+            if (env == null && Program.RunningE2eTests && Program.RunningOnUiThread)
+                env = _environmentForE2eTests;
             if (env == null)
             {
                 string dataFolder;
@@ -503,6 +524,18 @@ namespace Bloom
                 );
                 if (_useSharedEnvironment)
                     _sharedEnvironment = env;
+                // Only keep it when it actually carries a debugging port. The port lives in the
+                // options, which are fixed when the environment is made, so an environment built
+                // before BloomServer had its port would have none, and every UI-thread browser
+                // after it would inherit that: no browser in the run would ever listen, and the
+                // suite would report a startup timeout rather than a reason. No browser is built
+                // that early today, and this keeps it that way if one ever is.
+                if (
+                    Program.RunningE2eTests
+                    && Program.RunningOnUiThread
+                    && RemoteDebuggingPort.HasValue
+                )
+                    _environmentForE2eTests = env;
             }
             await _webview.EnsureCoreWebView2Async(env);
             // Added as a footnote to BL-15466 to prevent popups generated from title

--- a/src/BloomExe/Workspace/WorkspaceView.cs
+++ b/src/BloomExe/Workspace/WorkspaceView.cs
@@ -179,6 +179,8 @@ namespace Bloom.Workspace
                 _workspaceReactControl.BrowserCreated += (unused, args) =>
                 {
                     _mainBrowser = _workspaceReactControl.Browser;
+                    if (Program.RunningE2eTests)
+                        MainBrowserForE2eTests = _mainBrowser;
                     _mainBrowser?.SetBuiltInBrowserZoomEnabled(false);
                     _editingView.InitializeMainBrowserForEditMode();
                     MaybeOpenMainBrowserDevTools();
@@ -280,6 +282,14 @@ namespace Bloom.Workspace
                 shouldHideSplashScreen: true
             ); // possibility of error message boxes (BL-12155)
         }
+
+        /// <summary>
+        /// The browser holding the workspace root document that Bloom drives: the one whose page
+        /// iframe the Edit tab navigates. Set only under --e2e, for the e2e/shellUrl endpoint.
+        /// More than one document in a run carries the workspace root's markup, and a test that
+        /// attaches to the wrong one sees its own clicks work while nothing Bloom does arrives.
+        /// </summary>
+        internal static Browser MainBrowserForE2eTests { get; private set; }
 
         internal void ReloadWorkspaceRootDocument()
         {

--- a/src/BloomExe/web/controllers/E2eTestingApi.cs
+++ b/src/BloomExe/web/controllers/E2eTestingApi.cs
@@ -133,6 +133,15 @@ namespace Bloom.web.controllers
                 false // does not need the UI thread
             );
 
+            // GET returns the URL of the workspace root document Bloom drives, or an empty string
+            // before that browser exists. A run has more than one document carrying the workspace
+            // root's markup, so the top bar's test id alone does not identify the right one, and a
+            // test that attaches to the wrong one is silently broken: its own typing and clicking
+            // work, while every page Bloom loads goes somewhere it cannot see. Compare on the file
+            // name, which is unique per document; the rest of the URL is escaped differently by
+            // Bloom and by the debugging protocol. Needs the UI thread to read the browser.
+            apiHandler.RegisterEndpointHandler(kApiUrlPart + "shellUrl", HandleGetShellUrl, true);
+
             // POST {"email": ...}: which Bloom Library login state Bloom should REPORT. A test
             // needs this because the real login lives in machine-wide settings shared with the
             // developer's own Bloom: signing out for real would sign the developer out, and
@@ -145,6 +154,15 @@ namespace Bloom.web.controllers
                 HandleSetLoginState,
                 false // does not need the UI thread
             );
+        }
+
+        /// <summary>
+        /// Reply with the URL of the workspace root document Bloom drives (see the registration
+        /// above), or an empty string if the main browser is not up yet.
+        /// </summary>
+        private void HandleGetShellUrl(ApiRequest request)
+        {
+            request.ReplyWithText(Workspace.WorkspaceView.MainBrowserForE2eTests?.Url ?? "");
         }
 
         /// <summary>


### PR DESCRIPTION
More than one document in a run carries the workspace root's markup, so the
fixture's findShellPage returned whichever the debugging protocol listed first.
When that was not the document Bloom drives, the test was silently broken
rather than failing: its own clicking and typing worked, an expect on what it
typed passed, and every page Bloom loaded went into a document it could not
see. The symptom was a 60-second wait in goToPage for a page Bloom's own log
said it had shown. This is the flake in publish-text-languages.spec.ts.

Three parts.

The new e2e/shellUrl endpoint reports the URL of the browser holding the
document Bloom drives, which WorkspaceView records under --e2e when it builds
that browser. findShellPage now returns the page whose URL has the same file
name, and resolves it again after bloomApp.restart. It compares file names
because Bloom and the debugging protocol escape the rest of the URL
differently, and the workspace rewrites its own query string as the user moves
around.

The top bar carries data-testid="workspace-top-bar", so the candidates are
found by a marker of its own rather than by [role="tablist"]. When the endpoint
never answers, which is what an old Bloom.exe in output/Debug does, the fixture
falls back to the first page carrying that marker and says so.

Under --e2e, every browser built on the UI thread shares one
CoreWebView2Environment, so those documents live in one browser process with
one remote-debugging listener. Before, each environment was given the same port
number and only the first process to start could listen on it, so which browser
a test could reach depended on startup timing. The sharing is deliberately
limited to the UI thread: an environment belongs to the thread that created it,
and handing it to a browser built on the thread serving an API call hangs that
thread, which is what publishing a BloomPUB does.

Trims the AUTOMATION-DEBT.md entry "The top bar has no stable test ids" to the
tab half, which BL-16799-tab-test-ids finishes. Adds "A test can attach to a
shell document Bloom does not drive", because nobody knows why a run has a
second workspace root document at all, and that is what makes the test-side
check necessary.

Verified: BloomExe builds clean, and the e2e suite type checks.

## This is one of eleven stacked pull requests (BL-16799)

Each one pays down one entry of `src/BloomE2E/AUTOMATION-DEBT.md`, and each branches off the one before it. **Base: `BL-16799-toolbox-registration`.** Review only this pull request's own commit; the ones below it are reviewed in their own pull requests. The first six change test and tooling code only; the last five also change product code.

1. `BL-16799-automation-scripts` — Make the bloom-automation scripts safe to ask for help
2. `BL-16799-vr-collect-failures` — Report every failed image comparison in a visual-regression case, not the first
3. `BL-16799-component-tests-in-ci` — Run the component-tester Playwright suites nightly
4. `BL-16799-vite-port` — Let an e2e run test the working tree's front end
5. `BL-16799-type-in-one-call` — Type into a text box in one call, not one key press per character
6. `BL-16799-page-screenshot` — Capture a whole book page from a test
7. `BL-16799-toolbox-registration` — Register the toolbox tools from one list both callers share
8. `BL-16799-shell-document` — Stop a test attaching to a shell document Bloom does not drive
9. `BL-16799-tab-test-ids` — Click a workspace tab by a test id, not by its localized label
10. `BL-16799-page-change` — Refuse a page change the Edit tab cannot do, and wait before asking
11. `BL-16799-collection-languages` — Set a collection's languages through an e2e hook, not by writing XML

Replaces #8276, which did all of this in one pull request.

Verification of the whole stack, at its tip: the C# suite passes (3338 passed, 13 skipped), the front-end vitest suite passes (781 passed, 5 skipped), and the `src/BloomE2E` suite passes against a Vite dev server on the working tree (36 passed, 0 skipped, 8.2 minutes). Each pull request also has its own type check and lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8297)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8297)
<!-- Reviewable:end -->
