### PR TITLE
Refuse a page change the Edit tab cannot do, and wait before asking (BL-16799)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/bookAndPageSettings/StyleAndFontTable.tsx
+++ b/src/BloomBrowserUI/bookEdit/bookAndPageSettings/StyleAndFontTable.tsx
@@ -46,7 +46,9 @@ export const StyleAndFontTable: React.FunctionComponent<{
 
     function closeDialogAndJumpToPage(pageId: string) {
         props.closeDialog();
-        postString("editView/jumpToPage", pageId);
+        // report: false — the edit tab declines a jump it cannot do (it is mid-save), and that
+        // is not something to raise a problem report about. See EditingModel.JumpToPage.
+        postString("editView/jumpToPage", pageId, false);
     }
 
     return (

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/customXmatterPage.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/customXmatterPage.tsx
@@ -567,9 +567,13 @@ function renderPageLayoutMenu(page: HTMLElement): void {
                 );
                 // Persist the newly created custom layout state so a later switch back
                 // to standard has matching server-side state to work from.
+                // report: false — the edit tab declines a jump it cannot do (it is mid-save), and
+                // that is not something to raise a problem report about. See
+                // EditingModel.JumpToPage.
                 await postString(
                     "editView/jumpToPage",
                     page.getAttribute("id")!,
+                    false,
                 );
                 renderPageLayoutMenu(page);
             } else if (selection === "custom" && response) {

--- a/src/BloomBrowserUI/utils/bloomApi.ts
+++ b/src/BloomBrowserUI/utils/bloomApi.ts
@@ -580,7 +580,14 @@ export async function getWithConfigAsync<T>(
     return wrapAxios(axios.get<T>(getBloomApiPrefix() + urlSuffix, config));
 }
 
-export function postString(urlSuffix: string, value: string) {
+// Pass report: false for an endpoint whose failure is not worth a problem report, in the same
+// spirit as postThatMightNavigate: a request that asks Bloom to do something it may decline for
+// reasons of timing, where the user has nothing to fix and nothing to be told.
+export function postString(
+    urlSuffix: string,
+    value: string,
+    report: boolean = true,
+) {
     // Match post(): unit tests should not hit Bloom backend endpoints.
     const isTest =
         typeof process !== "undefined" && process.env.NODE_ENV === "test";
@@ -594,6 +601,7 @@ export function postString(urlSuffix: string, value: string) {
                 "Content-Type": "text/plain",
             },
         }),
+        report,
     );
 }
 

--- a/src/BloomE2E/AUTOMATION-DEBT.md
+++ b/src/BloomE2E/AUTOMATION-DEBT.md
@@ -21,7 +21,6 @@ the identity here. Before you start on a marked entry, ask the owner of its bran
 
 | Branch | What it pays down |
 | --- | --- |
-| `BL-16799-page-change` | `editView/jumpToPage` refuses a jump it cannot do, and every page-changing helper waits for the Edit tab to settle. |
 | `BL-16799-collection-languages` | The `e2e/setCollectionLanguages` hook, so no test composes `.bloomCollection` XML. |
 
 Three of these also add entries of their own, for the debt that is left after the fix. The
@@ -231,10 +230,10 @@ would look like the same flake. Fix direction: have `jumpToPage` queue the reque
 until the Edit tab is ready, or report that it refused it.
 (Found 2026-09-01 automating Test Case ID 169.)
 
-being fixed on `BL-16799-page-change`: it reports that it refused the jump, rather than
-queueing it, and the helpers wait for the Edit tab to settle before asking. Queueing was
-tried first and made things worse. That branch adds an entry for the Bloom defect behind
-this one, which it does not fix.
+Answered for tests, 2026-09-02: `editView/jumpToPage` no longer replies success to a jump
+it drops. It refuses the jump and says why, and every helper that changes the page waits for
+`waitForEditTabSettled` first. What remains is the Bloom defect itself, in the section "A page
+change asked for while the Edit tab is still loading a page can be lost" below.
 
 seen again 2026-09-02 (Test Case ID 72, `derivative-keeps-template-pages.spec.ts`): the
 same drop hits `addPage`. Every action that saves the page first goes through
@@ -476,3 +475,50 @@ creates one `_workspaceReactControl`. Worth finding, because the duplicate is wh
 the test-side check necessary.
 (Found 2026-09-01 while making `jumpToPage` queue a jump.)
 
+## A page change asked for while the Edit tab is still loading a page can be lost
+
+A page change that reaches the Edit tab between two announcements of one page load wedges
+that tab: it stays in SavePending and refuses every later page change. The caller waits 60
+seconds for a page that never comes, and a user who clicks a page thumbnail in that window
+cannot change pages at all until they leave the tab.
+
+The cause is a page that announces itself to Bloom twice. Bloom's own log, from the run
+that found this on 2026-09-02:
+
+```
+Navigating(f45a2ef8) --> editing(f45a2ef8)
+Editing(f45a2ef8) --> savePending()
+Ignoring edit() request while in SavePending(f45a2ef8)
+```
+
+The first announcement moves the tab to Editing. The page change then asks the browser for
+the page content so it can save the page it is leaving. The second announcement arrives, is
+refused because a save is in flight, and the browser never answers the save request. The
+tab stays in SavePending. The same three lines in the order that works read `--> editing`,
+`Ignoring edit()`, then `--> savePending`, and the save completes.
+
+Any request that changes the page does this, not only a jump. The run that found it lost a
+language change from `setContentLanguages`, and the Edit tab then held the tab switch that
+followed, so a Publish test failed instead.
+
+A first attempt at this, on 2026-09-02, had `JumpToPage` queue a jump that arrived while
+the tab was navigating and release it on the next page-load announcement. That made the
+wedge easier to reach rather than harder, because the released jump is itself a page change
+arriving in exactly the window above. `JumpToPage` now refuses such a jump and says so, so
+the caller can wait and ask again.
+
+Worked around for tests, 2026-09-02: `e2e/editState` reports what the Edit tab is doing and
+how many times the page it shows has announced itself, and every helper that changes the
+page waits for `waitForEditTabSettled` first. That keeps the request out of the window. The
+wait reads the state twice, 1500 ms apart, and needs Editing both times with the count
+unchanged: the state alone reads Editing between the two announcements, when a request
+would still be lost, and the gap between them has been seen to reach a second. No test can
+see any of this from the DOM, because Bloom leaves the previous page in the frame while it
+loads the next one.
+
+What remains: the Bloom defect itself, which is older than this suite. A user hits it
+whenever something asks for a page change in that window, and the Edit tab then stops
+responding to page changes altogether. Fix direction: either stop the browser announcing a
+page twice, or make the state machine treat a second announcement of the page it is saving
+as a reason to discard that save (`DiscardInFlightSave` already exists for BL-16766). Both
+change production save behavior, so this needs a decision rather than a quiet fix.

--- a/src/BloomE2E/helpers/bookMaking.ts
+++ b/src/BloomE2E/helpers/bookMaking.ts
@@ -279,6 +279,9 @@ export async function setContentLanguages(
     page: Page,
     tags: string[],
 ): Promise<void> {
+    // Each change makes Bloom reload the page, so this is a page-changing request and must not
+    // arrive while the Edit tab is still loading one. See waitForEditTabSettled.
+    await waitForEditTabSettled(page);
     const usage = await apiGetJson<IContentLanguageUsage>(
         page,
         "editView/topBar/contentLanguageUsage",
@@ -312,7 +315,7 @@ export async function setContentLanguages(
             )
             .toBe(wanted);
     }
-    await waitForEditablePage(page);
+    await waitForEditTabSettled(page);
 }
 
 /** The Edit tab's frame holding the page being edited. Throws if the Edit tab is not showing. */
@@ -366,6 +369,79 @@ export async function waitForEditablePage(
                 "Bloom never finished loading the page in the Edit tab (its editing state never became Editing).",
         })
         .toBe("true");
+}
+
+/** What e2e/editState replies with: what the Edit tab is doing. */
+interface IEditTabState {
+    /** A name from Bloom's State enum: NoPage, Navigating, Editing, SavePending, SavedAndStripped. */
+    state: string;
+    /** The page that state is about, or "". */
+    pageId: string;
+    /** Whether the Edit tab is the tab being shown. */
+    visible: boolean;
+    /** How many times the page now shown has told Bloom its DOM had loaded. */
+    pageLoadAnnouncements: number;
+}
+
+/**
+ * How long the Edit tab must report the same page, with no new announcement, before this counts
+ * as settled. It has to cover the gap between the two announcements of one page load, which has
+ * been seen to reach a second. John approved this wait on 2026-09-03, as
+ * src/BloomBrowserUI/AGENTS.md asks.
+ */
+const kEditTabQuietPeriodMs = 1500;
+
+/**
+ * Wait until the Edit tab is settled on a page: showing it, in the Editing state, and done
+ * announcing that the page has loaded.
+ *
+ * Ask this before any request that changes the page. The Edit tab refuses such a request while it
+ * navigates, and a page announces itself to Bloom more than once, so a request that arrives
+ * between two of those announcements starts a save that the second announcement leaves unanswered
+ * (AUTOMATION-DEBT.md: "A page change asked for while the Edit tab is still loading a page can be
+ * lost"). Waiting for the Editing state alone is therefore not enough. The condition this waits
+ * for is that the page and the count of announcements have both held still for
+ * kEditTabQuietPeriodMs, so it returns as soon as that holds.
+ *
+ * The DOM is no help here. Bloom leaves the previous page in the frame while it loads the next
+ * one, so a test looking at the frame sees a settled Edit tab throughout.
+ */
+export async function waitForEditTabSettled(
+    page: Page,
+    timeoutMs = 90000,
+): Promise<void> {
+    let lastReading = "";
+    let unchangedSince = 0;
+    await expect
+        .poll(
+            async () => {
+                const now = await apiGetJson<IEditTabState>(
+                    page,
+                    "e2e/editState",
+                );
+                if (!now.visible || now.state !== "Editing") {
+                    lastReading = "";
+                    return now.state;
+                }
+                const reading = `${now.pageId} ${now.pageLoadAnnouncements}`;
+                if (reading !== lastReading) {
+                    lastReading = reading;
+                    unchangedSince = Date.now();
+                }
+                const quietFor = Date.now() - unchangedSince;
+                if (quietFor < kEditTabQuietPeriodMs)
+                    return `Editing, but page ${now.pageId} last announced itself ${quietFor}ms ago`;
+                return "Editing";
+            },
+            {
+                // Poll often, so that the wait is only as long as the quiet period needs.
+                intervals: [250],
+                timeout: timeoutMs,
+                message:
+                    "The Edit tab never settled on a page, so a request to change pages could be lost.",
+            },
+        )
+        .toBe("Editing");
 }
 
 /** One page of the selected book, as e2e/pages reports it. */
@@ -467,7 +543,7 @@ export async function addPage(
             message: `Bloom never added the "${templatePageLabel}" page(s).`,
         })
         .toBe(before + times);
-    await waitForEditablePage(page);
+    await waitForEditTabSettled(page);
 }
 
 /**
@@ -491,31 +567,75 @@ export async function getShownPageId(page: Page): Promise<string | undefined> {
  * it is leaving, so text typed into a box reaches the file only once the book moves off that page.
  */
 export async function goToPage(page: Page, pageId: string): Promise<void> {
-    // The Edit tab drops a jump that arrives while it is still loading a page, so wait for it to
-    // be showing one before asking for another.
-    await waitForEditablePage(page);
-
-    // Ask up to three times. Coming back from the Publish tab, the Edit tab can still swallow a
-    // jump after it looks ready, and asking again costs a few seconds where failing costs the run.
+    // Wait for the Edit tab first. A jump asked for while it is still loading a page is refused,
+    // and one asked for between two announcements of one page load wedges it (see
+    // waitForEditTabSettled). Asking at a moment when the tab acts on the jump at once avoids
+    // both.
+    // Then ask, and ask again if the tab was busy after all. The tab answers with an error when
+    // it cannot jump (EditingModel.JumpToPage), rather than dropping the jump and reporting
+    // success as it used to, so a refusal is visible here instead of turning into a 60-second
+    // wait for a page that is not coming. Three tries, because the wait above closes the window
+    // for a refusal without quite shutting it: the tab can start loading the page list in the
+    // moment between the wait finishing and this request arriving.
+    let refusal: unknown;
+    for (let attempt = 0; attempt < 3; attempt++) {
+        if (attempt > 0) await waitForEditTabSettled(page);
+        refusal = undefined;
+        await apiPost(page, "editView/jumpToPage", pageId, "text/plain").catch(
+            (error) => {
+                refusal = error;
+            },
+        );
+        if (refusal === undefined) break;
+    }
+    if (refusal !== undefined)
+        throw new Error(
+            `The Edit tab refused to show page ${pageId} three times running: ${refusal}`,
+        );
     const showing = async () =>
         (await page
             .frame({ name: "page" })
             ?.locator(`.bloom-page[id="${pageId}"]`)
             .count()
             .catch(() => 0)) ?? 0;
-    for (let attempt = 1; attempt <= 3; attempt++) {
-        await apiPost(page, "editView/jumpToPage", pageId, "text/plain");
-        try {
-            await expect.poll(showing, { timeout: 20000 }).toBe(1);
-            await waitForEditablePage(page);
-            return;
-        } catch {
-            // fall through and ask again
-        }
+    try {
+        await expect.poll(showing, { timeout: 60000 }).toBe(1);
+    } catch {
+        // Say what the frame does hold. "Bloom never showed the page" on its own cannot tell a
+        // page that never arrived from a page that arrived and was replaced by another one.
+        const frame = page.frame({ name: "page" });
+        const heldPageIds = frame
+            ? await frame
+                  .locator(".bloom-page")
+                  .evaluateAll((pages) => pages.map((p) => p.id))
+                  .catch(() => ["(could not read the frame)"])
+            : [];
+        // Read this the forgiving way. A shell document Bloom is not driving is one of the
+        // failures this message exists to explain, and in exactly that case the request can
+        // fail. Letting it throw here would replace the whole diagnostic with its own error.
+        const drivenShell = await apiGet(page, "e2e/shellUrl")
+            .then((response) => response.body)
+            .catch((error) => `(could not be read: ${error})`);
+        // The state the Edit tab is stuck in says which of the two failures this is: a jump that
+        // wedged the tab leaves it in SavePending or Navigating on the page it already had.
+        const editState = await apiGet(page, "e2e/editState")
+            .then((response) => response.body)
+            .catch((error) => `(could not be read: ${error})`);
+        throw new Error(
+            `Bloom never showed page ${pageId} in the Edit tab. ` +
+                `The Edit tab is at ${editState}. ` +
+                (frame
+                    ? `The 'page' frame is at ${frame.url()} and holds [${heldPageIds.join(", ")}].`
+                    : `There is no 'page' frame.`) +
+                ` Bloom drives the shell at ${drivenShell}; ` +
+                `this test is watching ${page.url()}. If those name different documents, the test ` +
+                `attached to the wrong one and nothing Bloom does will ever appear (see AUTOMATION-DEBT.md).`,
+        );
     }
-    throw new Error(
-        `Bloom never showed page ${pageId} in the Edit tab, after three attempts.`,
-    );
+    // The page being in the frame is not the whole of arriving: Bloom is still setting it up, and
+    // it re-navigates the page list too. Leave the Edit tab settled, so whatever the test does
+    // next is not working against a frame that is about to be replaced.
+    await waitForEditTabSettled(page);
 }
 
 /**

--- a/src/BloomE2E/helpers/pageList.ts
+++ b/src/BloomE2E/helpers/pageList.ts
@@ -11,7 +11,7 @@
 
 import { expect, type Frame, type Page } from "@playwright/test";
 import { apiPost } from "./api";
-import { getPages, waitForEditablePage, type IBookPage } from "./bookMaking";
+import { getPages, waitForEditTabSettled, type IBookPage } from "./bookMaking";
 
 /** The Edit tab's frame holding the page thumbnails. Throws if the Edit tab is not showing. */
 export function pageListFrame(page: Page): Frame {
@@ -57,7 +57,7 @@ async function waitForOneNewPage(
             },
         )
         .toBe(before.length + 1);
-    await waitForEditablePage(page);
+    await waitForEditTabSettled(page);
     return added!;
 }
 
@@ -66,6 +66,9 @@ async function waitForOneNewPage(
  * return the new page. The copy lands right after the page it was made from.
  */
 export async function duplicatePageWithButton(page: Page): Promise<IBookPage> {
+    // Duplicating saves the page being shown, so this must not be asked for while the Edit tab is
+    // still loading one. See waitForEditTabSettled.
+    await waitForEditTabSettled(page);
     const before = await getPages(page);
     const button = pageListFrame(page).getByTestId("duplicate-page-button");
     await button.waitFor({ state: "visible", timeout: 30000 });
@@ -85,6 +88,9 @@ export async function duplicatePageWithContextMenu(
     page: Page,
     pageId: string,
 ): Promise<IBookPage> {
+    // Duplicating saves the page being shown, so this must not be asked for while the Edit tab is
+    // still loading one. See waitForEditTabSettled.
+    await waitForEditTabSettled(page);
     const before = await getPages(page);
     const target = thumbnail(page, pageId);
     await target.waitFor({ state: "visible", timeout: 30000 });
@@ -119,6 +125,9 @@ export async function movePageToSlotOf(
     pageId: string,
     targetPageId: string,
 ): Promise<void> {
+    // Moving a page saves the page being shown, so this must not be asked for while the Edit tab
+    // is still loading one. See waitForEditTabSettled.
+    await waitForEditTabSettled(page);
     const before = await getPages(page);
     const targetIndex = before.findIndex((p) => p.id === targetPageId);
     if (targetIndex < 0 || !before.some((p) => p.id === pageId))
@@ -158,7 +167,7 @@ export async function movePageToSlotOf(
             message: `Bloom never listed page ${pageId} in the slot of ${targetPageId}.`,
         })
         .toBe(pageId);
-    await waitForEditablePage(page);
+    await waitForEditTabSettled(page);
 }
 
 /**
@@ -172,6 +181,9 @@ export async function duplicateCurrentPage(
     page: Page,
     times = 1,
 ): Promise<void> {
+    // Duplicating saves the page being shown, so this must not be asked for while the Edit tab is
+    // still loading one. See waitForEditTabSettled.
+    await waitForEditTabSettled(page);
     const before = (await getPages(page)).length;
     await apiPost(
         page,
@@ -185,5 +197,5 @@ export async function duplicateCurrentPage(
             message: "Bloom never added the duplicated page(s).",
         })
         .toBe(before + times);
-    await waitForEditablePage(page);
+    await waitForEditTabSettled(page);
 }

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -47,6 +47,10 @@ namespace Bloom.Edit
         private bool _reloadFromDiskOnLeavingEditTab;
 
         public bool Visible;
+
+        // A page a JumpToPage call asked for while the Edit tab was not showing. OnBecomeVisible
+        // displays this page instead of the one it would otherwise choose. See JumpToPage.
+        private string _pageIdToShowWhenVisible;
         private Book.Book _currentlyDisplayedBook;
         private Book.Book _bookForToolboxContent;
         private EditingView _view;
@@ -113,6 +117,11 @@ namespace Bloom.Edit
             _server = server;
             _webSocketServer = webSocketServer;
             _sourceCollectionsList = sourceCollectionsList;
+            // A run has one EditingModel, and E2eTestingApi has no way to be handed it: the
+            // container builds that api before any book is selected. So hand it over here, the
+            // same way WorkspaceView hands over its browser for e2e/shellUrl.
+            if (Program.RunningE2eTests)
+                ModelForE2eTests = this;
 
             _stateMachine = new EditingStateMachine(
                 // navigate,
@@ -515,6 +524,8 @@ namespace Bloom.Edit
             // This edit tab can ignore changes that don't actually involve selecting a different book.
             if (_bookSelection.CurrentSelection == _currentlyDisplayedBook)
                 return;
+            // A jump queued for a page of the book we are leaving means nothing in the new one.
+            _pageIdToShowWhenVisible = null;
             //prevent trying to save this page in whatever comes next
             var hadPageToSave = _havePageToSave;
             _havePageToSave = false;
@@ -996,11 +1007,23 @@ namespace Bloom.Edit
 
             ErrorReportUtils.CheckForFakeTestErrorsIfNotRealUser(_currentlyDisplayedBook.Title);
 
-            // BL-2339: try to choose the last edited page
-            var page =
-                _currentlyDisplayedBook.GetPageByIndex(
-                    _currentlyDisplayedBook.UserPrefs.MostRecentPage
-                ) ?? _currentlyDisplayedBook.FirstPage;
+            // A jump asked for while this tab was not showing wins over the remembered page: it is
+            // the more recent request. See JumpToPage.
+            var requestedPageId = _pageIdToShowWhenVisible;
+            _pageIdToShowWhenVisible = null;
+            IPage page = null;
+            if (requestedPageId != null)
+                page = _currentlyDisplayedBook
+                    .GetPages()
+                    .FirstOrDefault(p => p.Id == requestedPageId);
+            if (page == null)
+            {
+                // BL-2339: try to choose the last edited page
+                page =
+                    _currentlyDisplayedBook.GetPageByIndex(
+                        _currentlyDisplayedBook.UserPrefs.MostRecentPage
+                    ) ?? _currentlyDisplayedBook.FirstPage;
+            }
 
             if (page != null)
                 _view.GoToPage(page);
@@ -1687,6 +1710,105 @@ namespace Bloom.Edit
             request.PostSucceeded();
         }
 
+        /// <summary>
+        /// The one EditingModel of an e2e run, or null outside such a run. See the constructor.
+        /// </summary>
+        public static EditingModel ModelForE2eTests;
+
+        /// <summary>
+        /// What the Edit tab is doing, for the e2e suite to wait on (see e2e/editState). Editing
+        /// is the only state in which the tab accepts a request without deferring it.
+        /// </summary>
+        public State EditTabState => _stateMachine.CurrentState;
+
+        /// <summary>
+        /// The page EditTabState is about, or null.
+        /// </summary>
+        public string EditTabStatePageId => _stateMachine.CurrentPageId;
+
+        // How many times the page named by _announcedPageId has told us its DOM had loaded. See
+        // HandlePageDomLoadedEvent.
+        private string _announcedPageId;
+        private int _pageLoadAnnouncements;
+
+        /// <summary>
+        /// How many times the page now being shown has announced that its DOM had loaded. A page
+        /// does that more than once, and a request that changes the page is lost if it arrives
+        /// between two of those announcements (see src/BloomE2E/AUTOMATION-DEBT.md). So the e2e
+        /// suite waits for this to stop rising. For automation only.
+        /// </summary>
+        public int PageLoadAnnouncements => _pageLoadAnnouncements;
+
+        /// <summary>
+        /// Show the page with this id in the Edit tab. The page being left is saved on the way,
+        /// which is how anything typed on it reaches the file.
+        ///
+        /// A jump that arrives before the Edit tab is showing is remembered, and OnBecomeVisible
+        /// displays that page instead of the one it would otherwise choose.
+        ///
+        /// Otherwise the jump either happens at once or is refused: this returns false when the
+        /// Edit tab is busy with a page (loading one, or saving one), when there is no book, and
+        /// when the tab is in the momentary state after a save in which no transition is allowed.
+        /// Bloom used to drop such a jump and report success, which left the caller waiting for a
+        /// page that was never coming (see src/BloomE2E/AUTOMATION-DEBT.md).
+        /// </summary>
+        public bool JumpToPage(string pageId)
+        {
+            if (CurrentBook == null || string.IsNullOrEmpty(pageId))
+                return false;
+
+            // A page the book does not have. Both paths below would otherwise show some other
+            // page and report success: OnBecomeVisible falls back to the most recently edited
+            // page, and a save-then-navigate lands wherever the id takes it. The caller would
+            // then wait for a page that cannot appear.
+            if (CurrentBook.GetPage(pageId) == null)
+            {
+                Logger.WriteEvent(
+                    $"EditingModel.JumpToPage({pageId}): the book has no such page, so the jump was refused."
+                );
+                return false;
+            }
+
+            if (!Visible)
+            {
+                // The Edit tab is not showing, so there is nothing to save and nowhere to
+                // navigate. OnBecomeVisible chooses the page to display, so hand it this one.
+                _pageIdToShowWhenVisible = pageId;
+                return true;
+            }
+
+            // The Edit tab is busy with a page: saving one, or loading one. Say so rather than
+            // queue the jump. A queued jump has to be released by some signal that the tab is
+            // ready, and the only signal available is a page announcing that its DOM has loaded,
+            // which a page does more than once. A jump released by the first announcement starts
+            // a save, the second announcement is then refused because a save is in flight, and
+            // the browser never answers the save request, which leaves the tab unable to change
+            // pages at all. See src/BloomE2E/AUTOMATION-DEBT.md.
+            if (_stateMachine.SavePending || _stateMachine.Navigating)
+            {
+                Logger.WriteEvent(
+                    $"EditingModel.JumpToPage({pageId}): the edit tab was busy with a page, so the jump was refused."
+                );
+                return false;
+            }
+
+            var jumped = true;
+            SaveThen(
+                () => pageId,
+                doIfNotInRightStateToSave: () =>
+                {
+                    // We ruled out the two states that refuse a save above, so we are in the
+                    // momentary SavedAndStripped state, which an API call should not be able to
+                    // observe. Say so rather than drop the request silently.
+                    Logger.WriteEvent(
+                        $"EditingModel.JumpToPage({pageId}): the edit tab was not in a state to save, so the jump was refused."
+                    );
+                    jumped = false;
+                }
+            );
+            return jumped;
+        }
+
         private bool CannotSavePage()
         {
             return _bookSelection == null
@@ -2186,6 +2308,16 @@ namespace Bloom.Edit
 
         public void HandlePageDomLoadedEvent(string pageId)
         {
+            // Count the announcement before acting on it. A page announces itself more than once,
+            // and the e2e suite has to know that the last one has been and gone before it asks
+            // this tab for anything (see the editState endpoint and PageLoadAnnouncements).
+            if (pageId != _announcedPageId)
+            {
+                _announcedPageId = pageId;
+                _pageLoadAnnouncements = 0;
+            }
+            _pageLoadAnnouncements++;
+
             var nowEditing = _stateMachine.ToEditing(pageId);
             if (nowEditing)
             {

--- a/src/BloomExe/Edit/EditingStateMachine.cs
+++ b/src/BloomExe/Edit/EditingStateMachine.cs
@@ -50,6 +50,7 @@ public class EditingStateMachine
     // save has completed and we are back in a state that allows transitions.
     // See DeferUntilSaveCompletes.
     private Action _workToDoAfterInFlightSave;
+
     private Action _hidePage;
 
     private Action<bool> _enableStateTransitions; // arg is (enabled)
@@ -148,6 +149,18 @@ public class EditingStateMachine
     /// one, such as duplicating or deleting the page) will be acted on rather than ignored.
     /// </summary>
     public bool Editing => _currentState == State.Editing;
+
+    /// <summary>
+    /// The state we are in, and the page it is about. These exist for automation: the e2e suite
+    /// waits until the Edit tab is settled before it asks that tab for anything, and the DOM
+    /// cannot tell it that (see E2eTestingApi's editState endpoint). Read only.
+    /// </summary>
+    public State CurrentState => _currentState;
+
+    /// <summary>
+    /// The page the current state is about, or null. See CurrentState.
+    /// </summary>
+    public string CurrentPageId => _pageId;
 
     /// <summary>
     /// Called to initiate navigation to a new page (or the same one again).
@@ -511,6 +524,11 @@ public class EditingStateMachine
     private void Log(string message)
     {
         Debug.WriteLine("[EditingStateMachine] " + message);
+        // Under --e2e these go into Bloom's log as well. A test that waits for a page the edit tab
+        // never shows is otherwise a mystery: nothing else records which state the tab was in or
+        // which request it turned down.
+        if (Bloom.Program.RunningE2eTests)
+            Logger.WriteEvent("[EditingStateMachine] " + message);
     }
 
     private void LogTransition(string nextState, string nextPageId)

--- a/src/BloomExe/web/controllers/E2eTestingApi.cs
+++ b/src/BloomExe/web/controllers/E2eTestingApi.cs
@@ -142,6 +142,22 @@ namespace Bloom.web.controllers
             // Bloom and by the debugging protocol. Needs the UI thread to read the browser.
             apiHandler.RegisterEndpointHandler(kApiUrlPart + "shellUrl", HandleGetShellUrl, true);
 
+            // GET returns what the Edit tab is doing, as
+            // {state, pageId, visible, pageLoadAnnouncements}. A test must not ask that tab to
+            // change pages while it is still loading one: the request is queued until the page
+            // loads, and a page announces itself more than once, so a request released by the
+            // first announcement starts a save that the second one leaves unanswered. Nothing
+            // happens after that (see src/BloomE2E/AUTOMATION-DEBT.md). The DOM cannot tell a test
+            // any of this, because the frame still holds the page from before the tab switch, so
+            // the count of announcements is how a test knows the last one has been and gone. Off
+            // the UI thread on purpose: this reads three fields, and a test asks for them exactly
+            // when the UI thread is busy.
+            apiHandler.RegisterEndpointHandler(
+                kApiUrlPart + "editState",
+                HandleGetEditState,
+                false // does not need the UI thread
+            );
+
             // POST {"email": ...}: which Bloom Library login state Bloom should REPORT. A test
             // needs this because the real login lives in machine-wide settings shared with the
             // developer's own Bloom: signing out for real would sign the developer out, and
@@ -153,6 +169,29 @@ namespace Bloom.web.controllers
                 kApiUrlPart + "loginState",
                 HandleSetLoginState,
                 false // does not need the UI thread
+            );
+        }
+
+        /// <summary>
+        /// Reply with what the Edit tab is doing (see the registration above). Before the first
+        /// book is selected there is no EditingModel, which reads as NoPage.
+        /// </summary>
+        private void HandleGetEditState(ApiRequest request)
+        {
+            var model = Bloom.Edit.EditingModel.ModelForE2eTests;
+            // The UI thread can change these fields between one read and the next, so keep
+            // pageLoadAnnouncements last. A count read after the state can only be the same or
+            // higher, which makes a test see the count still rising and wait again. Read first, it
+            // could pair a stale count with a settled state, and a test would stop waiting too
+            // soon.
+            request.ReplyWithJson(
+                new
+                {
+                    state = (model?.EditTabState ?? State.NoPage).ToString(),
+                    pageId = model?.EditTabStatePageId ?? "",
+                    visible = model?.Visible ?? false,
+                    pageLoadAnnouncements = model?.PageLoadAnnouncements ?? 0,
+                }
             );
         }
 

--- a/src/BloomExe/web/controllers/EditingViewApi.cs
+++ b/src/BloomExe/web/controllers/EditingViewApi.cs
@@ -320,11 +320,22 @@ namespace Bloom.web.controllers
             );
         }
 
+        /// <summary>
+        /// Show the page whose id is in the POST body. The reply comes after asking the model, so
+        /// that a jump the Edit tab cannot do is reported as a failure rather than as a success
+        /// that shows nothing. EditingModel.JumpToPage queues a jump that arrives at an awkward
+        /// moment, so a caller does not have to ask twice.
+        ///
+        /// A failure here is a matter of timing, not of anything a user could put right, so the
+        /// front end posts to this endpoint with error reporting turned off.
+        /// </summary>
         private void HandleJumpToPage(ApiRequest request)
         {
             var pageId = request.GetPostStringOrNull();
-            request.PostSucceeded();
-            View.Model.SaveThen(() => pageId, () => { });
+            if (View.Model.JumpToPage(pageId))
+                request.PostSucceeded();
+            else
+                request.Failed($"The edit tab could not show page {pageId}.");
         }
 
         /// <summary>


### PR DESCRIPTION
`editView/jumpToPage` replied success to a jump it dropped, so a test that asked at
the wrong moment saw an empty page iframe and asked again, up to three times, 20
seconds apart. A real "this page will not load" defect looked the same.

Two changes, one on each side:

- `EditingModel.JumpToPage` says whether it did the jump, and `HandleJumpToPage`
  replies with a failure when it did not. `postString` takes a `report` argument, so
  the two callers in the front end can turn off the problem report for a failure that
  is a matter of timing and that a user cannot put right.
- `e2e/editState` reports what the Edit tab is doing, and how many times the page it
  shows has announced itself. `waitForEditTabSettled` reads that twice, 1500 ms apart,
  and every helper that changes the page calls it first.

The count of announcements is the part that matters: a page announces itself twice, and
a page change that arrives between the two announcements wedges the Edit tab in
SavePending. The state alone reads Editing in that window. No test can see this from
the DOM, because Bloom leaves the previous page in the frame while it loads the next.

That Bloom defect is older than this suite and still open. AUTOMATION-DEBT.md now has
an entry for it, with the log lines that show it and two fix directions, both of which
change production save behavior.

## This is one of eleven stacked pull requests (BL-16799)

Each one pays down one entry of `src/BloomE2E/AUTOMATION-DEBT.md`, and each branches off the one before it. **Base: `BL-16799-tab-test-ids`.** Review only this pull request's own commit; the ones below it are reviewed in their own pull requests. The first six change test and tooling code only; the last five also change product code.

1. `BL-16799-automation-scripts` — Make the bloom-automation scripts safe to ask for help
2. `BL-16799-vr-collect-failures` — Report every failed image comparison in a visual-regression case, not the first
3. `BL-16799-component-tests-in-ci` — Run the component-tester Playwright suites nightly
4. `BL-16799-vite-port` — Let an e2e run test the working tree's front end
5. `BL-16799-type-in-one-call` — Type into a text box in one call, not one key press per character
6. `BL-16799-page-screenshot` — Capture a whole book page from a test
7. `BL-16799-toolbox-registration` — Register the toolbox tools from one list both callers share
8. `BL-16799-shell-document` — Stop a test attaching to a shell document Bloom does not drive
9. `BL-16799-tab-test-ids` — Click a workspace tab by a test id, not by its localized label
10. `BL-16799-page-change` — Refuse a page change the Edit tab cannot do, and wait before asking
11. `BL-16799-collection-languages` — Set a collection's languages through an e2e hook, not by writing XML

Replaces #8276, which did all of this in one pull request.

Verification of the whole stack, at its tip: the C# suite passes (3338 passed, 13 skipped), the front-end vitest suite passes (781 passed, 5 skipped), and the `src/BloomE2E` suite passes against a Vite dev server on the working tree (36 passed, 0 skipped, 8.2 minutes). Each pull request also has its own type check and lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8299)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8299)
<!-- Reviewable:end -->
