### PR TITLE
Render the visual-regression player pages from Bloom's own fonts

### DIFF
--- a/src/BloomE2E/AUTOMATION-DEBT.md
+++ b/src/BloomE2E/AUTOMATION-DEBT.md
@@ -204,20 +204,6 @@ Known WebView2/CDP behaviors that every ad-hoc script rediscovers the hard way; 
 
 (Promoted from PAPERCUTS 2026-07-22.)
 
-## Visual-regression baselines only match the CI runner
-
-The pixelmatch comparison demands zero differing pixels, and the committed baselines
-render exactly only on windows-latest CI. On a developer machine the bloom-player
-pages come out 1–884 pixels different (text shifted ~2 px vertically; previews match
-exactly), deterministically across runs, exe configs, and bloom-player versions —
-leading suspect: locally installed TTF Andika vs the WOFF2 Bloom ships. So a local
-run of the suite cannot go green, which makes local verification and baseline
-authoring painful. Fix direction: a small per-comparison pixel tolerance, or
-machine-profile baselines, or render fonts only from Bloom's own WOFF2 set in --e2e
-mode. (Found 2026-09-01 while verifying the bloom-testing-inputs rewire.)
-
-being fixed, from 2026-09-03, on `vr-baselines-match-locally` (no PR yet; not part of the BL-16799 stack): first measuring every comparison's pixel count on a developer machine, then trying standardized fonts (render only from Bloom's own WOFF2 set) and DPI as the cause.
-
 ## Automation helper scripts run destructive defaults on unknown flags
 
 `node .github/skills/bloom-automation/killBloomProcess.mjs --help` killed the running

--- a/src/BloomVisualRegressionTests/index.spec.ts
+++ b/src/BloomVisualRegressionTests/index.spec.ts
@@ -226,10 +226,6 @@ describe("All books", () => {
             ],
         });
         context = await browser.newContext();
-        andikaIsInstalled = await isFontInstalled(context, "Andika");
-        if (andikaIsInstalled) {
-            console.warn(chalk.black.bgYellow(ANDIKA_INSTALLED_WARNING));
-        }
         page = await context.newPage();
         playerPage = await context.newPage();
         await playerPage.setViewportSize({ width: 900, height: 1200 });
@@ -341,13 +337,10 @@ describe("All books", () => {
     // `screenshotsDir` is always in the SOURCE inputs tree (output/testing-inputs, or whatever
     // BLOOM_TESTING_INPUTS_DIR names), never in the temp copy, so that an accepted new baseline is
     // a file a developer can commit to the inputs repository. See readme.md.
-    // `isPlayerCapture` marks a bloom-player screenshot, whose text comes from whatever Andika the
-    // machine has (see andikaIsInstalled), as opposed to a book-preview one, which does not.
     async function captureOrCompare(
         label: string,
         screenshotsDir: string,
         shoot: (imagePath: string) => Promise<void>,
-        isPlayerCapture = false,
     ) {
         const referencePath = Path.join(
             screenshotsDir,
@@ -366,9 +359,6 @@ describe("All books", () => {
             referencePath,
             currentPath,
             Path.join(screenshotsDir, `${label}-diff.png`),
-            isPlayerCapture && andikaIsInstalled
-                ? ANDIKA_INSTALLED_WARNING
-                : undefined,
         );
     }
 
@@ -523,52 +513,6 @@ describe("All books", () => {
         return result.text();
     }
 
-    // The bloom-player captures must not depend on which fonts this machine has installed. When Bloom
-    // stages a BloomPUB it strips the book's own @font-face rules (BL-12594) and leaves the font to
-    // bloom-player, which declares Andika as `local("Andika")` first and the Bloom-served woff2 only
-    // as a fallback. So a machine with Andika installed renders every player page with its own copy of
-    // the font, and its glyphs differ from the reference images (which come from a machine without it,
-    // like the CI runner) by tens to hundreds of pixels per page. That has twice led someone to "fix"
-    // the suite by regenerating the baselines on their own machine, which just moved the failure to
-    // CI. The book-preview captures are unaffected: the staged book's own @font-face points at the
-    // served copy. So we don't refuse to run; we warn once up front, and when a player page then
-    // mismatches we say in the failure itself that the font is the likely cause, so nobody reads it
-    // as a regression or accepts it as a new baseline.
-    let andikaIsInstalled = false;
-    const ANDIKA_INSTALLED_WARNING =
-        `Andika is installed on this machine. bloom-player prefers an installed Andika over the copy ` +
-        `Bloom serves, so the bloom-player screenshots will be rendered with this machine's Andika and ` +
-        `will probably differ from the reference images (which are rendered without it, as on CI). ` +
-        `Player-page differences on this machine are probably that, not a regression, and must not be ` +
-        `accepted as new baselines. Uninstall Andika to make these comparisons meaningful; Bloom ` +
-        `does not need it installed.`;
-
-    // The probe is a @font-face whose only source is local(<family>): it loads if and only if the
-    // font is installed. Chrome may either resolve with no faces or reject when it is not.
-    async function isFontInstalled(
-        context: BrowserContext,
-        family: string,
-    ): Promise<boolean> {
-        const probe = await context.newPage();
-        try {
-            await probe.setContent(
-                `<style>@font-face { font-family: "bloom-vr-probe"; src: local("${family}"); }</style>`,
-            );
-            return await probe.evaluate(async () => {
-                try {
-                    const faces = await (globalThis as any).document.fonts.load(
-                        '16px "bloom-vr-probe"',
-                    );
-                    return faces.some((f: any) => f.status === "loaded");
-                } catch {
-                    return false;
-                }
-            });
-        } finally {
-            await probe.close();
-        }
-    }
-
     // Build the bloom-player URL for the staged book at a specific page (0-based). Mirrors what the
     // desktop app does (see RecordVideoWindow): the staged URL is already single-encoded, and
     // URLSearchParams encodes it again so it survives as a query parameter (see BL-11319).
@@ -635,6 +579,10 @@ describe("All books", () => {
                 content:
                     ".nicescroll-rails,.nicescroll-cursors{display:none!important}",
             });
+            // Render the book's text from the fonts Bloom serves, whatever this machine has
+            // installed; see SERVED_FONTS_ONLY_CSS. Also before the settle wait: it restyles the
+            // text, and the wait for document.fonts.ready below is what covers the reload.
+            await playerPage.addStyleTag({ content: SERVED_FONTS_ONLY_CSS });
             const active = await playerPage.waitForSelector(
                 ACTIVE_PLAYER_PAGE,
                 { timeout: 30000 },
@@ -689,18 +637,14 @@ describe("All books", () => {
                 async (imagePath) => {
                     await pageElement.screenshot({ path: imagePath });
                 },
-                true,
             );
         }
     }
 
-    // `likelyCause`, when given, is an explanation to attach to a mismatch (see andikaIsInstalled):
-    // something we know about this machine that makes the difference expected rather than a regression.
     async function comparePreviewImage(
         referencePath: string,
         testPath: string,
         diffPath: string,
-        likelyCause?: string,
     ) {
         const referenceImage = PNG.sync.read(fs.readFileSync(referencePath));
         const testImage = PNG.sync.read(fs.readFileSync(testPath));
@@ -735,8 +679,7 @@ describe("All books", () => {
             // a long run's output.
             throw new Error(
                 `${testPath} differed from the reference by ${numberOfDifferentPixels} pixels. ` +
-                    `The diff image is at ${diffPath}.` +
-                    (likelyCause ? `\n\n${likelyCause}` : ""),
+                    `The diff image is at ${diffPath}.`,
             );
         }
     }
@@ -775,6 +718,48 @@ function writeDirectionalDiff(reference: PNG, current: PNG, diffPath: string) {
         out.data[i + 3] = 255;
     }
     fs.writeFileSync(diffPath, PNG.sync.write(out) as Uint8Array);
+}
+
+// The bloom-player captures must not depend on which fonts this machine has installed. When Bloom
+// stages a BloomPUB it strips the book's own @font-face rules (BL-12594) and leaves the font to
+// bloom-player, which declares each Andika face as `local(...)` first and the Bloom-served WOFF2
+// only as a fallback. So a machine with Andika installed used to render every player page with
+// its own copy of the font, and its glyphs differed from the reference images (rendered without
+// it, as on the CI runner) by hundreds to thousands of pixels per page; that twice led someone to
+// "fix" the suite by regenerating the baselines on their own machine, which just moved the failure
+// to CI. (The book-preview captures were never affected: the staged book's own @font-face points at
+// the served copy.)
+//
+// So after loading a player page we add these rules: one @font-face per face bloom-player declares,
+// with the same family, weight and style descriptors, and the served WOFF2 as the ONLY source.
+// When several @font-face rules have identical descriptors the last one wins, so these replace the
+// player's own, and the text renders from Bloom's WOFF2 whatever is installed. The URLs are the
+// ones bloom-player itself falls back to, so a run requests exactly the files CI does. Measured
+// 2026-09-03: with Andika faces forced to an installed font, 51 of 84 comparisons differed (199 to
+// 14351 pixels); with these rules added as well, 0 of 84.
+const SERVED_FONTS_ONLY_CSS = [
+    servedFontFaces("Andika"),
+    servedFontFaces("Andika New Basic"),
+].join("\n");
+
+// The four @font-face rules (regular, bold, italic, bold italic) for one family, each with the
+// served file as its only source. The URL is the one bloom-player uses: the family name under
+// ./host/fonts/, followed by " Bold", " Italic" or " Bold Italic" for the other faces, which Bloom
+// answers with the matching WOFF2 (see FontsApi.ProcessHostFontsRequest).
+function servedFontFaces(family: string): string {
+    const variants = [
+        ["normal", "normal", ""],
+        ["bold", "normal", " Bold"],
+        ["normal", "italic", " Italic"],
+        ["bold", "italic", " Bold Italic"],
+    ];
+    return variants
+        .map(
+            ([weight, style, variant]) =>
+                `@font-face{font-family:"${family}";font-weight:${weight};font-style:${style};` +
+                `src:url("./host/fonts/${family}${variant}")}`,
+        )
+        .join("\n");
 }
 
 // Ports Bloom uses: it takes the next free block starting at 8089 (8089, 8092, 8095, ...). We probe

--- a/src/BloomVisualRegressionTests/readme.md
+++ b/src/BloomVisualRegressionTests/readme.md
@@ -15,16 +15,18 @@ over HTTP, and shuts it down and deletes the temp folder afterward. Because it l
 `--automation`, it can run alongside a Bloom you already have open. Because it operates on a temp
 copy, a run never modifies the books it renders.
 
-# If Andika is installed on your machine
+# Fonts installed on your machine do not matter
 
-bloom-player prefers an installed Andika (`local("Andika")`) over the copy Bloom serves, so with
-Andika installed the bloom-player screenshots come out with your machine's version of the font and
-differ from the reference images, which are rendered without it (as on the CI runner). The book
-previews are not affected. The suite detects this: it warns at the start of the run, and any
-player-page mismatch on such a machine says so in its failure message. Treat those failures as the
-font, not a regression, and do **not** fix them by regenerating the baselines on a machine that has
-Andika — that makes them wrong on CI and on everyone else's machine. To make the player comparisons
-meaningful, uninstall Andika; Bloom itself does not need it installed.
+The reference images are rendered on the CI runner, which has no Andika installed, and the suite
+renders the same way everywhere: text comes from the WOFF2 fonts Bloom itself serves, never from a
+font installed on the machine. That needs no care for the book previews, whose `@font-face` rules
+already point at the served copy. bloom-player is different: it declares Andika as
+`local("Andika")` first and the served copy only as a fallback, so a machine with Andika installed
+used to render every player page with its own copy and differ from the baselines by hundreds of
+pixels per page. The suite now adds its own `@font-face` rules to each player page (see
+`SERVED_FONTS_ONLY_CSS` in `index.spec.ts`), with the served file as the only source, and those
+replace the player's. So a player-page mismatch on your machine is a real difference, and a local
+run can go green whatever fonts you have.
 
 # Where the test inputs come from
 


### PR DESCRIPTION
Pays down the `AUTOMATION-DEBT.md` entry "Visual-regression baselines only match the CI runner", and removes it.

## Bloom production code changes

None. Everything here is under `src/BloomVisualRegressionTests` and `src/BloomE2E/AUTOMATION-DEBT.md`.

## Purpose

A local run of the visual-regression suite could not go green on a machine with Andika installed: bloom-player declares each Andika face as `local("Andika")` first and the Bloom-served WOFF2 only as a fallback, so such a machine rendered every player page with its own copy of the font and differed from the baselines (which CI renders without Andika) by hundreds to thousands of pixels per page. The readme's answer was "uninstall Andika", and the suite could only warn about it. This makes the suite render the player's text from the served fonts whatever the machine has installed, so local verification and baseline authoring work on any machine.

## What changes

- After loading each bloom-player page, the suite adds one `@font-face` rule per face bloom-player declares for Andika and Andika New Basic, with the same family/weight/style descriptors and the served WOFF2 as the only source. When several `@font-face` rules have identical descriptors the last one wins, so these replace the player's and the text renders from Bloom's WOFF2. The URLs are the ones bloom-player itself falls back to, so a run requests exactly the files CI does.
- The Andika-installed probe, its start-of-run warning and the "likely cause" text on player-page failures go away: they described a problem that no longer exists.
- The readme section "If Andika is installed on your machine" becomes "Fonts installed on your machine do not matter".
- The debt entry is removed.

## How it was verified

Measured on a Windows 11 developer machine at 96 DPI, against the pinned baselines (9b58f6b), with a local measurement patch that recorded every comparison's pixel count instead of stopping at a case's first mismatch:

| Run | Setup | Comparisons differing |
| --- | --- | --- |
| 1 | Unmodified suite | 0 of 84 |
| 2 | Player's Andika faces forced to an installed font (stands in for "Andika installed") | 51 of 84, 199 to 14351 px, all bloom-player pages with text |
| 3 | Run 2 plus url-only faces appended | 0 of 84 |
| 4 | This fix, with the run-2 simulation still on | 0 of 84 |
| 5 to 7 | This fix as committed, three consecutive real pass/fail runs | 12 of 12 cases passed, each run |

Run 1 shows that the debt entry's numbers (1 to 884 px) described the baselines before bloom-testing-inputs PR #2 regenerated the player baselines on a no-Andika machine on 2026-09-02; since then a machine without Andika already matched. Runs 2 to 4 show that the one remaining machine dependency, an installed Andika, is what this change removes.

DPI was considered and ruled out: every screenshot comes from Playwright's headless Chromium (device scale factor 1 regardless of the desktop scale), never from Bloom's WebView2 window, and the 96 DPI machine matched CI exactly.

No Bloom production code changed; Devin not run. No Notion test case: this is suite infrastructure, not a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8301)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8301)
<!-- Reviewable:end -->
