### PR TITLE
Treat Enter in a title as a line break, like Shift+Enter (BL-16808)

### DIFF
--- a/src/BloomExe/Book/Book.cs
+++ b/src/BloomExe/Book/Book.cs
@@ -455,6 +455,22 @@ namespace Bloom.Book
 
                 const char kBOM = '\uFEFF'; // Unicode Byte Order Mark character.
 
+                // The user sees a line break both for Shift+Enter (a bloom-linebreak span) and for
+                // plain Enter (a new block element), so both get the same replacement text.
+                var lineBreakReplacement = "";
+                switch (lineBreakSpanConversionOption)
+                {
+                    case LineBreakSpanConversionMode.ToNewline:
+                        lineBreakReplacement = Environment.NewLine;
+                        break;
+                    case LineBreakSpanConversionMode.ToSpace:
+                        lineBreakReplacement = " ";
+                        break;
+                    case LineBreakSpanConversionMode.ToSimpleNewline:
+                        lineBreakReplacement = "\n";
+                        break;
+                }
+
                 // Handle Shift+Enter, which gets translated to <span class="bloom-linebreak" />
                 // This is being handled using at the XML level instead of string level, so that it'll work regardless of
                 // whether it uses the <span /> form or <span></span> form. (I do see places in the debugger where the data is in <span></span> form.)
@@ -480,21 +496,40 @@ namespace Bloom.Book
                     }
 
                     // Now delete lineBreakSpan and replace it
-                    var replacementForLinebreakSpan = "";
-                    switch (lineBreakSpanConversionOption)
-                    {
-                        case LineBreakSpanConversionMode.ToNewline:
-                            replacementForLinebreakSpan = Environment.NewLine;
-                            break;
-                        case LineBreakSpanConversionMode.ToSpace:
-                            replacementForLinebreakSpan = " ";
-                            break;
-                        case LineBreakSpanConversionMode.ToSimpleNewline:
-                            replacementForLinebreakSpan = "\n";
-                            break;
-                    }
-                    var newlineNode = doc.CreateTextNode(replacementForLinebreakSpan);
+                    var newlineNode = doc.CreateTextNode(lineBreakReplacement);
                     lineBreakSpan.ParentNode.ReplaceChild(newlineNode, lineBreakSpan);
+                }
+
+                // Handle plain Enter, which starts a new block element (a paragraph, or with the
+                // heading support added in 6.4, a heading). InnerText just runs the blocks
+                // together, so we have to put the line break in ourselves. Up through Bloom 6.2 we
+                // got away without this because HTML Tidy always left whitespace between block
+                // elements when it wrote the book out; HtmlAgilityPack, which replaced Tidy in the
+                // .NET 8 upgrade, does not. See https://issues.bloomlibrary.org/youtrack/issue/BL-16808.
+                var blocks = doc.SafeSelectNodes("//p | //h1 | //h2 | //h3 | //h4 | //h5 | //h6")
+                    .Cast<SafeXmlElement>()
+                    .ToArray();
+                foreach (var block in blocks)
+                {
+                    var previous = block.PreviousSibling;
+                    if (previous == null)
+                        continue; // nothing comes before it, so there is no boundary to mark
+
+                    // Throw away any whitespace Tidy left between the block elements (books
+                    // written out by Bloom 6.2 and earlier have it). It isn't rendered anywhere,
+                    // and it is what used to stand in for the line break the user sees, so
+                    // replacing it rather than adding to it makes a book written by an older
+                    // Bloom give the same answer as one written by this one.
+                    var isWhitespaceNode =
+                        previous.NodeType == XmlNodeType.Whitespace
+                        || (
+                            previous.NodeType == XmlNodeType.Text
+                            && String.IsNullOrWhiteSpace(previous.Value)
+                        );
+                    if (isWhitespaceNode)
+                        block.ParentNode.RemoveChild(previous);
+
+                    block.ParentNode.InsertBefore(doc.CreateTextNode(lineBreakReplacement), block);
                 }
 
                 return doc.DocumentElement.InnerText;

--- a/src/BloomExe/SafeXml/SafeXmlElement.cs
+++ b/src/BloomExe/SafeXml/SafeXmlElement.cs
@@ -91,6 +91,15 @@ namespace Bloom.SafeXml
             }
         }
 
+        public SafeXmlNode PreviousSibling
+        {
+            get
+            {
+                lock (_doc.Lock)
+                    return WrapNode(WrappedElement.PreviousSibling, _doc);
+            }
+        }
+
         #region Additional Methods
 
         /// <summary>

--- a/src/BloomTests/Book/BookDataTests.cs
+++ b/src/BloomTests/Book/BookDataTests.cs
@@ -111,21 +111,92 @@ namespace BloomTests.Book
         [Test]
         public void TextOfInnerHtml_HandlesLinebreakSpanWithNoByteOrderMarkProperly()
         {
-            // Markup should be removed, linebreak replaced with \n, whitespace should be trimmed.
+            // Markup should be removed, both the linebreak span and the paragraph boundary
+            // replaced with \n, whitespace should be trimmed. (The space between the paragraphs
+            // is what Bloom 6.2 and earlier wrote out for a paragraph boundary.)
             var input =
                 "<p>Enter</p> <p>Shift-Enter<span class=\"bloom-linebreak\"></span>Last Line </p>";
             var output = BookData.TextOfInnerHtml(input);
-            Assert.That(output, Is.EqualTo("Enter Shift-Enter\nLast Line"));
+            Assert.That(output, Is.EqualTo("Enter\nShift-Enter\nLast Line"));
         }
 
         [Test]
         public void TextOfInnerHtml_HandlesLinebreakSpanWithByteOrderMarkProperly()
         {
-            // Markup should be removed, linebreak replaced with \n, byte order mark should be removed, whitespace should be trimmed.
+            // Markup should be removed, linebreak span and paragraph boundary replaced with \n,
+            // byte order mark should be removed, whitespace should be trimmed.
             var input =
                 "<p>Enter</p> <p>Shift-Enter<span class=\"bloom-linebreak\"></span>﻿Last Line </p>";
             var output = BookData.TextOfInnerHtml(input);
-            Assert.That(output, Is.EqualTo("Enter Shift-Enter\nLast Line"));
+            Assert.That(output, Is.EqualTo("Enter\nShift-Enter\nLast Line"));
+        }
+
+        [Test]
+        public void TextOfInnerHtml_EnterInTitle_BecomesNewline()
+        {
+            // A title typed as "a", Enter, "b" reaches us as two paragraphs with no whitespace
+            // between them. See https://issues.bloomlibrary.org/youtrack/issue/BL-16808.
+            var output = BookData.TextOfInnerHtml("<p>a</p><p>b</p>");
+            Assert.That(output, Is.EqualTo("a\nb"));
+        }
+
+        [Test]
+        public void TextOfInnerHtml_TitleFromOldBookWithTidyIndentation_SameAsFreshlyTyped()
+        {
+            // A book written by Bloom 6.2 or earlier has the paragraphs of its title separated by
+            // the indentation Tidy left in the file. Left alone, that indentation would end up in
+            // the title itself ("a\n            b"), so we replace it rather than adding to it and
+            // an old book reports what a new one does.
+            var oldBook = "<p>a</p>\n            <p>b</p>";
+            var freshlyTyped = "<p>a</p><p>b</p>";
+
+            // Sanity check that the two really do differ in the way this test is about.
+            Assert.That(
+                oldBook,
+                Does.Contain("</p>\n            <p>"),
+                "test data should carry the indentation an older Bloom wrote"
+            );
+            Assert.That(freshlyTyped, Does.Contain("</p><p>"));
+
+            Assert.That(BookData.TextOfInnerHtml(oldBook), Is.EqualTo("a\nb"));
+            Assert.That(
+                BookData.TextOfInnerHtml(oldBook),
+                Is.EqualTo(BookData.TextOfInnerHtml(freshlyTyped))
+            );
+        }
+
+        [Test]
+        public void SuckInDataFromEditedDom_TitleTypedWithEnter_NewlineReachesMetaData()
+        {
+            // The whole path a title takes from the editing DOM to meta.json (and so to
+            // bloomlibrary.org), for a title typed "Where Are", Enter, "The Fish Going?".
+            // See https://issues.bloomlibrary.org/youtrack/issue/BL-16808.
+            var titleXml = "<p>Where Are</p><p>The Fish Going?</p>";
+            HtmlDom bookDom = new HtmlDom(
+                $@"<html ><head></head><body>
+				<div class='bloom-page' id='guid2'>
+					<div lang='xyz' data-book='bookTitle'>{titleXml}</div>
+				</div>
+			 </body></html>"
+            );
+
+            // Sanity check: the paragraphs really are adjacent, which is what the browser gives
+            // us and what used to make the two lines run together.
+            Assert.That(
+                titleXml.Contains("</p><p>"),
+                Is.True,
+                "test data should have no whitespace between the paragraphs"
+            );
+
+            var data = new BookData(bookDom, _collectionSettings, null);
+            var info = new BookInfo(_collectionSettings.FolderPath, true);
+            Assert.That(info.Title, Is.Null.Or.Empty, "sanity check: no title before we start");
+
+            data.SuckInDataFromEditedDom(bookDom, info);
+
+            Assert.That(info.Title, Is.EqualTo("Where Are\nThe Fish Going?"));
+            Assert.That(info.AllTitles, Does.Contain("Where Are\nThe Fish Going?"));
+            Assert.That(info.OriginalTitle, Is.EqualTo("Where Are\nThe Fish Going?"));
         }
 
         [Test]

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -6775,7 +6775,81 @@ namespace BloomTests.Book
                 default:
                     break;
             }
-            Assert.That(result, Is.EqualTo($"Enter Shift-Enter{replacement}Last Line "));
+            // The space between the two paragraphs is what Bloom 6.2 and earlier wrote out; the
+            // paragraph boundary it stood for now gets the same replacement as the linebreak span.
+            Assert.That(
+                result,
+                Is.EqualTo($"Enter{replacement}Shift-Enter{replacement}Last Line ")
+            );
+        }
+
+        [TestCase(Bloom.Book.Book.LineBreakSpanConversionMode.ToSpace)]
+        [TestCase(Bloom.Book.Book.LineBreakSpanConversionMode.ToNewline)]
+        [TestCase(Bloom.Book.Book.LineBreakSpanConversionMode.ToSimpleNewline)]
+        public void RemoveHtmlMarkup_AdjacentParagraphs_BoundaryBecomesLineBreak(
+            Bloom.Book.Book.LineBreakSpanConversionMode conversionMode
+        )
+        {
+            // What the browser gives us for "a", Enter, "b": no whitespace at all between the
+            // paragraphs. See https://issues.bloomlibrary.org/youtrack/issue/BL-16808.
+            string input = "<p>a</p><p>b</p>";
+
+            // Sanity check: without the paragraph handling this runs the two together.
+            Assert.That(
+                input.Contains("</p><p>"),
+                Is.True,
+                "test input is supposed to have no whitespace between the paragraphs"
+            );
+
+            var result = Bloom.Book.Book.RemoveHtmlMarkup(input, conversionMode);
+
+            string replacement = " ";
+            switch (conversionMode)
+            {
+                case Bloom.Book.Book.LineBreakSpanConversionMode.ToNewline:
+                    replacement = Environment.NewLine;
+                    break;
+                case Bloom.Book.Book.LineBreakSpanConversionMode.ToSimpleNewline:
+                    replacement = "\n";
+                    break;
+                default:
+                    break;
+            }
+            Assert.That(result, Is.EqualTo($"a{replacement}b"));
+        }
+
+        [Test]
+        public void RemoveHtmlMarkup_HeadingFollowsParagraph_BoundaryBecomesLineBreak()
+        {
+            string input = "<p>a</p><h1>b</h1><p>c</p>";
+            var result = Bloom.Book.Book.RemoveHtmlMarkup(
+                input,
+                Bloom.Book.Book.LineBreakSpanConversionMode.ToSimpleNewline
+            );
+
+            Assert.That(result, Is.EqualTo("a\nb\nc"));
+        }
+
+        [Test]
+        public void RemoveHtmlMarkup_SingleParagraph_NoLeadingLineBreak()
+        {
+            var result = Bloom.Book.Book.RemoveHtmlMarkup(
+                "<p>a</p>",
+                Bloom.Book.Book.LineBreakSpanConversionMode.ToSimpleNewline
+            );
+
+            Assert.That(result, Is.EqualTo("a"));
+        }
+
+        [Test]
+        public void RemoveHtmlMarkup_MarkupInsideParagraph_NoSpuriousLineBreak()
+        {
+            var result = Bloom.Book.Book.RemoveHtmlMarkup(
+                "<p><strong>Where Are</strong></p><p><strong>The Fish Going?</strong></p>",
+                Bloom.Book.Book.LineBreakSpanConversionMode.ToSimpleNewline
+            );
+
+            Assert.That(result, Is.EqualTo("Where Are\nThe Fish Going?"));
         }
 
         [Test]


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
### Problem

Typing a book title with a line break in it — "a", Enter, "b" — gives a title of `ab` on
bloomlibrary.org: the line break is silently swallowed and the two lines are run together.
Titles typed with **Shift+Enter** are unaffected. This is a regression from 6.2, and it also
affects the book's folder name and the caption under its thumbnail in the collection tab.

### Cause

Plain Enter starts a new paragraph, so the title reaches us as `<p>a</p><p>b</p>`.
`Book.RemoveHtmlMarkup` reduces title markup to plain text by returning `InnerText`, which runs
adjacent paragraphs together; it has only ever special-cased `span.bloom-linebreak`
(Shift+Enter), never a paragraph boundary.

It used to come out as `a b` purely by accident: HTML Tidy always left whitespace between block
elements when it wrote the book out, and that whitespace stood in for the line break. The .NET 8
upgrade (BL-14973, `c0f8a714e`) replaced Tidy with HtmlAgilityPack, which doesn't, so the
separator disappeared — which is why this fails in 6.3 and later but not 6.2.

### Fix

- `Book.RemoveHtmlMarkup` now treats a **block-element boundary** as a line break, giving it the
  same replacement text it already gives a `bloom-linebreak` span — `"\n"` for `meta.json`,
  `Environment.NewLine`, or a space, per `LineBreakSpanConversionMode`. So plain Enter and
  Shift+Enter finally behave the same, which is what BL-10630 set out to do.
- Headings count too, not just `<p>`: 6.4 added minimal heading support (BL-16649).
- Any Tidy-era whitespace already sitting between the blocks is **replaced** rather than added
  to. Without that, a 6.2-era book carries the file's own indentation into its title — which is
  what it does today, giving `Where Are
            The Fish Going?`. Now an old book and a new
  one report the same thing.
- `SafeXmlElement` gains a `PreviousSibling` property, mirroring the existing `NextSibling`.

This fixes `meta.json`'s `title` and `allTitles` (and so what bloomlibrary.org shows),
`originalTitle`, and the collection-tab caption, since all of them go through this one method.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16808


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8305)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8305)
<!-- Reviewable:end -->

