### PR TITLE
Tidy the nightly's labels, and keep its reports in one thread

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,7 @@
 # Each suite publishes its own check run / job-summary section, so the commit shows five
 # independent results rather than one merged total. See the "Test reports" steps at the end.
 #
-# Every night is then reported to Zulip -- pass or fail, one topic per night -- with each suite's
+# Every night is then reported to Zulip -- pass or fail, all in one topic -- with each suite's
 # counts and how long it took. See "The nightly report" at the end.
 #
 # Schedule: 04:00 UTC daily. GitHub cron is always UTC (== GMT, no DST), so this is a
@@ -50,27 +50,27 @@ on:
     workflow_dispatch:
         inputs:
             run_frontend_tests:
-                description: "TypeScript unit tests (vitest, ~3 min)"
+                description: "TypeScript unit tests (~3 min)"
                 type: boolean
                 default: true
             run_csharp_tests:
-                description: "C# unit tests (NUnit, ~13 min)"
+                description: "C# unit tests (~13 min)"
                 type: boolean
                 default: true
             run_e2e_tests:
-                description: "BloomE2E tests (Playwright, ~9 min)"
+                description: "BloomE2E tests (~9 min)"
                 type: boolean
                 default: true
             run_component_tests:
-                description: "React component tests (Playwright, ~2 min)"
+                description: "React component tests (~2 min)"
                 type: boolean
                 default: true
             run_visual_regression:
-                description: "Visual regression tests (book page layout, ~3 min)"
+                description: "Visual regression tests -- book page layout (~3 min)"
                 type: boolean
                 default: true
             post_to_zulip:
-                description: "Post this run's report to Zulip (scheduled runs always do; this is for testing)"
+                description: "Post report to Zulip"
                 type: boolean
                 default: false
 
@@ -612,15 +612,21 @@ jobs:
                   retention-days: 14
 
             # ----- The nightly report -----
-            # Post a report of EVERY night to Zulip -- channel "developers", a topic per night --
+            # Post a report of EVERY night to Zulip -- channel "developers", topic "Nightly run" --
             # rather than speaking up only when something broke. Silence on a good night is
             # indistinguishable from a nightly that never ran at all, which is the failure that
             # hides longest; and the timings below are worth watching on a green night too, since
             # a suite doubling in length is news before it is a failure.
             #
-            # One topic per night ("Nightly run 2026-09-04"), so a bad night can be discussed under its
-            # own date without burying the others, and so the channel's topic list doubles as a
-            # record of which nights ran.
+            # One topic for all of them, so the nights sit together as a single thread you can
+            # follow or mute in one go, and so last night's numbers are one scroll from the night
+            # before's. Zulip's own date dividers separate them, so the report carries no date of
+            # its own.
+            #
+            # The cost of that, worth knowing because it undoes half an argument made when this was
+            # designed: a night that dies on the job timeout reports nothing, and with a shared
+            # topic that is a gap in a thread rather than a missing topic in a list. Less visible,
+            # though still a morning with no message in a channel that has one every other day.
             #
             # Two steps: compose the message here, hand it to Zulip's own action below. The split is
             # not decoration -- gathering the outcomes, counts and timings is our logic; talking to
@@ -898,9 +904,8 @@ jobs:
 
                   Write-Host $content
 
-                  # One topic per night. The schedule is 04:00 UTC, so the UTC date is the night's
-                  # own name and does not drift with whoever is reading.
-                  $topic = "Nightly run " + [datetimeoffset]::UtcNow.ToString("yyyy-MM-dd")
+                  # A fixed topic, so every night lands in the same thread.
+                  $topic = "Nightly run"
 
                   # Step outputs, so the send step below stays a pure "here is a message, post it".
                   # A multi-line value needs the delimiter form.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,8 +18,8 @@
 #
 # A manual run can pick which of the five suites to run; all five are ticked by default, so the
 # default manual run matches the scheduled one. Unticking the ones you don't need is how to iterate
-# quickly when chasing a failure in a single suite: the C# suite alone is ~9 minutes of a ~22-minute
-# run, so dropping it takes an attempt to ~12. That was added while hunting the intermittent
+# quickly when chasing a failure in a single suite: the C# suite alone is ~13 minutes of a
+# ~47-minute run, so dropping it takes an attempt to ~34. That was added while hunting the intermittent
 # visual-regression hang in BL-16612.
 #
 # The two BUILDS always run and are not selectable, because they are prerequisites rather than
@@ -30,8 +30,8 @@
 # Note this is a selection, not a reordering. Reordering the steps so a chosen suite runs earlier
 # would be safe on paper -- nothing gates on either test suite except its own publish step -- but the
 # scheduled run is where our record of how often something fails comes from, and a suite that runs on
-# a machine which has NOT just spent nine minutes being hammered by the C# tests is being sampled
-# under different conditions. For an intermittent, possibly load-sensitive failure that matters, so
+# a machine which has NOT just spent thirteen minutes being hammered by the C# tests is being
+# sampled under different conditions. For an intermittent, possibly load-sensitive failure that matters, so
 # the scheduled run keeps its shape and manual runs vary only in what they skip.
 #
 # The component-tester suite is the one deliberate exception, moved ahead of visual regression on
@@ -50,23 +50,23 @@ on:
     workflow_dispatch:
         inputs:
             run_frontend_tests:
-                description: "Front-end suite (vitest)"
+                description: "TypeScript unit tests (vitest, ~3 min)"
                 type: boolean
                 default: true
             run_csharp_tests:
-                description: "C# suite (NUnit) - the slowest, ~9 min"
+                description: "C# unit tests (NUnit, ~13 min)"
                 type: boolean
                 default: true
             run_e2e_tests:
-                description: "BloomE2E suite (clicks through a real Bloom)"
-                type: boolean
-                default: true
-            run_visual_regression:
-                description: "Visual-regression suite (drives a real Bloom)"
+                description: "BloomE2E tests (Playwright, ~9 min)"
                 type: boolean
                 default: true
             run_component_tests:
-                description: "Component-tester suite (Playwright against the Vite harness)"
+                description: "React component tests (Playwright, ~2 min)"
+                type: boolean
+                default: true
+            run_visual_regression:
+                description: "Visual regression tests (book page layout, ~3 min)"
                 type: boolean
                 default: true
             post_to_zulip:
@@ -101,8 +101,8 @@ jobs:
             RUN_FRONTEND_TESTS: ${{ github.event_name != 'workflow_dispatch' || inputs.run_frontend_tests }}
             RUN_CSHARP_TESTS: ${{ github.event_name != 'workflow_dispatch' || inputs.run_csharp_tests }}
             RUN_E2E_TESTS: ${{ github.event_name != 'workflow_dispatch' || inputs.run_e2e_tests }}
-            RUN_VISUAL_REGRESSION: ${{ github.event_name != 'workflow_dispatch' || inputs.run_visual_regression }}
             RUN_COMPONENT_TESTS: ${{ github.event_name != 'workflow_dispatch' || inputs.run_component_tests }}
+            RUN_VISUAL_REGRESSION: ${{ github.event_name != 'workflow_dispatch' || inputs.run_visual_regression }}
 
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
## Problem

Two loose ends left by #8307, which renamed the five nightly suites so the Zulip report and the
commit's check runs agree.

The **Run workflow** form was never updated: its checkboxes still read "Front-end suite (vitest)",
"Component-tester suite", and so on — a third vocabulary for the same five suites, in the one place
where someone is deciding what to spend forty minutes running. The form was also in a different
order from the run, and quoted timings that predate two of those suites existing.

Separately, each night's report went to its own topic, named for the date. That scattered the
reports across a new thread every morning instead of keeping them somewhere you can follow, mute,
or scroll back through in one place.

## What the PR does

- **Relabels the five checkboxes** to lead with the name used everywhere else, then what each suite
  runs on — or, for visual regression, what it covers — and roughly what it costs, so unticking a
  box tells you what you save:

  | before | after |
  | --- | --- |
  | Front-end suite (vitest) | TypeScript unit tests (vitest, ~3 min) |
  | C# suite (NUnit) - the slowest, ~9 min | C# unit tests (NUnit, ~13 min) |
  | BloomE2E suite (clicks through a real Bloom) | BloomE2E tests (Playwright, ~9 min) |
  | Component-tester suite (Playwright against the Vite harness) | React component tests (Playwright, ~2 min) |
  | Visual-regression suite (drives a real Bloom) | Visual regression tests (book page layout, ~3 min) |

- **Puts them in the order the job runs them** — the component suite before visual regression, as it
  has run since #8307 — which is also the order the report lists them in. The `RUN_*` env block
  follows suit, so the form, the env block, the steps and the report all read in one order.
- **Corrects three stale timing claims**, now that the report measures them nightly: the C# suite is
  ~13 minutes rather than ~9, and the whole run is ~47 minutes rather than ~22. Those figures were
  written before the BloomE2E and component suites joined the run, so the header's advice about how
  much time unticking C# saves you was out by more than a factor of two. The new times come from the
  2026-09-04 scheduled run, rounded to the minute.
- **Sends every report to one topic, `Nightly run`**, instead of one topic per night, so the nights
  sit together as a single thread. Zulip's own date dividers separate them, so the report carries no
  date of its own.

Worth flagging, because it undoes half an argument recorded on a resolved thread in #8307: a night
that dies on the 120-minute job timeout reports nothing, and with a shared topic that shows as a gap
in a thread rather than a missing topic in a list. Less visible than it was — though still a morning
with no message in a channel that has one every other day.

Nothing else changes: the input names, their defaults and every condition are untouched.
<!-- preflight-narrative:end -->


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8308)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8308)
<!-- Reviewable:end -->
