### PR TITLE
Fix BL-16809 Remove Page sometimes prevented by race condition

### DIFF
--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -19,6 +19,11 @@ House rules:
 
 ---
 
+## 2026-09-04 — Launcher times out waiting for BLOOM_AUTOMATION_READY while a direct dotnet watch works
+- **Cut:** `go.mjs` / `launcherControl.mjs --ensure-running` built Bloom in ~6s, printed `dotnet watch ⌚ Loaded 2 project(s)`, then never saw the ready marker and tore the whole stack down after the 120s `launchTimeoutMs` in `scripts/watchBloomExe.mjs` — three times in a row. Running `dotnet watch run --project src/BloomExe/BloomExe.csproj --non-interactive -- --automation` by hand from the same shell started Bloom and printed `BLOOM_AUTOMATION_READY` within seconds (alongside a running BetaInternal, so it was not the single-instance token).
+- **Idea:** Find what differs when `watchBloomExe.mjs` spawns dotnet watch (`--vite-port`/`--label` args, control-port env, stdout piping) and make the launcher print dotnet watch's later output or the Bloom PID's window titles when it gives up, so the failure is diagnosable. Consider making the timeout configurable.
+- **Context:** worktree Format-Gear-Positioning-356 at the Version6.5 tip, while fixing BL-16809; hit by Claude.
+
 ## 2026-07-30 — Visual regression suite reports only the first stale image per case
 - **Cut:** Each case in `src/BloomVisualRegressionTests/index.spec.ts` compares the book preview
   and then every bloom-player page in sequence, and every comparison throws on failure — so the

--- a/src/BloomBrowserUI/bookEdit/TopicChooser/TopicChooserDialog.tsx
+++ b/src/BloomBrowserUI/bookEdit/TopicChooser/TopicChooserDialog.tsx
@@ -54,10 +54,7 @@ export const TopicChooserDialog: React.FunctionComponent<
 
     const dialogTitle = useL10n("Choose Topic", "TopicChooser.Title");
 
-    // Tell edit tab to disable everything when the dialog is up.
-    // (Without this, the page list is not disabled since the modal
-    // div only exists in the book pane. Once the whole edit tab is inside
-    // one browser, this would not be necessary.)
+    // Tell C# to lock the workspace tabs while the dialog is up.
     React.useEffect(() => {
         if (propsForBloomDialog.open === undefined) return;
 

--- a/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
+++ b/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
@@ -7,7 +7,7 @@ import BloomMessageBoxSupport from "../../utils/bloomMessageBoxSupport";
 import { tryProcessHyperlink } from "./hyperlinks";
 import { EditableDivUtils } from "../js/editableDivUtils";
 import $ from "jquery";
-import { showLinkTargetChooserDialog } from "../../react_components/LinkTargetChooser/LinkTargetChooserDialogLauncher";
+import { getWorkspaceBundleExports } from "../js/workspaceFrames";
 import { getLocalization } from "../../react_components/l10n";
 import { kNoIndentClass } from "../textContextMenu/noIndent";
 
@@ -401,6 +401,9 @@ export default class BloomField {
 
         ckeditor.addCommand("setupHyperlink", {
             exec: function (edt) {
+                // Shown from the workspace root so its backdrop covers the page list too.
+                const showLinkTargetChooserDialog =
+                    getWorkspaceBundleExports().showLinkTargetChooserDialog;
                 showLinkTargetChooserDialog("", (url) => {
                     if (!url) return;
                     get("app/selectedBookInfo", (bookInfo) => {

--- a/src/BloomBrowserUI/bookEdit/copyrightAndLicense/CopyrightAndLicenseDialog.tsx
+++ b/src/BloomBrowserUI/bookEdit/copyrightAndLicense/CopyrightAndLicenseDialog.tsx
@@ -68,10 +68,7 @@ export const CopyrightAndLicenseDialog: React.FunctionComponent<{
 
     const dialogTitle = useL10n("Copyright and License", "CopyrightAndLicense");
 
-    // Tell edit tab to disable everything when the dialog is up.
-    // (Without this, the page list is not disabled since the modal
-    // div only exists in the book pane. Once the whole edit tab is inside
-    // one browser, this would not be necessary.)
+    // Tell C# to lock the workspace tabs while the dialog is up.
     React.useEffect(() => {
         if (propsForBloomDialog.open === undefined) return;
 

--- a/src/BloomBrowserUI/bookEdit/js/linkGrid.ts
+++ b/src/BloomBrowserUI/bookEdit/js/linkGrid.ts
@@ -4,7 +4,7 @@ import WebSocketManager, {
     IBloomWebSocketEvent,
 } from "../../utils/WebSocketManager";
 import { postJson } from "../../utils/bloomApi";
-import { showBookGridSetupDialog } from "../../react_components/BookGridSetup/BookGridSetupDialog";
+import { getWorkspaceBundleExports } from "./workspaceFrames";
 import { Link } from "../../react_components/BookGridSetup/BookLinkTypes";
 
 function getLanguage1Tag(): string {
@@ -56,7 +56,8 @@ export function editLinkGrid(linkGrid: HTMLElement) {
             };
         });
 
-    showBookGridSetupDialog(
+    // Shown from the workspace root so its backdrop covers the page list too.
+    getWorkspaceBundleExports().showBookGridSetupDialog(
         currentLinks,
         // callback if they press OK
         (links: Link[]) => {

--- a/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlRegistry.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/canvas/canvasControlRegistry.ts
@@ -74,7 +74,6 @@ import {
     showDialogToChooseSoundFileAsync,
 } from "../games/GameTool";
 import { showTalkingBookTool } from "../talkingBook/showTalkingBookTool";
-import { showLinkTargetChooserDialog } from "../../../react_components/LinkTargetChooser/LinkTargetChooserDialogLauncher";
 import { kBloomBlue } from "../../../bloomMaterialUITheme";
 import { trackEvent } from "../../../utils/bloomApi";
 import {
@@ -1149,6 +1148,9 @@ export const controlRegistry: Record<TopLevelControlId, IControlDefinition> = {
             // element itself (not on any nested image container).
             const currentUrl =
                 ctx.canvasElement.getAttribute("data-href") ?? "";
+            // Shown from the workspace root so its backdrop covers the page list too.
+            const showLinkTargetChooserDialog =
+                getWorkspaceBundleExports().showLinkTargetChooserDialog;
             showLinkTargetChooserDialog(currentUrl, (newUrl) => {
                 if (newUrl) {
                     ctx.canvasElement.setAttribute("data-href", newUrl);

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/AdjustTimingsDialog.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/AdjustTimingsDialog.tsx
@@ -115,10 +115,7 @@ export const AdjustTimingsDialog: React.FunctionComponent<{
     );
     const [timingsFilePath, setTimingsFilePath] = useState<string>();
 
-    // Tell edit tab to disable everything when the dialog is up.
-    // (Without this, the page list is not disabled since the modal
-    // div only exists in the book pane. Once the whole edit tab is inside
-    // one browser, this would not be necessary.)
+    // Tell C# to lock the workspace tabs while the dialog is up.
     React.useEffect(() => {
         if (propsForBloomDialog.open === undefined) return;
         postBoolean("editView/setModalState", propsForBloomDialog.open);

--- a/src/BloomBrowserUI/bookEdit/workspaceRoot.ts
+++ b/src/BloomBrowserUI/bookEdit/workspaceRoot.ts
@@ -8,6 +8,7 @@ import {
     hideColorPickerDialog as doHideColorPickerDialog,
 } from "../react_components/color-picking/colorPickerDialog";
 import { postJson } from "../utils/bloomApi";
+import { Link } from "../react_components/BookGridSetup/BookLinkTypes";
 import "../modified_libraries/jquery-ui/jquery-ui-1.10.3.custom.min.js"; //for dialog()
 import $ from "jquery";
 
@@ -33,6 +34,14 @@ export interface IWorkspaceExports {
     hideColorPickerDialog(): void;
     showCopyrightAndLicenseDialog(imageUrl?: string): void;
     showEditViewTopicChooserDialog(): void;
+    showLinkTargetChooserDialog(
+        currentUrl: string,
+        onSetUrl: (url: string) => void,
+    ): void;
+    showBookGridSetupDialog(
+        currentLinks: Link[],
+        setLinksCallback: (links: Link[]) => void,
+    ): void;
     showAdjustTimingsDialogFromWorkspaceRoot(
         currentTextBox: HTMLElement,
         // The split and applyTimingsFile calls both return a list of new timings,
@@ -70,6 +79,13 @@ import { getEditablePageBundleExports } from "./js/workspaceFrames";
 export { getEditablePageBundleExports };
 import { showPageChooserDialog } from "../pageChooser/PageChooserDialog";
 export { showPageChooserDialog };
+// These two are launched from code that runs in the page iframe. They must be shown from here,
+// the workspace root, so that their modal backdrop covers the whole workspace including the
+// page list; rendered in the page iframe the backdrop covers only the book pane (BL-16809).
+import { showLinkTargetChooserDialog } from "../react_components/LinkTargetChooser/LinkTargetChooserDialogLauncher";
+export { showLinkTargetChooserDialog };
+import { showBookGridSetupDialog } from "../react_components/BookGridSetup/BookGridSetupDialog";
+export { showBookGridSetupDialog };
 
 import "../lib/errorHandler";
 import { showBookSettingsDialog } from "./bookAndPageSettings/BookAndPageSettingsDialog";
@@ -449,6 +465,8 @@ interface WorkspaceBundleApi {
     getToolboxBundleExports: typeof getToolboxBundleExports;
     getEditablePageBundleExports: typeof getEditablePageBundleExports;
     showPageChooserDialog: typeof showPageChooserDialog;
+    showLinkTargetChooserDialog: typeof showLinkTargetChooserDialog;
+    showBookGridSetupDialog: typeof showBookGridSetupDialog;
     showBookSettingsDialog: typeof showBookSettingsDialog;
     showRegistrationDialog: typeof showRegistrationDialogForEditTab;
     showAboutDialog: typeof showAboutDialog;
@@ -495,6 +513,8 @@ window.workspaceBundle = {
     getToolboxBundleExports,
     getEditablePageBundleExports,
     showPageChooserDialog,
+    showLinkTargetChooserDialog,
+    showBookGridSetupDialog,
     showBookSettingsDialog,
     showRegistrationDialog: showRegistrationDialogForEditTab,
     showAboutDialog,

--- a/src/BloomBrowserUI/pageChooser/PageChooserDialog.tsx
+++ b/src/BloomBrowserUI/pageChooser/PageChooserDialog.tsx
@@ -124,10 +124,7 @@ export const PageChooserDialog: React.FunctionComponent<
         HTMLDivElement | undefined
     >(undefined);
 
-    // Tell edit tab to disable everything when the dialog is up.
-    // (Without this, the page list is not disabled since the modal
-    // div only exists in the book pane. Once the whole edit tab is inside
-    // one browser, this would not be necessary.)
+    // Tell C# to lock the workspace tabs while the dialog is up.
     useEffect(() => {
         if (open === undefined) return;
 

--- a/src/BloomBrowserUI/react_components/LinkTargetChooser/LinkTargetChooserDialogLauncher.tsx
+++ b/src/BloomBrowserUI/react_components/LinkTargetChooser/LinkTargetChooserDialogLauncher.tsx
@@ -2,6 +2,9 @@ import * as React from "react";
 import { ShowEditViewDialog } from "../../bookEdit/workspaceRoot";
 import { LinkTargetChooserDialog } from "./LinkTargetChooserDialog";
 
+// Call this only from the workspace root (from the page iframe, go through
+// getWorkspaceBundleExports().showLinkTargetChooserDialog): ShowEditViewDialog renders in the
+// calling frame's document, and only in the root does the dialog's backdrop cover the page list.
 export const showLinkTargetChooserDialog = (
     currentUrl: string,
     onSetUrl: (url: string) => void,

--- a/src/BloomBrowserUI/react_components/registration/registrationDialogLauncher.tsx
+++ b/src/BloomBrowserUI/react_components/registration/registrationDialogLauncher.tsx
@@ -38,7 +38,7 @@ export const RegistrationDialogLauncher: React.FunctionComponent<
 
     React.useEffect(() => {
         if (props.dialogEnvironment?.mode === Mode.Edit) {
-            // Tell edit tab to disable everything when the dialog is up
+            // Tell C# to lock the workspace tabs while the dialog is up
             postBoolean("editView/setModalState", propsForBloomDialog.open);
         }
     }, [props.dialogEnvironment?.mode, propsForBloomDialog.open]);

--- a/src/BloomExe/Edit/EditingView.cs
+++ b/src/BloomExe/Edit/EditingView.cs
@@ -506,7 +506,7 @@ namespace Bloom.Edit
                 _model.SetupServerWithCurrentBookToolboxContents();
                 WorkspaceView.ReloadWorkspaceRootDocument();
             }
-            SetModalState(false); // ensure _pageListView is enabled (BL-9712).
+            SetModalState(false); // ensure the tabs are not left locked (BL-9712).
 #if MEMORYCHECK
             // Check memory for the benefit of developers.
             Bloom.Utils.MemoryManagement.CheckMemory(
@@ -1545,8 +1545,17 @@ namespace Bloom.Edit
         public string HelpTopicUrl => "/Tasks/Edit_tasks/Edit_tasks_overview.htm";
 
         /// <summary>
-        /// Prevent navigation, e.g. while a dialog box is showing in the browser control
+        /// Lock workspace navigation (the tabs), e.g. while a dialog box is showing in the browser
+        /// control. Calls nest: each true must be matched by a false.
         /// </summary>
+        /// <remarks>
+        /// This used to disable the page list as well, because the page list lived in its own
+        /// browser and a modal dialog's backdrop in the main browser could not cover it. The whole
+        /// edit tab is in one browser now, so the backdrop already blocks the page list, and the
+        /// C# gate could only do harm: the browser posted the dialog's "closed" notice and the command
+        /// the dialog confirmed (e.g. Remove Page) as two concurrent requests, and when the command was
+        /// handled first it was silently refused (BL-16809).
+        /// </remarks>
         internal void SetModalState(bool isModal)
         {
             if (isModal)
@@ -1554,9 +1563,7 @@ namespace Bloom.Edit
             else
                 _modalDialogDepth = Math.Max(0, _modalDialogDepth - 1);
 
-            var isActuallyModal = _modalDialogDepth > 0;
-            _pageListView.Enabled = !isActuallyModal;
-            _workspaceView?.SetTabsEnabled(!isActuallyModal);
+            _workspaceView?.SetTabsEnabled(_modalDialogDepth == 0);
         }
 
         public void ShowAddPageDialog()

--- a/src/BloomExe/Edit/PageListController.cs
+++ b/src/BloomExe/Edit/PageListController.cs
@@ -105,10 +105,5 @@ namespace Bloom.Edit
         {
             _thumbNailList.EmptyThumbnailCache();
         }
-
-        public bool Enabled
-        {
-            set { _thumbNailList.Enabled = value; }
-        }
     }
 }

--- a/src/BloomExe/Edit/PageThumbnailList.cs
+++ b/src/BloomExe/Edit/PageThumbnailList.cs
@@ -203,8 +203,7 @@ namespace Bloom.Edit
 
         internal void PageClicked(IPage page)
         {
-            if (Enabled)
-                InvokePageSelectedChanged(page);
+            InvokePageSelectedChanged(page);
         }
 
         /// <summary>
@@ -217,7 +216,7 @@ namespace Bloom.Edit
         /// </remarks>
         internal bool IsContextMenuCommandEnabled(IPage page, string commandId)
         {
-            if (!Enabled || page == null)
+            if (page == null)
                 return false;
 
             switch (commandId)
@@ -272,7 +271,6 @@ namespace Bloom.Edit
         }
 
         private PageListApi _pageListApi;
-        internal bool Enabled = true;
 
         // This gets invoked by Javascript (via the PageListApi) when it determines that a particular page has been moved.
         // newIndex is the (zero-based) index that the page is moving to


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
### Problem

In the 6.5 betas, removing a page often does nothing: the context-menu command is enabled, the "Really Remove Page?" dialog appears, but after clicking Remove the page stays. It happens on any page, in any book, and repeats after a restart (BL-16809).

### Cause

Since BL-16421 the confirmation is a browser dialog. Like the other edit-tab dialogs it tells C# it is open and closed via `editView/setModalState`, and C# used that flag to disable the page list as well as to lock the workspace tabs. When the user clicks Remove, the browser sends the remove command and the "dialog closed" notice as two concurrent HTTP requests. Whenever the command is handled first (it runs on a deliberate short delay), the page list is still disabled and the command is refused silently. Captured live: the unlock was processed about 350 ms after the command had already been dropped.

### What the PR does

- `SetModalState` now only locks the tabs. Disabling the page list dates from when it lived in its own browser and a dialog's backdrop could not cover it; a dialog shown from the workspace root now has a backdrop that already blocks the page list.
- The C# gate is removed: `PageListController.Enabled`, `PageThumbnailList.Enabled`, and its checks on page clicks and context-menu commands. The same lag could also swallow a page click made right after a dialog closed.
- Two dialogs that were still launched from code in the page iframe, Choose Link Target and Book Grid Setup, are now shown through the workspace bundle like the copyright dialog, so their backdrop covers the whole workspace rather than only the book pane.
- The comments on the dialogs that post the flag now say what it does, and a papercut records the dev launcher timing out while a direct `dotnet watch run` works.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16809


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8309)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8309)
<!-- Reviewable:end -->

