### PR TITLE
BL-16822 Book CSS for inline (Word-style) images, and a layout suite for it

### DIFF
--- a/src/BloomBrowserUI/bookEdit/inline-images-e2e/AGENTS.md
+++ b/src/BloomBrowserUI/bookEdit/inline-images-e2e/AGENTS.md
@@ -1,0 +1,37 @@
+# Inline image wrap-geometry tests
+
+`pnpm e2e inline-images` (from `src/BloomBrowserUI`).
+
+These tests are about one thing: how text flows around an inline image. They compile the
+real `src/content/bookLayout/inlineImages.less`, build a page with one image in one
+`bloom-editable`, and read back where every line of text actually landed. Nothing here
+talks to a running Bloom, unlike the canvas suite next door, so it runs from a cold
+checkout in a couple of seconds.
+
+Layout is exactly the kind of thing unit tests cannot see: jsdom does not lay anything
+out, so `inlineImages.test.ts` (vitest) can only check the classes and custom properties
+we write. Whether those produce the intended shape on the page is what this suite is for.
+
+## What the contour tests are doing
+
+Contour wrap — text following the image's transparent silhouette rather than its
+rectangle — is a committed requirement that is not built yet. `inlineImages.less` already
+has the hooks for it (`--inline-image-contour` and `--inline-image-contour-margin`), and
+these tests set those properties by hand, which is what the eventual code will do.
+
+They exist because four separate things about CSS shapes turned out to work differently
+from what the design assumed, and each was settled by measuring Chromium (see the CONTOUR
+WRAP comment in `inlineImages.less`). Rediscovering any of them is expensive, so each is
+pinned by a test: the content-box reference, percentage scaling, the gap needing both a
+margin and a `shape-margin`, and the middle band staying out of it.
+
+## Adding a test
+
+`helpers/inlineImagePage.ts` builds the page and measures the lines. `measureLines`
+returns each line's top/left/right relative to the editable's content box; with the
+monospaced host font, a left edge is exact, while a right edge can fall a character short
+of the shape (use `measureCharacterWidth` for the tolerance).
+
+If a test seems to pass without proving anything, break it on purpose first: drop
+`content-box` from the polygon and four tests should go red. That check caught nothing
+this time, but it is the fastest way to notice that the CSS never loaded.

--- a/src/BloomBrowserUI/bookEdit/inline-images-e2e/helpers/inlineImagePage.ts
+++ b/src/BloomBrowserUI/bookEdit/inline-images-e2e/helpers/inlineImagePage.ts
@@ -1,0 +1,166 @@
+// Builds a page holding one inline image inside one bloom-editable, styled by the REAL
+// src/content/bookLayout/inlineImages.less (compiled here, not copied), and measures
+// where the text actually ended up on each line. Everything the tests assert about wrap
+// geometry comes out of a browser laying that CSS out, so the tests fail if the CSS
+// stops meaning what it says.
+
+import { Page } from "playwright/test";
+import * as fs from "node:fs";
+// "node:path", not "path": a bare specifier resolves to the path@0.12.7 package that is in
+// node_modules as somebody's dependency, and that package calls util.isString, which Node
+// removed. The whole suite then fails to load with "util.isString is not a function".
+import * as path from "node:path";
+import less from "less";
+
+const lessPath = path.join(
+    __dirname,
+    "../../../../content/bookLayout/inlineImages.less",
+);
+
+// A 1x1 fully transparent PNG. The picture's own pixels never matter here: the wrapper
+// sizes the img from --inline-image-width and --inline-image-aspect-ratio, and the
+// contour under test is a polygon, not the image's alpha.
+const TRANSPARENT_PNG =
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+
+export const EDITABLE_WIDTH = 400;
+export const LINE_HEIGHT = 20;
+export const FONT_SIZE = 16; // so that the CSS's 1em gap is 16px
+
+let compiledCss: string | undefined;
+
+/** Compile inlineImages.less once per worker. */
+const getInlineImageCss = async (): Promise<string> => {
+    if (compiledCss === undefined) {
+        const source = fs.readFileSync(lessPath, "utf8");
+        const result = await less.render(source, { filename: lessPath });
+        compiledCss = result.css;
+    }
+    return compiledCss;
+};
+
+export interface IInlineImageOptions {
+    /** dock suffix: "Left" | "Right" | "Middle" | "Bottom" */
+    dock: string;
+    /** value for --inline-image-width, e.g. "40%" */
+    width?: string;
+    /** value for --inline-image-offset, e.g. "60px" */
+    offset?: string;
+    /** value for --inline-image-contour, e.g. "polygon(...) content-box" */
+    contour?: string;
+    /** value for --inline-image-contour-margin */
+    contourMargin?: string;
+}
+
+/**
+ * Load a page with one inline image in one editable, plus enough text to wrap past it.
+ * The host styles are deliberately minimal and monospaced so that a line's measured
+ * edges mean something exact.
+ */
+export const loadInlineImagePage = async (
+    page: Page,
+    options: IInlineImageOptions,
+): Promise<void> => {
+    const css = await getInlineImageCss();
+    const vars = [
+        `--inline-image-width: ${options.width ?? "40%"}`,
+        `--inline-image-offset: ${options.offset ?? "0px"}`,
+        `--inline-image-aspect-ratio: 1`,
+        options.contour ? `--inline-image-contour: ${options.contour}` : "",
+        options.contourMargin
+            ? `--inline-image-contour-margin: ${options.contourMargin}`
+            : "",
+    ]
+        .filter(Boolean)
+        .join("; ");
+
+    await page.setContent(`<!doctype html>
+<html><head><meta charset="utf-8"><style>
+  body { margin: 0; }
+  .bloom-editable {
+      width: ${EDITABLE_WIDTH}px;
+      font: ${FONT_SIZE}px/${LINE_HEIGHT}px monospace;
+  }
+  .bloom-editable p { margin: 0; }
+  ${css}
+</style></head><body>
+  <div class="bloom-translationGroup">
+    <div class="bloom-editable bloom-visibility-code-on bloom-content1" lang="en">
+      <div class="bloom-inlineImage bloom-inlineImage${options.dock}"
+           contenteditable="false" style="${vars}">
+        <img src="${TRANSPARENT_PNG}">
+      </div>
+      <p id="text">${"i ".repeat(600)}</p>
+    </div>
+  </div>
+</body></html>`);
+    await page.waitForFunction(
+        () => (document.querySelector("#text") as HTMLElement).offsetHeight > 0,
+    );
+};
+
+export interface ILine {
+    /** top of the line, relative to the top of the editable's content box */
+    top: number;
+    /** left edge of the first glyph, relative to the editable's content box */
+    left: number;
+    /** right edge of the last glyph */
+    right: number;
+}
+
+/**
+ * Where the text really is, line by line. Measured from glyph rectangles rather than
+ * from the CSS, so it reports what the reader would see.
+ */
+export const measureLines = async (page: Page): Promise<ILine[]> =>
+    page.evaluate(() => {
+        const editable = document.querySelector(
+            ".bloom-editable",
+        ) as HTMLElement;
+        const node = (document.querySelector("#text") as HTMLElement)
+            .firstChild as Text;
+        const box = editable.getBoundingClientRect();
+        const lines = new Map<number, { left: number; right: number }>();
+        const range = document.createRange();
+        for (let i = 0; i < node.length; i++) {
+            if (node.data[i] === " ") continue;
+            range.setStart(node, i);
+            range.setEnd(node, i + 1);
+            const r = range.getBoundingClientRect();
+            if (!r.width && !r.height) continue;
+            const top = Math.round(r.top - box.top);
+            const current = lines.get(top) ?? {
+                left: Number.MAX_VALUE,
+                right: -Number.MAX_VALUE,
+            };
+            current.left = Math.min(current.left, r.left - box.left);
+            current.right = Math.max(current.right, r.right - box.left);
+            lines.set(top, current);
+        }
+        return [...lines.entries()]
+            .map(([top, ext]) => ({
+                top,
+                left: Math.round(ext.left),
+                right: Math.round(ext.right),
+            }))
+            .sort((a, b) => a.top - b.top);
+    });
+
+/** The advance width of one character, which is the resolution of a `right` reading. */
+export const measureCharacterWidth = async (page: Page): Promise<number> =>
+    page.evaluate(() => {
+        const node = (document.querySelector("#text") as HTMLElement)
+            .firstChild as Text;
+        const range = document.createRange();
+        range.setStart(node, 0);
+        range.setEnd(node, 2); // "i " -- one character plus its space
+        return range.getBoundingClientRect().width;
+    });
+
+/** The left edges of the lines starting at the given tops, for readable assertions. */
+export const leftEdgesAt = (lines: ILine[], tops: number[]): number[] =>
+    tops.map((top) => {
+        const line = lines.find((l) => l.top === top);
+        if (!line) throw new Error(`no line of text at y=${top}`);
+        return line.left;
+    });

--- a/src/BloomBrowserUI/bookEdit/inline-images-e2e/playwright.config.ts
+++ b/src/BloomBrowserUI/bookEdit/inline-images-e2e/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "playwright/test";
+
+// Unlike the canvas suite next door, nothing here talks to a running Bloom: each test
+// builds its own page out of the real compiled inlineImages.less, so `pnpm e2e
+// inline-images` works from a cold checkout.
+const config = defineConfig({
+    testDir: "./specs",
+    testMatch: "**/*.spec.ts",
+    timeout: 30000,
+    expect: {
+        timeout: 5000,
+    },
+});
+
+export default config;

--- a/src/BloomBrowserUI/bookEdit/inline-images-e2e/specs/contour-wrap.spec.ts
+++ b/src/BloomBrowserUI/bookEdit/inline-images-e2e/specs/contour-wrap.spec.ts
@@ -1,0 +1,184 @@
+// What inlineImages.less promises about wrap geometry, checked by laying it out.
+//
+// The rectangle tests describe how inline images wrap today. The contour tests describe
+// the four things contour wrap (text following the image's transparent silhouette)
+// depends on; contour wrap is not built yet, so they drive the CSS by setting
+// --inline-image-contour by hand, which is exactly what the future code will do. They
+// exist because each of those four was measured in a browser after the plan had assumed
+// something else about it, and an assumption that expensive should not be re-derived.
+
+import { test, expect } from "playwright/test";
+import {
+    loadInlineImagePage,
+    measureLines,
+    measureCharacterWidth,
+    leftEdgesAt,
+} from "../helpers/inlineImagePage";
+
+// The editable is 400px and the image 40% of it, so the picture is 160x160 (aspect 1),
+// sitting 60px down. A 1em gap on a 16px font is 16px, so wrapped text starts at 176.
+const IMAGE_WIDTH = 160;
+const OFFSET = 60;
+const GAP = 16;
+
+// A staircase silhouette: a quarter of the way down the picture the shape reaches a
+// quarter of the way across it, and so on. Percentages, so it describes the same
+// silhouette whatever size the picture is drawn at.
+const STAIRCASE =
+    "polygon(0% 0%, 25% 0%, 25% 25%, 50% 25%, 50% 50%, 75% 50%, 75% 75%, 100% 75%, 100% 100%, 0% 100%) content-box";
+
+// The same silhouette mirrored, for an image docked right: the shape's LEFT edge is
+// what the text on that side runs into.
+const STAIRCASE_MIRRORED =
+    "polygon(100% 0%, 100% 100%, 0% 100%, 0% 75%, 25% 75%, 25% 50%, 50% 50%, 50% 25%, 75% 25%, 75% 0%) content-box";
+
+test.describe("inline image wrap geometry", () => {
+    test("rectangle wrap: text crosses the offset at full width, then clears image + gap", async ({
+        page,
+    }) => {
+        await loadInlineImagePage(page, {
+            dock: "Left",
+            width: "40%",
+            offset: `${OFFSET}px`,
+        });
+        const lines = await measureLines(page);
+
+        // Above the picture the offset is transparent padding that the wrap shape
+        // excludes, so those lines are not indented at all.
+        expect(leftEdgesAt(lines, [0, 20, 40])).toEqual([0, 0, 0]);
+        // Beside it, every line clears the picture and the gap.
+        expect(leftEdgesAt(lines, [60, 100, 200])).toEqual([
+            IMAGE_WIDTH + GAP,
+            IMAGE_WIDTH + GAP,
+            IMAGE_WIDTH + GAP,
+        ]);
+        // Below it, full width again.
+        expect(leftEdgesAt(lines, [240])).toEqual([0]);
+    });
+
+    test("contour: text follows the silhouette, and the offset above it stays full width", async ({
+        page,
+    }) => {
+        await loadInlineImagePage(page, {
+            dock: "Left",
+            width: "40%",
+            offset: `${OFFSET}px`,
+            contour: STAIRCASE,
+        });
+        const lines = await measureLines(page);
+
+        // Sanity: without a contour this same block indents every one of these lines to
+        // 176 (previous test), so a staircase here cannot be the rectangle in disguise.
+        expect(leftEdgesAt(lines, [0, 20, 40])).toEqual([0, 0, 0]);
+        expect(
+            leftEdgesAt(lines, [60, 80, 100, 120, 140, 160, 180, 200]),
+        ).toEqual([40, 40, 80, 80, 120, 120, 160, 160]);
+        expect(leftEdgesAt(lines, [220])).toEqual([0]);
+    });
+
+    // If the contour resolved against the default reference box (the margin box) it
+    // would be stretched over the offset padding and the gap margin, and the staircase
+    // would start at the top of the block instead of at the top of the picture.
+    test("contour resolves against the content box, which is exactly the picture", async ({
+        page,
+    }) => {
+        await loadInlineImagePage(page, {
+            dock: "Left",
+            width: "40%",
+            offset: `${OFFSET}px`,
+            contour: STAIRCASE,
+        });
+        const lines = await measureLines(page);
+
+        // First step of the staircase is a quarter of the way down the PICTURE
+        // (y=60..100), not a quarter of the way down the wrapper (y=0..55).
+        expect(leftEdgesAt(lines, [0])).toEqual([0]);
+        expect(leftEdgesAt(lines, [60])).toEqual([40]);
+    });
+
+    // The reason the contour is a polygon in percentages rather than a picture of the
+    // silhouette: one value has to stay correct at every rendered size.
+    test("contour scales with the picture", async ({ page }) => {
+        await loadInlineImagePage(page, {
+            dock: "Left",
+            width: "20%", // half as wide as the other tests: an 80x80 picture
+            offset: `${OFFSET}px`,
+            contour: STAIRCASE,
+        });
+        const lines = await measureLines(page);
+
+        // Every step is half what it was at 40%, and the staircase ends half as far down.
+        expect(leftEdgesAt(lines, [60, 80, 100, 120])).toEqual([
+            20, 40, 60, 80,
+        ]);
+        expect(leftEdgesAt(lines, [140])).toEqual([0]);
+    });
+
+    // A shape replaces the margin box for wrapping purposes, so the side margin alone
+    // stops holding the text off; but the shape, once expanded by shape-margin, is
+    // clipped back to the margin box, so shape-margin alone has nothing to expand into.
+    // Hence the gap is stated as both, from one variable.
+    test("contour gap: shape-margin holds text off, out to the same edge as a rectangle", async ({
+        page,
+    }) => {
+        await loadInlineImagePage(page, {
+            dock: "Left",
+            width: "40%",
+            offset: `${OFFSET}px`,
+            contour: STAIRCASE,
+            contourMargin: "var(--inline-image-gap)",
+        });
+        const lines = await measureLines(page);
+
+        // Each step is pushed out by the gap...
+        expect(leftEdgesAt(lines, [60, 100])).toEqual([40 + GAP, 80 + GAP]);
+        // ...and at the picture's widest the text sits exactly where the rectangle
+        // wrap would have put it, so contoured and plain images agree.
+        expect(leftEdgesAt(lines, [180])).toEqual([IMAGE_WIDTH + GAP]);
+    });
+
+    test("contour works for an image docked right", async ({ page }) => {
+        await loadInlineImagePage(page, {
+            dock: "Right",
+            width: "40%",
+            offset: `${OFFSET}px`,
+            contour: STAIRCASE_MIRRORED,
+        });
+        const lines = await measureLines(page);
+        const characterWidth = await measureCharacterWidth(page);
+
+        // A line's right edge lands on the last character that fits, so it can fall
+        // short of the contour by up to one character.
+        const expectRightEdgeNear = (top: number, expected: number) => {
+            const line = lines.find((l) => l.top === top);
+            if (!line) throw new Error(`no line of text at y=${top}`);
+            expect(line.right).toBeLessThanOrEqual(expected + 1);
+            expect(line.right).toBeGreaterThan(expected - characterWidth - 1);
+        };
+
+        expect(leftEdgesAt(lines, [0, 20, 40])).toEqual([0, 0, 0]);
+        expectRightEdgeNear(60, 400 - 40); // shape reaches a quarter across
+        expectRightEdgeNear(100, 400 - 80);
+        expectRightEdgeNear(140, 400 - 120);
+        expectRightEdgeNear(180, 400 - 160);
+    });
+
+    // The middle dock's wrapper is a full-width band, so percentages of it would not
+    // land on the picture inside it. The CSS therefore does not read the contour there,
+    // and setting one must not turn the band into something text can flow beside.
+    test("the middle band ignores a contour", async ({ page }) => {
+        await loadInlineImagePage(page, {
+            dock: "Middle",
+            width: "40%",
+            offset: `${OFFSET}px`,
+            contour: STAIRCASE,
+        });
+        const lines = await measureLines(page);
+
+        // No line is ever indented...
+        expect(lines.every((l) => l.left === 0)).toBe(true);
+        // ...and none is inside the band: text goes above it and resumes below it.
+        const insideBand = lines.filter((l) => l.top > OFFSET && l.top < 220);
+        expect(insideBand).toEqual([]);
+    });
+});

--- a/src/BloomBrowserUI/scripts/e2e.js
+++ b/src/BloomBrowserUI/scripts/e2e.js
@@ -52,6 +52,14 @@ const suiteCommands = {
         "./bookEdit/canvas-e2e-tests/playwright.config.ts",
         "--reporter=line",
     ],
+    // Self-contained: builds its own pages from the compiled book CSS, so unlike
+    // canvas it does not need a running Bloom.
+    "inline-images": [
+        "test",
+        "--config",
+        "./bookEdit/inline-images-e2e/playwright.config.ts",
+        "--reporter=line",
+    ],
 };
 
 const printUsage = () => {

--- a/src/BloomBrowserUI/vite.config.mts
+++ b/src/BloomBrowserUI/vite.config.mts
@@ -850,6 +850,7 @@ export default defineConfig(async ({ command }) => {
                 "**/.{idea,git,cache,output,temp}/**",
                 "**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*",
                 "**/bookEdit/canvas-e2e-tests/**", // Exclude Playwright e2e suite (run via pnpm e2e canvas)
+                "**/bookEdit/inline-images-e2e/**", // Exclude Playwright e2e suite (run via pnpm e2e inline-images)
                 "**/react_components/component-tester/**", // Exclude playwright component tests
                 "**/*.uitest.{ts,tsx}", // Exclude UI tests that use Playwright
             ],

--- a/src/content/bookLayout/basePage-legacy-5-6.less
+++ b/src/content/bookLayout/basePage-legacy-5-6.less
@@ -1816,3 +1816,8 @@ body[data-bfnomargin*="video"][data-media*="video"][data-bfnomargin*="portrait"]
     height: 100%;
     width: 100%;
 }
+
+// Inline (Word-style) images are new in 6.5, long after this legacy copy of basePage.css
+// was frozen, but a book using the legacy theme can still contain them, so it needs the
+// same rules. Imported rather than copied so the two themes can't drift apart.
+@import "inlineImages.less";

--- a/src/content/bookLayout/basePage-sharedRules.less
+++ b/src/content/bookLayout/basePage-sharedRules.less
@@ -1,5 +1,9 @@
 ﻿// Styles that are shared by both the regular book css and the more minimalist epub css.
 @import (reference) "../../BloomBrowserUI/bloomUI.less";
+// Inline (Word-style) images docked inside a bloom-editable with text wrapping around
+// them. In its own file because basePage-legacy-5-6.less needs the same rules and we
+// don't want two copies of them.
+@import "inlineImages.less";
 
 @preferredBackgroundGray: hsl(0, 0%, 86%);
 

--- a/src/content/bookLayout/inlineImages.less
+++ b/src/content/bookLayout/inlineImages.less
@@ -1,0 +1,229 @@
+// Inline (Word-style) images: an image that lives inside a bloom-editable so that the
+// text of that editable wraps around it. See INLINE-IMAGES-PLAN.md, and
+// BloomBrowserUI/bookEdit/js/inlineImages.ts for the edit-time behavior.
+//
+// This file is imported by basePage-sharedRules.less (which serves basePage.css and the
+// ePUB stylesheet, so edit, PDF, bloom-player and ePUB all get these rules) and also by
+// basePage-legacy-5-6.less, so that books using the legacy theme render inline images
+// too. It is deliberately not in the compileLess "entries" list for bookLayout, so no
+// standalone inlineImages.css is produced; it only ever arrives via those imports.
+//
+// GEOMETRY MODEL
+// Everything about an inline image's position and size is either a dock class or a
+// custom property in the wrapper's style attribute. Nothing else. That is what lets
+// inlineImages.ts treat (class list + style attribute) as the complete state of an
+// inline image and stamp one language's copy onto its sibling editables without
+// parsing or recomputing anything.
+//     --inline-image-width         width of the visible image, as a % of the editable
+//     --inline-image-offset        how far down from the top of the editable the image
+//                                  sits (see the offset comment below)
+//     --inline-image-aspect-ratio  natural width/height of the image, so that layout
+//                                  (and therefore the overflow checker) is right even
+//                                  before the image has loaded
+//     --inline-image-contour       the wrap shape, when text is to follow the image's
+//                                  transparent silhouette instead of its rectangle;
+//                                  unset means the rectangle (see CONTOUR WRAP below)
+//     --inline-image-contour-margin  the gap along that contour
+// --inline-image-gap below is not part of that per-image state: it is a constant that
+// happens to be expressed as a custom property so the two places that need the same
+// number (the margin and the contour's gap) cannot drift apart.
+// The width is a custom property rather than a plain `width` because the middle dock
+// needs a full-width wrapper containing a narrower image: with the number in a
+// variable, one declaration serves both cases, with no !important fight and no second
+// width to keep in sync. Similarly the aspect ratio is applied to the img rather than
+// the wrapper, since for the middle dock the wrapper is wider than the image.
+.bloom-editable .bloom-inlineImage {
+    box-sizing: border-box;
+
+    // How much space to leave between the picture and the text it displaces. It is
+    // needed twice over -- see the gap note under CONTOUR WRAP below -- so it lives in
+    // one place.
+    --inline-image-gap: 1em;
+
+    img {
+        display: block;
+        width: 100%;
+        aspect-ratio: var(--inline-image-aspect-ratio, auto);
+    }
+
+    // The vertical offset is transparent padding on top of the wrapper, and the wrap
+    // shape excludes that padding, so the text flows *through* it at the editable's
+    // full width and only starts avoiding the image lower down. Nothing else can do
+    // this: line boxes avoid a float's whole margin box (so margin-top gives a
+    // narrowed column instead), translateY moves paint but not the wrap, anchor
+    // positioning is out of flow, and CSS Exclusions never shipped.
+    // SEVERAL IMAGES IN ONE BLOCK
+    // A text block may hold any number of inline images. The clears are per side: a left
+    // image clears only earlier LEFT floats and a right image only earlier RIGHT ones, so
+    // two same-side images stack vertically down that edge (each offset measured from where
+    // the previous one ended), while a left image and a right image can sit at the same
+    // height on opposite sides. clear:both here would force every new image below ALL
+    // existing ones -- with one image dragged low, a newly added one landed below the block
+    // itself (John, live testing). Same-side stacking cannot produce overlapping images and
+    // degrades the same way in every renderer.
+    &.bloom-inlineImageLeft,
+    &.bloom-inlineImageRight,
+    &.bloom-inlineImageMiddle {
+        padding-top: var(--inline-image-offset, 0px);
+        shape-outside: inset(var(--inline-image-offset, 0px) 0 0 0);
+    }
+
+    // CONTOUR WRAP
+    // Word-style wrapping along the image's transparent silhouette rather than its
+    // rectangle is a requirement we have not built yet. Nothing here turns it on:
+    // with --inline-image-contour unset these two declarations are exactly the
+    // rectangle above. What they do is make it a one-property switch later, and pin
+    // down the geometry it needs, which was measured in Chromium rather than assumed
+    // (bookEdit/inline-images-e2e locks the four measurements down):
+    //
+    //  - The contour is a polygon(), NOT `url(<the image>)`. For an element that is
+    //    not itself an image, Chromium sizes an <image> shape at the image's NATURAL
+    //    size, anchored top left and clipped to the box -- so a 1200px-wide photo in a
+    //    160px-wide box would contribute only its top left corner as the wrap shape.
+    //    (Chromium does scale such a mask to fit when the float IS an <img>, but the
+    //    float here is the wrapper, and it has to be: the wrapper is what carries the
+    //    offset padding, the dock, and the middle band.) Percentages in a polygon, by
+    //    contrast, resolve against the reference box, so one polygon stays right at
+    //    every width, zoom level and print resolution, and it deforms with the box
+    //    exactly as the picture inside it does.
+    //  - It must name `content-box`. The default reference box is the margin box,
+    //    which here includes the offset padding and the gap margin, so the silhouette
+    //    would be stretched over both. The content box is precisely the picture.
+    //  - The gap has to be stated twice, as the margin AND as shape-margin: a shape
+    //    replaces the margin box for wrapping (so the margin alone stops mattering),
+    //    while the shape once expanded by shape-margin is clipped BACK to the margin
+    //    box (so shape-margin alone has nothing to expand into). With both at
+    //    --inline-image-gap, a contoured image and a rectangular one hold the text off
+    //    by the same distance at the image's widest point.
+    //
+    // So the work left is to derive the silhouette from the image's alpha channel when
+    // the image changes and write `--inline-image-contour: polygon(...) content-box`
+    // and `--inline-image-contour-margin: var(--inline-image-gap)` onto the wrapper.
+    // Nothing in the markup or the rest of this file has to move.
+    //
+    // Only the side docks can take a contour. The middle band's wrapper is wider than
+    // its image, so percentages of that wrapper would not land on the picture -- and a
+    // full-width band has no text beside it to wrap in the first place.
+    &.bloom-inlineImageLeft,
+    &.bloom-inlineImageRight {
+        shape-outside: var(
+            --inline-image-contour,
+            inset(var(--inline-image-offset, 0px) 0 0 0)
+        );
+        shape-margin: var(--inline-image-contour-margin, 0px);
+    }
+
+    &.bloom-inlineImageLeft {
+        float: left;
+        clear: left;
+        width: var(--inline-image-width, 40%);
+        margin: 0 var(--inline-image-gap) 0.5em 0;
+    }
+
+    &.bloom-inlineImageRight {
+        float: right;
+        clear: right;
+        width: var(--inline-image-width, 40%);
+        margin: 0 0 0.5em var(--inline-image-gap);
+    }
+
+    // A band with text above and below: the wrapper spans the whole editable, so no
+    // line box can fit beside it, and the image is centered inside it at its own
+    // width. It still has to be a float, because that is what allows text above it
+    // (the un-excluded offset region at the top of the shape); an ordinary block
+    // first child would always sit at the very top of the editable. Being full-width,
+    // it genuinely belongs below every earlier float on either side, so this one
+    // keeps clear:both.
+    &.bloom-inlineImageMiddle {
+        float: left;
+        clear: both;
+        width: 100%;
+
+        img {
+            width: var(--inline-image-width, 40%);
+            margin: 0 auto;
+        }
+    }
+
+    // The bottom dock is the one case where the wrapper is not the editable's first
+    // child but its last, and it is not floated at all: it is simply the final block
+    // of the field, centered. (Because of that, inlineImages.ts leaves
+    // bloom-keepFirstInField off a bottom-docked wrapper.)
+    &.bloom-inlineImageBottom {
+        float: none;
+        clear: both;
+        width: var(--inline-image-width, 40%);
+        margin: 0.5em auto 0 auto;
+    }
+}
+
+// FLOAT CONTAINMENT
+// An editable holding an inline image has to contain its float, or the image hangs out
+// below the editable, over the next language's block or whatever follows on the page.
+// There are two separate obstacles:
+//   1. an ordinary block does not contain its floats, so we need flow-root;
+//   2. a *visible* editable is display:flex inside a vertically-aligned text block
+//      (see langVisibility.less), and float is ignored on the child of a flex
+//      container, so the text would not wrap at all.
+// display:flow-root fixes both. The cost is that an editable showing an inline image
+// can no longer vertically center or bottom-align its own text (which only comes up
+// for a monolingual bloom-vertical-align-* block, since in multilingual ones the
+// alignment is applied to the translation group instead); wrapping wins.
+// The class is repeated to raise specificity above langVisibility.less's display:flex,
+// which is otherwise an exact tie and is imported later.
+// :has is supported by every renderer we control. An ancient ePUB reader that ignores
+// it just gets an uncontained float, which is the same class of graceful degradation we
+// already accept there for shape-outside.
+.bloom-editable.bloom-editable.bloom-visibility-code-on:has(
+        > .bloom-inlineImage
+    ) {
+    display: flow-root;
+}
+
+// SHOW ONCE PER TRANSLATION GROUP
+// Every language's editable carries its own copy of the image (that is the only way a
+// float can wrap that language's text), but showing the same picture once per visible
+// language looks broken. So the image renders only in the first visible language block.
+//
+// "First" here is precedence, not DOM order: the .bloom-content* classes drive the flex
+// `order` property, so the DOM order of the editables tells us nothing about which one
+// the reader sees first. Precedence is bloom-contentFirst (assigned by the appearance
+// system) when the group has one, otherwise bloom-content1, then content2, then
+// content3 -- the same preference bloomEditing.ts uses in
+// SetupThingsSensitiveToStyleChanges.
+//
+// Rather than pick a winner, each rule below hides the copy in a visible editable that
+// is outranked by some other visible editable in the same group. Reading it that way:
+//   - monolingual: nothing outranks the single visible editable, so it shows;
+//   - bilingual/trilingual: only the highest-precedence visible one shows;
+//   - L1 not among the visible languages (so no visible bloom-content1): the highest
+//     visible language still shows it, rather than the image silently vanishing.
+// This is display-only. All the copies stay in the DOM, in every language, so nothing
+// here affects what is saved or published.
+.bloom-translationGroup {
+    // Outranked by a visible bloom-contentFirst.
+    &:has(> .bloom-editable.bloom-visibility-code-on.bloom-contentFirst)
+        > .bloom-editable.bloom-visibility-code-on:not(.bloom-contentFirst)
+        > .bloom-inlineImage,
+    // Outranked by a visible bloom-content1 (no visible contentFirst outranking it).
+    &:has(> .bloom-editable.bloom-visibility-code-on.bloom-content1)
+        > .bloom-editable.bloom-visibility-code-on:not(.bloom-contentFirst):not(
+            .bloom-content1
+        )
+        > .bloom-inlineImage,
+    // Outranked by a visible bloom-content2.
+    &:has(> .bloom-editable.bloom-visibility-code-on.bloom-content2)
+        > .bloom-editable.bloom-visibility-code-on:not(.bloom-contentFirst):not(
+            .bloom-content1
+        ):not(.bloom-content2)
+        > .bloom-inlineImage,
+    // Outranked by a visible bloom-content3. (Only reachable for a visible editable
+    // with no content class at all, which would be unusual.)
+    &:has(> .bloom-editable.bloom-visibility-code-on.bloom-content3)
+        > .bloom-editable.bloom-visibility-code-on:not(.bloom-contentFirst):not(
+            .bloom-content1
+        ):not(.bloom-content2):not(.bloom-content3)
+        > .bloom-inlineImage {
+        display: none;
+    }
+}


### PR DESCRIPTION
The rules that make a picture sit inside a text block with the text flowing around
it: the four docks, the width and aspect-ratio custom properties the editor writes,
the vertical offset, and the shape-outside that gives the wrap its contour.

They live in their own file, src/content/bookLayout/inlineImages.less, because two
themes need them and a second copy would drift. basePage-sharedRules.less imports it
for the current themes; basePage-legacy-5-6.less imports the same file, because that
legacy copy of basePage.css was frozen long before this feature existed and a book
using the legacy theme can still contain a picture in its text.

This is the part of the feature that lands in published books, so it comes with its
own layout suite: bookEdit/inline-images-e2e/ builds pages from the compiled book CSS
and measures the wrap geometry directly. Unlike the canvas suite next to it, it needs
no running Bloom, which is why it is registered as its own `pnpm e2e inline-images`
target and excluded from the vitest globs.

Card: https://issues.bloomlibrary.org/youtrack/issue/BL-16822

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DCBGajN5YyAYPBenEf1yy


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8319)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8319)
<!-- Reviewable:end -->
