### PR TITLE
BL-16822 Inline images: the model, its persisted state, and its undo stack

### DIFF
--- a/INLINE-IMAGES-PLAN.md
+++ b/INLINE-IMAGES-PLAN.md
@@ -1,0 +1,156 @@
+# Inline (Word-style) images in Bloom text blocks
+
+## Context
+
+Bloom text blocks (translation groups) currently cannot contain images the way Word paragraphs can: docked left or right with text wrapping around, or as a band with text above and below. Users producing textbook-style material (e.g. the SIL LEAD Uganda P4 books) have hand-hacked this with custom templates. We want a first-class feature: an image inside a text block, docked left / right / middle band / bottom, draggable and resizable, language-neutral in effect (every language version of the block shows the same image), never leaking into source bubbles.
+
+**Chosen approach (with John):** the image markup lives *inside each `bloom-editable`* (the only way CSS floats can wrap text), replicated per language and kept in sync by edit-time JS. The copy in the first-visible-language editable is canonical; `normalizeInlineImages()` stamps it to siblings at page load and after every edit.
+
+**Position is geometry, never DOM anchoring.** Cross-language sync forces this: languages differ in text and paragraph structure, so "after the second paragraph" cannot be translated across sibling editables, but "docked right, offset 120px, width 40%" renders identically in every language copy. The wrapper therefore never moves within the text. It is always the FIRST child of the editable (LAST child for bottom dock, the one DOM move). Dragging changes only a class and two numbers.
+
+**Why per-editable copies rather than a canonical TG-child element:**
+- New-language creation already works with **zero C# changes**: `MakeElementWithLanguageForOneGroup` + `StripOutText` clone an embedded image div into new language editables, text stripped (proven by `TranslationGroupManagerTests.cs:900`).
+- No lang-less TG child means we never arm the trap in `TranslationGroupManager.cs:804` (deletes lang-less `<div>` direct children of a TG on every page load), and old Bloom versions opening the book can't destroy a canonical element, because there isn't one.
+- No book-format structural change; old Bloom / bloom-player / ePub readers render the markup inertly with shipped CSS.
+- Sibling editables are separate block formatting contexts (flex items), so even a TG-level image could never be wrapped by more than one language's text without per-editable spacer injection and baked geometry, which reflow (ePub) breaks. TG-level storage buys no rendering ability; ruled out for v1. Upgrade seam if ever needed: `data-*` attributes on the TG (attributes survive all C# sweeps), and the canonical copy converts mechanically.
+
+## Requirements added 2026-08-08 (John)
+
+- **Spreadsheet round-trip is a requirement, not an option.** A book using inline images must survive export-to-spreadsheet → import-from-spreadsheet with the images and their geometry (dock class, offset, width, wrapper id) intact. The C# spreadsheet code (`src/BloomExe/Spreadsheet/`) processes translation-group content per language, so the per-editable replicated wrappers are exactly the markup it will see; the round-trip work is making sure export carries the wrapper through (or serializes it once and re-stamps on import via the same normalize/sync rules) and that import doesn't strip the `contenteditable="false"` island. Needs its own C# round-trip test.
+- **Contour wrap is a committed future capability**, not a maybe-bonus: text wrapping the alpha silhouette of a transparent image. The full design is below under "Contour wrap"; the v1 requirement is that nothing we ship precludes it — in particular the offset mechanism must be swappable from `padding-top`+`inset()` to `margin-top` (the prerequisite that design identifies) without a book-format migration, which holds because the offset lives in one CSS custom property and the realization is entirely in shipped stylesheet rules.
+
+## Bilingual / trilingual behavior (designed v1 behavior, not deferred)
+
+Showing the same image in each visible language block looks broken. Rule: the image renders only in the **first visible language block**; the editable showing it contains its float (`display: flow-root` or equivalent) so lower language blocks start cleanly below the image at full width. CSS hook: prefer `.bloom-contentFirst` (maintained by `TranslationGroupManager.AddThemeVisibleOrderClass`), falling back to `.bloom-content1` where contentFirst isn't assigned (same preference logic as `bloomEditing.ts:411`). All copies stay in the DOM in all languages; this is display-only.
+
+## Key existing machinery (reuse, don't rebuild)
+
+- `src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts`: `bloom-keepFirstInField` (image stays first in field, `EnsureParagraphsPresent` puts the required `<p>` after it), `bloom-preventRemoval` (undo-based ctrl+a+Del protection), backspace-at-start guard. Demo page: `src/BloomBrowserUI/bookEdit/bloomField/test.pug:93-105`.
+- `src/BloomBrowserUI/bookEdit/js/bloomImages.ts`: `doImageCommand(img, "change")` works on any `<img>` (element-reference + temp-id round trip, location-agnostic); `GetRawImageUrl`, `isPlaceHolderImage`, metadata dialog.
+- `contenteditable=false` islands inside CKEditor-managed editables are proven safe: the format cog (`StyleEditor.ts:1264`) is exactly that. The old guard that supposedly disabled CKEditor for embedded-image fields (`bloomEditing.ts:1216`, BL-3125) is dead code (`$(this)` in `bootstrap()` is an empty set); delete it as part of this work.
+- Canvas element context menu (`CanvasElementContextControls.tsx`, `canvasControlRegistry`) is the UI pattern for the right-click menu; `CanvasElementHandleDragInteractions.ts` has the pointer-math patterns for drag/resize (ours is far simpler: one class, one offset, one width).
+
+## Markup (new class; do NOT reuse `bloom-imageContainer`)
+
+```html
+<div class="bloom-editable ..." lang="en" contenteditable="true">
+  <div class="bloom-inlineImage bloom-inlineImageRight bloom-keepFirstInField bloom-preventRemoval"
+       contenteditable="false" style="--inline-image-offset: 120px; width: 40%; aspect-ratio: 800 / 600;">
+    <img src="flower.jpg" data-copyright="..." data-license="..."/>
+  </div>
+  <p>Text that wraps…</p>
+</div>
+```
+
+- Dock modifiers: `bloom-inlineImageLeft` / `bloom-inlineImageRight` / `bloom-inlineImageMiddle` (full-width band, image centered, text above and below) / `bloom-inlineImageBottom` (wrapper is last child, normal flow).
+- Vertical offset (left/right/middle docks) = `--inline-image-offset`, realized with `padding-top` + `shape-outside: inset(...)`; see CSS.
+- Size = inline `width` (% of editable) + `aspect-ratio` from natural dimensions (stable layout before image load; keeps OverflowChecker honest).
+- The new class dodges `BookStorage.MigrateToLevel7BloomCanvas` (matches only `bloom-imageContainer`) and `SetupImagesInContainer`'s selectors (`bloomImages.ts:117`). Never prefix inline-image classes with `bloom-content` (the `UpdateContentLanguageClasses` sweep strips those).
+- Locked in by C# tests (see Tests): the class sweep visits the wrapper on every page load and strips any `bloom-visibility-code*`/`bloom-content*` class and `dir` attribute from it, so the wrapper must never rely on those; and `contenteditable="false"` in the PERSISTED DOM is load-bearing, since it is the only thing keeping the lang-stamping sweep (`TranslationGroupManager.cs:816`) from treating the wrapper as an editable. Edit-time code must never save it as `true`.
+- No limit on the number of inline images per translation group (requirement from live testing 2026-08-05; replaces the earlier one-image v1 rule). Each wrapper carries a persistent id attribute so sync/undo can match copies across editables. Floating-dock wrappers cluster in order at the top of the editable; bottom-docked ones at the end.
+
+## CSS: shape-outside, not the legacy pusher-downer
+
+Decision (John): give no weight to the old `imagePusherDowner` two-element trick; that feature is no longer supported. `shape-outside` (all engines since ~2018; every renderer we control is current Chromium) is the mechanism. The wrapper's own box includes the offset as transparent padding; the shape excludes only where the image is, so text flows through the padding at full width:
+
+```less
+// → src/content/bookLayout/basePage-sharedRules.less
+// (imported by basePage.less AND publish/ePUBPublish/baseEPUB.less:48 —
+//  covers edit, PDF, bloom-player, ePub with zero publish-code changes)
+.bloom-editable .bloom-inlineImage {
+    --inline-image-offset: 0px;
+    img { display: block; width: 100%; }
+
+    &.bloom-inlineImageLeft, &.bloom-inlineImageRight, &.bloom-inlineImageMiddle {
+        padding-top: var(--inline-image-offset);
+        shape-outside: inset(var(--inline-image-offset) 0 0 0);
+        clear: both;
+    }
+    &.bloom-inlineImageLeft   { float: left;  margin: 0 1em 0.5em 0; }
+    &.bloom-inlineImageRight  { float: right; margin: 0 0 0.5em 1em; }
+    &.bloom-inlineImageMiddle { float: left; width: 100% !important; // band; inner img centered at its own width
+                                img { width: var(--inline-image-width, 40%); margin: 0 auto; } }
+    &.bloom-inlineImageBottom { float: none; clear: both; margin: 0.5em auto 0 auto; }
+}
+// containment + bilingual show-once rules alongside (see Bilingual section)
+```
+
+(Exact selectors/structure to be refined in implementation; the middle band may carry width on the img via a second variable as sketched.)
+
+- Margin-top can't replace the padding trick (line boxes avoid a float's whole margin box). `translateY` moves paint, not wrap. Anchor positioning is out-of-flow, never wrapped. CSS Exclusions is dead. Floats + shape-outside is the whole design space.
+- **ePub on ancient readers degrades gracefully**: without shape-outside the text runs in a narrower column beside the transparent padding instead of flowing above the image. Readable, accepted (we routinely compromise on ePub). Only if QA on real readers demands it: a contained publish-time transform in `EpubMaker` (insert spacer, drop padding). Not built now.
+- Committed later: contour wrap along the image's transparency (see "Contour wrap" under Deferred; a requirement per 2026-08-08, not a bonus). The CSS hooks for it are already in `inlineImages.less` and cost nothing until something sets them; the gap is `--inline-image-gap` so the margin and the contour's `shape-margin` cannot drift apart.
+- Edit-time rules (drag handles, cursor, wrapper stacking) → `bookEdit/css/editMode.less`. No hover/selected outline on the wrapper: its box includes the transparent offset padding, so an outline runs to the top of the block when the image is dragged down (John, live testing); the corner handles on the image box are the selection indicator. The wrapper needs `position: relative; z-index: 1` at edit time because Bloom's paragraphs are position:relative and would otherwise hit-test above the float, making the image unclickable.
+
+## Edit UX
+
+**Insertion: right-click context menu.** Master's BL-16649 `textContextMenu/TextContextMenu.tsx` is the menu; the inline-image items are wired into it (`buildInlineImageMenuItems` returns `ILocalizableMenuItemProps[]`). Right-click in an eligible `bloom-editable` (inside a TG, not inside a canvas element) shows "Add Image" — always, with no limit on how many images the TG already has. Choosing it inserts the wrapper (placeHolder.png, docked right, 40%, offset 0) into ALL sibling editables via sync and selects it. It does NOT open the image chooser (John, live testing); the user changes the picture afterwards via right-click → Change Image. Right-click on an existing wrapper offers Change Image, image credits, Remove Image.
+
+**Drag = updating numbers, never re-parenting (except bottom).** While dragging the image:
+- crossing horizontal thirds of the box switches dock class (left / middle band / right);
+- vertical delta writes `--inline-image-offset`, clamped so the whole wrapper stays inside the block (the maximum is measured live from the wrapper's rendered bottom, since a same-side float above shifts where the offset starts);
+- the bottom zone (last fifth) belongs to the bottom dock only in the MIDDLE third and anywhere below the block; in the outer thirds the side docks win all the way down, so the lower corners are reachable (John, live testing);
+- several images share a side by stacking (DOM order within the floating cluster = vertical order); dragging an image above/below a neighbor reorders the cluster, and cluster order is normalized to visual order at drag end;
+- moving one image never moves the others (John): every move holds all neighbors at their drag-start positions, and removing an image holds the survivors in place instead of letting them spring up;
+- each move either fits or is undone: if a move adds scroll overflow to the block (measured on the whole block, since a full-width band can displace a NEIGHBOR out the bottom), the move reverts to the start-of-move arrangement, so nothing ever hangs below the block. This is what refuses a drag into a side or bottom with no room;
+- drop in the bottom dock moves the wrapper to last child (`bloom-inlineImageBottom`); dragging out moves it back;
+- corner handles write `width` (aspect-ratio keeps height honest). Continuous drag-resize, not presets.
+Then one call to `syncInlineImagesFromEditable()` stamps the wrapper into sibling editables, plus overflow re-check. Floats clear per side (left clears left, right clears right), so same-side images stack down that edge while opposite sides are independent; `clear: both` forced every new image below all existing ones, which dropped a new image below the block itself when one had been dragged low (John, live testing).
+
+**Undo: every operation undoable via the workspace undo chain.** `workspaceRoot.handleUndo()`/`canUndo()` try origami → toolbox → `ImageUndoManager` → CKEditor, and CKEditor's stack cannot see programmatic DOM changes, so inline-image operations need their own layer, modeled on `ImageUndoManager.ts`: `inlineImages.ts` keeps a stack of per-operation snapshots of the whole TG's inline-image state (wrapper outerHTML + slot per editable, or null), recorded before insert / remove / image change / dock change / drag (at drag start, committed at drop) / resize. Undo restores the snapshot to all editables. Stack clears on page change (same `clearImageOperationUndoOnPageChange` pattern). Gate `inlineImageCanUndo()` on the inline image being selected/active, mirroring how `canUndoImageOperation` gates on an image container, so our stack never shadows a more recent text edit. Wire `inlineImageCanUndo`/`inlineImageUndo` into the chain in `workspaceRoot.ts` (both `handleUndo` and `canUndo`) and export through `editablePage.ts` like `imageOperationUndo`. No redo, matching the image-operation layer.
+
+**Hover buttons on the wrapper** (all `bloom-ui`, auto-stripped on save): change image (`doImageCommand`), metadata (thin parallel of `SetupMetadataButton`, which is hard-wired to canvas structure; reuse `doImageCommand`/`GetRawImageUrl`/`isPlaceHolderImage`/`showCopyrightAndLicenseDialog`), delete inline image (removes from all siblings).
+
+## Implementation steps
+
+**Phase 1 — Rendering + format lock-in.**
+1. CSS in `basePage-sharedRules.less` (+ `basePage-legacy-5-6.less` check), incl. bilingual show-once + float containment.
+2. C# tests locking the dodges (no production C# change expected):
+   - `TranslationGroupManagerTests`: new-language creation clones `.bloom-inlineImage` intact; `PrepareElementsOnPageOneLanguage` leaves it alone (nested, not direct child).
+   - `BookStorageTests`: `MigrateToLevel7BloomCanvas` ignores `.bloom-inlineImage`.
+3. Audio exclusion: `audioRecording.ts` child recursion (~line 3722) must skip the island (skip `contenteditable="false"` children).
+
+**Phase 2 — Edit experience. New module `src/BloomBrowserUI/bookEdit/js/inlineImages.ts`:**
+4. `setupInlineImages(container)` wired into `SetupElements` (`bloomEditing.ts`, near `SetupImagesInContainer`): normalization at load, hover buttons, drag/resize handlers, context-menu registration.
+5. Sync: `syncInlineImagesFromEditable(editable)` — serialize wrapper (strip `bloom-ui` children), replace/insert at the correct slot in each sibling editable; idempotent. `normalizeInlineImages(tg)` — canonical = first-visible copy (contentFirst, else content1, else first found); stamp to all. Hook `changeImage` completion in `bloomImages.ts` (~445-495): if img is inside `.bloom-inlineImage`, sync.
+6. Delete dead CKEditor guard `bloomEditing.ts:1216-1222`.
+7. BloomField: confirm keepFirstInField/preventRemoval cover the new class (they key off classes); extend `bloomFieldSpec.ts`; `img.onload` overflow re-check. Note keepFirstInField logic must tolerate the bottom-dock last-child slot.
+
+**Source bubbles: no change needed for v1.** `BloomSourceBubbles.tsx:109` strips text-less divs from bubble clones (`hasNoText`), so image-only wrappers vanish; the spurious `find("textarea, div").length > 1` gate then produces an empty bubble set. Lock with a vitest.
+
+**Publishing: no changes needed.** Copies are persisted real content; hidden-language copies leave with their editables via `PublishHelper.RemoveUnwantedContent` (display-based); ePub/BloomPub collect files via generic `//img[@src]` (`EpubMaker.cs`, `HtmlDom.cs:3012`). QA: epubcheck a sample; eyeball a reader without shape-outside for the accepted degradation.
+
+## Tests
+
+- C#: the two lock-in tests above + an ePub/PublishHelper test (image file in manifest; hidden-language copy removed).
+- Vitest: `inlineImages.test.ts` (insert into all siblings; sync preserves sibling text; idempotence; canonical selection; bloom-ui stripping; dock class switching; bottom dock moves slot; offset/width writes); `bloomFieldSpec.ts` (ctrl+a Del protection, `<p>` after image); source-bubble spec (no img/.bloom-inlineImage in bubble clone); audio spec (markup skips the island).
+- Manual: extend `bookEdit/bloomField/test.pug` with docked variants; QA book covering bilingual display, talking-book recording over a wrapped block, overflow, ePub/BloomPub/PDF outputs.
+
+## Deferred (later phases)
+
+Captions (bubble-stripping + `StripOutText` interplay); crop (canvas-element crop machinery reuse); contour wrap (see below — committed requirement, deferred only in build order); Word-style in-text anchoring as an advanced mode for monolingual books; spreadsheet round-trip (committed requirement, see "Requirements added 2026-08-08"); possible `FeatureVersionRequirement` entry for old-Bloom editing warnings; publish-time ePub spacer fallback only if reader QA demands it.
+
+### Contour wrap (design corrected 2026-08-08 by measuring Chromium; CSS hooks in place, nothing else built)
+
+Text wrapping the image's alpha silhouette instead of its rectangle. The CSS is already there and inert: the side docks read `shape-outside: var(--inline-image-contour, inset(<offset> 0 0 0))` and `shape-margin: var(--inline-image-contour-margin, 0px)`, so switching it on for an image means writing two custom properties onto its wrapper. No markup, dock, offset or sync change. `src/BloomBrowserUI/bookEdit/inline-images-e2e` (`pnpm e2e inline-images`, no running Bloom) locks the geometry, and the CONTOUR WRAP comment in `inlineImages.less` carries the reasoning.
+
+Left to build: derive the silhouette from the image's alpha at image-change time and write `--inline-image-contour: polygon(<points in %>) content-box` plus `--inline-image-contour-margin: var(--inline-image-gap)`. Detect real transparency by drawing to an offscreen canvas and scanning for alpha < 255 (extension sniffing fails for WebP: lossy photo compression and an alpha channel in one file); opaque images keep the rectangle wrap. Open question: the polygon is derived data, so decide between recomputing it on load and persisting it in the wrapper's style — it has to survive into published books, where ePub and PDF get no JS.
+
+**The 2026-08-05 design above was wrong on two counts**, both found by measuring rather than by reading specs:
+
+- `shape-outside: url(<the image>)` cannot work on the wrapper. For an element that is not itself an image, Chromium sizes an image shape at the image's **natural** size, anchored top-left and clipped to the box — so a 1200px-wide photo in a 160px-wide box contributes only its top-left corner as the wrap shape. (Chromium *does* scale such a mask when the float is an `<img>`; the float here is the wrapper, and has to be, since the wrapper carries the offset padding, the dock and the middle band.) A `polygon()` in percentages resolves against the reference box instead, so one value stays right at every width, zoom level and print resolution, and it deforms with the box exactly as the picture does — which also means a stale `--inline-image-aspect-ratio` cannot misalign it.
+- There is no prerequisite change to the offset. The old note had it backwards: `padding-top` is what makes the content box coincide with the picture, and naming `content-box` on the shape is what the contour needs. `margin-top` would put the offset *inside* the reference box.
+
+Two further measurements worth keeping: the gap has to be stated twice (side margin **and** `shape-margin`) because a shape replaces the margin box for wrapping while the shape-margin-expanded shape is then clipped back to it; and `shape-image-threshold` only discriminates partial alpha when the shape image happens to be drawn at its natural size, which is one more reason the silhouette is ours to compute rather than the browser's. Limits unchanged: contour affects only the wrap side, and interior transparent holes are not flowed through (each line ends at first contact).
+
+Apply only when the image has real transparency: extension sniffing fails for WebP (lossy photo compression + alpha channel in one file — the main format where "photo" ≠ "opaque rectangle"), so detect by drawing once to an offscreen canvas at image-change time and scanning for alpha < 255. Opaque images keep the plain rectangle wrap and margin gap. Limits: contour affects only the wrap side; interior transparent holes are not flowed through (each line ends at first contact with the shape). Same-origin serving makes CORS a non-issue in edit/PDF/player; ePub readers without image-shape support degrade to rectangle wrap.
+
+## Critical files
+
+- `src/BloomBrowserUI/bookEdit/js/inlineImages.ts` (new)
+- `src/BloomBrowserUI/bookEdit/js/bloomImages.ts`, `bookEdit/js/bloomEditing.ts`
+- `src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts` + `test.pug`
+- `src/content/bookLayout/basePage-sharedRules.less`, `bookEdit/css/editMode.less`
+- `src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts`
+- `src/BloomBrowserUI/bookEdit/js/canvasElementManager/CanvasElementContextControls.tsx` (menu pattern; possibly shared components)
+- `src/BloomExe/Book/TranslationGroupManager.cs`, `src/BloomExe/Book/BookStorage.cs` (tests only)

--- a/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
+++ b/src/BloomBrowserUI/bookEdit/bloomField/BloomField.ts
@@ -35,7 +35,9 @@ import { kNoIndentClass } from "../textContextMenu/noIndent";
 // one must not have an empty paragraph pushed in above it. Several places below ask "which
 // block am I in?" or "does this box have any blocks yet?"; they all consult this rather than
 // looking for a <p> specifically, so a heading counts as a block everywhere or nowhere.
-const kBlockElementSelector = "p,h1,h2,h3,h4,h5,h6";
+// Exported because inlineImages.ts asks the same "does this box have any blocks yet?" question
+// when it inserts an image, and the answer has to be the same one BloomField would give.
+export const kBlockElementSelector = "p,h1,h2,h3,h4,h5,h6";
 
 export default class BloomField {
     public static ManageField(bloomEditableDiv: HTMLElement) {

--- a/src/BloomBrowserUI/bookEdit/editablePage.ts
+++ b/src/BloomBrowserUI/bookEdit/editablePage.ts
@@ -71,6 +71,8 @@ export interface IPageFrameExports {
     ckeditorUndo(): void;
     imageOperationCanUndo(): boolean;
     imageOperationUndo(): boolean;
+    inlineImageCanUndo(): boolean;
+    inlineImageUndo(): boolean;
 
     addRequestPageContentDelay(id: string): void;
     removeRequestPageContentDelay(id: string): void;
@@ -165,6 +167,10 @@ export {
     showGamePromptDialog,
     applyAiImageEditorReplacements,
 };
+// Inline (Word-style) images keep their own undo stack, for the same reason origami and the
+// image operations do: the workspace undo command has to be able to reach it. See inlineImages.ts.
+import { inlineImageCanUndo, inlineImageUndo } from "./js/inlineImages";
+export { inlineImageCanUndo, inlineImageUndo };
 import { origamiCanUndo, origamiUndo } from "./js/origami";
 import { postString } from "../utils/bloomApi";
 export { origamiCanUndo, origamiUndo };
@@ -417,6 +423,8 @@ interface EditablePageBundleApi {
     changeImageByElement: typeof changeImageByElement;
     imageOperationCanUndo: typeof imageOperationCanUndo;
     imageOperationUndo: typeof imageOperationUndo;
+    inlineImageCanUndo: typeof inlineImageCanUndo;
+    inlineImageUndo: typeof inlineImageUndo;
     origamiCanUndo: typeof origamiCanUndo;
     origamiUndo: typeof origamiUndo;
     getTheOneCanvasElementManager: typeof getTheOneCanvasElementManager;
@@ -496,6 +504,8 @@ window.editablePageBundle = {
     changeImageByElement,
     imageOperationCanUndo: imageOperationCanUndo,
     imageOperationUndo: imageOperationUndo,
+    inlineImageCanUndo,
+    inlineImageUndo,
     origamiCanUndo,
     origamiUndo,
     getTheOneCanvasElementManager,

--- a/src/BloomBrowserUI/bookEdit/js/inlineImages.test.ts
+++ b/src/BloomBrowserUI/bookEdit/js/inlineImages.test.ts
@@ -1,0 +1,1352 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import {
+    getTestRoot,
+    cleanTestRoot,
+    removeTestRoot,
+} from "../../utils/testHelper";
+import {
+    clearInlineImageUndoState,
+    commitPendingInlineImageUndo,
+    discardPendingInlineImageUndo,
+    getEditables,
+    getInlineImage,
+    getInlineImageById,
+    getInlineImageId,
+    getInlineImageInEditable,
+    getInlineImages,
+    getInlineImagesInEditable,
+    handleInlineImageChanged,
+    kInlineImageChangedEvent,
+    kInlineImageLeftClass,
+    kInlineImageMiddleClass,
+    inlineImageCanUndo,
+    noteInlineImageBlockWasEdited,
+    inlineImageUndo,
+    insertInlineImage,
+    kInlineImageBottomClass,
+    kInlineImageClass,
+    kInlineImageRightClass,
+    kInlineImageWidthVar,
+    kInlineImageSelectedClass,
+    kInlineImagesRestoredEvent,
+    kKeepFirstInFieldClass,
+    normalizeInlineImages,
+    prepareInlineImageUndo,
+    prepareInlineImageUndoForImageChange,
+    recordInlineImageUndoPoint,
+    removeInlineImage,
+    setInlineImageDock,
+    setupInlineImages,
+    syncInlineImagesFromEditable,
+} from "./inlineImages";
+
+// Each group is built inside its own .bloom-page with a fresh data-page-id, both because
+// that is how it looks in Bloom and because the undo layer keys its "did the page change?"
+// check on that id, so a new one per test gives each test a clean undo stack.
+let pageCounter = 0;
+
+// Builds a translation group, one editable per entry. `id` names it and puts it on the page
+// beside any group already there, which is what a test about two blocks of one page needs;
+// without it the page is rebuilt with this as its only group.
+function makeTranslationGroup(
+    editables: { lang: string; classes?: string; content?: string }[],
+    id?: string,
+): HTMLElement {
+    const root = getTestRoot();
+    const groupHtml =
+        `<div class="bloom-translationGroup" id="${id ?? "group"}">` +
+        editables
+            .map(
+                (e) =>
+                    `<div class="bloom-editable ${e.classes ?? ""}" lang="${e.lang}">${
+                        e.content ?? ""
+                    }</div>`,
+            )
+            .join("") +
+        `</div>`;
+    const page = id ? root.querySelector(".bloom-page") : null;
+    if (page) page.insertAdjacentHTML("beforeend", groupHtml);
+    else
+        root.innerHTML =
+            `<div class="bloom-page" data-page-id="test-page-${++pageCounter}">` +
+            groupHtml +
+            `</div>`;
+    return root.querySelector("#" + (id ?? "group")) as HTMLElement;
+}
+
+// Stands in for the page's CKEditor: whether it holds text editing it could undo, and `index`,
+// CKEditor's own name for where it stands in its stack of snapshots (one per edit, going down
+// as edits are undone). `snapshots` and `limit` are how the real thing says its stack is full,
+// which is when the position stops counting up. The real thing is a global the page's CKEditor
+// puts up; absent, as in these tests unless a test says otherwise, it reads as "nothing to
+// undo".
+const fakeCkeditorUndoManager = {
+    undoable: () => fakeCkeditorUndoManager.state,
+    index: undefined as number | undefined,
+    state: false,
+    snapshots: [] as unknown[],
+    limit: 20,
+};
+
+function setCkeditorUndoable(
+    undoable: boolean | undefined,
+    index?: number,
+    historyIsFull = false,
+): void {
+    const global = globalThis as unknown as { CKEDITOR?: unknown };
+    if (undoable === undefined) {
+        delete global.CKEDITOR;
+        return;
+    }
+    // One manager per editable, kept across calls, because that is what the real thing does and
+    // what makes two of its positions comparable.
+    fakeCkeditorUndoManager.state = undoable;
+    fakeCkeditorUndoManager.index = index;
+    fakeCkeditorUndoManager.snapshots = new Array(
+        historyIsFull ? fakeCkeditorUndoManager.limit : 1,
+    ).fill(undefined);
+    global.CKEDITOR = {
+        currentInstance: { undoManager: fakeCkeditorUndoManager },
+    };
+}
+
+// The undo layer only fires when an inline image is the active thing, which in the real
+// editor is the interaction layer's selected class.
+const select = (wrapper: HTMLElement) =>
+    wrapper.classList.add(kInlineImageSelectedClass);
+
+// Stands in for the user's caret sitting in a block's text.
+function putCaretIn(editable: HTMLElement): void {
+    const selection = document.getSelection()!;
+    selection.removeAllRanges();
+    const range = document.createRange();
+    range.selectNodeContents(editable.querySelector("p")!);
+    range.collapse(true);
+    selection.addRange(range);
+}
+
+const editableFor = (group: HTMLElement, lang: string) =>
+    group.querySelector(`[lang="${lang}"]`) as HTMLElement;
+
+describe("inlineImages", () => {
+    beforeEach(() => {
+        cleanTestRoot();
+        // A caret left in a removed element would leak into the next test's undo gate.
+        document.getSelection()?.removeAllRanges();
+    });
+    afterAll(removeTestRoot);
+
+    describe("insertInlineImage", () => {
+        it("puts a wrapper in every editable, including the lang=z prototype", () => {
+            const group = makeTranslationGroup([
+                {
+                    lang: "en",
+                    classes: "bloom-content1 bloom-visibility-code-on",
+                    content: "<p>English</p>",
+                },
+                { lang: "fr", content: "<p>French</p>" },
+                { lang: "z", content: "<p></p>" },
+            ]);
+            // Sanity check: nothing there before we start.
+            expect(getInlineImages(group).length).toBe(0);
+
+            const returned = insertInlineImage(group);
+
+            expect(getInlineImages(group).length).toBe(3);
+            ["en", "fr", "z"].forEach((lang) => {
+                const wrapper = getInlineImageInEditable(
+                    editableFor(group, lang),
+                );
+                expect(
+                    wrapper,
+                    `expected a wrapper in the ${lang} editable`,
+                ).not.toBeNull();
+                expect(wrapper!.getAttribute("contenteditable")).toBe("false");
+                expect(
+                    wrapper!.classList.contains(kInlineImageRightClass),
+                ).toBe(true);
+                expect(
+                    wrapper!.classList.contains(kKeepFirstInFieldClass),
+                ).toBe(true);
+                expect(wrapper!.querySelector("img")!.getAttribute("src")).toBe(
+                    "placeHolder.png",
+                );
+                // The wrapper goes first so text wraps around it; BloomField keeps the <p> after it.
+                expect(editableFor(group, lang).firstElementChild).toBe(
+                    wrapper,
+                );
+            });
+            // The caller gets back the copy the reader is looking at.
+            expect(returned).toBe(
+                getInlineImageInEditable(editableFor(group, "en")),
+            );
+        });
+
+        it("gives an editable with no paragraph one, so there is somewhere to type", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "" },
+            ]);
+            insertInlineImage(group);
+            expect(editableFor(group, "en").querySelectorAll("p").length).toBe(
+                1,
+            );
+        });
+
+        // A heading is a block too (BloomField's kBlockElementSelector), so a box holding one
+        // already has somewhere to type and must not collect an empty paragraph under it --
+        // that would show as a blank line, and persist once the page is saved.
+        it("does not add a paragraph to an editable that holds only a heading", () => {
+            const group = makeTranslationGroup([
+                {
+                    lang: "en",
+                    classes: "bloom-content1",
+                    content: "<h1>A heading</h1>",
+                },
+            ]);
+            const editable = editableFor(group, "en");
+            // Sanity check: a heading and no paragraph is the case under test.
+            expect(editable.querySelectorAll("h1").length).toBe(1);
+            expect(editable.querySelectorAll("p").length).toBe(0);
+
+            insertInlineImage(group);
+
+            expect(editable.querySelectorAll("p").length).toBe(0);
+            expect(editable.querySelector("h1")!.textContent).toBe("A heading");
+        });
+    });
+
+    describe("syncInlineImagesFromEditable", () => {
+        it("stamps the wrapper onto siblings without touching their text", () => {
+            const group = makeTranslationGroup([
+                {
+                    lang: "en",
+                    classes: "bloom-content1 bloom-visibility-code-on",
+                    content: "<p>English text</p>",
+                },
+                { lang: "fr", content: "<p>Texte français</p>" },
+            ]);
+            const source = editableFor(group, "en");
+            const sibling = editableFor(group, "fr");
+            insertInlineImage(group);
+            // Make the canonical copy different from the others.
+            const wrapper = getInlineImageInEditable(source)!;
+            wrapper.style.setProperty("--inline-image-width", "25%");
+            wrapper.style.setProperty("--inline-image-offset", "120px");
+            // Sanity check: the sibling has not got that yet.
+            expect(
+                getInlineImageInEditable(sibling)!.style.getPropertyValue(
+                    "--inline-image-width",
+                ),
+            ).toBe("40%");
+
+            syncInlineImagesFromEditable(source);
+
+            const stamped = getInlineImageInEditable(sibling)!;
+            expect(stamped.getAttribute("style")).toBe(
+                wrapper.getAttribute("style"),
+            );
+            expect(sibling.querySelector("p")!.textContent).toBe(
+                "Texte français",
+            );
+        });
+
+        // Hand-edited markup, or a paste from another program, can hold a wrapper with no
+        // data-bloom-inline-image-id. Everything here pairs copies up by that id, so without
+        // one the sibling's copy could not be recognized and a second was appended beside it
+        // -- once per language per page setup, for as long as the book was open.
+        it("does not multiply a wrapper that arrived without an id", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+                { lang: "fr", content: "<p>b</p>" },
+            ]);
+            const source = editableFor(group, "en");
+            const sibling = editableFor(group, "fr");
+            insertInlineImage(group);
+            getInlineImages(group).forEach((wrapper) =>
+                wrapper.removeAttribute("data-bloom-inline-image-id"),
+            );
+            // Sanity check: one each, and no identity to pair them by.
+            expect(getInlineImagesInEditable(source).length).toBe(1);
+            expect(getInlineImagesInEditable(sibling).length).toBe(1);
+            expect(
+                getInlineImageId(getInlineImageInEditable(source)!),
+            ).toBeUndefined();
+
+            syncInlineImagesFromEditable(source);
+            syncInlineImagesFromEditable(source);
+            syncInlineImagesFromEditable(source);
+
+            expect(getInlineImagesInEditable(source).length).toBe(1);
+            expect(getInlineImagesInEditable(sibling).length).toBe(1);
+            // ...and it has been given an identity, shared by both copies, so the next
+            // operation can pair them.
+            const id = getInlineImageId(getInlineImageInEditable(source)!);
+            expect(id).toBeTruthy();
+            expect(getInlineImageId(getInlineImageInEditable(sibling)!)).toBe(
+                id,
+            );
+        });
+
+        it("is idempotent", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+                { lang: "fr", content: "<p>b</p>" },
+                { lang: "z", content: "<p></p>" },
+            ]);
+            insertInlineImage(group);
+            const source = editableFor(group, "en");
+
+            syncInlineImagesFromEditable(source);
+            const afterFirst = group.innerHTML;
+            syncInlineImagesFromEditable(source);
+
+            expect(group.innerHTML).toBe(afterFirst);
+        });
+
+        it("adds a missing wrapper to a sibling that has none", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+                { lang: "fr", content: "<p>b</p>" },
+            ]);
+            insertInlineImage(group);
+            const sibling = editableFor(group, "fr");
+            getInlineImageInEditable(sibling)!.remove();
+            // Sanity check: it really is gone.
+            expect(getInlineImageInEditable(sibling)).toBeNull();
+
+            syncInlineImagesFromEditable(editableFor(group, "en"));
+
+            expect(getInlineImageInEditable(sibling)).not.toBeNull();
+            expect(sibling.firstElementChild!.classList).toContain(
+                kInlineImageClass,
+            );
+        });
+
+        it("puts a bottom-docked wrapper last in each sibling", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+                { lang: "fr", content: "<p>b</p><p>c</p>" },
+            ]);
+            insertInlineImage(group);
+            const source = editableFor(group, "en");
+            setInlineImageDock(
+                getInlineImageInEditable(source)!,
+                kInlineImageBottomClass,
+            );
+            // Sanity check: the dock change moved the canonical copy to the end.
+            expect(source.lastElementChild).toBe(
+                getInlineImageInEditable(source),
+            );
+
+            syncInlineImagesFromEditable(source);
+
+            const sibling = editableFor(group, "fr");
+            const stamped = getInlineImageInEditable(sibling)!;
+            expect(sibling.lastElementChild).toBe(stamped);
+            // A bottom-docked wrapper must not claim to keep first in field, or BloomField
+            // would put the field's required <p> after it.
+            expect(stamped.classList.contains(kKeepFirstInFieldClass)).toBe(
+                false,
+            );
+            expect(sibling.querySelectorAll("p").length).toBe(2);
+        });
+
+        it("moves a sibling's wrapper back to the first slot when the dock leaves bottom", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+                { lang: "fr", content: "<p>b</p>" },
+            ]);
+            insertInlineImage(group);
+            const source = editableFor(group, "en");
+            const sibling = editableFor(group, "fr");
+            setInlineImageDock(
+                getInlineImageInEditable(source)!,
+                kInlineImageBottomClass,
+            );
+            syncInlineImagesFromEditable(source);
+            // Sanity check: the sibling's copy is at the end before we dock it elsewhere.
+            expect(sibling.lastElementChild).toBe(
+                getInlineImageInEditable(sibling),
+            );
+
+            setInlineImageDock(
+                getInlineImageInEditable(source)!,
+                kInlineImageRightClass,
+            );
+            syncInlineImagesFromEditable(source);
+
+            expect(sibling.firstElementChild).toBe(
+                getInlineImageInEditable(sibling),
+            );
+        });
+
+        it("strips edit-time-only markup from the copies it stamps", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+                { lang: "fr", content: "<p>b</p>" },
+            ]);
+            insertInlineImage(group);
+            const source = editableFor(group, "en");
+            const wrapper = getInlineImageInEditable(source)!;
+            wrapper.classList.add(kInlineImageSelectedClass);
+            wrapper.insertAdjacentHTML(
+                "beforeend",
+                '<div class="bloom-ui" id="inlineImageButtons">buttons</div>',
+            );
+            // A change-image round trip leaves a temporary id on the img.
+            wrapper.querySelector("img")!.setAttribute("id", "tempImageId");
+
+            syncInlineImagesFromEditable(source);
+
+            const stamped = getInlineImageInEditable(editableFor(group, "fr"))!;
+            expect(stamped.querySelector(".bloom-ui")).toBeNull();
+            expect(stamped.classList.contains(kInlineImageSelectedClass)).toBe(
+                false,
+            );
+            expect(stamped.querySelector("[id]")).toBeNull();
+            // ...and the original keeps its UI; syncing is not a cleanup pass on the source.
+            expect(wrapper.querySelector(".bloom-ui")).not.toBeNull();
+        });
+
+        it("does nothing when the editable has no inline image", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+                { lang: "fr", content: "<p>b</p>" },
+            ]);
+            insertInlineImage(group);
+            const before = group.innerHTML;
+
+            // The 'fr' copy exists, so use an editable we deliberately emptied instead.
+            const other = editableFor(group, "fr");
+            getInlineImageInEditable(other)!.remove();
+            const afterRemoval = group.innerHTML;
+            syncInlineImagesFromEditable(other);
+
+            expect(group.innerHTML).toBe(afterRemoval);
+            expect(group.innerHTML).not.toBe(before); // sanity check on the test itself
+        });
+    });
+
+    describe("normalizeInlineImages", () => {
+        it("prefers the bloom-contentFirst copy", () => {
+            const group = makeTranslationGroup([
+                {
+                    lang: "en",
+                    classes: "bloom-content1 bloom-contentSecond",
+                    content: "<p>a</p>",
+                },
+                {
+                    lang: "fr",
+                    classes: "bloom-content2 bloom-contentFirst",
+                    content: "<p>b</p>",
+                },
+            ]);
+            insertInlineImage(group);
+            getInlineImageInEditable(
+                editableFor(group, "fr"),
+            )!.style.setProperty("--inline-image-width", "15%");
+
+            expect(getInlineImage(group)).toBe(
+                getInlineImageInEditable(editableFor(group, "fr")),
+            );
+            normalizeInlineImages(group);
+
+            expect(
+                getInlineImageInEditable(
+                    editableFor(group, "en"),
+                )!.style.getPropertyValue("--inline-image-width"),
+            ).toBe("15%");
+        });
+
+        it("falls back to bloom-content1 when no editable has bloom-contentFirst", () => {
+            const group = makeTranslationGroup([
+                { lang: "fr", classes: "bloom-content2", content: "<p>b</p>" },
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+            ]);
+            insertInlineImage(group);
+            getInlineImageInEditable(
+                editableFor(group, "en"),
+            )!.style.setProperty("--inline-image-width", "15%");
+
+            normalizeInlineImages(group);
+
+            expect(
+                getInlineImageInEditable(
+                    editableFor(group, "fr"),
+                )!.style.getPropertyValue("--inline-image-width"),
+            ).toBe("15%");
+        });
+
+        it("falls back to the first editable that has a copy", () => {
+            const group = makeTranslationGroup([
+                { lang: "es", content: "<p>c</p>" },
+                { lang: "fr", content: "<p>b</p>" },
+            ]);
+            insertInlineImage(group);
+            getInlineImageInEditable(
+                editableFor(group, "es"),
+            )!.style.setProperty("--inline-image-width", "15%");
+
+            normalizeInlineImages(group);
+
+            expect(
+                getInlineImageInEditable(
+                    editableFor(group, "fr"),
+                )!.style.getPropertyValue("--inline-image-width"),
+            ).toBe("15%");
+        });
+
+        // Turning language 1 off on the page leaves its editable in the DOM with a copy
+        // nobody can see. Preferring that copy stamped it over the language the person was
+        // actually working in.
+        it("prefers a visible language over a hidden bloom-content1", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+                {
+                    lang: "fr",
+                    classes: "bloom-content2 bloom-visibility-code-on",
+                    content: "<p>b</p>",
+                },
+            ]);
+            insertInlineImage(group);
+            getInlineImageInEditable(
+                editableFor(group, "fr"),
+            )!.style.setProperty("--inline-image-width", "15%");
+            // Sanity check: the two copies really do disagree before we normalize.
+            expect(
+                getInlineImageInEditable(
+                    editableFor(group, "en"),
+                )!.style.getPropertyValue("--inline-image-width"),
+            ).toBe("40%");
+
+            normalizeInlineImages(group);
+
+            expect(
+                getInlineImageInEditable(
+                    editableFor(group, "en"),
+                )!.style.getPropertyValue("--inline-image-width"),
+            ).toBe("15%");
+        });
+
+        it("does nothing to a group with no inline image", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+            ]);
+            const before = group.innerHTML;
+            normalizeInlineImages(group);
+            expect(group.innerHTML).toBe(before);
+        });
+    });
+
+    describe("removeInlineImage", () => {
+        it("clears the image from every editable", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+                { lang: "fr", content: "<p>b</p>" },
+                { lang: "z", content: "<p></p>" },
+            ]);
+            const wrapper = insertInlineImage(group);
+            // Sanity check: all three have one before we remove.
+            expect(getInlineImages(group).length).toBe(3);
+
+            removeInlineImage(wrapper);
+
+            expect(getInlineImages(group).length).toBe(0);
+            expect(getInlineImage(group)).toBeNull();
+            // The text survives.
+            expect(editableFor(group, "fr").textContent).toBe("b");
+        });
+
+        it("removes only the image it was given, in every language", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+                { lang: "fr", content: "<p>b</p>" },
+            ]);
+            const first = insertInlineImage(group);
+            const second = insertInlineImage(group);
+            const firstId = getInlineImageId(first);
+            const secondId = getInlineImageId(second);
+            // Sanity check: two distinct images, both in both languages.
+            expect(firstId).not.toBe(secondId);
+            expect(getInlineImages(group).length).toBe(4);
+
+            removeInlineImage(second);
+
+            expect(getInlineImages(group).length).toBe(2);
+            getEditables(group).forEach((editable) => {
+                expect(
+                    getInlineImageById(editable, firstId!),
+                    "the untouched image should survive in every language",
+                ).not.toBeNull();
+                expect(getInlineImageById(editable, secondId!)).toBeNull();
+            });
+        });
+
+        it("throws rather than guess when handed something that is not an inline image", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+            ]);
+            insertInlineImage(group);
+            // Passing the translation group used to mean "remove them all"; with several
+            // images per block that could only guess, so it must fail loudly instead.
+            expect(() => removeInlineImage(group)).toThrow();
+            expect(getInlineImages(group).length).toBe(1);
+        });
+    });
+
+    // A text block may hold any number of inline images (requirement from live testing,
+    // 2026-08-05). Copies are matched across languages by kInlineImageIdAttr, and the order
+    // within a cluster is the images' order.
+    describe("several images in one block", () => {
+        it("gives each image its own identity, in every language, in insertion order", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+                { lang: "fr", content: "<p>b</p>" },
+                { lang: "z", content: "<p></p>" },
+            ]);
+
+            const first = insertInlineImage(group);
+            const second = insertInlineImage(group);
+
+            expect(getInlineImages(group).length).toBe(6);
+            const ids = [getInlineImageId(first)!, getInlineImageId(second)!];
+            expect(ids[0]).not.toBe(ids[1]);
+            getEditables(group).forEach((editable) => {
+                // Same two ids, in the same order, in every language.
+                expect(
+                    getInlineImagesInEditable(editable).map(getInlineImageId),
+                ).toEqual(ids);
+            });
+        });
+
+        it("keeps each image's geometry and dock separate when syncing", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+                { lang: "fr", content: "<p>b</p>" },
+            ]);
+            const first = insertInlineImage(group);
+            const second = insertInlineImage(group);
+            const source = editableFor(group, "en");
+            const sibling = editableFor(group, "fr");
+
+            first.style.setProperty("--inline-image-width", "20%");
+            first.style.setProperty("--inline-image-offset", "10px");
+            setInlineImageDock(second, kInlineImageLeftClass);
+            second.style.setProperty("--inline-image-width", "70%");
+            second.style.setProperty("--inline-image-offset", "200px");
+            syncInlineImagesFromEditable(source);
+
+            const [stampedFirst, stampedSecond] =
+                getInlineImagesInEditable(sibling);
+            expect(getInlineImageId(stampedFirst)).toBe(
+                getInlineImageId(first),
+            );
+            expect(
+                stampedFirst.style.getPropertyValue("--inline-image-width"),
+            ).toBe("20%");
+            expect(
+                stampedFirst.style.getPropertyValue("--inline-image-offset"),
+            ).toBe("10px");
+            expect(
+                stampedFirst.classList.contains(kInlineImageRightClass),
+            ).toBe(true);
+            expect(
+                stampedSecond.style.getPropertyValue("--inline-image-width"),
+            ).toBe("70%");
+            expect(
+                stampedSecond.style.getPropertyValue("--inline-image-offset"),
+            ).toBe("200px");
+            expect(
+                stampedSecond.classList.contains(kInlineImageLeftClass),
+            ).toBe(true);
+        });
+
+        it("clusters floating images before the text and bottom-docked ones after it", () => {
+            const group = makeTranslationGroup([
+                {
+                    lang: "en",
+                    classes: "bloom-content1",
+                    content: "<p>one</p><p>two</p>",
+                },
+                { lang: "fr", content: "<p>un</p>" },
+            ]);
+            const floating = insertInlineImage(group);
+            const bottom = insertInlineImage(group);
+            const source = editableFor(group, "en");
+
+            setInlineImageDock(bottom, kInlineImageBottomClass);
+            syncInlineImagesFromEditable(source);
+
+            [source, editableFor(group, "fr")].forEach((editable) => {
+                const children = Array.from(editable.children);
+                const floatingCopy = getInlineImageById(
+                    editable,
+                    getInlineImageId(floating)!,
+                )!;
+                const bottomCopy = getInlineImageById(
+                    editable,
+                    getInlineImageId(bottom)!,
+                )!;
+                expect(children.indexOf(floatingCopy)).toBe(0);
+                expect(children.indexOf(bottomCopy)).toBe(children.length - 1);
+                // The text is still between them, and unharmed.
+                expect(editable.querySelectorAll("p").length).toBeGreaterThan(
+                    0,
+                );
+            });
+            expect(editableFor(group, "fr").textContent).toBe("un");
+        });
+
+        it("switching between floating docks does not reorder the images", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+            ]);
+            const first = insertInlineImage(group);
+            const second = insertInlineImage(group);
+            const editable = editableFor(group, "en");
+            // Sanity check on the starting order.
+            expect(getInlineImagesInEditable(editable)).toEqual([
+                first,
+                second,
+            ]);
+
+            setInlineImageDock(first, kInlineImageLeftClass);
+            setInlineImageDock(first, kInlineImageMiddleClass);
+
+            expect(getInlineImagesInEditable(editable)).toEqual([
+                first,
+                second,
+            ]);
+        });
+
+        it("sync is still idempotent with several images", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+                { lang: "fr", content: "<p>b</p>" },
+            ]);
+            insertInlineImage(group);
+            const second = insertInlineImage(group);
+            setInlineImageDock(second, kInlineImageBottomClass);
+            const source = editableFor(group, "en");
+
+            syncInlineImagesFromEditable(source);
+            const afterFirst = group.innerHTML;
+            syncInlineImagesFromEditable(source);
+
+            expect(group.innerHTML).toBe(afterFirst);
+        });
+
+        it("undo restores the whole set, in order", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+                { lang: "fr", content: "<p>b</p>" },
+            ]);
+            const first = insertInlineImage(group);
+            const second = insertInlineImage(group);
+            const idsBefore = [
+                getInlineImageId(first)!,
+                getInlineImageId(second)!,
+            ];
+            putCaretIn(editableFor(group, "en"));
+
+            removeInlineImage(second);
+            // Sanity check: one image left in each of the two languages.
+            expect(getInlineImages(group).length).toBe(2);
+
+            expect(inlineImageCanUndo()).toBe(true);
+            expect(inlineImageUndo()).toBe(true);
+
+            getEditables(group).forEach((editable) => {
+                expect(
+                    getInlineImagesInEditable(editable).map(getInlineImageId),
+                ).toEqual(idsBefore);
+            });
+            expect(editableFor(group, "fr").textContent).toBe("b");
+        });
+    });
+
+    describe("handleInlineImageChanged", () => {
+        it("syncs the new picture to the siblings and announces it", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+                { lang: "fr", content: "<p>b</p>" },
+            ]);
+            const wrapper = insertInlineImage(group);
+            const img = wrapper.querySelector("img")!;
+            // A stale ratio from the old picture must not survive the change.
+            wrapper.style.setProperty("--inline-image-aspect-ratio", "3 / 2");
+            let wrapperFromEvent: unknown;
+            document.addEventListener(kInlineImageChangedEvent, (e) => {
+                wrapperFromEvent = (e as CustomEvent).detail;
+            });
+
+            img.setAttribute("src", "flower.jpg");
+            handleInlineImageChanged(img);
+
+            expect(
+                wrapper.style.getPropertyValue("--inline-image-aspect-ratio"),
+            ).toBe("");
+            expect(
+                getInlineImageInEditable(editableFor(group, "fr"))!
+                    .querySelector("img")!
+                    .getAttribute("src"),
+            ).toBe("flower.jpg");
+            expect(wrapperFromEvent).toBe(wrapper);
+        });
+    });
+
+    describe("undo", () => {
+        it("undoes an insert, back to no image in any editable", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+                { lang: "fr", content: "<p>b</p>" },
+                { lang: "z", content: "<p></p>" },
+            ]);
+
+            select(insertInlineImage(group));
+            // Sanity check: the insert really happened and is undoable.
+            expect(getInlineImages(group).length).toBe(3);
+            expect(inlineImageCanUndo()).toBe(true);
+
+            expect(inlineImageUndo()).toBe(true);
+
+            expect(getInlineImages(group).length).toBe(0);
+            // The text is untouched by the round trip.
+            expect(editableFor(group, "fr").textContent).toBe("b");
+        });
+
+        // Deleting the image leaves nothing to select, so this is the one case where the gate
+        // falls back to "is the caret still in that block". Without it, deleting an inline
+        // image could never be undone at all.
+        it("undoes a remove, restoring the image to every editable", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+                { lang: "fr", content: "<p>b</p>" },
+            ]);
+            removeInlineImage(insertInlineImage(group));
+            // Sanity check: they really are gone, and nothing is selected.
+            expect(getInlineImages(group).length).toBe(0);
+            putCaretIn(editableFor(group, "en"));
+
+            expect(inlineImageCanUndo()).toBe(true);
+            expect(inlineImageUndo()).toBe(true);
+
+            expect(getInlineImages(group).length).toBe(2);
+            expect(
+                getInlineImageInEditable(editableFor(group, "fr")),
+            ).not.toBeNull();
+            expect(editableFor(group, "fr").textContent).toBe("b");
+        });
+
+        // The other half of that fallback. Once the person has typed in the block, their typing
+        // is the most recent thing they did, so ctrl+z belongs to ckeditor: going first here
+        // would bring the picture back BEFORE the typing, which is not the order anything
+        // happened in. These two stacks cannot be merged, so this is how they are ordered.
+        it("declines the removed-image case once the user has typed in that block", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+            ]);
+            removeInlineImage(insertInlineImage(group));
+            const editable = editableFor(group, "en");
+            putCaretIn(editable);
+            // Sanity check: with nothing typed since, this is the case that says yes.
+            expect(inlineImageCanUndo()).toBe(true);
+
+            editable.querySelector("p")!.textContent = "a and some more words";
+
+            expect(inlineImageCanUndo()).toBe(false);
+        });
+
+        // Same order-of-operations question as the test above, but the edit leaves the text
+        // alone: bolding a word changes only the markup. CKEditor has an undo point for it,
+        // so ctrl+z belongs to CKEditor, and going first here would bring the picture back
+        // while the bolding stood.
+        it("declines the removed-image case once the user has changed formatting", () => {
+            const group = makeTranslationGroup([
+                {
+                    lang: "en",
+                    classes: "bloom-content1",
+                    content: "<p>some words</p>",
+                },
+            ]);
+            removeInlineImage(insertInlineImage(group));
+            const editable = editableFor(group, "en");
+            putCaretIn(editable);
+            // Sanity check: with nothing changed since, this is the case that says yes.
+            expect(inlineImageCanUndo()).toBe(true);
+
+            const paragraph = editable.querySelector("p")!;
+            paragraph.innerHTML = "<strong>some</strong> words";
+            // Sanity check: the text really is unchanged, so only the markup can tell.
+            expect(paragraph.textContent).toBe("some words");
+
+            expect(inlineImageCanUndo()).toBe(false);
+        });
+
+        // Selecting a picture does not stop the person typing: the caret stays in the block, and
+        // the picture keeps its handles. So the selected picture must not win ctrl+z forever --
+        // once they have typed, their typing is the most recent thing they did. Right-clicking
+        // the text is the way to get into this state without meaning to, since the menu selects
+        // nothing and leaves the picture as it was.
+        it("declines with a picture still selected once the person has typed in the block", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+            ]);
+            select(insertInlineImage(group));
+            const editable = editableFor(group, "en");
+            // Sanity check: with nothing typed since, the selected picture is what ctrl+z is for.
+            expect(inlineImageCanUndo()).toBe(true);
+
+            editable.querySelector("p")!.textContent = "a and some more words";
+
+            expect(inlineImageCanUndo()).toBe(false);
+        });
+
+        // The content comparison cannot see an edit that undid itself -- typing a word and
+        // deleting it again leaves the markup identical -- but CKEditor has two undo points for
+        // it, and they are newer than ours. So the editing itself is reported, and that is what
+        // hands ctrl+z over.
+        it("declines after an edit that left the content exactly as it was", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+            ]);
+            select(insertInlineImage(group));
+            const editable = editableFor(group, "en");
+            expect(inlineImageCanUndo()).toBe(true);
+
+            // What the page reports for any typing in the block, however it ends up, and
+            // CKEditor holding the undo points for it.
+            noteInlineImageBlockWasEdited(editable);
+            setCkeditorUndoable(true);
+
+            expect(inlineImageCanUndo()).toBe(false);
+            setCkeditorUndoable(undefined);
+        });
+
+        // The report of an edit must not be a one-way latch. Once the person has undone their
+        // text editing, CKEditor has nothing left and the picture operation from before it is
+        // the next thing back -- so it has to be reachable again, or ctrl+z simply stops
+        // working and the insert can never be taken back.
+        it("comes back once the text edits have been undone", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+            ]);
+            select(insertInlineImage(group));
+            noteInlineImageBlockWasEdited(editableFor(group, "en"));
+            setCkeditorUndoable(true);
+            // Sanity check: their editing goes first while CKEditor still holds it.
+            expect(inlineImageCanUndo()).toBe(false);
+
+            setCkeditorUndoable(false);
+
+            expect(inlineImageCanUndo()).toBe(true);
+            setCkeditorUndoable(undefined);
+        });
+
+        // "Is there anything to undo" is not the same question as "is any of it newer than
+        // this snapshot". With text editing on BOTH sides of the picture operation, undoing the
+        // newer half leaves CKEditor still holding the older half -- and answering the first
+        // question there made every ctrl+z go to CKEditor, so it undid text from before the
+        // picture operation while the picture change stood.
+        it("comes back with older typing still behind it", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+            ]);
+            const editable = editableFor(group, "en");
+            // Typing first, so CKEditor holds one snapshot when ours is taken.
+            noteInlineImageBlockWasEdited(editable);
+            setCkeditorUndoable(true, 0);
+
+            select(insertInlineImage(group));
+
+            // Then typing that leaves the content exactly as it was, which only the report can
+            // see, and which CKEditor takes a snapshot of.
+            noteInlineImageBlockWasEdited(editable);
+            setCkeditorUndoable(true, 1);
+            // Sanity check: their newer typing goes first.
+            expect(inlineImageCanUndo()).toBe(false);
+
+            // Ctrl+Z takes that typing back; the older typing is still there to take back.
+            setCkeditorUndoable(true, 0);
+
+            expect(inlineImageCanUndo()).toBe(true);
+            setCkeditorUndoable(undefined);
+        });
+
+        // CKEditor's stack has a limit (20 snapshots), and once it is full its position stops
+        // counting up: save() drops the oldest snapshot before pushing the newest, so the
+        // newest is at the same position as before. Reading the position alone therefore said
+        // "nothing typed since" for typing in a long block, and ctrl+z took the picture back
+        // before it.
+        it("defers to typing after the snapshot once CKEditor's history is full", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+            ]);
+            const editable = editableFor(group, "en");
+            // A block with plenty of typing behind it, so CKEditor's stack is already full.
+            noteInlineImageBlockWasEdited(editable);
+            setCkeditorUndoable(true, 19, true);
+
+            select(insertInlineImage(group));
+            // Sanity check: with nothing typed since, the picture operation is what ctrl+z is for.
+            expect(inlineImageCanUndo()).toBe(true);
+
+            // Then typing that leaves the content exactly as it was, which only the report can
+            // see. CKEditor saves it, and the saving leaves its position where it was.
+            noteInlineImageBlockWasEdited(editable);
+            setCkeditorUndoable(true, 19, true);
+
+            expect(inlineImageCanUndo()).toBe(false);
+
+            // And once that typing is undone, the position drops below ours and the picture
+            // operation is reachable again.
+            setCkeditorUndoable(true, 18, true);
+            expect(inlineImageCanUndo()).toBe(true);
+            setCkeditorUndoable(undefined);
+        });
+
+        // The report names a block, and the undo point for that block need not be the top of
+        // the stack: a picture operation in another block can be sitting on top of it. Marking
+        // only the top left the older one looking untouched, so undoing the newer one exposed
+        // a picture from before an edit the person has made since.
+        it("marks the block's own undo point, not just the top of the stack", () => {
+            const first = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+            ]);
+            const second = makeTranslationGroup(
+                [
+                    {
+                        lang: "en",
+                        classes: "bloom-content1",
+                        content: "<p>b</p>",
+                    },
+                ],
+                "group2",
+            );
+            select(insertInlineImage(first));
+            const secondWrapper = insertInlineImage(second);
+            // An edit in the FIRST block, reported while the second block's operation is on
+            // top. It leaves the content as it was, so only the report can know about it.
+            noteInlineImageBlockWasEdited(editableFor(first, "en"));
+            setCkeditorUndoable(true);
+
+            // Undo the second block's insert, which is the top of the stack.
+            select(secondWrapper);
+            expect(inlineImageUndo()).toBe(true);
+
+            // Now the first block's operation is on top, and it is older than that edit.
+            putCaretIn(editableFor(first, "en"));
+            expect(inlineImageCanUndo()).toBe(false);
+            setCkeditorUndoable(undefined);
+        });
+
+        // SetupElements runs on a PIECE of the page whenever a canvas element is added (and
+        // for the image description tool), and setupInlineImages goes with it. Clearing the
+        // whole stack there took away the undo for a picture move the user had just made in a
+        // block that setup never touched.
+        it("survives a setup of another part of the page", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+            ]);
+            const wrapper = insertInlineImage(group);
+            recordInlineImageUndoPoint(group);
+            wrapper.style.setProperty("--inline-image-width", "80%");
+            syncInlineImagesFromEditable(editableFor(group, "en"));
+            select(wrapper);
+            // Sanity check: there is something to undo before the setup.
+            expect(inlineImageCanUndo()).toBe(true);
+
+            // Something elsewhere on the page gets set up. It holds no inline images, which is
+            // the case that matters: the picture's own group is untouched.
+            const elsewhere = document.createElement("div");
+            group.closest(".bloom-page")!.appendChild(elsewhere);
+            setupInlineImages(elsewhere);
+
+            expect(inlineImageCanUndo()).toBe(true);
+            expect(inlineImageUndo()).toBe(true);
+            expect(
+                getInlineImageInEditable(
+                    editableFor(group, "en"),
+                )!.style.getPropertyValue("--inline-image-width"),
+            ).toBe("40%");
+        });
+
+        // The other side of it: a page frame rebuilt under us leaves every recorded element
+        // detached, and restoring into those would put the picture nowhere the user can see.
+        it("drops an undo point whose group has left the document", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+            ]);
+            const wrapper = insertInlineImage(group);
+            recordInlineImageUndoPoint(group);
+            wrapper.style.setProperty("--inline-image-width", "80%");
+            select(wrapper);
+            // Sanity check: recorded, and reachable.
+            expect(inlineImageCanUndo()).toBe(true);
+
+            const page = group.closest(".bloom-page") as HTMLElement;
+            group.remove();
+            setupInlineImages(page);
+
+            expect(inlineImageCanUndo()).toBe(false);
+        });
+
+        it("undoes a dock and size change in every editable at once", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+                { lang: "fr", content: "<p>b</p>" },
+            ]);
+            insertInlineImage(group);
+            const source = editableFor(group, "en");
+            const sibling = editableFor(group, "fr");
+
+            recordInlineImageUndoPoint(group);
+            const wrapper = getInlineImageInEditable(source)!;
+            wrapper.style.setProperty("--inline-image-width", "80%");
+            setInlineImageDock(wrapper, kInlineImageBottomClass);
+            syncInlineImagesFromEditable(source);
+            // Sanity check: the change landed in the sibling too.
+            expect(sibling.lastElementChild).toBe(
+                getInlineImageInEditable(sibling),
+            );
+            expect(
+                getInlineImageInEditable(sibling)!.style.getPropertyValue(
+                    "--inline-image-width",
+                ),
+            ).toBe("80%");
+
+            select(getInlineImageInEditable(source)!);
+            expect(inlineImageUndo()).toBe(true);
+
+            [source, sibling].forEach((editable) => {
+                const restored = getInlineImageInEditable(editable)!;
+                expect(
+                    restored.style.getPropertyValue("--inline-image-width"),
+                ).toBe("40%");
+                expect(
+                    restored.classList.contains(kInlineImageRightClass),
+                ).toBe(true);
+                expect(
+                    restored.classList.contains(kInlineImageBottomClass),
+                ).toBe(false);
+                // Back in the first slot, with the text after it.
+                expect(editable.firstElementChild).toBe(restored);
+            });
+        });
+
+        it("keeps the selection on the restored image, so a second undo is reachable", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+            ]);
+            const source = editableFor(group, "en");
+            select(insertInlineImage(group));
+            // Two more operations on top of the insert.
+            recordInlineImageUndoPoint(group);
+            getInlineImageInEditable(source)!.style.setProperty(
+                "--inline-image-width",
+                "60%",
+            );
+            recordInlineImageUndoPoint(group);
+            getInlineImageInEditable(source)!.style.setProperty(
+                "--inline-image-width",
+                "80%",
+            );
+
+            expect(inlineImageUndo()).toBe(true);
+            expect(
+                getInlineImageInEditable(source)!.style.getPropertyValue(
+                    "--inline-image-width",
+                ),
+            ).toBe("60%");
+            // The restored wrapper is a new element, but it inherits the selection...
+            expect(
+                getInlineImageInEditable(source)!.classList.contains(
+                    kInlineImageSelectedClass,
+                ),
+            ).toBe(true);
+            // ...so the next undo is still routed to us.
+            expect(inlineImageCanUndo()).toBe(true);
+            expect(inlineImageUndo()).toBe(true);
+            expect(
+                getInlineImageInEditable(source)!.style.getPropertyValue(
+                    "--inline-image-width",
+                ),
+            ).toBe("40%");
+        });
+
+        it("announces the restore, so the interaction layer can rebuild what it attached", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+            ]);
+            select(insertInlineImage(group));
+            let eventsSeen = 0;
+            let groupFromEvent: EventTarget | null = null;
+            // Listening at the document proves it bubbles, which is what lets the interaction
+            // layer use one listener for the whole page.
+            document.addEventListener(kInlineImagesRestoredEvent, (e) => {
+                eventsSeen++;
+                groupFromEvent = e.target;
+            });
+
+            inlineImageUndo();
+
+            expect(eventsSeen).toBe(1);
+            expect(groupFromEvent).toBe(group);
+        });
+
+        // Undo replaces the wrappers, so the copy that was selected is gone -- and when the
+        // operation it took back was the insert that created that picture, there is no copy of
+        // it left to hand the selection to. Requiring a selected picture made the second ctrl+z
+        // in a row fall through to text undo.
+        it("allows a second undo after the first one left nothing selected", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+            ]);
+            const first = insertInlineImage(group);
+            // An earlier operation on the first picture: this is what the second ctrl+z has to
+            // reach. It is deliberately never selected -- the user moves on to the new picture.
+            prepareInlineImageUndo(group);
+            first.style.setProperty(kInlineImageWidthVar, "80%");
+            commitPendingInlineImageUndo(group);
+            select(insertInlineImage(group));
+            // Sanity check: two pictures, and the newer insert is what undo takes back first.
+            expect(getInlineImages(group).length).toBe(2);
+
+            expect(inlineImageUndo()).toBe(true);
+            expect(getInlineImages(group).length).toBe(1);
+            // Nothing is selected now: the picture that was is the one undo took away.
+            expect(
+                group.querySelector("." + kInlineImageSelectedClass),
+            ).toBeNull();
+            // The caret is where selecting a picture leaves it: in the block's text.
+            putCaretIn(editableFor(group, "en"));
+
+            expect(inlineImageCanUndo()).toBe(true);
+            expect(inlineImageUndo()).toBe(true);
+            expect(
+                getInlineImageInEditable(
+                    editableFor(group, "en"),
+                )!.style.getPropertyValue(kInlineImageWidthVar),
+            ).toBe("40%");
+        });
+
+        it("declines when nothing has been recorded", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+            ]);
+            const wrapper = insertInlineImage(group);
+            select(wrapper);
+            // Sanity check: the only reason it would say yes is the recorded insert.
+            expect(inlineImageCanUndo()).toBe(true);
+
+            clearInlineImageUndoState();
+
+            expect(inlineImageCanUndo()).toBe(false);
+            expect(inlineImageUndo()).toBe(false);
+        });
+
+        it("declines when no inline image is the active thing", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+            ]);
+            insertInlineImage(group);
+
+            // Recorded, but nothing selected: undo must fall through to ckeditor rather than
+            // shadowing whatever the user did most recently.
+            expect(inlineImageCanUndo()).toBe(false);
+        });
+
+        it("declines when the active inline image is in a different translation group", () => {
+            const root = getTestRoot();
+            root.innerHTML =
+                `<div class="bloom-page" data-page-id="test-page-${++pageCounter}">` +
+                `<div class="bloom-translationGroup" id="groupA">` +
+                `<div class="bloom-editable bloom-content1" lang="en"><p>a</p></div></div>` +
+                `<div class="bloom-translationGroup" id="groupB">` +
+                `<div class="bloom-editable bloom-content1" lang="en"><p>b</p></div></div>` +
+                `</div>`;
+            const groupA = root.querySelector("#groupA") as HTMLElement;
+            const groupB = root.querySelector("#groupB") as HTMLElement;
+            insertInlineImage(groupB);
+            clearInlineImageUndoState();
+
+            // The recorded operation is in A, but the user is working on B's image.
+            recordInlineImageUndoPoint(groupA);
+            select(getInlineImage(groupB)!);
+
+            expect(inlineImageCanUndo()).toBe(false);
+        });
+
+        it("records on commit but not on discard", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+            ]);
+            select(insertInlineImage(group));
+            clearInlineImageUndoState();
+
+            const image = getInlineImages(group)[0];
+
+            prepareInlineImageUndo(group);
+            discardPendingInlineImageUndo();
+            commitPendingInlineImageUndo(group);
+            expect(inlineImageCanUndo()).toBe(false);
+
+            // Something has to actually change between prepare and commit: on this two-phase
+            // path the change has already landed by the time we commit, so a snapshot that
+            // still describes the group means the operation ended where it began, and that is
+            // deliberately not recorded.
+            prepareInlineImageUndo(group);
+            image.style.setProperty(kInlineImageWidthVar, "55%");
+            commitPendingInlineImageUndo(group);
+            expect(inlineImageCanUndo()).toBe(true);
+        });
+
+        it("does not record an operation that ended where it began", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+            ]);
+            select(insertInlineImage(group));
+            clearInlineImageUndoState();
+
+            // What a drag reverted by the fit-or-revert rule leaves behind: the gesture ran, so
+            // it prepared and committed, but the picture is back where it started. An undo point
+            // there would do nothing visible, and would make the NEXT undo take back a change
+            // the person had stopped thinking about.
+            prepareInlineImageUndo(group);
+            commitPendingInlineImageUndo(group);
+
+            expect(inlineImageCanUndo()).toBe(false);
+        });
+
+        it("forgets everything when the page changes", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+            ]);
+            select(insertInlineImage(group));
+            // Sanity check: recorded and reachable on this page.
+            expect(inlineImageCanUndo()).toBe(true);
+
+            group
+                .closest(".bloom-page")!
+                .setAttribute("data-page-id", "some-other-page");
+
+            expect(inlineImageCanUndo()).toBe(false);
+        });
+
+        it("takes charge of undo only for images that really are inline images", () => {
+            const group = makeTranslationGroup([
+                { lang: "en", classes: "bloom-content1", content: "<p>a</p>" },
+            ]);
+            const wrapper = insertInlineImage(group);
+            const inlineImg = wrapper.querySelector("img") as HTMLElement;
+            const ordinaryImg = document.createElement("img");
+            group.closest(".bloom-page")!.appendChild(ordinaryImg);
+
+            // This is what tells bloomEditing's changeImage which undo layer owns the change.
+            expect(prepareInlineImageUndoForImageChange(inlineImg)).toBe(true);
+            expect(prepareInlineImageUndoForImageChange(ordinaryImg)).toBe(
+                false,
+            );
+        });
+    });
+});

--- a/src/BloomBrowserUI/bookEdit/js/inlineImages.ts
+++ b/src/BloomBrowserUI/bookEdit/js/inlineImages.ts
@@ -1,0 +1,1252 @@
+// Inline (Word-style) images: an image that lives *inside* a bloom-editable, docked left,
+// right, as a full-width band, or at the bottom, with the text of that editable wrapping
+// around it. See INLINE-IMAGES-PLAN.md for the design and its rationale; the layout rules
+// are in content/bookLayout/inlineImages.less and the edit-time affordances in
+// bookEdit/css/editMode.less.
+//
+// Two facts shape everything in this file:
+//
+// 1. The markup has to be inside each bloom-editable, because a CSS float can only wrap
+//    the text of the block it is in. So every language's editable in a translation group
+//    carries its own copy of the wrapper, and they are kept identical by JS: the copy in
+//    the first visible language's editable is canonical, and normalizeInlineImages()
+//    stamps it onto the siblings at page load, while syncInlineImagesFromEditable() does
+//    so after every edit. (CSS then shows the image in only one visible editable, so the
+//    reader sees the picture once; see inlineImages.less.)
+//
+// 2. Position is geometry, never DOM anchoring. Sibling editables hold different text with
+//    different paragraph structure, so "after the second paragraph" cannot be carried
+//    across languages, but "docked right, 40% wide, 120px down" renders the same in all of
+//    them. So the wrapper never moves within the text: it is always the editable's first
+//    child, or its last child when docked at the bottom -- the one DOM move there is. All
+//    the rest of the state is a dock class plus the three custom properties below, which
+//    makes (class list + style attribute) the complete, copyable state of an inline image.
+import OverflowChecker from "../OverflowChecker/OverflowChecker";
+import { kBlockElementSelector } from "../bloomField/BloomField";
+import { createValidXhtmlUniqueId } from "./xhtmlIdUtils";
+
+export const kInlineImageClass = "bloom-inlineImage";
+
+export const kInlineImageLeftClass = "bloom-inlineImageLeft";
+export const kInlineImageRightClass = "bloom-inlineImageRight";
+export const kInlineImageMiddleClass = "bloom-inlineImageMiddle";
+export const kInlineImageBottomClass = "bloom-inlineImageBottom";
+
+// The four docks. Exactly one is on a wrapper at any time.
+export const kInlineImageDockClasses = [
+    kInlineImageLeftClass,
+    kInlineImageRightClass,
+    kInlineImageMiddleClass,
+    kInlineImageBottomClass,
+];
+
+export type InlineImageDock =
+    | typeof kInlineImageLeftClass
+    | typeof kInlineImageRightClass
+    | typeof kInlineImageMiddleClass
+    | typeof kInlineImageBottomClass;
+
+// Edit-time only (a bloom-ui-ish marker; it is stripped from the copies we stamp onto
+// sibling editables, and from the canonical copy when it is serialized). The interaction
+// layer puts this on the wrapper the user has selected, and the undo gate reads it.
+export const kInlineImageSelectedClass = "bloom-inlineImage-selected";
+
+// Raised on the translation group (and bubbling) after an undo has replaced its wrappers, so
+// that whatever was attached to the old elements can be rebuilt. See inlineImageUndo.
+export const kInlineImagesRestoredEvent = "bloom-inlineImagesRestored";
+
+// Raised on the translation group (and bubbling) when a new picture has landed in an inline
+// image, with the wrapper as event.detail. The image chooser round trip goes out through C#
+// and comes back into changeImage, so this is the only point at which the code that started
+// the operation can learn it finished -- which matters because that code owns the selection,
+// and the undo of the change (or of the insert that preceded it) is only reachable while the
+// wrapper is selected. See handleInlineImageChanged.
+export const kInlineImageChangedEvent = "bloom-inlineImageChanged";
+
+// The identity of an inline image, shared by its copy in every language's editable. A text
+// block may hold any number of inline images, so "the wrapper in this editable" is not a
+// thing: sync, normalize and undo all match copies up by this value. It has to be an
+// attribute rather than an id, because TranslationGroupManager strips the id from an
+// editable it clones for a new language (TranslationGroupManager.cs:998) -- whereas nothing
+// in the C# sweeps touches an unknown data-*, and StripOutText only removes p/br/u/b/i
+// elements and text nodes, so the wrapper and this attribute survive into the new language
+// with the value intact, which is exactly what we need.
+export const kInlineImageIdAttr = "data-bloom-inline-image-id";
+
+// Custom properties carrying the geometry. See inlineImages.less for what each does.
+export const kInlineImageWidthVar = "--inline-image-width";
+export const kInlineImageOffsetVar = "--inline-image-offset";
+export const kInlineImageAspectRatioVar = "--inline-image-aspect-ratio";
+
+/**
+ * The size of the block that --inline-image-offset was measured against, "width,height" in
+ * layout pixels. The offset is the one piece of an inline image's geometry that is an absolute
+ * distance -- the width is a percentage of the block and the aspect ratio is a ratio -- so it is
+ * the one piece that means something different when the block changes size, which happens when
+ * the book is drawn at another page size, when a different layout is chosen for the page, and
+ * when a pane is dragged in Change Layout. Keeping the size it was measured against lets the
+ * offset be re-measured for the new block (adjustInlineImageOffsetsIfBlockSizeChanged).
+ *
+ * This is what bloom-canvas does for canvas elements, with data-imgsizebasedon; the name follows
+ * that one, and like it the attribute must be all lowercase to be a valid data-* attribute.
+ */
+export const kInlineImageOffsetBasedOnAttr = "data-inline-image-offset-basedon";
+
+// Classes owned by BloomField.ts, which already knows how to protect an embedded image:
+// keepFirstInField keeps the required <p> after the image, and preventRemoval undoes a
+// ctrl+a DEL that would otherwise take the image with it.
+export const kKeepFirstInFieldClass = "bloom-keepFirstInField";
+export const kPreventRemovalClass = "bloom-preventRemoval";
+
+export const kDefaultInlineImageWidth = "40%";
+// A new wrapper holds a placeholder, which never loads, so there is no natural size to
+// take a ratio from. Without one the wrapper would have no height at all, and the user
+// would have nothing to see or click. 4/3 is the usual photo shape and is replaced by the
+// real ratio as soon as a real image loads.
+export const kDefaultInlineImageAspectRatio = "4 / 3";
+
+const kEditableSelector = ".bloom-editable";
+const kInlineImageSelector = "." + kInlineImageClass;
+
+// The imgs whose load handler we have already installed. Kept out here rather than marked
+// on the element, so that nothing about it can end up in the saved HTML; weak so that it
+// doesn't hold onto the images of pages we have navigated away from.
+const imagesWithLoadHandler = new WeakSet<HTMLImageElement>();
+
+/**
+ * The bloom-editable children of a translation group, in DOM order. (Only direct
+ * children: a translation group nested in a canvas element still owns just its own.)
+ */
+export function getEditables(translationGroup: HTMLElement): HTMLElement[] {
+    return Array.from(translationGroup.children).filter((child) =>
+        child.classList.contains("bloom-editable"),
+    ) as HTMLElement[];
+}
+
+const isVisible = (editable: HTMLElement): boolean =>
+    editable.classList.contains("bloom-visibility-code-on");
+
+/**
+ * The inline images of one bloom-editable, in DOM order -- which is also the order the
+ * reader sees them in, and the order sync replicates to the other languages.
+ */
+export function getInlineImagesInEditable(
+    editable: HTMLElement,
+): HTMLElement[] {
+    return Array.from(
+        editable.querySelectorAll(":scope > " + kInlineImageSelector),
+    ) as HTMLElement[];
+}
+
+/**
+ * The FIRST inline image of one bloom-editable, or null. A block may hold any number of them,
+ * so prefer getInlineImagesInEditable (or a lookup by id) unless you genuinely mean "the
+ * first" or you already know there is only one.
+ */
+export function getInlineImageInEditable(
+    editable: HTMLElement,
+): HTMLElement | null {
+    return getInlineImagesInEditable(editable)[0] ?? null;
+}
+
+/**
+ * The FIRST inline image of the group's canonical editable (see
+ * getCanonicalInlineImageEditable), or null if the group has none. As above: with several
+ * images in a block this is "the first", not "the image", so reach for getInlineImages or
+ * hasInlineImages when that is what you mean.
+ */
+export function getInlineImage(
+    translationGroup: HTMLElement,
+): HTMLElement | null {
+    const editable = getCanonicalInlineImageEditable(translationGroup);
+    return editable ? getInlineImageInEditable(editable) : null;
+}
+
+/**
+ * The identity of one inline image. The same value appears on this image's copy in every
+ * language's editable, which is what lets sync, normalize and undo tell "this image" from
+ * "the other image in the same block". Undefined only for a wrapper built by hand (an old
+ * book, or the test.pug page), which insertInlineImage never produces.
+ */
+/**
+ * Records the block size this image's offset was measured against. Call it wherever the offset
+ * has just been settled, so that a later change of block size has something to re-measure from.
+ */
+export function recordInlineImageOffsetBaseline(
+    wrapper: HTMLElement,
+    editable: HTMLElement,
+): void {
+    wrapper.setAttribute(
+        kInlineImageOffsetBasedOnAttr,
+        `${editable.clientWidth},${editable.clientHeight}`,
+    );
+}
+
+/**
+ * The block size this image's offset was measured against, or undefined for an image saved
+ * before this was recorded (or by a Bloom that did not record it), which is not an error: the
+ * caller records the current size and leaves the offset alone.
+ */
+export function getInlineImageOffsetBaseline(
+    wrapper: HTMLElement,
+): { widthLayoutPx: number; heightLayoutPx: number } | undefined {
+    const parts = (
+        wrapper.getAttribute(kInlineImageOffsetBasedOnAttr) ?? ""
+    ).split(",");
+    if (parts.length !== 2) return undefined;
+    const widthLayoutPx = parseFloat(parts[0]);
+    const heightLayoutPx = parseFloat(parts[1]);
+    if (!(widthLayoutPx > 0) || !(heightLayoutPx > 0)) return undefined;
+    return { widthLayoutPx, heightLayoutPx };
+}
+
+export function getInlineImageId(wrapper: HTMLElement): string | undefined {
+    return wrapper.getAttribute(kInlineImageIdAttr) ?? undefined;
+}
+
+/** This editable's copy of a particular image, or null if it hasn't got one. */
+export function getInlineImageById(
+    editable: HTMLElement,
+    id: string,
+): HTMLElement | null {
+    return editable.querySelector(
+        `:scope > ${kInlineImageSelector}[${kInlineImageIdAttr}="${id}"]`,
+    ) as HTMLElement | null;
+}
+
+/** Whether any editable of the group holds an inline image. */
+export function hasInlineImages(translationGroup: HTMLElement): boolean {
+    return getEditables(translationGroup).some(
+        (editable) => getInlineImagesInEditable(editable).length > 0,
+    );
+}
+
+/**
+ * Every inline image wrapper anywhere in the container (all languages, so this includes
+ * the copies that CSS is hiding). Useful for whole-page passes.
+ */
+export function getInlineImages(container: HTMLElement): HTMLElement[] {
+    return Array.from(
+        container.querySelectorAll(
+            kEditableSelector + " > " + kInlineImageSelector,
+        ),
+    ) as HTMLElement[];
+}
+
+/**
+ * The editable whose set of inline images is canonical: the one the user is looking at, and
+ * therefore the one whose images, geometry and order win when we sync. A visible editable is
+ * always preferred over a hidden one; among equals the preference is bloom-contentFirst (which
+ * the appearance system assigns when it is in charge of visibility), then bloom-content1, then
+ * whichever editable has any -- matching both the CSS that decides where images show and
+ * bloomEditing.ts's SetupThingsSensitiveToStyleChanges.
+ * Returns null if no editable in the group has an inline image.
+ */
+export function getCanonicalInlineImageEditable(
+    translationGroup: HTMLElement,
+): HTMLElement | null {
+    const withImages = getEditables(translationGroup).filter(
+        (editable) => getInlineImagesInEditable(editable).length > 0,
+    );
+    if (withImages.length === 0) return null;
+    // Turning language 1 off on a page leaves its bloom-editable in the DOM, holding a copy
+    // nobody can see. That copy must not be the one that wins: normalizeInlineImages would
+    // stamp it over the language the person has been working in, undoing what they just did.
+    // A group whose only copies are in hidden editables still has to normalize, though (a
+    // template page, or one where every language is off), so hidden ones remain the fallback.
+    const visibleWithImages = withImages.filter(isVisible);
+    const candidates =
+        visibleWithImages.length > 0 ? visibleWithImages : withImages;
+    return (
+        candidates.find((e) => e.classList.contains("bloom-contentFirst")) ??
+        candidates.find((e) => e.classList.contains("bloom-content1")) ??
+        candidates[0]
+    );
+}
+
+/**
+ * The editable whose copy of the image the reader sees, using the same precedence as the
+ * show-once CSS: a visible bloom-contentFirst, else a visible bloom-content1, else the
+ * first visible editable. Undefined if the group has no visible editable at all (which
+ * happens for the language-prototype-only groups on template pages).
+ */
+export function getFirstVisibleEditable(
+    translationGroup: HTMLElement,
+): HTMLElement | undefined {
+    const visibles = getEditables(translationGroup).filter(isVisible);
+    return (
+        visibles.find((e) => e.classList.contains("bloom-contentFirst")) ??
+        visibles.find((e) => e.classList.contains("bloom-content1")) ??
+        visibles[0]
+    );
+}
+
+/**
+ * Gives a wrapper an identity if it has not got one, and returns it. Every lookup that pairs a
+ * wrapper with its copies in the other languages matches on kInlineImageIdAttr, so a wrapper
+ * without one cannot be paired: syncInlineImagesFromEditable would keep it and append another
+ * copy beside it on every page setup, and arrangeInlineImages would never place it.
+ * makeInlineImageWrapper always mints one, so this is for markup that came from somewhere
+ * else -- hand-edited HTML, or a paste from another program.
+ */
+export function ensureInlineImageId(wrapper: HTMLElement): string {
+    const existing = getInlineImageId(wrapper);
+    if (existing) return existing;
+    const id = createValidXhtmlUniqueId();
+    wrapper.setAttribute(kInlineImageIdAttr, id);
+    return id;
+}
+
+/**
+ * Builds a new inline image wrapper: a contenteditable=false island holding a placeholder
+ * image, docked right at the default width. Not attached to anything; see insertInlineImage.
+ * Pass the id when building the copies of one image for the sibling editables, so that all
+ * of them share an identity; omit it to mint a new one.
+ */
+export function makeInlineImageWrapper(id?: string): HTMLElement {
+    const wrapper = document.createElement("div");
+    wrapper.setAttribute(kInlineImageIdAttr, id ?? createValidXhtmlUniqueId());
+    wrapper.classList.add(
+        kInlineImageClass,
+        kInlineImageRightClass,
+        kKeepFirstInFieldClass,
+        kPreventRemovalClass,
+    );
+    // The island is not text. CKEditor tolerates such islands inside the fields it
+    // manages -- the format cog is one (StyleEditor.ts) -- and the talking book tool skips
+    // them when adding audio markup (audioRecording.ts).
+    wrapper.setAttribute("contenteditable", "false");
+    wrapper.style.setProperty(kInlineImageWidthVar, kDefaultInlineImageWidth);
+    wrapper.style.setProperty(
+        kInlineImageAspectRatioVar,
+        kDefaultInlineImageAspectRatio,
+    );
+    const img = document.createElement("img");
+    // We no longer ship a placeHolder.png file; the src is just how Bloom marks an image
+    // as "not chosen yet" (see bloomImages.ts), and CSS draws the flower.
+    img.setAttribute("src", "placeHolder.png");
+    img.setAttribute("alt", "");
+    wrapper.appendChild(img);
+    return wrapper;
+}
+
+/**
+ * Adds a new inline image to a translation group, putting a copy in *every* bloom-editable
+ * child -- including the lang="z" prototype. That is deliberate: when Bloom later adds a
+ * language to this group, MakeElementWithLanguageForOneGroup clones an existing editable
+ * and StripOutText empties the text out of the clone, so a copy in the prototype means the
+ * new language inherits the image with no C# involvement (TranslationGroupManagerTests
+ * covers that cloning). Returns the copy in the editable the reader sees, which is the one
+ * the caller will want to work with (e.g. to open the image chooser on it).
+ */
+export function insertInlineImage(translationGroup: HTMLElement): HTMLElement {
+    recordInlineImageUndoPoint(translationGroup);
+    // One identity, shared by the copy we put in each language's editable.
+    const id = createValidXhtmlUniqueId();
+    const editables = getEditables(translationGroup);
+    editables.forEach((editable) => {
+        ensureEditableHasAParagraph(editable);
+        // A new image joins the end of the floating cluster, so it appears after the images
+        // already there rather than jumping in front of them.
+        editable.insertBefore(
+            makeInlineImageWrapper(id),
+            getFloatingClusterEnd(editable),
+        );
+    });
+    const preferred = getFirstVisibleEditable(translationGroup) ?? editables[0];
+    return getInlineImageById(preferred, id)!;
+}
+
+/**
+ * Deletes ONE inline image -- the one this wrapper is a copy of -- from every bloom-editable
+ * of its group, which is what "delete this image" means for a feature whose copies are
+ * per-language. Other images in the same block are left alone.
+ *
+ * Takes the wrapper the user acted on, not the translation group: with several images in a
+ * block, a group-level remove could only guess which one was meant. Throws if handed
+ * something that is not an inline image, rather than silently deleting the wrong thing.
+ */
+export function removeInlineImage(wrapper: HTMLElement): void {
+    const id = getInlineImageId(wrapper);
+    const translationGroup = getTranslationGroupOf(wrapper);
+    if (!wrapper.classList.contains(kInlineImageClass) || !translationGroup) {
+        throw new Error(
+            "removeInlineImage requires an inline image wrapper inside a translation group",
+        );
+    }
+    recordInlineImageUndoPoint(translationGroup);
+    getEditables(translationGroup).forEach((editable) => {
+        // An id is missing only for hand-written markup, which by definition has no copies
+        // to match; then all we can do is remove the one we were given.
+        if (id) getInlineImageById(editable, id)?.remove();
+    });
+    if (!id) wrapper.remove();
+}
+
+/**
+ * Moves an inline image to a different dock. For the three floating docks this is purely a
+ * class change unless the image is coming back from the bottom, which is what makes dragging
+ * safe to replicate across languages; the bottom dock moves it to the trailing cluster. Also
+ * keeps bloom-keepFirstInField consistent: BloomField uses that class to decide whether the
+ * field's required <p> goes after the images (floating docks) or before them (bottom dock),
+ * so a bottom-docked wrapper must not carry it.
+ * The caller is responsible for the follow-up syncInlineImagesFromEditable().
+ */
+export function setInlineImageDock(
+    wrapper: HTMLElement,
+    dock: InlineImageDock,
+): void {
+    kInlineImageDockClasses.forEach((c) => wrapper.classList.remove(c));
+    wrapper.classList.add(dock);
+    if (dock === kInlineImageBottomClass) {
+        wrapper.classList.remove(kKeepFirstInFieldClass);
+    } else {
+        wrapper.classList.add(kKeepFirstInFieldClass);
+    }
+    const editable = wrapper.parentElement;
+    if (editable) moveToDockCluster(editable, wrapper);
+}
+
+/**
+ * Copies this editable's inline images onto its sibling editables, so that every language
+ * shows the same images, the same way, in the same order. Call it after anything that
+ * changes an image: choosing a different picture, dragging, resizing, changing the dock.
+ *
+ * This editable is the authority for the whole set. Copies are matched up by
+ * kInlineImageIdAttr, so an image whose geometry changed is updated in place, one that is new
+ * here is added there, and one that is gone from here is removed there. Sibling text is never
+ * touched. It is idempotent, so callers may be generous with it, and it strips transient UI
+ * (bloom-ui children, the selected-state class, temporary ids) so none of that is replicated
+ * or saved.
+ *
+ * Does nothing if this editable has no inline images, since that is indistinguishable from
+ * "this editable is not the one being edited"; deletion goes through removeInlineImage.
+ */
+export function syncInlineImagesFromEditable(editable: HTMLElement): void {
+    const sources = getInlineImagesInEditable(editable);
+    if (sources.length === 0) return;
+    const translationGroup = getTranslationGroupOf(editable);
+    if (!translationGroup) return;
+
+    // Everything below matches copies up by id, so anything that arrived without one gets one
+    // first. See ensureInlineImageId for what goes wrong otherwise.
+    sources.forEach(ensureInlineImageId);
+    const wantedIds = new Set(
+        sources.map((source) => getInlineImageId(source)),
+    );
+    getEditables(translationGroup).forEach((sibling) => {
+        if (sibling === editable) return;
+        ensureEditableHasAParagraph(sibling);
+        // Anything here that the source no longer has is gone.
+        getInlineImagesInEditable(sibling).forEach((existing) => {
+            if (!wantedIds.has(getInlineImageId(existing))) existing.remove();
+        });
+        // Stamp each source copy over its counterpart, or add it if there isn't one. Note
+        // that we rebuild rather than patch: the whole state of an inline image is its class
+        // list and style attribute, so a fresh copy is both simpler and exactly right.
+        sources.forEach((source) => {
+            const clone = makeSerializedCopy(source);
+            const id = getInlineImageId(source);
+            const existing = id ? getInlineImageById(sibling, id) : null;
+            if (existing) existing.replaceWith(clone);
+            else sibling.appendChild(clone);
+        });
+        // ...and put them in the source's order, in the right cluster.
+        arrangeInlineImages(sibling, sources);
+    });
+}
+
+/**
+ * Makes every editable of the group agree about its inline image, by finding the canonical
+ * copy (see getInlineImage) and stamping it onto the others. This is what fixes up a group
+ * where the copies have diverged, or where some editable has no copy at all -- for
+ * instance a language added by an older Bloom, or an editable a user managed to delete the
+ * image out of. A no-op for a group with no inline image.
+ */
+export function normalizeInlineImages(translationGroup: HTMLElement): void {
+    const canonicalEditable = getCanonicalInlineImageEditable(translationGroup);
+    if (!canonicalEditable) return;
+    syncInlineImagesFromEditable(canonicalEditable);
+}
+
+/**
+ * Page-load setup for every translation group in the container that has an inline image:
+ * normalize the copies, and arrange for the real image's dimensions to be recorded (and
+ * the page's overflow re-checked) once it loads. Called from SetupElements.
+ */
+export function setupInlineImages(container: HTMLElement): void {
+    // Undo snapshots hold element references, so setup has to throw away the ones that can no
+    // longer be restored. Two things do that: a different page (the page-id check), and a
+    // rebuilt page frame, where the id is the same but every element is new (the isConnected
+    // check). What must NOT throw anything away is a setup of one PIECE of the page --
+    // CanvasElementManager calls SetupElements with just the bloom-canvas it added, and the
+    // image description tool with just its container -- because the groups there keep their
+    // editables and a blanket clear would silently make the user's last picture move
+    // un-undoable.
+    clearInlineImageUndoOnPageChange();
+    dropInlineImageUndoStateForDetachedGroups();
+    getTranslationGroupsWithInlineImages(container).forEach(
+        (translationGroup) => {
+            normalizeInlineImages(translationGroup);
+            getEditables(translationGroup).forEach((editable) => {
+                getInlineImagesInEditable(editable).forEach(wireUpImage);
+            });
+        },
+    );
+}
+
+/**
+ * Call when the image inside an inline image wrapper has been replaced (a different
+ * picture chosen). The old natural dimensions no longer apply, so we drop the recorded
+ * aspect ratio and let the new image's load supply a new one; meanwhile the new src has to
+ * reach the other languages' copies. bloomEditing.ts's changeImageInfo calls this for any
+ * img that turns out to be inside an inline image.
+ */
+export function handleInlineImageChanged(img: HTMLElement): void {
+    const wrapper = img.closest(kInlineImageSelector) as HTMLElement | null;
+    if (!wrapper) return;
+    const editable = wrapper.closest(kEditableSelector) as HTMLElement | null;
+    if (!editable) return;
+    wrapper.style.removeProperty(kInlineImageAspectRatioVar);
+    wireUpImage(wrapper);
+    syncInlineImagesFromEditable(editable);
+    OverflowChecker.AdjustSizeOrMarkOverflowSoon(editable);
+    // Tell the interaction layer, which started this and owns the selection, that the
+    // picture has arrived. It needs to re-assert selection on the wrapper, because the
+    // chooser round trip can leave the focus in the text, and undo of this change (or of
+    // the insert that led to it) is only reachable while the wrapper is selected.
+    wrapper.dispatchEvent(
+        new CustomEvent(kInlineImageChangedEvent, {
+            bubbles: true,
+            detail: wrapper,
+        }),
+    );
+}
+
+// --- undo --------------------------------------------------------------------
+//
+// Inline-image operations need an undo layer of their own. CKEditor's stack cannot see
+// changes we make to the DOM programmatically, and the image-operation layer
+// (ImageUndoManager.ts) only knows how to put one img's src and crop back: it knows nothing
+// about a wrapper that exists once per language and has to be restored in all of them at
+// once. So this is a third small layer built on the same shape as ImageUndoManager --
+// snapshot stack, two-phase prepare/commit, cleared on page change, gated on the relevant
+// thing being active, and no redo.
+//
+// A snapshot is the whole inline-image state of one translation group: for every one of its
+// editables, the serialized markup of all its inline images, in order. That is deliberately
+// coarse: a single operation may touch every editable (sync stamps all of them) and any number
+// of images in each, so restoring the group wholesale is both simpler and more robust than
+// trying to reverse individual mutations. The markup carries each image's identity, dock and
+// geometry, and the list order carries their order, so a snapshot needs nothing else.
+
+type InlineImageEditableSnapshot = {
+    editable: HTMLElement;
+    // The markup of each inline image, in the order they appeared. Empty when this editable
+    // had none.
+    wrapperHtmls: string[];
+};
+
+type InlineImageUndoItem = {
+    translationGroup: HTMLElement;
+    editables: InlineImageEditableSnapshot[];
+    // The group's content at the moment of the snapshot, so we can tell whether the person has
+    // edited since. See inlineImageCanUndo, where that decides who ctrl+z belongs to.
+    contentAtSnapshot: string;
+    // Set when the page reports typing in this block (noteInlineImageBlockWasEdited). The
+    // content comparison above cannot see an edit that undid itself -- a word typed and deleted
+    // again -- and CKEditor holds undo points for both halves of it. It defers to those points
+    // rather than replacing them: see hasEditedSinceInlineImageSnapshot.
+    wasEditedSinceSnapshot: boolean;
+    // How deep CKEditor's undo stack was when the snapshot was taken, so that the typing it
+    // holds can be told apart from typing older than this operation. Undefined when there was
+    // no CKEditor to ask.
+    ckeditorUndoAtSnapshot?: CkeditorUndoPosition;
+};
+
+// Where CKEditor stands in its own stack of undo snapshots, and which editable's stack that is.
+// `index` is CKEditor's own name for the position, one snapshot per edit, going down as edits
+// are undone. Two positions are only comparable when they came from the same undoManager: every
+// editable has one of its own, and they count from zero independently.
+// `historyIsFull` says the stack has reached the limit it keeps (20 snapshots), which is where
+// the position stops being able to count any higher.
+type CkeditorUndoPosition = {
+    undoManager: unknown;
+    index: number;
+    historyIsFull: boolean;
+};
+
+const inlineImageUndoStack: InlineImageUndoItem[] = [];
+let pendingInlineImageUndo: InlineImageUndoItem | undefined;
+let pageIdForInlineImageUndo: string | undefined;
+
+/**
+ * Captures the undo state for an operation that is about to happen but might not complete
+ * (a drag the user may abandon, an image change that may fail). Pair it with
+ * commitPendingInlineImageUndo once the change has actually landed, or
+ * discardPendingInlineImageUndo if it didn't. Cheap enough to call at drag start.
+ * Takes the translation group, or any element inside one.
+ */
+export function prepareInlineImageUndo(element: HTMLElement): void {
+    clearInlineImageUndoOnPageChange();
+    const translationGroup = getTranslationGroupOf(element);
+    pendingInlineImageUndo = translationGroup
+        ? takeInlineImageSnapshot(translationGroup)
+        : undefined;
+}
+
+/**
+ * Pushes the state captured by prepareInlineImageUndo, now that the operation really
+ * happened. Ignores a pending snapshot belonging to some other translation group, so a
+ * mismatched or superseded operation cannot push a misleading undo point.
+ *
+ * A snapshot identical to where the group has ended up is dropped rather than pushed. A drag
+ * arrives here whenever the pointer moved at all, and the fit-or-revert rule can put every
+ * move of a gesture back where it started -- a drag into a full side, or past another image's
+ * level, ends exactly where it began. Pushing that would give the person an Undo that visibly
+ * does nothing, and would make the NEXT Undo take back a change they had stopped thinking about.
+ */
+export function commitPendingInlineImageUndo(element: HTMLElement): void {
+    clearInlineImageUndoOnPageChange();
+    const translationGroup = getTranslationGroupOf(element);
+    if (
+        pendingInlineImageUndo &&
+        pendingInlineImageUndo.translationGroup === translationGroup &&
+        // Only meaningful on this path: here the change has already landed, so a snapshot that
+        // still matches the group means the operation ended where it began. The one-call
+        // recordInlineImageUndoPoint runs BEFORE its change, where the snapshot always matches.
+        !isInlineImageSnapshotStillTrue(pendingInlineImageUndo)
+    ) {
+        inlineImageUndoStack.push(pendingInlineImageUndo);
+    }
+    pendingInlineImageUndo = undefined;
+}
+
+/**
+ * Whether the group looks exactly as this snapshot recorded it, image for image. The wrapper
+ * markup carries identity, dock and geometry, so comparing it compares everything an undo
+ * would restore.
+ */
+function isInlineImageSnapshotStillTrue(item: InlineImageUndoItem): boolean {
+    const now = takeInlineImageSnapshot(item.translationGroup);
+    if (now.editables.length !== item.editables.length) return false;
+    return now.editables.every((current, i) => {
+        const then = item.editables[i];
+        return (
+            current.editable === then.editable &&
+            current.wrapperHtmls.length === then.wrapperHtmls.length &&
+            current.wrapperHtmls.every(
+                (html, j) => html === then.wrapperHtmls[j],
+            )
+        );
+    });
+}
+
+/** Throws away a prepared snapshot, for an operation that turned out not to happen. */
+export function discardPendingInlineImageUndo(): void {
+    pendingInlineImageUndo = undefined;
+}
+
+/**
+ * Records an undo point for an operation that definitely changes something (insert, remove,
+ * a completed dock change). Prepare and commit in one call; use the two-phase pair instead
+ * when the operation might not complete. Takes the translation group, or any element in one.
+ */
+export function recordInlineImageUndoPoint(element: HTMLElement): void {
+    prepareInlineImageUndo(element);
+    const translationGroup = getTranslationGroupOf(element);
+    // Pushed straight, not through commitPendingInlineImageUndo: the change this records has
+    // not happened yet, so that function's "did anything actually change?" test would be
+    // asking about a change still in the future and would throw the snapshot away.
+    if (
+        pendingInlineImageUndo &&
+        pendingInlineImageUndo.translationGroup === translationGroup
+    ) {
+        inlineImageUndoStack.push(pendingInlineImageUndo);
+    }
+    pendingInlineImageUndo = undefined;
+}
+
+/**
+ * Forgets all inline-image undo state. Called when something happens that we cannot undo,
+ * so that undo can't reach back past it and restore a state that never followed from what
+ * the user sees now.
+ */
+export function clearInlineImageUndoState(): void {
+    inlineImageUndoStack.length = 0;
+    pendingInlineImageUndo = undefined;
+}
+
+/**
+ * Forgets the undo state whose translation group has left the document, which is what a
+ * rebuilt page frame leaves behind: a snapshot restores into the very elements it recorded, so
+ * one pointing at a detached group could only restore into elements nothing shows.
+ */
+function dropInlineImageUndoStateForDetachedGroups(): void {
+    for (let i = inlineImageUndoStack.length - 1; i >= 0; i--) {
+        if (!inlineImageUndoStack[i].translationGroup.isConnected) {
+            inlineImageUndoStack.splice(i, 1);
+        }
+    }
+    if (pendingInlineImageUndo?.translationGroup.isConnected === false) {
+        pendingInlineImageUndo = undefined;
+    }
+}
+
+/**
+ * Whether the workspace undo command should route to this layer. Normally it takes two
+ * things: something recorded, and an inline image in the *same* translation group being the
+ * active thing. That gate matters, because this layer is tried ahead of CKEditor and without
+ * it an old inline-image snapshot would shadow the text the user typed a moment ago. It
+ * mirrors canUndoImageOperation's requirement that an image container be active, and adds
+ * the same-group check, so we can never restore a block the user isn't working in.
+ */
+export function inlineImageCanUndo(): boolean {
+    clearInlineImageUndoOnPageChange();
+    const top = inlineImageUndoStack[inlineImageUndoStack.length - 1];
+    if (!top) return false;
+    // Whatever the person edited last is what ctrl+z belongs to, and an edit is always more
+    // recent than the snapshot it followed. Going first here would bring the picture back from
+    // before their edit, which is not the order anything happened in, and it is the one thing
+    // these independent stacks can get wrong (see the comment on the chain in
+    // workspaceRoot.handleUndo). A selected picture does not exempt them: selecting one leaves
+    // the caret in the text and the person free to type, and right-clicking the text gets into
+    // that state without their meaning to -- the menu selects nothing and leaves the picture
+    // as it was.
+    if (hasEditedSinceInlineImageSnapshot(top)) return false;
+    const activeWrapper = getActiveInlineImage();
+    if (activeWrapper) {
+        return getTranslationGroupOf(activeWrapper) === top.translationGroup;
+    }
+    // Insisting on an active inline image would be wrong whenever what the user did last left
+    // no picture selected, and two things do that. Deleting one: the image they were working on
+    // is gone, so saying no here would mean deleting an inline image could never be undone at
+    // all. And undo itself: it rebuilds the wrappers, and when the operation it took back was
+    // the insert that created the selected picture there is no copy left to hand the selection
+    // to -- which used to make the second ctrl+z in a row unreachable.
+    // What is required instead is that the caret is still in the block we would restore into.
+    const focused = getElementWithFocusOrSelection();
+    return !!focused && top.translationGroup.contains(focused);
+}
+
+/**
+ * Whether the person has editing of their own that is newer than this snapshot, and so has to
+ * be undone before it. Two ways to tell, because neither sees everything.
+ *
+ * The content comparison catches an edit nobody reported, including one that changes only
+ * markup (bolding a word), and it clears itself: undoing the edit puts the content back and
+ * the snapshot matches again.
+ *
+ * The reported flag catches an edit that left the content identical -- typed and deleted
+ * again -- which nothing else can see. That flag never clears, so on its own it would say
+ * "no" forever and leave the picture operation permanently unreachable, with ctrl+z doing
+ * nothing at all once CKEditor ran out. So the flag only defers to typing CKEditor is still
+ * holding, and the position it was holding when we snapshotted says which of that typing is
+ * newer than us: see hasNewerTypingThanInlineImageSnapshot.
+ */
+function hasEditedSinceInlineImageSnapshot(item: InlineImageUndoItem): boolean {
+    if (
+        item.wasEditedSinceSnapshot &&
+        hasNewerTypingThanInlineImageSnapshot(item)
+    )
+        return true;
+    return (
+        getInlineImageUndoContentFingerprint(item.translationGroup) !==
+        item.contentAtSnapshot
+    );
+}
+
+/**
+ * Whether the typing CKEditor is holding includes any from after this snapshot.
+ *
+ * "Is there anything to undo" is the wrong question when the person typed on both sides of the
+ * picture operation: undoing the newer typing leaves CKEditor still holding the older, and
+ * answering that question would keep handing ctrl+z to CKEditor, which would then take back
+ * text from before the picture operation while the picture change stood. So the answer is the
+ * position, compared with the one recorded when the snapshot was taken.
+ *
+ * Positions from two different editables count from zero independently, so when the person has
+ * moved to another editable since -- or there was no CKEditor to ask at either end -- the most
+ * that can be said is whether CKEditor holds anything at all.
+ */
+function hasNewerTypingThanInlineImageSnapshot(
+    item: InlineImageUndoItem,
+): boolean {
+    const now = getCkeditorUndoPosition();
+    const atSnapshot = item.ckeditorUndoAtSnapshot;
+    if (now && atSnapshot && now.undoManager === atSnapshot.undoManager) {
+        // CKEditor keeps a limited number of snapshots (20), and once it has that many its
+        // position stops counting up: saving one drops the oldest and then appends, which
+        // leaves the newest where the previous newest was. So in a block with that much typing
+        // behind it, the same position no longer means nothing has been saved since ours, and
+        // typing has to be assumed. Undoing that typing takes the position below ours, which is
+        // how this still clears rather than latching.
+        if (now.index === atSnapshot.index) return now.historyIsFull;
+        return now.index > atSnapshot.index;
+    }
+    return ckeditorHasSomethingToUndo();
+}
+
+/**
+ * Where the focused editable's CKEditor stands in its undo stack, or undefined if there is no
+ * CKEditor or it does not say. Read off the global the page's CKEditor puts up, since there is
+ * no api for it -- the same implementation secret editablePage.ts's ckeditorCanUndo relies on.
+ */
+function getCkeditorUndoPosition(): CkeditorUndoPosition | undefined {
+    const undoManager = getCkeditorUndoManager();
+    const index = undoManager?.index;
+    if (!undoManager || typeof index !== "number") return undefined;
+    const kept = undoManager.snapshots?.length ?? 0;
+    const limit = undoManager.limit ?? 0;
+    return {
+        undoManager,
+        index,
+        historyIsFull: !!limit && kept >= limit,
+    };
+}
+
+/**
+ * Whether CKEditor has text editing it could undo, at all. Same fallback as
+ * editablePage.ts's ckeditorCanUndo: no CKEditor means nothing to undo.
+ */
+function ckeditorHasSomethingToUndo(): boolean {
+    return !!getCkeditorUndoManager()?.undoable?.();
+}
+
+function getCkeditorUndoManager(): CkeditorUndoManager | undefined {
+    return (
+        globalThis as unknown as {
+            CKEDITOR?: { currentInstance?: { undoManager?: unknown } };
+        }
+    ).CKEDITOR?.currentInstance?.undoManager as CkeditorUndoManager | undefined;
+}
+
+// As much of CKEditor's undo manager as is read here: whether it has anything to undo, where it
+// stands, and the snapshots it keeps against the number it will keep.
+type CkeditorUndoManager = {
+    undoable?: () => boolean;
+    index?: number;
+    snapshots?: unknown[];
+    limit?: number;
+};
+
+/**
+ * Reports that the person has just edited the text of a block, so that ctrl+z goes to
+ * CKEditor rather than to an inline-image operation from before the edit. Call it for any
+ * editing in a bloom-editable; it is only of interest when an inline-image undo point is
+ * waiting in that same group. Takes the editable, or anything inside one.
+ */
+export function noteInlineImageBlockWasEdited(element: HTMLElement): void {
+    const translationGroup = getTranslationGroupOf(element);
+    if (!translationGroup) return;
+    // Every undo point for this block, not just the top of the stack: an operation in another
+    // block can be sitting on top of one in this block, and undoing that would then expose a
+    // picture from before this edit.
+    inlineImageUndoStack.forEach((item) => {
+        if (item.translationGroup === translationGroup)
+            item.wasEditedSinceSnapshot = true;
+    });
+    if (pendingInlineImageUndo?.translationGroup === translationGroup)
+        pendingInlineImageUndo.wasEditedSinceSnapshot = true;
+}
+
+/**
+ * Undoes the most recent inline-image operation by restoring its snapshot to every editable
+ * of the translation group, and re-checks overflow since the image's size may have changed.
+ * Returns false if there was nothing to undo. There is no redo, matching the
+ * image-operation layer.
+ */
+export function inlineImageUndo(): boolean {
+    clearInlineImageUndoOnPageChange();
+    const undoItem = inlineImageUndoStack.pop();
+    if (!undoItem) return false;
+    // Restoring replaces the wrapper elements, which would drop the selection and so make a
+    // second ctrl+z unreachable (the gate needs an active inline image). So carry the
+    // selection over to the restored copy of the same image -- by id, since the block may hold
+    // several and re-selecting the wrong one would be worse than re-selecting none.
+    const wasSelected = document.querySelector(
+        kInlineImageSelector + "." + kInlineImageSelectedClass,
+    ) as HTMLElement | null;
+    const selectedId = wasSelected ? getInlineImageId(wasSelected) : undefined;
+    const editableThatWasSelected = wasSelected?.closest(
+        kEditableSelector,
+    ) as HTMLElement | null;
+    undoItem.editables.forEach((snapshot) => {
+        restoreInlineImageSnapshot(snapshot);
+    });
+    if (editableThatWasSelected && selectedId) {
+        getInlineImageById(editableThatWasSelected, selectedId)?.classList.add(
+            kInlineImageSelectedClass,
+        );
+    }
+    // Undo is the one operation that replaces the very wrapper the user is working on (sync
+    // and normalize only ever rewrite the siblings). So anything holding a reference to it,
+    // or anything it was hosting -- drag handles, the hover button cluster, all of which are
+    // bloom-ui and therefore not part of a snapshot -- is now stale. This event is how the
+    // interaction layer knows to re-derive from the DOM.
+    undoItem.translationGroup.dispatchEvent(
+        new CustomEvent(kInlineImagesRestoredEvent, { bubbles: true }),
+    );
+    return true;
+}
+
+/**
+ * The "before" half of undo for a change of the image inside an inline image. Returns true
+ * if this img is in fact in an inline image, in which case this layer has taken charge and
+ * the caller must not also record an image-operation undo point: that layer would restore
+ * one language's src and leave the other languages showing the new picture.
+ */
+export function prepareInlineImageUndoForImageChange(
+    img: HTMLElement,
+): boolean {
+    if (!img.closest(kInlineImageSelector)) return false;
+    prepareInlineImageUndo(img);
+    return true;
+}
+
+/**
+ * The "after" half: pushes what prepareInlineImageUndoForImageChange captured, now that the
+ * new image is really in place. Returns true if this img is in an inline image, as above.
+ */
+export function commitInlineImageUndoForImageChange(img: HTMLElement): boolean {
+    if (!img.closest(kInlineImageSelector)) return false;
+    commitPendingInlineImageUndo(img);
+    return true;
+}
+
+// --- internals ---------------------------------------------------------------
+
+const getTranslationGroupOf = (element: HTMLElement): HTMLElement | undefined =>
+    (element.closest(".bloom-translationGroup") as HTMLElement | null) ??
+    undefined;
+
+/**
+ * The content of a translation group, ignoring the inline images themselves. Comparing this
+ * with what it was when a snapshot was taken says whether the person has edited since, which
+ * is what decides whether ctrl+z belongs to the picture or to the edit (see
+ * inlineImageCanUndo).
+ *
+ * It is the markup, not just the characters: bolding a word changes nothing about the text but
+ * is an edit CKEditor has an undo point for, and if we did not see it we would go first and
+ * bring the picture back while the bolding stood. Transient UI (.bloom-ui) is dropped so that
+ * a toolbar or a format cog appearing does not read as an edit.
+ *
+ * A wrapper's own content is left out on purpose: an operation that adds or removes a picture
+ * also adds or removes whatever is inside it, and that must not read as an edit.
+ */
+function getInlineImageUndoContentFingerprint(
+    translationGroup: HTMLElement,
+): string {
+    return getEditables(translationGroup)
+        .map((editable) => {
+            const copy = editable.cloneNode(true) as HTMLElement;
+            copy.querySelectorAll(kInlineImageSelector).forEach((wrapper) =>
+                wrapper.remove(),
+            );
+            copy.querySelectorAll(".bloom-ui").forEach((e) => e.remove());
+            return copy.innerHTML;
+        })
+        .join("|");
+}
+
+function takeInlineImageSnapshot(
+    translationGroup: HTMLElement,
+): InlineImageUndoItem {
+    return {
+        translationGroup,
+        contentAtSnapshot:
+            getInlineImageUndoContentFingerprint(translationGroup),
+        wasEditedSinceSnapshot: false,
+        ckeditorUndoAtSnapshot: getCkeditorUndoPosition(),
+        editables: getEditables(translationGroup).map((editable) => ({
+            editable,
+            wrapperHtmls: getInlineImagesInEditable(editable).map(
+                (wrapper) => makeSerializedCopy(wrapper).outerHTML,
+            ),
+        })),
+    };
+}
+
+function restoreInlineImageSnapshot(
+    snapshot: InlineImageEditableSnapshot,
+): void {
+    const editable = snapshot.editable;
+    getInlineImagesInEditable(editable).forEach((wrapper) => wrapper.remove());
+    // Rebuild them all, then place them: appending first and arranging afterwards means the
+    // cluster anchors are computed against the finished set rather than a half-built one.
+    const restored = snapshot.wrapperHtmls.map((html) => {
+        const template = document.createElement("template");
+        template.innerHTML = html;
+        const wrapper = template.content.firstElementChild as HTMLElement;
+        editable.appendChild(wrapper);
+        wireUpImage(wrapper);
+        return wrapper;
+    });
+    arrangeInlineImages(editable, restored);
+    OverflowChecker.AdjustSizeOrMarkOverflowSoon(editable);
+}
+
+/**
+ * Take the selection marking off every inline image in the given DOM.
+ *
+ * bloom-inlineImage-selected is editing UI, but it is not a bloom-ui class (it sits on the
+ * wrapper the book owns, and removing bloom-ui elements would take the picture with it), so
+ * nothing strips it on the way to disk. Saving with a picture selected therefore writes the
+ * class into the book's HTML, and from there into spreadsheet exports and published books.
+ * removeEditingDebris is where the other marks of an editing session come off for the same
+ * reason -- origami-layout-mode, the textBox-identifier labels -- so this belongs with them.
+ */
+export function clearInlineImageSelection(container: HTMLElement): void {
+    container
+        .querySelectorAll(
+            kInlineImageSelector + "." + kInlineImageSelectedClass,
+        )
+        .forEach((wrapper) =>
+            wrapper.classList.remove(kInlineImageSelectedClass),
+        );
+}
+// The inline image the user is working on, if any: the one the interaction layer has marked
+// as selected, else one that contains the focus or the caret (which is how an island the
+// user clicked into shows up before there is any selection UI).
+function getActiveInlineImage(): HTMLElement | undefined {
+    const selected = document.querySelector(
+        kInlineImageSelector + "." + kInlineImageSelectedClass,
+    ) as HTMLElement | null;
+    if (selected) return selected;
+    return (
+        (getElementWithFocusOrSelection()?.closest(
+            kInlineImageSelector,
+        ) as HTMLElement | null) ?? undefined
+    );
+}
+
+// Where the user is: the focused element, or failing that the element holding the caret.
+function getElementWithFocusOrSelection(): HTMLElement | undefined {
+    const active = document.activeElement as HTMLElement | null;
+    // document.body is what we get when nothing in the page has focus; it tells us nothing.
+    if (active && active !== document.body) return active;
+    const anchorNode = document.getSelection()?.anchorNode;
+    const anchorElement =
+        anchorNode instanceof Element ? anchorNode : anchorNode?.parentElement;
+    return (anchorElement as HTMLElement | null) ?? undefined;
+}
+
+// Snapshots hold element references, so they are only meaningful for the page they were
+// taken on. Same approach (and same data-page-id check) as
+// ImageUndoManager.clearImageOperationUndoOnPageChange.
+function clearInlineImageUndoOnPageChange(): void {
+    const currentPageId =
+        (
+            document.getElementsByClassName("bloom-page")[0] as
+                | HTMLElement
+                | undefined
+        )?.getAttribute("data-page-id") ?? undefined;
+    if (pageIdForInlineImageUndo !== currentPageId) {
+        clearInlineImageUndoState();
+        pageIdForInlineImageUndo = currentPageId;
+    }
+}
+
+// All the translation groups in (or equal to) the container that hold at least one inline
+// image.
+export function getTranslationGroupsWithInlineImages(
+    container: HTMLElement,
+): HTMLElement[] {
+    const groups = new Set<HTMLElement>();
+    getInlineImages(container).forEach((wrapper) => {
+        const group = wrapper.closest(
+            ".bloom-translationGroup",
+        ) as HTMLElement | null;
+        if (group) groups.add(group);
+    });
+    return Array.from(groups);
+}
+
+// Records the image's real shape so that layout (and therefore the overflow checker) is
+// right, and re-checks overflow, because an image that just got taller can push the text
+// past the bottom of the block. A placeholder never loads, so it keeps the default ratio.
+function wireUpImage(wrapper: HTMLElement): void {
+    const img = wrapper.querySelector("img") as HTMLImageElement | null;
+    if (!img) return;
+    setAspectRatioFromNaturalSize(wrapper, img);
+    if (imagesWithLoadHandler.has(img)) return;
+    imagesWithLoadHandler.add(img);
+    img.addEventListener("load", () => {
+        setAspectRatioFromNaturalSize(wrapper, img);
+        const editable = wrapper.closest(
+            kEditableSelector,
+        ) as HTMLElement | null;
+        if (editable) OverflowChecker.AdjustSizeOrMarkOverflowSoon(editable);
+    });
+}
+
+/**
+ * Writes the picture's real shape onto the wrapper, and onto this picture's copies in the
+ * group's other editables.
+ *
+ * Each copy has its own img and could in principle learn its own ratio, but only the copy in
+ * the showing language reliably does: a copy's load can land before the src changed, or not
+ * at the moment the sync stamps the markup across. A copy left with no ratio falls back to
+ * kDefaultInlineImageAspectRatio and is the wrong shape -- and the one that mattered was the
+ * lang="z" prototype, which is hidden, so nothing showed it, and which is what
+ * TranslationGroupManager clones when a language is added to the collection later. Measured:
+ * choosing a 274x300 picture left "en" at "274 / 300" and "z" at "".
+ */
+function setAspectRatioFromNaturalSize(
+    wrapper: HTMLElement,
+    img: HTMLImageElement,
+): void {
+    if (!img.naturalWidth || !img.naturalHeight) return; // not loaded (or a placeholder)
+    const ratio = `${img.naturalWidth} / ${img.naturalHeight}`;
+    wrapper.style.setProperty(kInlineImageAspectRatioVar, ratio);
+    const id = getInlineImageId(wrapper);
+    const group = getTranslationGroupOf(wrapper);
+    if (!id || !group) return;
+    getEditables(group).forEach((editable) => {
+        getInlineImagesInEditable(editable)
+            .filter((each) => getInlineImageId(each) === id)
+            .forEach((each) =>
+                each.style.setProperty(kInlineImageAspectRatioVar, ratio),
+            );
+    });
+}
+
+// A copy of the wrapper as it should be persisted and replicated: no transient UI, no
+// selected state, and no ids (a change-image round trip puts a temporary id on the img,
+// and duplicating ids across the languages' copies would be worse than useless).
+// Note that this strips the `id` attribute only. kInlineImageIdAttr is a data-* attribute and
+// deliberately survives: it is what makes this copy recognizable as the same image in another
+// language, and every copy of one image is meant to share it.
+function makeSerializedCopy(wrapper: HTMLElement): HTMLElement {
+    const clone = wrapper.cloneNode(true) as HTMLElement;
+    clone.classList.remove(kInlineImageSelectedClass);
+    clone.querySelectorAll(".bloom-ui").forEach((e) => e.remove());
+    clone.removeAttribute("id");
+    clone.querySelectorAll("[id]").forEach((e) => e.removeAttribute("id"));
+    return clone;
+}
+
+// SLOT MODEL
+// An editable's children run: the floating images (left/right/middle) in a leading cluster,
+// then the text, then the bottom-docked images in a trailing cluster, then any bloom-ui (the
+// format cog). Within a cluster, DOM order is the images' order, and sync replicates it. The
+// wrappers never move relative to the text beyond that, which is what keeps a position
+// meaningful across languages whose text is entirely different.
+
+// The node a new or returning floating image should be inserted before: the first child that
+// is neither a floating inline image nor bloom-ui, i.e. where the text starts. Null when the
+// editable has no content yet, in which case appending is right.
+function getFloatingClusterEnd(editable: HTMLElement): Node | null {
+    const firstContent = Array.from(editable.children).find(
+        (child) =>
+            !child.classList.contains("bloom-ui") &&
+            !(
+                child.classList.contains(kInlineImageClass) &&
+                !child.classList.contains(kInlineImageBottomClass)
+            ),
+    );
+    return firstContent ?? null;
+}
+
+// The node a bottom-docked image should be inserted before: the trailing bloom-ui run, so the
+// images stay after all the text but the format cog stays last. Null when there is no such
+// run, in which case appending puts it at the end.
+function getBottomClusterEnd(editable: HTMLElement): Node | null {
+    const children = Array.from(editable.children);
+    for (let i = children.length - 1; i >= 0; i--) {
+        if (!children[i].classList.contains("bloom-ui")) {
+            return children[i].nextSibling;
+        }
+    }
+    return editable.firstChild;
+}
+
+// Is this wrapper already ahead of all the text, i.e. in the leading cluster?
+const isInFloatingCluster = (wrapper: HTMLElement): boolean => {
+    let sibling = wrapper.previousElementSibling;
+    while (sibling) {
+        const isFloatingImage =
+            sibling.classList.contains(kInlineImageClass) &&
+            !sibling.classList.contains(kInlineImageBottomClass);
+        if (!isFloatingImage && !sibling.classList.contains("bloom-ui")) {
+            return false;
+        }
+        sibling = sibling.previousElementSibling;
+    }
+    return true;
+};
+
+// Is this wrapper already after all the text, i.e. in the trailing cluster?
+const isInBottomCluster = (wrapper: HTMLElement): boolean => {
+    let sibling = wrapper.nextElementSibling;
+    while (sibling) {
+        const isBottomImage =
+            sibling.classList.contains(kInlineImageClass) &&
+            sibling.classList.contains(kInlineImageBottomClass);
+        if (!isBottomImage && !sibling.classList.contains("bloom-ui")) {
+            return false;
+        }
+        sibling = sibling.nextElementSibling;
+    }
+    return true;
+};
+
+// Puts one wrapper in the cluster its dock calls for. A wrapper already in the right cluster
+// is left exactly where it is: switching between left, right and middle must not reshuffle an
+// image past its neighbors, since the order within a cluster is the images' order.
+function moveToDockCluster(editable: HTMLElement, wrapper: HTMLElement): void {
+    if (wrapper.classList.contains(kInlineImageBottomClass)) {
+        if (isInBottomCluster(wrapper)) return;
+        editable.insertBefore(wrapper, getBottomClusterEnd(editable));
+        return;
+    }
+    if (isInFloatingCluster(wrapper)) return;
+    editable.insertBefore(wrapper, getFloatingClusterEnd(editable));
+}
+
+// Puts this editable's images into the same order and clusters as the source list, which is
+// the authority for both. Inserting each in turn before a fixed anchor reproduces the source
+// order; the floating cluster goes first so that the bottom cluster's anchor is computed once
+// the text boundary has settled.
+function arrangeInlineImages(
+    editable: HTMLElement,
+    sources: HTMLElement[],
+): void {
+    const idsFor = (wantBottom: boolean) =>
+        sources
+            .filter(
+                (source) =>
+                    source.classList.contains(kInlineImageBottomClass) ===
+                    wantBottom,
+            )
+            .map((source) => getInlineImageId(source))
+            .filter((id): id is string => !!id);
+
+    const floatingAnchor = getFloatingClusterEnd(editable);
+    idsFor(false).forEach((id) => {
+        const wrapper = getInlineImageById(editable, id);
+        if (wrapper) editable.insertBefore(wrapper, floatingAnchor);
+    });
+    const bottomAnchor = getBottomClusterEnd(editable);
+    idsFor(true).forEach((id) => {
+        const wrapper = getInlineImageById(editable, id);
+        if (wrapper) editable.insertBefore(wrapper, bottomAnchor);
+    });
+}
+
+// An editable whose only content is the non-editable island would give the user nowhere to
+// type. BloomField.EnsureParagraphsPresent does this at page load; we do it here too
+// because we insert wrappers after that has run.
+//
+// "Has somewhere to type" means any block element, not just a <p>: converted content can
+// legitimately hold a real heading and no paragraph, and appending an empty paragraph under
+// that heading would give the reader a blank line that then persists into the saved page.
+// We borrow BloomField's own selector so the two cannot disagree about what counts.
+// Note that for every dock except bottom the wrapper carries bloom-keepFirstInField, and
+// BloomField deliberately still insists on a real trailing <p> in that case (the paragraph
+// the text wraps around), so it will add one itself; this only decides whether we add one
+// first. The bottom dock is where it actually shows.
+function ensureEditableHasAParagraph(editable: HTMLElement): void {
+    if (editable.querySelector(kBlockElementSelector)) return;
+    editable.appendChild(document.createElement("p"));
+}

--- a/src/BloomBrowserUI/bookEdit/workspaceRoot.ts
+++ b/src/BloomBrowserUI/bookEdit/workspaceRoot.ts
@@ -129,7 +129,13 @@ export function handleUndo(): void {
     // boxes will operate on a single undo stack unlike mutiple textboxes.
     // Because they are independent, and operational only the the proper context, it doesn't really
     // matter in which order we check for undo operations.
-    if (contentWindow && contentWindow.imageOperationCanUndo()) {
+    // Inline (Word-style) images are a third such independent stack: their operations change
+    // the DOM programmatically in every language's editable at once, which neither ckeditor
+    // nor the image-operation layer can reverse. Like the image check, it only says yes when
+    // an inline image is the active thing, so the order among these three doesn't matter.
+    if (contentWindow && contentWindow.inlineImageCanUndo()) {
+        contentWindow.inlineImageUndo();
+    } else if (contentWindow && contentWindow.imageOperationCanUndo()) {
         contentWindow.imageOperationUndo();
     } else if (contentWindow && contentWindow.ckeditorCanUndo()) {
         contentWindow.ckeditorUndo();
@@ -271,6 +277,9 @@ export function canUndo(): string {
     }
     const toolboxWindow = getToolboxBundleExports();
     if (toolboxWindow && toolboxWindow.canUndo && toolboxWindow.canUndo()) {
+        return "yes";
+    }
+    if (contentWindow && contentWindow.inlineImageCanUndo()) {
         return "yes";
     }
     if (contentWindow && contentWindow.imageOperationCanUndo()) {


### PR DESCRIPTION
The whole of what an inline (Word-style) image is on disk, and the operations that
read and write it. A picture is a div.bloom-inlineImage wrapper carrying one of four
dock classes, contenteditable="false", a data-bloom-inline-image-id shared by its
per-language copies, and three custom properties: a width percent, an aspect ratio,
and a vertical offset in layout pixels.

The one design point worth knowing before reading the code: a float only wraps the
text of the block it sits in, so a picture cannot be one element. It exists once in
every bloom-editable of the translation group, the hidden lang="z" prototype
included, and the copies are kept identical by syncInlineImagesFromEditable at
operation time and normalizeInlineImages at page setup. The prototype's copy matters
more than it looks: it is what TranslationGroupManager clones when a language is
added to the collection later.

Also here, because the model owns it: the feature's own undo stack. Inline-image
operations change the DOM programmatically in several editables at once, which
neither ckeditor nor the image-operation layer can reverse, so workspaceRoot's undo
command consults a third stack the way it already consults origami's and the image
operations'. A snapshot is taken before an operation and dropped again if the
operation ended where it began.

Nothing in this commit creates a picture -- the menu item and the gestures are the
next one -- so merged alone it changes no behaviour. INLINE-IMAGES-PLAN.md is the
design document.

featureStatus.ts gains a rejection handler: without it the promise never settles when
the api is unreachable, which is the case under unit test, and the error goes to the
global reporter.

Card: https://issues.bloomlibrary.org/youtrack/issue/BL-16822

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DCBGajN5YyAYPBenEf1yy


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8320)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8320)
<!-- Reviewable:end -->
