### PR TITLE
BL-16822 Inline images survive a spreadsheet round trip

### DIFF
--- a/src/BloomExe/Spreadsheet/InternalSpreadsheet.cs
+++ b/src/BloomExe/Spreadsheet/InternalSpreadsheet.cs
@@ -39,6 +39,14 @@ namespace Bloom.Spreadsheet
         public const string WidgetSourceColumnLabel = "[activities source]";
         public const string PageTypeColumnLabel = "[page type]";
         public const string AttributeColumnLabel = "[attribute]";
+
+        // A hidden column holding a JSON object with whatever non-textual state a row's
+        // object needs to be reconstructed on import. Currently used by [inline image]
+        // rows; the plan is for future canvas-element rows to share it. Its presence
+        // anywhere in a spreadsheet marks that spreadsheet as the authority on the
+        // objects whose rows use it.
+        public const string DetailsColumnLabel = "[details]";
+        public const string DetailsColumnFriendlyName = "Details";
         public const string ImageSourceColumnFriendlyName = "Image File Path";
 
         public const string BlankContentIndicator = "[blank]";
@@ -47,6 +55,13 @@ namespace Bloom.Spreadsheet
         public const string CoverImageRowLabel = "[cover image]";
         public const string PageContentRowLabel = "[page content]";
         public const string ImageDescriptionRowLabel = "[image description]";
+
+        // A row for one inline image (a .bloom-inlineImage wrapper in a text block; see
+        // inlineImages.ts). Such rows immediately follow the [page content] row of the
+        // translation group the image belongs to, in stacking order. The image file rides
+        // in the normal [image source] column (and so gets a thumbnail); the geometry
+        // needed to reconstruct the wrapper rides in [details] as JSON.
+        public const string InlineImageRowLabel = "[inline image]";
 
         internal static string MapRowLabelToDataBookLabel(string rowTypeLabel)
         {
@@ -350,7 +365,10 @@ namespace Bloom.Spreadsheet
             {
                 GetColumnForTag(PageNumberColumnLabel),
                 GetColumnForTag(ImageSourceColumnLabel),
-            };
+                GetColumnForTag(DetailsColumnLabel),
+            }
+                .Where(i => i >= 0) // optional columns may be absent
+                .ToList();
 
         public void SortHiddenContentRowsToTheBottom()
         {

--- a/src/BloomExe/Spreadsheet/SpreadsheetExporter.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetExporter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
@@ -18,6 +18,7 @@ using Bloom.Publish;
 using Bloom.SafeXml;
 using Bloom.web;
 using L10NSharp;
+using Newtonsoft.Json.Linq;
 using SIL.IO;
 using SIL.Reporting;
 
@@ -265,6 +266,12 @@ namespace Bloom.Spreadsheet
                 if (translationGroup != null)
                 {
                     WriteTranslationGroup(translationGroup, row, bookFolderPath);
+                    ExportInlineImageRows(
+                        translationGroup,
+                        pageNumber,
+                        colorForPage,
+                        bookFolderPath
+                    );
                 }
 
                 if (videoContainer != null)
@@ -389,6 +396,40 @@ namespace Bloom.Spreadsheet
             }
         }
 
+        /// <summary>
+        /// The editable's markup with its inline-image wrappers taken out. The cell is the
+        /// block's text, and each picture has an [inline image] row of its own, so the wrapper
+        /// markup does not belong here as well.
+        ///
+        /// A cell could not carry it anyway: a cell holds MarkedUpText (paragraphs, and bold,
+        /// italic and underline runs), so WriteToFile drops any other element and ReadFromFile
+        /// cannot bring it back -- which is why the rows are the only carrier, and why an
+        /// import from a file was never at risk of writing these wrappers back. What this
+        /// prevents is a consumer that reads the sheet without going through a file (the
+        /// importer's own tests do) writing the cell back verbatim, since StampInlineImages
+        /// will not stamp over pictures that are already there.
+        /// </summary>
+        private static string GetEditableXmlWithoutInlineImages(SafeXmlElement editable)
+        {
+            if (
+                !editable
+                    .ChildNodes.OfType<SafeXmlElement>()
+                    .Any(e => (" " + e.GetAttribute("class") + " ").Contains(" bloom-inlineImage "))
+            )
+                return editable.InnerXml;
+            var clone = (SafeXmlElement)editable.CloneNode(true);
+            foreach (
+                var wrapper in clone
+                    .ChildNodes.OfType<SafeXmlElement>()
+                    .Where(e =>
+                        (" " + e.GetAttribute("class") + " ").Contains(" bloom-inlineImage ")
+                    )
+                    .ToArray()
+            )
+                clone.RemoveChild(wrapper);
+            return clone.InnerXml;
+        }
+
         private void WriteTranslationGroup(
             SafeXmlElement translationGroup,
             ContentRow row,
@@ -405,7 +446,7 @@ namespace Bloom.Spreadsheet
                 if (langCode == "z" || langCode == "")
                     continue;
                 var index = GetOrAddColumnForLang(langCode);
-                var content = editable.InnerXml;
+                var content = GetEditableXmlWithoutInlineImages(editable);
                 content = content.Replace(
                     "<span class=\"bloom-audio-split-marker\">\u200B</span>",
                     "|"
@@ -838,6 +879,164 @@ namespace Bloom.Spreadsheet
                 ExportAudio(dataBookElement, row, bookFolderPath);
                 prevDataBookLabel = dataBookLabel;
             }
+        }
+
+        /// <summary>
+        /// Inline images (.bloom-inlineImage wrappers; see inlineImages.ts) live inside the
+        /// text of a translation group but are language-neutral: the edit-time code keeps an
+        /// identical copy in every editable of the group. The language cells carry only that
+        /// language's text, so each inline image gets its own [inline image] row, immediately
+        /// after the group's row, in stacking order: the image file in the normal
+        /// [image source] column (copied to the spreadsheet's images folder, thumbnail and
+        /// all, like any other image) and the geometry needed to reconstruct the wrapper —
+        /// location, displacement, width — as JSON in the hidden [details] column.
+        /// </summary>
+        private void ExportInlineImageRows(
+            SafeXmlElement translationGroup,
+            string pageNumber,
+            Color colorForPage,
+            string bookFolderPath
+        )
+        {
+            // Any one editable's copies are canonical, since edit-time sync keeps them
+            // identical; take the first editable that has any.
+            var wrappers = translationGroup
+                .SafeSelectNodes("./*[contains(@class, 'bloom-editable')]")
+                .Cast<SafeXmlElement>()
+                .Select(editable =>
+                    editable
+                        .ChildNodes.OfType<SafeXmlElement>()
+                        .Where(e =>
+                            (" " + e.GetAttribute("class") + " ").Contains(" bloom-inlineImage ")
+                        )
+                        .ToArray()
+                )
+                .FirstOrDefault(w => w.Length > 0);
+            if (wrappers == null)
+                return;
+
+            // Make sure the details column exists even if every detail turns out to be a
+            // default; its presence is what tells the importer this spreadsheet is the
+            // authority on inline images.
+            _spreadsheet.AddColumnForTag(
+                InternalSpreadsheet.DetailsColumnLabel,
+                InternalSpreadsheet.DetailsColumnFriendlyName
+            );
+
+            foreach (var wrapper in wrappers)
+            {
+                var row = new ContentRow(_spreadsheet);
+                row.SetCell(
+                    InternalSpreadsheet.RowTypeColumnLabel,
+                    InternalSpreadsheet.InlineImageRowLabel
+                );
+                row.SetCell(InternalSpreadsheet.PageNumberColumnLabel, pageNumber);
+                row.BackgroundColor = colorForPage;
+
+                var img = wrapper.GetElementsByTagName("img").Cast<SafeXmlElement>().First();
+                var src = img.GetAttribute("src");
+                if (string.IsNullOrEmpty(src) || ImageUtils.IsPlaceholderImageFilename(src))
+                {
+                    row.SetCell(
+                        InternalSpreadsheet.ImageSourceColumnLabel,
+                        InternalSpreadsheet.BlankContentIndicator
+                    );
+                }
+                else
+                {
+                    var fileName = UrlPathString.CreateFromUrlEncodedString(src).NotEncoded;
+                    CopyImageFileToSpreadsheetFolder(Path.Combine(bookFolderPath, fileName));
+                    row.SetCell(
+                        InternalSpreadsheet.ImageSourceColumnLabel,
+                        Path.Combine("images", fileName)
+                    );
+                }
+
+                row.SetCell(InternalSpreadsheet.DetailsColumnLabel, GetInlineImageDetails(wrapper));
+            }
+        }
+
+        /// <summary>
+        /// Reads the geometry off an inline-image wrapper and renders it as the JSON the
+        /// [details] cell holds, e.g.
+        /// {"kind":"inline-image","location":"right","offset":"24px","width":"40%"}.
+        /// The kind comes first so the blob identifies itself even apart from its row;
+        /// other kinds (canvas elements) will share this column.
+        /// The offset comes with the block size it was measured against ("offsetBasedOn", from
+        /// data-inline-image-offset-basedon), because the offset is an absolute distance and the
+        /// destination block is very often a different size -- a different page size, a different
+        /// layout, another book. Without it adjustInlineImageOffsetsIfBlockSizeChanged
+        /// (inlineImageInteractions.ts) has nothing to re-measure from and leaves the old
+        /// displacement in place, which pushes the text after the picture off the end of the
+        /// block. The aspect ratio is deliberately NOT included:
+        /// we never stretch images, so the image file itself (in the same row's
+        /// [image source]) is the authority, and the importer measures it.
+        /// Whether the picture's white is transparent ("transparency") is a choice the person
+        /// made from the image's own menu, held as a class on the img; with neither class the
+        /// page's background decides, and nothing is written.
+        /// SpreadsheetImporter.BuildInlineImageWrapper is the inverse.
+        /// </summary>
+        internal static string GetInlineImageDetails(SafeXmlElement wrapper)
+        {
+            var classes = " " + wrapper.GetAttribute("class") + " ";
+            string location = "right";
+            if (classes.Contains(" bloom-inlineImageLeft "))
+                location = "left";
+            else if (classes.Contains(" bloom-inlineImageMiddle "))
+                location = "middle";
+            else if (classes.Contains(" bloom-inlineImageBottom "))
+                location = "bottom";
+
+            var details = new JObject { ["kind"] = "inline-image", ["location"] = location };
+            var offset = GetStyleVariable(wrapper, "--inline-image-offset");
+            if (!string.IsNullOrEmpty(offset) && offset != "0px" && location != "bottom")
+            {
+                details["offset"] = offset;
+                var basedOn = wrapper.GetAttribute("data-inline-image-offset-basedon");
+                if (!string.IsNullOrEmpty(basedOn))
+                    details["offsetBasedOn"] = basedOn;
+            }
+            var width = GetStyleVariable(wrapper, "--inline-image-width");
+            if (!string.IsNullOrEmpty(width))
+                details["width"] = width;
+            var transparency = GetInlineImageTransparency(wrapper);
+            if (transparency != null)
+                details["transparency"] = transparency;
+            return details.ToString(Newtonsoft.Json.Formatting.None);
+        }
+
+        /// <summary>
+        /// "transparent" or "opaque" if the wrapper's img has been given one of those
+        /// choices (see the transparency submenu in canvasControlRegistry.ts), otherwise
+        /// null, which means the page's background decides.
+        /// </summary>
+        private static string GetInlineImageTransparency(SafeXmlElement wrapper)
+        {
+            var img = wrapper.SafeSelectNodes(".//img").FirstOrDefault() as SafeXmlElement;
+            if (img == null)
+                return null;
+            var classes = " " + img.GetAttribute("class") + " ";
+            if (classes.Contains(" bloom-transparent "))
+                return "transparent";
+            if (classes.Contains(" bloom-opaque "))
+                return "opaque";
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the value of one custom property (e.g. "--inline-image-width") from an
+        /// element's style attribute, or null if it isn't set.
+        /// </summary>
+        private static string GetStyleVariable(SafeXmlElement element, string variableName)
+        {
+            var style = element.GetAttribute("style") ?? "";
+            foreach (var declaration in style.Split(';'))
+            {
+                var parts = declaration.Split(new[] { ':' }, 2);
+                if (parts.Length == 2 && parts[0].Trim() == variableName)
+                    return parts[1].Trim();
+            }
+            return null;
         }
 
         private void CopyImageFileToSpreadsheetFolder(string imageSourcePath)

--- a/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
@@ -392,6 +392,7 @@ namespace Bloom.Spreadsheet
                 || key == InternalSpreadsheet.WidgetSourceColumnLabel
                 || key == InternalSpreadsheet.PageTypeColumnLabel
                 || key == InternalSpreadsheet.AttributeColumnLabel
+                || key == InternalSpreadsheet.DetailsColumnLabel
             )
                 return false;
             return !nonWysiwygColumns.Contains(key);

--- a/src/BloomExe/Spreadsheet/SpreadsheetImporter.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetImporter.cs
@@ -1,10 +1,11 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Security;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -19,6 +20,7 @@ using Bloom.TeamCollection;
 using Bloom.Utils;
 using Bloom.web;
 using Bloom.web.controllers;
+using Newtonsoft.Json.Linq;
 using SIL.Extensions;
 using SIL.IO;
 using SIL.Progress;
@@ -299,6 +301,28 @@ namespace Bloom.Spreadsheet
                     bool rowHasWidget = !string.IsNullOrWhiteSpace(
                         currentRow.GetCell(InternalSpreadsheet.WidgetSourceColumnLabel).Text
                     );
+                    // Any [inline image] rows for this row's translation group immediately
+                    // follow it (possibly after an [image description] row, which the image
+                    // handling below consumes separately).
+                    var inlineImageRows = new List<ContentRow>();
+                    {
+                        var lookAhead = _currentRowIndex + 1;
+                        if (
+                            lookAhead < _inputRows.Count
+                            && _inputRows[lookAhead].MetadataKey
+                                == InternalSpreadsheet.ImageDescriptionRowLabel
+                        )
+                            lookAhead++;
+                        while (
+                            lookAhead < _inputRows.Count
+                            && _inputRows[lookAhead].MetadataKey
+                                == InternalSpreadsheet.InlineImageRowLabel
+                        )
+                        {
+                            inlineImageRows.Add(_inputRows[lookAhead]);
+                            lookAhead++;
+                        }
+                    }
                     var typesInRow = MakeBlockTypes(
                         rowHasText,
                         rowHasImage,
@@ -345,7 +369,8 @@ namespace Bloom.Spreadsheet
                                 currentRow,
                                 _blocksOnPage[translationGroupIndex][
                                     _blockOnPageIndexes[translationGroupIndex]
-                                ]
+                                ],
+                                inlineImageRows
                             );
                         }
 
@@ -377,6 +402,18 @@ namespace Bloom.Spreadsheet
                         // not have all the required slots.
                         typesInRow &= ~typesToPut;
                     }
+                    // The [inline image] rows belong to this row's group; consume them so the
+                    // main loop doesn't see them (their bracketed label would otherwise be
+                    // misread as xmatter).
+                    _currentRowIndex += inlineImageRows.Count;
+                }
+                else if (rowTypeLabel == InternalSpreadsheet.InlineImageRowLabel)
+                {
+                    // Normally consumed by the [page content] handling above; one can only
+                    // reach the main loop this way if it was separated from its group's row.
+                    Warn(
+                        $"Row {CurrentRowIndexForMessages} is an {InternalSpreadsheet.InlineImageRowLabel} row that does not directly follow its text row, so Bloom could not use it."
+                    );
                 }
                 else if (rowTypeLabel.StartsWith("[") && rowTypeLabel.EndsWith("]")) //This row is xmatter
                 {
@@ -1695,6 +1732,308 @@ namespace Bloom.Spreadsheet
                 .Contains(className);
         }
 
+        /// <summary>
+        /// Builds inline-image wrappers from the [inline image] rows that followed a
+        /// group's row: for each row, copies the image file from the spreadsheet's images
+        /// folder into the book folder and reconstructs the wrapper markup from the
+        /// [details] JSON. Only called when the spreadsheet has the [details] column;
+        /// the rows (possibly none) are then the authority on what inline images the
+        /// group has.
+        /// </summary>
+        private SafeXmlElement[] BuildInlineImageWrappers(List<ContentRow> inlineImageRows)
+        {
+            if (inlineImageRows == null)
+                return Array.Empty<SafeXmlElement>();
+            return inlineImageRows.Select(BuildInlineImageWrapper).ToArray();
+        }
+
+        /// <summary>
+        /// The inverse of SpreadsheetExporter.GetInlineImageDetails plus makeInlineImageWrapper
+        /// (inlineImages.ts): reconstructs one .bloom-inlineImage wrapper from an
+        /// [inline image] row's [image source] file and [details] JSON
+        /// (e.g. {"kind":"inline-image","location":"right","offset":"24px","width":"40%"}).
+        /// The aspect ratio is
+        /// measured from the image file itself (we never stretch images), or left off when
+        /// the file can't be found, since the CSS falls back to the image's natural ratio.
+        /// Everything else about the wrapper is constant or freshly minted, notably the id
+        /// shared by the copies that will be stamped into each editable, which only
+        /// edit-time sync/undo cares about.
+        /// </summary>
+        private SafeXmlElement BuildInlineImageWrapper(ContentRow row)
+        {
+            var location = "right";
+            string offset = null;
+            string offsetBasedOn = null;
+            string transparency = null;
+            var width = "40%";
+            var details = row.GetCell(InternalSpreadsheet.DetailsColumnLabel).Content;
+            if (!string.IsNullOrWhiteSpace(details))
+            {
+                try
+                {
+                    foreach (var property in JObject.Parse(details).Properties())
+                    {
+                        switch (property.Name)
+                        {
+                            case "kind":
+                                if (property.Value.ToString() != "inline-image")
+                                    Warn(
+                                        $"Row {CurrentRowIndexForMessages} is an {InternalSpreadsheet.InlineImageRowLabel} row, but its {InternalSpreadsheet.DetailsColumnLabel} cell says its kind is \"{property.Value}\"."
+                                    );
+                                break;
+                            case "location":
+                                location = property.Value.ToString();
+                                break;
+                            case "offset":
+                                offset = property.Value.ToString();
+                                break;
+                            case "offsetBasedOn":
+                                offsetBasedOn = property.Value.ToString();
+                                break;
+                            case "width":
+                                width = property.Value.ToString();
+                                break;
+                            case "transparency":
+                                transparency = property.Value.ToString();
+                                break;
+                            default:
+                                Warn(
+                                    $"Bloom did not understand \"{property.Name}\" in the {InternalSpreadsheet.DetailsColumnLabel} cell of row {CurrentRowIndexForMessages}."
+                                );
+                                break;
+                        }
+                    }
+                }
+                catch (Newtonsoft.Json.JsonReaderException)
+                {
+                    Warn(
+                        $"Bloom could not read the {InternalSpreadsheet.DetailsColumnLabel} cell of row {CurrentRowIndexForMessages} (\"{details}\"); the image will get a default position and size."
+                    );
+                }
+            }
+            if (
+                location != "left"
+                && location != "right"
+                && location != "middle"
+                && location != "bottom"
+            )
+            {
+                Warn(
+                    $"Bloom did not understand the location \"{location}\" in the {InternalSpreadsheet.DetailsColumnLabel} cell of row {CurrentRowIndexForMessages}."
+                );
+                location = "right";
+            }
+
+            // These two go straight into the wrapper's style attribute, and the cell they come
+            // from is one a person can edit (it is hidden, not locked). A value that is not a
+            // length would leave the browser using some default they did not ask for, and a
+            // value with a semicolon in it would add declarations of its own to the wrapper.
+            if (!IsInlineImageLength(width))
+            {
+                Warn(
+                    $"Bloom did not understand the width \"{width}\" in the {InternalSpreadsheet.DetailsColumnLabel} cell of row {CurrentRowIndexForMessages}."
+                );
+                width = "40%";
+            }
+            if (offset != null && !IsInlineImageLength(offset))
+            {
+                Warn(
+                    $"Bloom did not understand the offset \"{offset}\" in the {InternalSpreadsheet.DetailsColumnLabel} cell of row {CurrentRowIndexForMessages}."
+                );
+                offset = null;
+            }
+
+            var wrapper = (SafeXmlElement)_destinationDom.RawDom.CreateElement("div");
+            wrapper.SetAttribute("data-bloom-inline-image-id", HtmlDom.GenerateNewHtmlId());
+            var dockClass =
+                "bloom-inlineImage" + char.ToUpperInvariant(location[0]) + location.Substring(1);
+            // bloom-keepFirstInField tells BloomField to put the field's required empty <p>
+            // AFTER the pictures, which is what a floating dock wants. A bottom-docked picture
+            // sits at the end of the block, so the <p> belongs before it, and the class has to
+            // stay off -- setInlineImageDock (inlineImages.ts) removes it for the same reason.
+            // With it on, importing a bottom picture added a blank line under the text.
+            var keepFirst = location == "bottom" ? "" : " bloom-keepFirstInField";
+            wrapper.SetAttribute(
+                "class",
+                $"bloom-inlineImage {dockClass}{keepFirst} bloom-preventRemoval"
+            );
+            wrapper.SetAttribute("contenteditable", "false");
+            var src = CopyInlineImageFileToBook(row, out var copiedImagePath);
+            var style = $"--inline-image-width: {width};";
+            if (
+                copiedImagePath != null
+                && ImageUtils.TryGetImageSize(copiedImagePath, out var size)
+            )
+                style += $" --inline-image-aspect-ratio: {size.Width} / {size.Height};";
+            if (!string.IsNullOrEmpty(offset) && location != "bottom")
+            {
+                style += $" --inline-image-offset: {offset};";
+                // The offset is an absolute distance, so it means the right thing only in a block
+                // the size of the one it was measured in. Carrying that size over is what lets the
+                // editor re-measure it for the block it has landed in
+                // (adjustInlineImageOffsetsIfBlockSizeChanged, inlineImageInteractions.ts); without
+                // it the picture keeps a displacement from another layout and pushes the text after
+                // it off the end.
+                if (!string.IsNullOrEmpty(offsetBasedOn))
+                    wrapper.SetAttribute("data-inline-image-offset-basedon", offsetBasedOn);
+            }
+            wrapper.SetAttribute("style", style);
+
+            var img = (SafeXmlElement)_destinationDom.RawDom.CreateElement("img");
+            img.SetAttribute("src", src);
+            img.SetAttribute("alt", "");
+            // Whether the white of the picture is transparent; with neither class the page's
+            // background decides, which is what an absent value means.
+            if (transparency == "transparent")
+                img.SetAttribute("class", "bloom-transparent");
+            else if (transparency == "opaque")
+                img.SetAttribute("class", "bloom-opaque");
+            else if (transparency != null)
+                Warn(
+                    $"Bloom did not understand the transparency \"{transparency}\" in the {InternalSpreadsheet.DetailsColumnLabel} cell of row {CurrentRowIndexForMessages}."
+                );
+            // Bloom mirrors the image file's copyright, creator and license onto the img so the
+            // rest of the program does not have to open the file; the ordinary [image] import
+            // does the same as it copies (CopyImageFileToDestination). Nothing else on this path
+            // would fill them in, and a command-line import is never followed by the pass that
+            // brings a book up to date in the editor.
+            if (copiedImagePath != null)
+                ImageUpdater.UpdateImgMetadataAttributesToMatchImage(
+                    _pathToBookFolder,
+                    img,
+                    new NullProgress()
+                );
+            wrapper.AppendChild(img);
+            return wrapper;
+        }
+
+        /// <summary>
+        /// Whether this is a CSS length we are prepared to write into a style attribute: a
+        /// number and one of the units the inline-image geometry uses (a width is a percentage
+        /// of the block, an offset a distance down it). Anything else came from a hand-edited
+        /// cell and is refused.
+        /// </summary>
+        private static bool IsInlineImageLength(string value)
+        {
+            return value != null && Regex.IsMatch(value, @"^\d+(\.\d+)?(%|px|em|rem)$");
+        }
+
+        /// <summary>
+        /// Copies an [inline image] row's image file (its [image source] cell, e.g.
+        /// "images/foo.jpg") from the spreadsheet folder into the book folder, and returns
+        /// the url-encoded src the book's img element should carry. A blank cell means the
+        /// image was never chosen; it becomes the placeholder src. copiedImagePath is the
+        /// full path of the file now in the book folder, or null when nothing was copied
+        /// (blank cell, missing file, or the null folders of unit tests).
+        /// </summary>
+        private string CopyInlineImageFileToBook(ContentRow row, out string copiedImagePath)
+        {
+            copiedImagePath = null;
+            var source = row.GetCell(InternalSpreadsheet.ImageSourceColumnLabel).Content;
+            if (
+                string.IsNullOrWhiteSpace(source)
+                || source == InternalSpreadsheet.BlankContentIndicator
+            )
+                return "placeHolder.png";
+            var fileName = Path.GetFileName(source);
+            // Paths can be null in unit tests. Like the video import, we overwrite an
+            // existing file of the same name rather than renaming, on the theory that
+            // identical names in one book refer to the same image.
+            if (_pathToSpreadsheetFolder != null && _pathToBookFolder != null)
+            {
+                var sourcePath = Path.Combine(_pathToSpreadsheetFolder, source);
+                if (!RobustFile.Exists(sourcePath))
+                {
+                    Warn(
+                        $"Image \"{sourcePath}\" for an inline image on row {CurrentRowIndexForMessages} was not found."
+                    );
+                }
+                else
+                {
+                    try
+                    {
+                        var destPath = Path.Combine(_pathToBookFolder, fileName);
+                        RobustFile.Copy(sourcePath, destPath, true);
+                        copiedImagePath = destPath;
+                    }
+                    catch (Exception e)
+                        when (e is IOException
+                            || e is SecurityException
+                            || e is UnauthorizedAccessException
+                        )
+                    {
+                        Warn(
+                            $"Bloom had trouble copying the file \"{sourcePath}\" to the book: {e.Message}"
+                        );
+                    }
+                }
+            }
+            return UrlPathString.CreateFromUnencodedString(fileName).UrlEncoded;
+        }
+
+        /// <summary>
+        /// Gets clones of the group's inline-image wrappers: the .bloom-inlineImage children
+        /// of the first bloom-editable that has any. The edit-time code (inlineImages.ts)
+        /// keeps every editable's copies identical, so any one editable's set is canonical.
+        /// The clones preserve document order: floating-dock wrappers first, bottom-docked last.
+        /// </summary>
+        private static SafeXmlElement[] GetInlineImageWrappers(SafeXmlElement group)
+        {
+            foreach (var editable in SafeSelectNodesByClassName(group, "./div", "bloom-editable"))
+            {
+                var wrappers = editable
+                    .ChildNodes.OfType<SafeXmlElement>()
+                    .Where(e => HasExactClassName(e, "bloom-inlineImage"))
+                    .Select(e => (SafeXmlElement)e.CloneNode(true))
+                    .ToArray();
+                if (wrappers.Length > 0)
+                    return wrappers;
+            }
+            return Array.Empty<SafeXmlElement>();
+        }
+
+        /// <summary>
+        /// Puts clones of the given inline-image wrappers back into an editable whose content
+        /// the import has just replaced. Floating-dock wrappers go at the top of the editable
+        /// in their original order; bottom-docked ones go at the end -- the two slots the
+        /// edit-time code maintains. Does nothing if the new content already contains inline
+        /// images (a cell that carried its own markup must not be second-guessed).
+        /// </summary>
+        /// <summary>
+        /// Takes every inline image wrapper out of this editable, leaving its text alone.
+        /// </summary>
+        private static void RemoveInlineImages(SafeXmlElement editable)
+        {
+            foreach (
+                var wrapper in editable
+                    .ChildNodes.OfType<SafeXmlElement>()
+                    .Where(e => HasExactClassName(e, "bloom-inlineImage"))
+                    .ToArray()
+            )
+                editable.RemoveChild(wrapper);
+        }
+
+        private static void StampInlineImages(SafeXmlElement editable, SafeXmlElement[] wrappers)
+        {
+            if (wrappers.Length == 0)
+                return;
+            if (
+                editable
+                    .ChildNodes.OfType<SafeXmlElement>()
+                    .Any(e => HasExactClassName(e, "bloom-inlineImage"))
+            )
+                return;
+            var firstChild = editable.FirstChild;
+            foreach (var wrapper in wrappers)
+            {
+                var clone = (SafeXmlElement)wrapper.CloneNode(true);
+                if (HasExactClassName(clone, "bloom-inlineImageBottom"))
+                    editable.AppendChild(clone);
+                else
+                    editable.InsertBefore(clone, firstChild);
+            }
+        }
+
         private List<SafeXmlElement> GetBloomCanvases(SafeXmlElement ancestor)
         {
             return SafeSelectNodesByClassName(ancestor, ".//div", "bloom-canvas").ToList();
@@ -1824,7 +2163,11 @@ namespace Bloom.Spreadsheet
         /// </summary>
         /// <param name="row"></param>
         /// <param name="group"></param>
-        private async Task PutRowInGroupAsync(ContentRow row, SafeXmlElement group)
+        private async Task PutRowInGroupAsync(
+            ContentRow row,
+            SafeXmlElement group,
+            List<ContentRow> inlineImageRows = null
+        )
         {
             if (HasExactClassName(group, "QuizAnswer-style"))
             {
@@ -1863,6 +2206,31 @@ namespace Bloom.Spreadsheet
                     }
                 }
             }
+            // Inline images (.bloom-inlineImage wrappers; see inlineImages.ts) are replicated
+            // into every editable of the group. The language cells carry only text; the export
+            // writes each image to its own [inline image] row after the group's row, and when
+            // the spreadsheet has the [details] column those rows are the authority. A
+            // spreadsheet without the column (e.g. made by an older Bloom) can't tell us
+            // anything about inline images, so then we preserve whatever the target group
+            // already has, snapshotted before we overwrite any editable.
+            // CONSTRAINT: [details] is written today only by the inline-image export, which is
+            // what makes its presence a safe signal. Whatever else starts writing that column
+            // (canvas elements are the plan) must bring its own signal for this test, or a sheet
+            // carrying only canvas-element details would be read as saying "this group has no
+            // inline images" and would clear the pictures the group has.
+            // The rows have to be able to reach us as well. An image description is exported
+            // as a cell on its image's row, not as a group row, so no [inline image] rows can
+            // follow it and this caller passes null -- which is "nothing can be said about
+            // this group's pictures", not "it has none". Treating it as the latter cleared the
+            // pictures such a group had.
+            SafeXmlElement[] inlineImageWrappers;
+            var sheetKnowsAboutInlineImages =
+                inlineImageRows != null
+                && _sheet.GetColumnForTag(InternalSpreadsheet.DetailsColumnLabel) >= 0;
+            if (sheetKnowsAboutInlineImages)
+                inlineImageWrappers = BuildInlineImageWrappers(inlineImageRows);
+            else
+                inlineImageWrappers = GetInlineImageWrappers(group);
             var sheetLanguages = _sheet.Languages;
             foreach (var lang in sheetLanguages)
             {
@@ -1882,11 +2250,23 @@ namespace Bloom.Spreadsheet
 
                 if (IsEmptyCell(content))
                 {
-                    editable.ParentNode.RemoveChild(editable);
+                    if (inlineImageWrappers.Length > 0)
+                    {
+                        // An editable whose only content is an inline image exports as a blank
+                        // cell; deleting the editable would delete the image. Keep it, with
+                        // empty text.
+                        editable.InnerXml = "<p></p>";
+                        StampInlineImages(editable, inlineImageWrappers);
+                    }
+                    else
+                    {
+                        editable.ParentNode.RemoveChild(editable);
+                    }
                 }
                 else
                 {
                     editable.InnerXml = content;
+                    StampInlineImages(editable, inlineImageWrappers);
                 }
 
                 await AddAudioAsync(editable, lang, row);
@@ -1904,6 +2284,22 @@ namespace Bloom.Spreadsheet
                         "<span class='bloom-audio-split-marker'>\u200B</span></span>"
                     );
                 }
+            }
+
+            // The lang="z" prototype editable also carries a copy of each inline image, so
+            // that a language added later inherits it (see insertInlineImage); keep it in step.
+            var prototype = HtmlDom.GetEditableChildInLang(group, "z");
+            if (prototype != null)
+            {
+                // Unlike the language editables, the prototype is not rewritten from a cell, so
+                // whatever it holds is what it held before the import. When the spreadsheet is
+                // the authority and says this block has no pictures, the prototype's copies have
+                // to go as well: otherwise a picture the user deleted from the spreadsheet is
+                // still there, invisibly, and comes back the next time a language is added to
+                // the collection.
+                if (sheetKnowsAboutInlineImages)
+                    RemoveInlineImages(prototype);
+                StampInlineImages(prototype, inlineImageWrappers);
             }
 
             if (RemoveOtherLanguages)

--- a/src/BloomTests/Spreadsheet/SpreadsheetInlineImageTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetInlineImageTests.cs
@@ -1,0 +1,859 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Bloom.Book;
+using Bloom.SafeXml;
+using Bloom.Spreadsheet;
+using Moq;
+using NUnit.Framework;
+using OfficeOpenXml;
+using SIL.IO;
+using SIL.TestUtilities;
+using SIL.Windows.Forms.ClearShare;
+
+namespace BloomTests.Spreadsheet
+{
+    /// <summary>
+    /// Tests that inline images (Word-style images inside text blocks; .bloom-inlineImage
+    /// wrappers replicated into every bloom-editable of a translation group) survive a
+    /// spreadsheet export → import round trip. Export gives each inline image its own
+    /// [inline image] row right after its group's row: the file in the normal [image source]
+    /// column, and the geometry (location, displacement, width) as JSON in the hidden
+    /// [details] column, which future canvas-element rows are meant to share. The aspect
+    /// ratio is not in the JSON: the importer measures the image file itself. Import
+    /// reconstructs the wrappers from those parameters — whether importing over the same
+    /// book or into a book that has no inline images at all. A spreadsheet without the
+    /// [details] column (from an older Bloom) falls back to preserving whatever the target
+    /// book already has.
+    /// </summary>
+    public class SpreadsheetInlineImageTests
+    {
+        static SpreadsheetInlineImageTests()
+        {
+            // The package requires us to do this as a way of acknowledging that we
+            // accept the terms of the NonCommercial license.
+            ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
+        }
+
+        // A floating (right-docked) wrapper and a bottom-docked wrapper, exactly as
+        // makeInlineImageWrapper/insertInlineImage (inlineImages.ts) produce them, in every
+        // editable of the group including the lang="z" prototype.
+        private const string floatWrapper =
+            @"<div data-bloom-inline-image-id=""ii-float"" data-inline-image-offset-basedon=""380,300"" class=""bloom-inlineImage bloom-inlineImageRight bloom-keepFirstInField bloom-preventRemoval"" contenteditable=""false"" style=""--inline-image-width: 40%; --inline-image-aspect-ratio: 800 / 600; --inline-image-offset: 24px;""><img class=""bloom-transparent"" src=""flower.jpg"" alt=""""></img></div>";
+
+        private const string bottomWrapper =
+            @"<div data-bloom-inline-image-id=""ii-bottom"" class=""bloom-inlineImage bloom-inlineImageBottom bloom-keepFirstInField bloom-preventRemoval"" contenteditable=""false"" style=""--inline-image-width: 60%; --inline-image-aspect-ratio: 4 / 3;""><img src=""fish.png"" alt=""""></img></div>";
+
+        /// <summary>
+        /// The test book, parameterized so we can build it with the inline images (the book
+        /// that gets exported, and the same-book import target) or without them (the
+        /// "blank book" import target, proving the spreadsheet itself carries the images).
+        /// </summary>
+        /// <param name="imageOnlyImg">the second group's picture; defaults to the first
+        /// group's floating one, since most callers want both groups to look the same.
+        /// Pass it separately to build a book (or a sheet) where only one group has a
+        /// picture.</param>
+        private static string MakeBook(
+            string floatImg,
+            string bottomImg,
+            string imageOnlyImg = null
+        )
+        {
+            imageOnlyImg = imageOnlyImg ?? floatImg;
+            return @"
+<!DOCTYPE html>
+
+<html>
+<head>
+</head>
+
+<body data-l1=""es"" data-l2="""" data-l3="""">
+	<div id=""bloomDataDiv"">
+		<div data-book=""bookTitle"" lang=""en"">
+			<p>Inline image round trip</p>
+		</div>
+	</div>
+    <div class=""bloom-page numberedPage customPage A5Portrait side-right bloom-monolingual"" data-page="""" id=""3a71a95a-4b62-4890-80b6-6b5b26f1b78a"" data-pagelineage=""adcd48df-e9ab-4a07-afd4-6a24d0398382"" data-page-number=""1"" lang="""">
+        <div class=""pageLabel"" data-i18n=""TemplateBooks.PageLabel.Just Text"" lang=""en"">
+            Just Text
+        </div>
+
+        <div class=""pageDescription"" lang=""en""></div>
+
+        <div class=""split-pane-component marginBox"" style="""">
+            <div class=""split-pane-component-inner"">
+                <div class=""bloom-translationGroup bloom-trailingElement"" data-default-languages=""auto"">
+                    <div class=""bloom-editable normal-style bloom-content1 bloom-visibility-code-on"" id=""groupWithTextAndImages-es"" lang=""es"" contenteditable=""true"">"
+                + floatImg
+                + @"
+                        <p>Un perro muy valiente.</p>"
+                + bottomImg
+                + @"
+                    </div>
+
+                    <div class=""bloom-editable normal-style"" lang=""z"" contenteditable=""true"">"
+                + floatImg
+                + @"
+                        <p></p>"
+                + bottomImg
+                + @"
+                    </div>
+
+                    <div class=""bloom-editable normal-style bloom-contentNational1"" id=""groupWithTextAndImages-en"" lang=""en"" contenteditable=""true"">"
+                + floatImg
+                + @"
+                        <p>A very bold dog.</p>"
+                + bottomImg
+                + @"
+                    </div>
+                </div>
+
+                <div class=""bloom-translationGroup bloom-trailingElement"" data-default-languages=""auto"">
+                    <div class=""bloom-editable normal-style bloom-content1 bloom-visibility-code-on"" id=""imageOnlyGroup-es"" lang=""es"" contenteditable=""true"">"
+                + imageOnlyImg
+                + @"
+                        <p></p>
+                    </div>
+
+                    <div class=""bloom-editable normal-style"" lang=""z"" contenteditable=""true"">"
+                + imageOnlyImg
+                + @"
+                        <p></p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>
+";
+        }
+
+        private InternalSpreadsheet _sheetFromExport;
+        private HtmlDom _roundtrippedDom; // imported over a copy of the exported book
+        private HtmlDom _blankBookDom; // imported into a book with no inline images
+
+        private static InternalSpreadsheet ExportBook(string bookHtml)
+        {
+            var mockLangDisplayNameResolver = new Mock<ILanguageDisplayNameResolver>();
+            mockLangDisplayNameResolver
+                .Setup(x => x.GetLanguageDisplayName("en"))
+                .Returns("English");
+            var exporter = new SpreadsheetExporter(mockLangDisplayNameResolver.Object);
+            exporter.Params = new SpreadsheetExportParams();
+            return exporter.Export(new HtmlDom(bookHtml, true), "fakeImagesFolderpath");
+        }
+
+        private static async Task<InternalSpreadsheet> RoundTripThroughFileAndImportAsync(
+            InternalSpreadsheet sheetFromExport,
+            params HtmlDom[] targets
+        )
+        {
+            using (var tempFile = TempFile.WithExtension("xlsx"))
+            {
+                sheetFromExport.WriteToFile(tempFile.Path);
+                var sheet = InternalSpreadsheet.ReadFromFile(tempFile.Path);
+                foreach (var target in targets)
+                    await new TestSpreadsheetImporter(null, target).ImportAsync(sheet);
+                return sheet;
+            }
+        }
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            var bookWithImages = MakeBook(floatWrapper, bottomWrapper);
+            var origDom = new HtmlDom(bookWithImages, true);
+            _roundtrippedDom = new HtmlDom(bookWithImages, true);
+            _blankBookDom = new HtmlDom(MakeBook("", ""), true);
+
+            // Sanity: the test books are what we think they are before the round trip.
+            AssertThatXmlIn
+                .Dom(origDom.RawDom)
+                .HasSpecifiedNumberOfMatchesForXpath(
+                    "//div[contains(@class,'bloom-inlineImage')]",
+                    8
+                );
+            AssertThatXmlIn
+                .Dom(_blankBookDom.RawDom)
+                .HasNoMatchForXpath("//div[contains(@class,'bloom-inlineImage')]");
+
+            _sheetFromExport = ExportBook(bookWithImages);
+            await RoundTripThroughFileAndImportAsync(
+                _sheetFromExport,
+                _roundtrippedDom,
+                _blankBookDom
+            );
+        }
+
+        private HtmlDom GetDom(string target)
+        {
+            switch (target)
+            {
+                case "roundtrip":
+                    return _roundtrippedDom;
+                case "blankbook":
+                    return _blankBookDom;
+                default:
+                    throw new ArgumentException($"unknown test dom '{target}'");
+            }
+        }
+
+        private SafeXmlElement GetEditable(HtmlDom dom, string id)
+        {
+            var editable =
+                dom.SafeSelectNodes($"//div[@id='{id}']").FirstOrDefault() as SafeXmlElement;
+            Assert.That(editable, Is.Not.Null, $"editable '{id}' should survive the import");
+            return editable;
+        }
+
+        private static List<SafeXmlElement> GetWrappers(SafeXmlElement editable)
+        {
+            return editable
+                .ChildNodes.OfType<SafeXmlElement>()
+                .Where(e => (" " + e.GetAttribute("class") + " ").Contains(" bloom-inlineImage "))
+                .ToList();
+        }
+
+        private SafeXmlElement GetFloatWrapper(SafeXmlElement editable)
+        {
+            var wrapper = GetWrappers(editable)
+                .FirstOrDefault(e => e.GetAttribute("class").Contains("bloom-inlineImageRight"));
+            Assert.That(
+                wrapper,
+                Is.Not.Null,
+                $"'{editable.GetAttribute("id")}' should have a right-docked inline image"
+            );
+            return wrapper;
+        }
+
+        [Test]
+        public void SheetHasInlineImageRowsAfterTheirGroupRow()
+        {
+            var rows = _sheetFromExport.ContentRows.ToList();
+            var group1Index = rows.FindIndex(r =>
+                r.GetCell("[es]").Content.Contains("Un perro muy valiente.")
+            );
+            Assert.That(group1Index, Is.GreaterThanOrEqualTo(0), "first group's row exists");
+
+            // First group: two inline images, in stacking order, directly after its row.
+            Assert.That(
+                rows[group1Index + 1].MetadataKey,
+                Is.EqualTo(InternalSpreadsheet.InlineImageRowLabel)
+            );
+            Assert.That(
+                rows[group1Index + 2].MetadataKey,
+                Is.EqualTo(InternalSpreadsheet.InlineImageRowLabel)
+            );
+            Assert.That(
+                rows[group1Index + 1]
+                    .GetCell(InternalSpreadsheet.ImageSourceColumnLabel)
+                    .Content.Replace('\\', '/'),
+                Is.EqualTo("images/flower.jpg")
+            );
+            Assert.That(
+                rows[group1Index + 1].GetCell(InternalSpreadsheet.DetailsColumnLabel).Content,
+                Is.EqualTo(
+                    "{\"kind\":\"inline-image\",\"location\":\"right\",\"offset\":\"24px\",\"offsetBasedOn\":\"380,300\",\"width\":\"40%\",\"transparency\":\"transparent\"}"
+                )
+            );
+            Assert.That(
+                rows[group1Index + 2]
+                    .GetCell(InternalSpreadsheet.ImageSourceColumnLabel)
+                    .Content.Replace('\\', '/'),
+                Is.EqualTo("images/fish.png")
+            );
+            Assert.That(
+                rows[group1Index + 2].GetCell(InternalSpreadsheet.DetailsColumnLabel).Content,
+                Is.EqualTo("{\"kind\":\"inline-image\",\"location\":\"bottom\",\"width\":\"60%\"}")
+            );
+
+            // Second group (image-only): its row follows, then its one inline image.
+            Assert.That(
+                rows[group1Index + 3].MetadataKey,
+                Is.EqualTo(InternalSpreadsheet.PageContentRowLabel)
+            );
+            Assert.That(
+                rows[group1Index + 4].MetadataKey,
+                Is.EqualTo(InternalSpreadsheet.InlineImageRowLabel)
+            );
+            Assert.That(
+                rows[group1Index + 4].GetCell(InternalSpreadsheet.DetailsColumnLabel).Content,
+                Is.EqualTo(
+                    "{\"kind\":\"inline-image\",\"location\":\"right\",\"offset\":\"24px\",\"offsetBasedOn\":\"380,300\",\"width\":\"40%\",\"transparency\":\"transparent\"}"
+                )
+            );
+        }
+
+        [Test]
+        public void DetailsColumnIsHidden()
+        {
+            // Like [image source], [details] is machinery, not something a translator
+            // should be invited to edit.
+            var detailsColumn = _sheetFromExport.GetColumnForTag(
+                InternalSpreadsheet.DetailsColumnLabel
+            );
+            Assert.That(detailsColumn, Is.GreaterThanOrEqualTo(0), "sanity: column exists");
+            Assert.That(_sheetFromExport.HiddenColumns, Does.Contain(detailsColumn));
+        }
+
+        [TestCase("roundtrip", "groupWithTextAndImages-es", "Un perro muy valiente.")]
+        [TestCase("roundtrip", "groupWithTextAndImages-en", "A very bold dog.")]
+        [TestCase("blankbook", "groupWithTextAndImages-es", "Un perro muy valiente.")]
+        [TestCase("blankbook", "groupWithTextAndImages-en", "A very bold dog.")]
+        public void FloatingImageSurvivesWithGeometry(
+            string target,
+            string editableId,
+            string expectedText
+        )
+        {
+            var editable = GetEditable(GetDom(target), editableId);
+            Assert.That(editable.InnerText, Does.Contain(expectedText));
+
+            var wrapper = GetFloatWrapper(editable);
+            var classes = wrapper.GetAttribute("class");
+            Assert.That(classes, Does.Contain("bloom-inlineImage"));
+            Assert.That(classes, Does.Contain("bloom-inlineImageRight"), "location survives");
+            Assert.That(classes, Does.Contain("bloom-keepFirstInField"));
+            Assert.That(classes, Does.Contain("bloom-preventRemoval"));
+            Assert.That(wrapper.GetAttribute("contenteditable"), Is.EqualTo("false"));
+            Assert.That(
+                wrapper.GetAttribute("data-bloom-inline-image-id"),
+                Is.Not.Null.And.Not.Empty,
+                "the rebuilt wrapper needs an id for edit-time sync"
+            );
+
+            var style = wrapper.GetAttribute("style");
+            Assert.That(style, Does.Contain("--inline-image-width: 40%"), "width survives");
+            // The aspect ratio is measured from the image file on import. These imports run
+            // with null folders, so there is no file to measure and the property is omitted;
+            // the CSS then falls back to the image's natural ratio. See
+            // ImportMeasuresAspectRatioFromImageFile for the with-files case.
+            Assert.That(style, Does.Not.Contain("--inline-image-aspect-ratio"));
+            Assert.That(
+                style,
+                Does.Contain("--inline-image-offset: 24px"),
+                "displacement survives"
+            );
+
+            var img = wrapper.ChildNodes.OfType<SafeXmlElement>().FirstOrDefault();
+            Assert.That(img?.Name, Is.EqualTo("img"));
+            Assert.That(
+                img.GetAttribute("src"),
+                Is.EqualTo("flower.jpg"),
+                "src points at the book folder again after import"
+            );
+
+            // The floating wrapper must be at the top of the editable, before the text.
+            var elementChildren = editable.ChildNodes.OfType<SafeXmlElement>().ToList();
+            Assert.That(
+                elementChildren.First().GetAttribute("class"),
+                Does.Contain("bloom-inlineImageRight"),
+                "floating wrapper is the first child"
+            );
+        }
+
+        [TestCase("roundtrip", "groupWithTextAndImages-es")]
+        [TestCase("roundtrip", "groupWithTextAndImages-en")]
+        [TestCase("blankbook", "groupWithTextAndImages-es")]
+        [TestCase("blankbook", "groupWithTextAndImages-en")]
+        public void BottomImageSurvivesAsLastChild(string target, string editableId)
+        {
+            var editable = GetEditable(GetDom(target), editableId);
+            var elementChildren = editable.ChildNodes.OfType<SafeXmlElement>().ToList();
+            var wrapper = elementChildren.Last();
+            Assert.That(
+                wrapper.GetAttribute("class"),
+                Does.Contain("bloom-inlineImageBottom"),
+                "bottom wrapper is the last child"
+            );
+            // BloomField reads bloom-keepFirstInField to decide whether the field's required
+            // empty <p> goes after the pictures or before them. A bottom-docked picture is at
+            // the end of the block, so the <p> belongs before it; with the class on, field
+            // setup appended a blank paragraph after the picture (a blank line under the text).
+            // setInlineImageDock (inlineImages.ts) takes it off for the same reason.
+            Assert.That(
+                wrapper.GetAttribute("class"),
+                Does.Not.Contain("bloom-keepFirstInField"),
+                "a bottom-docked wrapper must not keep the paragraph after it"
+            );
+            var style = wrapper.GetAttribute("style");
+            Assert.That(style, Does.Contain("--inline-image-width: 60%"));
+            Assert.That(
+                style,
+                Does.Not.Contain("--inline-image-offset"),
+                "a bottom-docked image has no displacement"
+            );
+            var img = wrapper.ChildNodes.OfType<SafeXmlElement>().FirstOrDefault();
+            Assert.That(img?.GetAttribute("src"), Is.EqualTo("fish.png"));
+        }
+
+        [TestCase("roundtrip")]
+        [TestCase("blankbook")]
+        public void ImageIdsAgreeAcrossEditablesAndDifferBetweenImages(string target)
+        {
+            var dom = GetDom(target);
+            var es = GetEditable(dom, "groupWithTextAndImages-es");
+            var en = GetEditable(dom, "groupWithTextAndImages-en");
+            var esWrappers = GetWrappers(es);
+            var enWrappers = GetWrappers(en);
+            Assert.That(esWrappers.Count, Is.EqualTo(2), "sanity: float + bottom in es");
+            Assert.That(enWrappers.Count, Is.EqualTo(2), "sanity: float + bottom in en");
+            for (var i = 0; i < 2; i++)
+            {
+                Assert.That(
+                    esWrappers[i].GetAttribute("data-bloom-inline-image-id"),
+                    Is.EqualTo(enWrappers[i].GetAttribute("data-bloom-inline-image-id")),
+                    "copies of one image share one id across the group's editables"
+                );
+            }
+            Assert.That(
+                esWrappers[0].GetAttribute("data-bloom-inline-image-id"),
+                Is.Not.EqualTo(esWrappers[1].GetAttribute("data-bloom-inline-image-id")),
+                "different images have different ids"
+            );
+        }
+
+        [TestCase("roundtrip")]
+        [TestCase("blankbook")]
+        public void ImageOnlyEditableIsNotDeleted(string target)
+        {
+            // The es cell exports as the blank-content indicator (the image contributes no
+            // text), and the importer normally deletes an editable whose cell is blank. An
+            // editable whose group has an inline image must survive that.
+            var editable = GetEditable(GetDom(target), "imageOnlyGroup-es");
+            GetFloatWrapper(editable);
+        }
+
+        [TestCase("roundtrip")]
+        [TestCase("roundtrip")]
+        [TestCase("blankbook")]
+        public void OffsetKeepsTheBlockSizeItWasMeasuredIn(string target)
+        {
+            // The offset is an absolute distance, and the block it lands in is very often a
+            // different size (another page size, another layout, another book). Dropping the
+            // size it was measured against leaves the editor nothing to re-measure from
+            // (adjustInlineImageOffsetsIfBlockSizeChanged), so the picture keeps a displacement
+            // from the other layout and pushes the text after it off the end of the block.
+            var wrapper = GetFloatWrapper(GetEditable(GetDom(target), "groupWithTextAndImages-es"));
+            // Sanity check: the offset that baseline describes really did come through.
+            Assert.That(wrapper.GetAttribute("style"), Does.Contain("--inline-image-offset: 24px"));
+            Assert.That(
+                wrapper.GetAttribute("data-inline-image-offset-basedon"),
+                Is.EqualTo("380,300")
+            );
+        }
+
+        [TestCase("roundtrip")]
+        [TestCase("blankbook")]
+        public void TransparencySurvivesTheRoundTrip(string target)
+        {
+            // Whether a picture's white is transparent is a choice the person made from the
+            // image's own menu (the "image" section of canvasControlRegistry, shared with
+            // canvas elements), and it is held as a class on the img. Dropping it turns a
+            // picture that was drawn on the page's background into one sitting in a white box.
+            var editable = GetEditable(GetDom(target), "groupWithTextAndImages-es");
+            var floatImg = GetFloatWrapper(editable).ChildNodes.OfType<SafeXmlElement>().First();
+            Assert.That(floatImg.GetAttribute("class"), Does.Contain("bloom-transparent"));
+            // The bottom picture made no such choice, and must not acquire one: with neither
+            // class the page's background decides.
+            var bottomImg = GetWrappers(editable)
+                .Last()
+                .ChildNodes.OfType<SafeXmlElement>()
+                .First();
+            Assert.That(bottomImg.GetAttribute("class") ?? "", Does.Not.Contain("bloom-"));
+        }
+
+        [TestCase("blankbook")]
+        public void PrototypeEditableGetsImages(string target)
+        {
+            // The lang="z" prototype editable carries a copy of each inline image, so a
+            // language added later inherits it (see insertInlineImage in inlineImages.ts).
+            var group = GetEditable(GetDom(target), "groupWithTextAndImages-es").ParentNode;
+            var prototype = group
+                .ChildNodes.OfType<SafeXmlElement>()
+                .FirstOrDefault(e => e.GetAttribute("lang") == "z");
+            Assert.That(prototype, Is.Not.Null, "the group should still have a z prototype");
+            Assert.That(GetWrappers(prototype).Count, Is.EqualTo(2));
+        }
+
+        [TestCase("roundtrip")]
+        [TestCase("blankbook")]
+        public void NoWrapperIsDuplicated(string target)
+        {
+            var dom = GetDom(target);
+            Assert.That(
+                GetWrappers(GetEditable(dom, "groupWithTextAndImages-es")).Count,
+                Is.EqualTo(2)
+            );
+            Assert.That(
+                GetWrappers(GetEditable(dom, "groupWithTextAndImages-en")).Count,
+                Is.EqualTo(2)
+            );
+            Assert.That(GetWrappers(GetEditable(dom, "imageOnlyGroup-es")).Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task ImportMeasuresAspectRatioFromImageFile()
+        {
+            // The [details] JSON carries no aspect ratio; we never stretch images, so the
+            // file itself is the authority and the importer measures it after copying it
+            // into the book.
+            using (var spreadsheetFolder = new TemporaryFolder("inlineImageSheetFolder"))
+            using (var bookFolder = new TemporaryFolder("inlineImageBookFolder"))
+            {
+                var imagesFolder = Path.Combine(spreadsheetFolder.Path, "images");
+                Directory.CreateDirectory(imagesFolder);
+                using (var bitmap = new Bitmap(100, 50))
+                    bitmap.Save(Path.Combine(imagesFolder, "flower.jpg"), ImageFormat.Jpeg);
+                using (var bitmap = new Bitmap(30, 60))
+                    bitmap.Save(Path.Combine(imagesFolder, "fish.png"), ImageFormat.Png);
+
+                var dom = new HtmlDom(MakeBook("", ""), true);
+                // Like the shared setup, go through a real .xlsx: only the written file has
+                // the language cells flattened to text the way a real import sees them.
+                InternalSpreadsheet sheet;
+                using (var tempFile = TempFile.WithExtension("xlsx"))
+                {
+                    _sheetFromExport.WriteToFile(tempFile.Path);
+                    sheet = InternalSpreadsheet.ReadFromFile(tempFile.Path);
+                }
+                await new TestSpreadsheetImporter(
+                    null,
+                    dom,
+                    spreadsheetFolder.Path,
+                    bookFolder.Path
+                ).ImportAsync(sheet);
+
+                var editable = GetEditable(dom, "groupWithTextAndImages-es");
+                var floatStyle = GetFloatWrapper(editable).GetAttribute("style");
+                Assert.That(floatStyle, Does.Contain("--inline-image-aspect-ratio: 100 / 50"));
+                var bottomStyle = GetWrappers(editable).Last().GetAttribute("style");
+                Assert.That(bottomStyle, Does.Contain("--inline-image-aspect-ratio: 30 / 60"));
+
+                Assert.That(
+                    RobustFile.Exists(Path.Combine(bookFolder.Path, "flower.jpg")),
+                    "the image file lands in the book folder"
+                );
+            }
+        }
+
+        [Test]
+        public async Task ImportPutsTheImageFileMetadataOnTheImg()
+        {
+            // Bloom mirrors an image file's copyright, creator and license onto the img element
+            // so that the credits and the UI can read them without opening every file, and the
+            // ordinary [image] import fills them in as it copies the file
+            // (CopyImageFileToDestination). An inline image has to do the same: nothing else on
+            // this path would, and a command-line import is never followed by the pass that
+            // brings a book up to date in the editor.
+            using (var spreadsheetFolder = new TemporaryFolder("inlineImageCreditsSheetFolder"))
+            using (var bookFolder = new TemporaryFolder("inlineImageCreditsBookFolder"))
+            {
+                var imagesFolder = Path.Combine(spreadsheetFolder.Path, "images");
+                Directory.CreateDirectory(imagesFolder);
+                var flowerPath = Path.Combine(imagesFolder, "flower.jpg");
+                using (var bitmap = new Bitmap(100, 50))
+                    bitmap.Save(flowerPath, ImageFormat.Jpeg);
+                using (var bitmap = new Bitmap(30, 60))
+                    bitmap.Save(Path.Combine(imagesFolder, "fish.png"), ImageFormat.Png);
+                var metadata = new Metadata
+                {
+                    CopyrightNotice = "Copyright 2026 Emilia Example",
+                    Creator = "Emilia Example",
+                    License = CreativeCommonsLicense.FromLicenseUrl(
+                        "http://creativecommons.org/licenses/by/4.0/"
+                    ),
+                };
+                metadata.Write(flowerPath);
+                Assert.That(
+                    Bloom.RobustFileIO.MetadataFromFile(flowerPath).CopyrightNotice,
+                    Is.EqualTo("Copyright 2026 Emilia Example"),
+                    "sanity: the test image has metadata for the import to find"
+                );
+
+                var dom = new HtmlDom(MakeBook("", ""), true);
+                InternalSpreadsheet sheet;
+                using (var tempFile = TempFile.WithExtension("xlsx"))
+                {
+                    _sheetFromExport.WriteToFile(tempFile.Path);
+                    sheet = InternalSpreadsheet.ReadFromFile(tempFile.Path);
+                }
+                await new TestSpreadsheetImporter(
+                    null,
+                    dom,
+                    spreadsheetFolder.Path,
+                    bookFolder.Path
+                ).ImportAsync(sheet);
+
+                var img = GetFloatWrapper(GetEditable(dom, "groupWithTextAndImages-es"))
+                    .ChildNodes.OfType<SafeXmlElement>()
+                    .First();
+                Assert.That(img.Name, Is.EqualTo("img"), "sanity: the wrapper holds the picture");
+                Assert.That(
+                    img.GetAttribute("data-copyright"),
+                    Is.EqualTo("Copyright 2026 Emilia Example")
+                );
+                Assert.That(img.GetAttribute("data-creator"), Is.EqualTo("Emilia Example"));
+                Assert.That(img.GetAttribute("data-license"), Is.EqualTo("cc-by"));
+            }
+        }
+
+        // A book with a picture inside an image description, alongside a text block that has
+        // one too (so the sheet gets its [details] column and IS the authority on inline
+        // images). Bloom no longer offers Add Image inside an image description, so this is a
+        // book made before that or edited by hand -- and either way the picture is the
+        // person's and must not be thrown away by an import.
+        private static string MakeBookWithPictureInImageDescription()
+        {
+            return @"
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body data-l1=""es"" data-l2="""" data-l3="""">
+    <div id=""bloomDataDiv"">
+        <div data-book=""bookTitle"" lang=""en""><p>Picture in a description</p></div>
+    </div>
+    <div class=""bloom-page numberedPage customPage A5Portrait side-right bloom-monolingual"" data-page="""" id=""4b71a95a-4b62-4890-80b6-6b5b26f1b78b"" data-pagelineage=""adcd48df-e9ab-4a07-afd4-6a24d0398382"" data-page-number=""1"" lang="""">
+        <div class=""pageLabel"" data-i18n=""TemplateBooks.PageLabel.Basic Text &amp; Image"" lang=""en"">
+            Basic Text &amp; Image
+        </div>
+
+        <div class=""pageDescription"" lang=""en""></div>
+
+        <div class=""split-pane-component marginBox"" style="""">
+            <div class=""bloom-translationGroup bloom-trailingElement"" data-default-languages=""auto"">
+                <div class=""bloom-editable normal-style bloom-content1 bloom-visibility-code-on"" id=""textGroup-es"" lang=""es"" contenteditable=""true"">"
+                + floatWrapper
+                + @"
+                    <p>Un perro muy valiente.</p>
+                </div>
+            </div>
+            <div class=""bloom-canvas"">
+                <img src=""placeHolder.png""></img>
+                <div class=""bloom-translationGroup bloom-imageDescription bloom-trailingElement"" data-default-languages=""auto"">
+                    <div class=""bloom-editable normal-style bloom-content1 bloom-visibility-code-on"" id=""description-es"" lang=""es"" contenteditable=""true"">"
+                + bottomWrapper
+                + @"
+                        <p>Un pez que salta.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>
+";
+        }
+
+        [Test]
+        public async Task ImportKeepsAPictureInAnImageDescription()
+        {
+            // An image description is exported as a cell on its image's row, not as a group
+            // row of its own, so no [inline image] rows can follow it and the sheet has
+            // nothing to say about pictures in it. That is not the same as saying it has
+            // none: the group has to keep what the book gave it.
+            var bookHtml = MakeBookWithPictureInImageDescription();
+            var targetDom = new HtmlDom(bookHtml, true);
+            var sheet = ExportBook(bookHtml);
+            Assert.That(
+                sheet.GetColumnForTag(InternalSpreadsheet.DetailsColumnLabel),
+                Is.GreaterThanOrEqualTo(0),
+                "sanity: this sheet has the details column, so it is the authority"
+            );
+
+            await RoundTripThroughFileAndImportAsync(sheet, targetDom);
+
+            // Sanity check: the text block's own picture came through, so the import really
+            // did rebuild inline images on this page.
+            Assert.That(GetWrappers(GetEditable(targetDom, "textGroup-es")).Count, Is.EqualTo(1));
+            var description = GetEditable(targetDom, "description-es");
+            Assert.That(description.InnerText, Does.Contain("Un pez que salta."));
+            Assert.That(
+                GetWrappers(description).Select(w => w.GetAttribute("data-bloom-inline-image-id")),
+                Is.EquivalentTo(new[] { "ii-bottom" }),
+                "the description keeps the picture the book gave it"
+            );
+        }
+
+        [Test]
+        public async Task PictureMarkupCannotTravelInACell()
+        {
+            // Why the [inline image] rows are the only carrier, and worth pinning because it is
+            // not obvious from the code: a cell holds MarkedUpText -- paragraphs, and bold,
+            // italic and underline runs (see SpreadsheetIO) -- so writing the file drops any
+            // other element and reading it cannot bring one back. Markup in a cell therefore
+            // cannot move a picture to another book, and an import from a file was never at risk
+            // of writing old wrappers into an editable either.
+            var sheet = ExportBook(MakeBookWithPictureInImageDescription());
+            var row = sheet.ContentRows.First(r =>
+                r.MetadataKey == InternalSpreadsheet.ImageDescriptionRowLabel
+            );
+            row.SetCell("[es]", bottomWrapper + "<p>Un pez que salta.</p>");
+            Assert.That(
+                row.GetCell("[es]").Content,
+                Does.Contain("bloom-inlineImage"),
+                "sanity: the cell holds the markup before the file is written"
+            );
+            var targetDom = new HtmlDom(
+                MakeBookWithPictureInImageDescription()
+                    .Replace(bottomWrapper, "")
+                    .Replace("Un pez que salta.", ""),
+                true
+            );
+
+            var readBack = await RoundTripThroughFileAndImportAsync(sheet, targetDom);
+
+            Assert.That(
+                readBack
+                    .ContentRows.First(r =>
+                        r.MetadataKey == InternalSpreadsheet.ImageDescriptionRowLabel
+                    )
+                    .GetCell("[es]")
+                    .Content,
+                Does.Not.Contain("bloom-inlineImage"),
+                "the file cannot hold the wrapper"
+            );
+            var description = GetEditable(targetDom, "description-es");
+            Assert.That(description.InnerText, Does.Contain("Un pez que salta."));
+            Assert.That(
+                GetWrappers(description),
+                Is.Empty,
+                "so no picture arrives in a book that had none"
+            );
+        }
+
+        [Test]
+        public void LanguageCellsCarryNoPictureMarkup()
+        {
+            // The cell is the block's text. A picture in the block has a row of its own, so its
+            // markup has no business in the language cell as well. In a cell it is also a trap
+            // for anything that reads the sheet without going through a file, as the importer's
+            // own tests do: the cell would be written back verbatim, and StampInlineImages
+            // leaves alone an editable that already has pictures, so a change made through the
+            // picture rows would be ignored. Through a real file the markup never arrives at all
+            // -- see PictureMarkupCannotTravelInACell.
+            var content = _sheetFromExport
+                .ContentRows.First(r =>
+                    r.GetCell("[es]").Content.Contains("Un perro muy valiente.")
+                )
+                .GetCell("[es]")
+                .Content;
+            Assert.That(content, Does.Not.Contain("bloom-inlineImage"));
+            Assert.That(content, Does.Not.Contain("flower.jpg"));
+        }
+
+        [Test]
+        public async Task ImportRejectsGeometryItCannotUse()
+        {
+            // A person can edit the [details] cell -- it is hidden, not locked -- and these two
+            // values go straight into the wrapper's style attribute. A value that is not a
+            // length would either be ignored by the browser (leaving a picture at some default
+            // that surprises them) or, with a semicolon in it, add declarations of its own to
+            // the wrapper's style. So an unusable value is refused, with a warning, and the
+            // picture gets the default.
+            var sheet = ExportBook(MakeBook(floatWrapper, bottomWrapper));
+            var row = sheet.ContentRows.First(r =>
+                r.MetadataKey == InternalSpreadsheet.InlineImageRowLabel
+            );
+            row.SetCell(
+                InternalSpreadsheet.DetailsColumnLabel,
+                "{\"kind\":\"inline-image\",\"location\":\"right\",\"offset\":\"12px; display: none\",\"width\":\"wide\"}"
+            );
+            var targetDom = new HtmlDom(MakeBook("", ""), true);
+
+            await RoundTripThroughFileAndImportAsync(sheet, targetDom);
+
+            var wrapper = GetFloatWrapper(GetEditable(targetDom, "groupWithTextAndImages-es"));
+            var style = wrapper.GetAttribute("style");
+            Assert.That(style, Does.Not.Contain("display"));
+            Assert.That(style, Does.Not.Contain("wide"));
+            Assert.That(style, Does.Contain("--inline-image-width: 40%"), "the default width");
+            Assert.That(style, Does.Not.Contain("--inline-image-offset"));
+        }
+
+        [Test]
+        public async Task SpreadsheetWithoutDetailsColumnPreservesBookImages()
+        {
+            // A spreadsheet made from a book with no inline images (like any spreadsheet
+            // from an older Bloom) has no [details] column, so it is not an authority
+            // on inline images: importing it over a book that has them must not destroy them.
+            var targetDom = new HtmlDom(MakeBook(floatWrapper, bottomWrapper), true);
+            var sheet = ExportBook(MakeBook("", ""));
+            Assert.That(
+                sheet.GetColumnForTag(InternalSpreadsheet.DetailsColumnLabel),
+                Is.LessThan(0),
+                "sanity: this sheet should have no details column"
+            );
+            await RoundTripThroughFileAndImportAsync(sheet, targetDom);
+
+            var editable = GetEditable(targetDom, "groupWithTextAndImages-es");
+            Assert.That(editable.InnerText, Does.Contain("Un perro muy valiente."));
+            var wrappers = GetWrappers(editable);
+            Assert.That(wrappers.Count, Is.EqualTo(2), "both images preserved");
+            Assert.That(
+                wrappers.Select(w => w.GetAttribute("data-bloom-inline-image-id")),
+                Is.EquivalentTo(new[] { "ii-float", "ii-bottom" }),
+                "the book's own wrappers survive untouched"
+            );
+        }
+
+        [Test]
+        public async Task ASheetWithNoRowsForABlockClearsItsImages()
+        {
+            // Removing a block's [inline image] rows is how a person deletes its pictures
+            // through the spreadsheet. The language editables are rewritten from their cells,
+            // so their copies go with the text; the lang="z" prototype is not, and its copy
+            // used to stay -- invisible, so nothing showed the picture was still there, until
+            // a language was added to the collection and inherited it (TranslationGroupManager
+            // clones the prototype).
+            //
+            // The sheet here still carries the second group's picture, so it has a [details]
+            // column and IS the authority on inline images; it just says the first group has
+            // none.
+            var targetDom = new HtmlDom(MakeBook(floatWrapper, bottomWrapper, floatWrapper), true);
+            var sheet = ExportBook(MakeBook("", "", floatWrapper));
+            Assert.That(
+                sheet.GetColumnForTag(InternalSpreadsheet.DetailsColumnLabel),
+                Is.GreaterThanOrEqualTo(0),
+                "sanity: this sheet has the details column, so it is the authority"
+            );
+            Assert.That(
+                sheet.ContentRows.Count(r =>
+                    r.MetadataKey == InternalSpreadsheet.InlineImageRowLabel
+                ),
+                Is.EqualTo(1),
+                "sanity: one image row, and it belongs to the second group"
+            );
+
+            await RoundTripThroughFileAndImportAsync(sheet, targetDom);
+
+            AssertThatXmlIn
+                .Dom(targetDom.RawDom)
+                .HasSpecifiedNumberOfMatchesForXpath(
+                    "//div[@id='groupWithTextAndImages-es']/div[contains(@class,'bloom-inlineImage')]",
+                    0
+                );
+            var group = GetEditable(targetDom, "groupWithTextAndImages-es").ParentNode;
+            var prototype = group
+                .ChildNodes.OfType<SafeXmlElement>()
+                .FirstOrDefault(e => e.GetAttribute("lang") == "z");
+            Assert.That(prototype, Is.Not.Null, "sanity: the group still has a z prototype");
+            Assert.That(
+                GetWrappers(prototype).Count,
+                Is.EqualTo(0),
+                "the prototype's copies go too, or the picture comes back with the next language"
+            );
+            // ...and the group the sheet DOES have a picture for still has it.
+            Assert.That(
+                GetWrappers(GetEditable(targetDom, "imageOnlyGroup-es")).Count,
+                Is.EqualTo(1)
+            );
+        }
+    }
+}


### PR DESCRIPTION
A translator's spreadsheet has one row per text block, so a picture inside a block
had nowhere to go: exporting a book with one and importing it back lost the picture.

The export now writes one [inline image] row per picture, directly after the row of
the block it belongs to, carrying the file name in the image column. Which side the
picture is docked to, how wide it is, and how far down the block it sits go into a
new hidden [details] column as self-identifying JSON, so a spreadsheet a person edits
by hand shows them a picture and its file and nothing they can break by accident.

Two things are deliberately left out of that column. The aspect ratio, because we
never stretch an image: the file named in the same row's [image source] is the
authority and the importer measures it. And the id, because it does not need to
survive: every lookup is scoped to one translation group, so all the id has to
guarantee is that a group's per-language copies of one picture share a value and two
pictures differ. The importer mints new ones to that rule, which
ImageIdsAgreeAcrossEditablesAndDifferBetweenImages pins.

The importer reads those rows back, rebuilds the wrapper in every language of the
group, and puts them in the order the export wrote. A spreadsheet made before this
change has no such rows and imports as it always did.

The [details] column is hidden and excluded from the wysiwyg-formatted columns, which
is what stops SpreadsheetIO trying to interpret its JSON as rich text.

Card: https://issues.bloomlibrary.org/youtrack/issue/BL-16822

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DCBGajN5YyAYPBenEf1yy


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8323)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8323)
<!-- Reviewable:end -->

