### PR TITLE
BL-16822 Inline images: the end-to-end suite, and two test affordances Bloom needed

### DIFF
--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -19,6 +19,22 @@ House rules:
 
 ---
 
+## 2026-09-06 — The e2e suite can hijack and then kill the developer's own Bloom
+
+- **Cut:** Running `pnpm exec playwright test` while a Bloom from the same worktree is running
+  ended that Bloom, its `dotnet watch`, the go.sh launcher and the Vite dev server. Bloom hands a
+  collection off to an already-running instance of itself (the case `launchBloom.ts:666` allows
+  for), so the developer's Bloom became the one serving the test collection, discovery matched it,
+  and `stopBloom` killed its whole process tree. Nothing warns about this: `launchBloom.ts` says
+  it "ALWAYS launches its own Bloom", and the README's only note about a running Bloom is about
+  port 5173.
+- **Idea:** Refuse to start when a Bloom from this repo root is already running (the
+  `bloom-automation` skill's `bloomProcessStatus.mjs` already detects it), or make discovery
+  refuse a serving pid that is not a descendant of the pid we spawned. At the least, say it in
+  README.md and in `launchBloom.ts`.
+- **Context:** branch inline-images, while running the whole suite for the inline-image toolbar
+  tests.
+
 ## 2026-09-02 — notion_automation.py needs Python, which not every dev machine has
 
 - **Cut:** `.github/skills/improve-test-automation-coverage/notion_automation.py` is the only way the
@@ -189,6 +205,14 @@ House rules:
   `Bloom.dll`, is older than its source, and names the newer file (`assertBuildIsNotStale` in
   `src/BloomE2E/fixtures/launchBloom.ts`). The stale build still has to be rebuilt by hand, or
   bypassed with `BLOOM_E2E_VITE_PORT`, but it can no longer fail a test in silence.
+- **Seen again 2026-09-07:** the `BLOOM_E2E_VITE_PORT` escape covers only the front end. A C#
+  edit makes `Bloom.dll` stale, and `build/agent-dotnet.sh` cannot clear it: it builds into a
+  private per-terminal tree by design, while `assertBuildIsNotStale` reads
+  `output\Debug\AnyCPU\Bloom.dll`. So the only way through is a plain
+  `dotnet build src/BloomExe/BloomExe.csproj`, which needs the developer's Bloom stopped first
+  (MSB3027) -- the one thing AGENTS.md otherwise arranges for agents never to have to do. Cost
+  here: 16 failed tests and a full suite run. Worth saying in the fixture's error text, which
+  names the file but not how to rebuild it.
 
 
 ## 2026-08-10 — check-csharp-ApplicationExit.sh greps whole files, not the diff

--- a/src/BloomBrowserUI/react_components/bloomButton.tsx
+++ b/src/BloomBrowserUI/react_components/bloomButton.tsx
@@ -56,6 +56,15 @@ export default class BloomButton extends LocalizableElement<
         const hidden = this.props.hidden ? "hidden" : "";
         const commonProps = {
             id: this.props.id,
+            // The l10n key is the only stable name a BloomButton has: its text is localized, and
+            // most callers give it neither an id nor a class. Tests find buttons by this, the same
+            // way they find menu items (localizableMenuItem.tsx does the same with its l10nId). A
+            // caller that passes its own data-testid still wins, because propsToPass is spread
+            // after this.
+            // Several callers pass "" (ZoomControl, TopRightMenuButton, Toast, BloomMessageBox,
+            // NotifyDialog): an empty test id is not a name, and it would make every one of those
+            // buttons answer to the same one, so they get no attribute at all.
+            "data-testid": this.props.l10nKey || undefined,
             title: tip,
             onClick: () => this.onClick(),
             disabled: !this.props.enabled,

--- a/src/BloomE2E/AUTOMATION-DEBT.md
+++ b/src/BloomE2E/AUTOMATION-DEBT.md
@@ -543,3 +543,51 @@ creates one `_workspaceReactControl`. Worth finding, because the duplicate is wh
 the test-side check necessary.
 (Found 2026-09-01 while making `jumpToPage` queue a jump.)
 
+
+## The spreadsheet round trip: fixed, except for the Export dialog
+
+Exporting a book to a spreadsheet used to end by calling `ProcessExtra.SafeStartInFront` on the
+.xlsx it wrote, which opens the file in whatever the machine uses for spreadsheets. A test that
+exported left an Excel window on the developer's screen that nothing in the test could close, so
+neither half of the round trip could be driven.
+
+fixed for the file handling 2026-09-06 (`inline-images-spreadsheet.spec.ts`,
+`helpers/spreadsheet.ts`): under `--e2e`, `SpreadsheetApi.ExportToSpreadsheet` records the path it
+wrote instead of opening the file, and `e2e/lastExportedSpreadsheet` reports it. That path is also
+the test's completion signal, since the export runs in the background behind a progress dialog.
+The import side needed nothing new: its file chooser already takes its answer from
+`e2e/nextFileToChoose`. `SetSpreadsheetFolder` also stops writing
+`Settings.Default.ExportImportFileFolder` under `--e2e`, for the reason
+`FileIOApi.SelectFileUsingDialog` stops writing `FilePathMemory`: those settings are machine-wide
+and shared with the developer's own Bloom.
+
+Still open: **the Export dialog is not driven.** `helpers/spreadsheet.ts` sends the same
+`spreadsheet/export` POST that the dialog's Export button sends, so the dialog itself, and the
+folder its Choose Folder button picks, are untested. Everything after the POST is Bloom's own
+work. Fixing this needs no new hook, only a test id on the two buttons; `BloomButton` now carries
+its `l10nKey` as `data-testid`, so a `data-testid` reaches every dialog button, and what is left
+is a test that walks the dialog.
+
+Also still open: **a nested context-menu item has no test id.** Both spreadsheet commands are on
+the book menu's "More" submenu, and `LocalizableNestedMenuItem` renders through a third-party
+`NestedMenuItem` that does not carry one, unlike every other item in that menu. So
+`helpers/spreadsheet.ts` finds "More" by its English label. See "The Edit tab's page thumbnail
+menu has no stable test ids" for the same problem elsewhere.
+
+## A launched Bloom sometimes exposes no debugging target at all
+
+Once in a nine-file run on 2026-09-07, `inline-images-zoom.spec.ts` failed before any test code
+ran: `Bloom's WebView2 never exposed the shell document it is driving within 90s`, with
+`Targets seen: none` -- so it is not the wrong-document case above (that one lists the documents
+it found), and not the worker crash either (the worker was alive and reported the failure). The
+spec passed on its own immediately afterwards, and the other eight files in the same run were
+green.
+
+`Targets seen: none` says the debugging listener answered but had nothing on it, which points at
+Bloom still starting rather than at anything the test did. Whether the 90 seconds is simply too
+short on a loaded machine is not known; nobody has caught it with Bloom's own log alongside.
+
+How to react, until it is understood: **re-run the file**, and treat a failure that follows one
+file across runs as a real problem in that file rather than this entry. Fix direction: have
+`findShellPage` say what Bloom's process was doing when it gave up (it has the pid), so the next
+occurrence distinguishes a slow start from a Bloom that never got there.

--- a/src/BloomE2E/fixtures/launchBloom.ts
+++ b/src/BloomE2E/fixtures/launchBloom.ts
@@ -218,7 +218,12 @@ const FOLDERS_THAT_ARE_NOT_SOURCE = new Set([
     "__tests__",
     "component-tests",
     "canvas-e2e-tests",
+    "inline-images-e2e",
     "test",
+    // Playwright writes .last-run.json here whenever somebody runs one of the front end's own
+    // Playwright suites (pnpm e2e ...). It is an artifact, but it sits inside the source tree, so
+    // without this the next e2e run refuses to start, naming a file nobody edited.
+    "test-results",
 ]);
 
 /**

--- a/src/BloomE2E/helpers/addPageDialog.ts
+++ b/src/BloomE2E/helpers/addPageDialog.ts
@@ -62,9 +62,15 @@ export async function openAddPageDialog(page: Page): Promise<void> {
     await waitForAddPageThumbnails(page);
 }
 
+// The two things this one dialog (PageChooserDialog) calls itself: "Add Page..." when it is
+// adding a page and "Choose Different Layout..." when it is changing the layout of the page the
+// person is on. Everything else about it is the same, so both are recognized here.
+const kPageChooserDialogTitles = /(Add Page|Choose Different Layout)/;
+
 /**
- * The open Add Page dialog, wherever Bloom mounted it. Throws, naming the frames it looked in, if
- * no dialog appears within the timeout.
+ * The open page chooser dialog, wherever Bloom mounted it, whether it was opened to add a page or
+ * to choose a different layout. Throws, naming the frames it looked in, if no dialog appears
+ * within the timeout.
  */
 async function findAddPageDialog(
     page: Page,
@@ -77,7 +83,7 @@ async function findAddPageDialog(
                 for (const frame of page.frames()) {
                     const dialog = frame
                         .locator('[role="dialog"]')
-                        .filter({ hasText: "Add Page" });
+                        .filter({ hasText: kPageChooserDialogTitles });
                     if ((await dialog.count().catch(() => 0)) > 0) {
                         found = dialog.first();
                         return true;
@@ -88,7 +94,7 @@ async function findAddPageDialog(
             {
                 timeout: timeoutMs,
                 message:
-                    "The Add Page dialog never appeared. Frames: " +
+                    "The page chooser dialog never appeared. Frames: " +
                     page
                         .frames()
                         .map((f) => f.name() || "(main)")
@@ -99,12 +105,12 @@ async function findAddPageDialog(
     return found!;
 }
 
-/** True while an Add Page dialog is open in any frame. */
+/** True while the page chooser dialog is open in any frame, in either of its two roles. */
 async function isAddPageDialogOpen(page: Page): Promise<boolean> {
     for (const frame of page.frames()) {
         const count = await frame
             .locator('[role="dialog"]')
-            .filter({ hasText: "Add Page" })
+            .filter({ hasText: kPageChooserDialogTitles })
             .count()
             .catch(() => 0);
         if (count > 0) return true;
@@ -273,7 +279,74 @@ export async function addPageFromDialog(
     label: string,
     templateBookFolderName?: string,
 ): Promise<void> {
+    const dialog = await selectTemplatePageInDialog(
+        page,
+        label,
+        templateBookFolderName,
+    );
+    const before = (await getPages(page)).length;
+    await dialog.getByRole("button", { name: "Add Page", exact: true }).click();
+    await expect
+        .poll(() => isAddPageDialogOpen(page), {
+            timeout: 30000,
+            message: "The Add Page dialog did not close after Add Page.",
+        })
+        .toBe(false);
+    await expect
+        .poll(async () => (await getPages(page)).length, {
+            timeout: 60000,
+            message: `Bloom never added the "${label}" page from the dialog.`,
+        })
+        .toBe(before + 1);
+    await waitForEditablePage(page);
+}
+
+/**
+ * In the dialog opened by the page menu's "Choose Different Layout", select this layout and
+ * click "Use This Layout", then wait for the page to be shown again. The book keeps the same
+ * number of pages: Bloom imports the template page and moves the existing text into it
+ * (HtmlDom.MigrateEditableData), so this is how a test exercises what that migration does to
+ * content the person has already put on the page.
+ */
+export async function chooseDifferentLayout(
+    page: Page,
+    label: string,
+    templateBookFolderName?: string,
+): Promise<void> {
+    const dialog = await selectTemplatePageInDialog(
+        page,
+        label,
+        templateBookFolderName,
+    );
+    await dialog
+        .getByRole("button", { name: "Use This Layout", exact: true })
+        .click();
+    await expect
+        .poll(() => isAddPageDialogOpen(page), {
+            timeout: 30000,
+            message: "The dialog did not close after Use This Layout.",
+        })
+        .toBe(false);
+    await waitForEditablePage(page);
+}
+
+/**
+ * Select a template page in the open dialog and return the dialog, for a caller that will then
+ * click whichever confirming button it wants. Shared by adding a page and choosing a different
+ * layout, which differ only in that button and in what happens afterwards.
+ */
+async function selectTemplatePageInDialog(
+    page: Page,
+    label: string,
+    templateBookFolderName?: string,
+): Promise<Locator> {
     const dialog = await findAddPageDialog(page);
+    // The groups are read from thumbnails that arrive over a websocket, so a dialog asked what it
+    // offers too early answers "nothing" -- and the error below then reports an empty list of
+    // layouts rather than a dialog that was not ready. openAddPageDialog waits for these itself;
+    // this is for the caller that opened the dialog some other way (the page menu's Choose
+    // Different Layout), and waiting twice costs nothing.
+    await waitForAddPageThumbnails(page);
     const groups = await getAddPageDialogGroups(page);
     const group = groups.find(
         (g) =>
@@ -315,19 +388,5 @@ export async function addPageFromDialog(
         `Selecting "${label}" never showed it in the dialog's preview pane.`,
     ).toBeVisible({ timeout: 15000 });
 
-    const before = (await getPages(page)).length;
-    await dialog.getByRole("button", { name: "Add Page", exact: true }).click();
-    await expect
-        .poll(() => isAddPageDialogOpen(page), {
-            timeout: 30000,
-            message: "The Add Page dialog did not close after Add Page.",
-        })
-        .toBe(false);
-    await expect
-        .poll(async () => (await getPages(page)).length, {
-            timeout: 60000,
-            message: `Bloom never added the "${label}" page from the dialog.`,
-        })
-        .toBe(before + 1);
-    await waitForEditablePage(page);
+    return dialog;
 }

--- a/src/BloomE2E/helpers/bookMaking.ts
+++ b/src/BloomE2E/helpers/bookMaking.ts
@@ -338,6 +338,19 @@ export function editablePageFrame(page: Page): Frame {
  * any command that begins with saving it (add a page, duplicate, delete, jump elsewhere). The page
  * can look ready in the DOM a moment before Bloom is, so this asks Bloom as well, through the e2e
  * hook that reports its editing state.
+ *
+ * And the third: the frame's own element in Bloom's window. Every other check here asks the
+ * document INSIDE the frame, and that document can be fully laid out while the frame it sits in
+ * has no box yet -- switching back to the Edit tab rebuilds the view around it. Measuring an
+ * element through a frame with no box gets nothing back, however well laid out the element is
+ * inside it, so a helper measuring an inline image fails in a test whose subject is somewhere
+ * else entirely, reporting an element that the page itself says has a perfectly good rectangle.
+ *
+ * And the fourth: Bloom reports itself as editing before the page's own script has decided which
+ * language boxes to show. Until it has, every box on the page is hidden, so anything in one --
+ * an inline image, say -- is in the DOM with no box on the screen at all, and a helper that
+ * measures it fails in a test whose subject is somewhere else entirely. So where the page has
+ * text boxes, wait for one of them to be showing.
  */
 export async function waitForEditablePage(
     page: Page,
@@ -366,6 +379,47 @@ export async function waitForEditablePage(
                 "Bloom never finished loading the page in the Edit tab (its editing state never became Editing).",
         })
         .toBe("true");
+    await expect
+        .poll(
+            async () => {
+                const box = await page
+                    .locator("iframe#page")
+                    .boundingBox()
+                    .catch(() => null);
+                return box ? Math.min(box.width, box.height) : 0;
+            },
+            {
+                timeout: timeoutMs,
+                message:
+                    "The Edit tab's page frame never got a box of its own in Bloom's window, so " +
+                    "nothing inside it can be measured.",
+            },
+        )
+        .toBeGreaterThan(0);
+    // bloom-visibility-code-on is what the page's own script puts on the boxes it has decided to
+    // show (updateLanguageVisibility); the CSS hides every box without it.
+    const groupCount = await editablePageFrame(page)
+        .locator(".bloom-page .bloom-translationGroup")
+        .count()
+        .catch(() => 0);
+    if (groupCount === 0) return;
+    await expect
+        .poll(
+            async () =>
+                await editablePageFrame(page)
+                    .locator(
+                        ".bloom-page .bloom-editable.bloom-visibility-code-on",
+                    )
+                    .count()
+                    .catch(() => 0),
+            {
+                timeout: timeoutMs,
+                message:
+                    "The page's script never decided which language boxes to show, so every box " +
+                    "on the page is still hidden.",
+            },
+        )
+        .toBeGreaterThan(0);
 }
 
 /** One page of the selected book, as e2e/pages reports it. */

--- a/src/BloomE2E/helpers/inlineImages.ts
+++ b/src/BloomE2E/helpers/inlineImages.ts
@@ -1,0 +1,1473 @@
+// Inline (Word-style) images: a picture that lives inside a text block so that the text of the
+// block wraps around it. See INLINE-IMAGES-PLAN.md, and bookEdit/js/inlineImages.ts for the
+// edit-time code these helpers drive.
+//
+// The feature has no dialog. Everything a person does to an inline image they do with the mouse,
+// on the picture itself: the right-click menu of the text block adds one, a drag of the picture
+// decides which side it docks to and how far down the block it starts, and a drag of a corner
+// handle decides how wide it is. Selecting one also puts up the same toolbar an image has on a
+// canvas. So nearly every helper here is a real mouse gesture, and each one waits for the state
+// Bloom ends up in rather than for the gesture to finish.
+//
+// WHAT "THE STATE OF AN INLINE IMAGE" IS. One image is one wrapper div per language, all sharing
+// an identity attribute, and everything about its position and size is either a dock class or a
+// custom property in the wrapper's style attribute -- nothing else (the GEOMETRY MODEL comment in
+// content/bookLayout/inlineImages.less). getInlineImages reads exactly that, per language, so a
+// test can say "every language's copy is docked left at 40%" without naming a class or a property.
+//
+// WHY THE READERS ALSO REPORT COMPUTED STYLE. The CSS is half the feature: the float and its wrap
+// shape are what make the text flow beside the picture, display:flow-root is what keeps the float
+// inside its block, and a rule hides the copies in every language but the first visible one. None
+// of that can be seen in the markup, and none of it is exercised by the vitest suite, which runs
+// in jsdom. So `shown`, `float` and `wrapShape` come from getComputedStyle.
+
+import { expect, type Locator, type Page } from "@playwright/test";
+import * as fs from "node:fs";
+import * as Path from "node:path";
+import { apiPost } from "./api";
+import { bookHtmlPath } from "./bookHtml";
+import { editablePageFrame } from "./bookMaking";
+import type { IRect } from "./geometry";
+import { realClick, realClickAt } from "./realClick";
+
+/**
+ * Where an inline image sits in its block, in the words the feature uses: docked against the left
+ * or right edge with the text wrapping beside it, a full-width band with text above and below, or
+ * below the text altogether.
+ */
+export type InlineImageDock = "left" | "right" | "middle" | "bottom";
+
+/** The four corner handles of a selected inline image, by compass direction. */
+export type InlineImageCorner = "nw" | "ne" | "sw" | "se";
+
+/** The localization id of the "Add Image" command on a text block's right-click menu. */
+const kAddImageCommand = "EditTab.InlineImage.AddImage";
+
+/** The localization id of the Delete command on an inline image's right-click menu. */
+const kDeleteCommand = "Common.Delete";
+
+/** The localization id of the command that opens the image chooser on an existing inline image. */
+const kChooseImageCommand = "EditTab.Image.ChooseImage";
+
+// The markup, all of it confined to this file. A test never names any of these.
+const kWrapperClass = "bloom-inlineImage";
+const kIdAttribute = "data-bloom-inline-image-id";
+const kSelectedClass = "bloom-inlineImage-selected";
+const kHandleClass = "bloom-ui-inlineImage-handle";
+// The toolbar under the selected picture, and the prefix Bloom puts on each of its buttons.
+const kToolbarSelector = "#inline-image-context-controls";
+const kToolbarButtonPrefix = "toolbar-";
+const kDockClass: Record<InlineImageDock, string> = {
+    left: "bloom-inlineImageLeft",
+    right: "bloom-inlineImageRight",
+    middle: "bloom-inlineImageMiddle",
+    bottom: "bloom-inlineImageBottom",
+};
+const kWidthProperty = "--inline-image-width";
+const kOffsetProperty = "--inline-image-offset";
+const kAspectRatioProperty = "--inline-image-aspect-ratio";
+
+/** One language's copy of one inline image, as the page being edited shows it. */
+export interface IInlineImageState {
+    /** The identity every language's copy of this image shares. */
+    id: string;
+    /** The language of the text block this copy is in. */
+    languageTag: string;
+    /** Which side of the block the image is docked to. */
+    dock: InlineImageDock;
+    /** How wide the picture is, as a percentage of the block. */
+    widthPercent: number;
+    /** How far below the top of the block the picture starts, in the page's own pixels. */
+    offsetPx: number;
+    /** The picture's natural width/height, as the wrapper records it, e.g. "4 / 3". */
+    aspectRatio: string;
+    /** The file name in the picture's src; "placeHolder.png" while no picture has been chosen. */
+    fileName: string;
+    /**
+     * The wrapper's contenteditable attribute. It must stay "false" in the saved markup: that is
+     * the only thing stopping Bloom's language-stamping sweep from treating the wrapper as a text
+     * box (TranslationGroupManager.cs).
+     */
+    contentEditable: string | null;
+    /** Which slot the wrapper holds among the block's children, and how many children there are. */
+    slot: { index: number; childCount: number };
+    /** True when this copy is the selected object, so its corner handles are showing. */
+    selected: boolean;
+    /** How many corner handles the copy has. Four when it is selected, none when it is not. */
+    handleCount: number;
+    /**
+     * True when a reader would see this copy of the picture. False when the CSS is hiding the copy
+     * itself, which it does in all but the first showing language, and false when the copy's whole
+     * block is hidden -- so the copy in the lang="z" prototype block is never shown.
+     */
+    shown: boolean;
+    /** The wrapper's computed float: "left", "right" or "none". */
+    float: string;
+    /** The wrapper's computed shape-outside, which is what makes the text follow the picture. */
+    wrapShape: string;
+    /** Every class on the wrapper, for the rare assertion that has to look at one by name. */
+    classes: string[];
+}
+
+/** A text block of a translation group, and the inline images in it. */
+export interface IBlockInlineImages {
+    languageTag: string;
+    /** True when Bloom is showing this language's block on the page. */
+    visible: boolean;
+    /**
+     * The block's computed display. An editable holding an inline image must be "flow-root", or
+     * the float escapes the bottom of the block (the FLOAT CONTAINMENT comment in
+     * inlineImages.less).
+     */
+    display: string;
+    images: IInlineImageState[];
+}
+
+/**
+ * Every inline image of one translation group on the page being edited, one entry per language
+ * block, in the order the blocks appear in the markup. `groupSelector` picks the group, e.g.
+ * ".bloom-translationGroup" for the only one on a Just Text page.
+ *
+ * The lang="z" prototype block is included, because a copy in it is how a language added later
+ * inherits the image with no C# involvement (insertInlineImage in inlineImages.ts).
+ */
+export async function getInlineImages(
+    page: Page,
+    groupSelector: string,
+): Promise<IBlockInlineImages[]> {
+    const group = editablePageFrame(page).locator(groupSelector).first();
+    await group.waitFor({ state: "attached", timeout: 30000 });
+    return group.evaluate(
+        (
+            element,
+            markup: {
+                wrapperClass: string;
+                idAttribute: string;
+                selectedClass: string;
+                handleClass: string;
+                dockClass: Record<string, string>;
+                widthProperty: string;
+                offsetProperty: string;
+                aspectRatioProperty: string;
+            },
+        ) => {
+            const blocks = Array.from(
+                element.querySelectorAll(":scope > .bloom-editable"),
+            ) as HTMLElement[];
+            return blocks.map((block) => {
+                const children = Array.from(block.children);
+                const wrappers = children.filter((child) =>
+                    child.classList.contains(markup.wrapperClass),
+                ) as HTMLElement[];
+                return {
+                    languageTag: block.getAttribute("lang") ?? "",
+                    visible: block.classList.contains(
+                        "bloom-visibility-code-on",
+                    ),
+                    display: window.getComputedStyle(block).display,
+                    images: wrappers.map((wrapper) => {
+                        const style = window.getComputedStyle(wrapper);
+                        const picture = wrapper.querySelector("img");
+                        const source = picture?.getAttribute("src") ?? "";
+                        const dockEntry = Object.entries(markup.dockClass).find(
+                            ([, className]) =>
+                                wrapper.classList.contains(className),
+                        );
+                        const readNumber = (property: string) =>
+                            parseFloat(
+                                wrapper.style.getPropertyValue(property),
+                            ) || 0;
+                        return {
+                            id: wrapper.getAttribute(markup.idAttribute) ?? "",
+                            languageTag: block.getAttribute("lang") ?? "",
+                            // The wrapper always carries exactly one dock class; a missing one
+                            // could only come from hand-edited markup, and saying so beats
+                            // reporting a dock the image is not in.
+                            dock: dockEntry ? dockEntry[0] : "(no dock class)",
+                            widthPercent: readNumber(markup.widthProperty),
+                            offsetPx: readNumber(markup.offsetProperty),
+                            aspectRatio: wrapper.style
+                                .getPropertyValue(markup.aspectRatioProperty)
+                                .trim(),
+                            // Without the query: Bloom appends "?transparent=yes" to an image
+                            // on a page with a coloured background (getImageTransparencyMode),
+                            // so a picture chosen on the front cover has one and the same
+                            // picture on a content page does not. Which file it is is the
+                            // question here.
+                            fileName: decodeURIComponent(
+                                (source.split("?")[0].split("/").pop() ??
+                                    source) as string,
+                            ),
+                            contentEditable:
+                                wrapper.getAttribute("contenteditable"),
+                            slot: {
+                                index: children.indexOf(wrapper),
+                                childCount: children.length,
+                            },
+                            selected: wrapper.classList.contains(
+                                markup.selectedClass,
+                            ),
+                            handleCount: wrapper.querySelectorAll(
+                                "." + markup.handleClass,
+                            ).length,
+                            // checkVisibility(), not display alone: a copy in a hidden block
+                            // has no display of its own to give it away.
+                            shown: wrapper.checkVisibility(),
+                            float: style.float,
+                            wrapShape: style.shapeOutside,
+                            classes: Array.from(wrapper.classList),
+                        };
+                    }),
+                };
+            });
+        },
+        {
+            wrapperClass: kWrapperClass,
+            idAttribute: kIdAttribute,
+            selectedClass: kSelectedClass,
+            handleClass: kHandleClass,
+            dockClass: kDockClass,
+            widthProperty: kWidthProperty,
+            offsetProperty: kOffsetProperty,
+            aspectRatioProperty: kAspectRatioProperty,
+        },
+    ) as Promise<IBlockInlineImages[]>;
+}
+
+/**
+ * One language's copy of one inline image. Throws, naming what the group does hold, when there is
+ * no such copy -- which is the failure a test wants spelled out, since "the copy is missing" and
+ * "the copy has the wrong geometry" are different bugs.
+ */
+export async function getInlineImage(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+    id: string,
+): Promise<IInlineImageState> {
+    const blocks = await getInlineImages(page, groupSelector);
+    const found = blocks
+        .find((block) => block.languageTag === languageTag)
+        ?.images.find((image) => image.id === id);
+    if (!found)
+        throw new Error(
+            `The "${languageTag}" block of "${groupSelector}" has no inline image ${id}. ` +
+                `The group holds: ${describeBlocks(blocks)}.`,
+        );
+    return found;
+}
+
+/** Every copy of one inline image, one per language block that has it. */
+export async function getInlineImageInEveryLanguage(
+    page: Page,
+    groupSelector: string,
+    id: string,
+): Promise<IInlineImageState[]> {
+    const blocks = await getInlineImages(page, groupSelector);
+    return blocks.flatMap((block) =>
+        block.images.filter((image) => image.id === id),
+    );
+}
+
+/**
+ * Add an inline image to a text block the way a person does: right-click in its text and choose
+ * Add Image. Returns the identity of the new image, which every language's copy of it shares.
+ *
+ * The command deliberately does not open the image chooser (a picture is chosen afterwards, from
+ * the same menu), so what arrives is a placeholder, docked right at the default width. It arrives
+ * in EVERY language's block at once, prototype included, and this returns once it has.
+ */
+export async function addInlineImage(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+): Promise<string> {
+    const before = await getInlineImages(page, groupSelector);
+    const known = new Set(
+        before.flatMap((block) => block.images.map((image) => image.id)),
+    );
+    await openInlineImageMenuInText(page, groupSelector, languageTag);
+    await clickInlineImageMenuCommand(page, kAddImageCommand);
+    const wanted = before.length;
+    await expect
+        .poll(
+            async () =>
+                (await getInlineImages(page, groupSelector)).filter((block) =>
+                    block.images.some((image) => !known.has(image.id)),
+                ).length,
+            {
+                timeout: 30000,
+                message:
+                    `Add Image did not put a new inline image in all ${wanted} language blocks ` +
+                    `of "${groupSelector}".`,
+            },
+        )
+        .toBe(wanted);
+    const after = await getInlineImages(page, groupSelector);
+    const added = after
+        .flatMap((block) => block.images)
+        .find((image) => !known.has(image.id))!;
+    return added.id;
+}
+
+/**
+ * Delete an inline image the way a person does: right-click the picture and choose Delete. That
+ * takes this image's copy out of every language, and leaves any other inline image in the block
+ * alone. Returns once every copy has gone.
+ */
+export async function deleteInlineImage(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+    id: string,
+): Promise<void> {
+    await openInlineImageMenu(page, groupSelector, languageTag, id);
+    await clickInlineImageMenuCommand(page, kDeleteCommand);
+    await expect
+        .poll(
+            async () =>
+                (await getInlineImageInEveryLanguage(page, groupSelector, id))
+                    .length,
+            {
+                timeout: 30000,
+                message: `Delete left copies of inline image ${id} behind.`,
+            },
+        )
+        .toBe(0);
+}
+
+/**
+ * The commands an inline image's right-click menu offers, by localization id, each paired with
+ * whether it is enabled. Leaves the menu open; close it with closeInlineImageMenu.
+ *
+ * A command behind a subscription tier the collection does not have counts as not enabled: Bloom
+ * keeps such an item clickable and marks it with data-subscription-gated instead of disabling it
+ * (see helpers/canvasElements.ts, which makes the same distinction for the canvas element menu).
+ */
+export async function getInlineImageMenuCommands(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+    id: string,
+): Promise<{ id: string; enabled: boolean }[]> {
+    await openInlineImageMenu(page, groupSelector, languageTag, id);
+    const frame = editablePageFrame(page);
+    await expect(
+        frame.locator(`${kMenuSelector} >> li[data-feature-status-pending]`),
+        "Some inline image menu commands never learned whether their feature is on offer.",
+    ).toHaveCount(0, { timeout: 30000 });
+    return frame
+        .locator(`${kMenuSelector} >> li[role="menuitem"]`)
+        .evaluateAll((items) =>
+            items.map((item) => ({
+                id: item.getAttribute("data-testid") ?? "",
+                enabled:
+                    !item.classList.contains("Mui-disabled") &&
+                    !item.hasAttribute("data-subscription-gated"),
+            })),
+        );
+}
+
+/**
+ * The buttons showing on the selected inline image's toolbar, by control id, each paired with
+ * whether it is enabled. Empty when no toolbar is up, which is what "nothing is selected" looks
+ * like.
+ *
+ * The "..." button that opens the menu is not a control and is left out; read the menu itself
+ * with getInlineImageMenuCommands. Which buttons appear depends on the picture: the one that
+ * warns about missing copyright and license information, for instance, only appears while that
+ * information is missing. So a test should ask for the buttons it cares about rather than for a
+ * whole list.
+ */
+export async function getInlineImageToolbarButtons(
+    page: Page,
+): Promise<{ id: string; enabled: boolean }[]> {
+    const bar = editablePageFrame(page).locator(kToolbarSelector);
+    if (!(await bar.isVisible().catch(() => false))) return [];
+    return bar
+        .locator(`button[data-testid^="${kToolbarButtonPrefix}"]`)
+        .evaluateAll((buttons) =>
+            buttons.map((button) => ({
+                id: (button.getAttribute("data-testid") ?? "").replace(
+                    /^toolbar-/,
+                    "",
+                ),
+                enabled: !(button as HTMLButtonElement).disabled,
+            })),
+        );
+}
+
+/**
+ * Where the inline image toolbar is on the screen, or undefined when no toolbar is up. Use it to
+ * check that the bar belongs to the picture the person selected, which is the part a list of
+ * button names cannot show.
+ */
+export async function getInlineImageToolbarRect(
+    page: Page,
+): Promise<IRect | undefined> {
+    const bar = editablePageFrame(page).locator(kToolbarSelector);
+    if (!(await bar.isVisible().catch(() => false))) return undefined;
+    return (await bar.boundingBox()) ?? undefined;
+}
+
+/** True when the block's right-click menu offers to add an inline image at all. */
+export async function textBlockOffersAddImage(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+): Promise<boolean> {
+    await openInlineImageMenuInText(page, groupSelector, languageTag);
+    const offered =
+        (await editablePageFrame(page)
+            .locator(
+                `${kMenuSelector} >> li[data-testid="${kAddImageCommand}"]`,
+            )
+            .count()) > 0;
+    await closeInlineImageMenu(page);
+    return offered;
+}
+
+/**
+ * Dismiss the text block's right-click menu without choosing anything, the way clicking away from
+ * it does.
+ *
+ * A bare Escape key press does not do it. The menu is opened with focus left alone, so that the
+ * caret stays in the text the person right-clicked on (disableAutoFocus in TextContextMenu), and
+ * a key press therefore goes to the page rather than to the menu. So this clicks the invisible
+ * backdrop the menu lays over the page, which is what a click away from the menu lands on, and
+ * presses Escape on the menu itself only if there is no backdrop to click.
+ */
+export async function closeInlineImageMenu(page: Page): Promise<void> {
+    const frame = editablePageFrame(page);
+    const menu = frame.locator(kMenuSelector).first();
+    if (!(await menu.isVisible().catch(() => false))) return;
+    const backdrop = frame.locator(kMenuBackdropSelector).first();
+    if ((await backdrop.count()) > 0) await backdrop.click({ force: true });
+    else await menu.press("Escape");
+    await menu.waitFor({ state: "hidden", timeout: 30000 });
+}
+
+/**
+ * Select an inline image the way a person does, with a click on the picture, and wait until its
+ * four corner handles are showing. Selecting is what a drag or a resize starts from, and both
+ * gestures below do it for themselves; call this directly only when the selection IS the subject.
+ */
+export async function selectInlineImage(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+    id: string,
+): Promise<void> {
+    const picture = inlineImagePicture(page, groupSelector, languageTag, id);
+    // A real press, not Playwright's own click: the picture sits inside a contenteditable that
+    // CKEditor manages, and the code that selects it listens for pointerdown in the capture phase
+    // (setupInlineImageInteractions), having cancelled the mousedown that would put the caret in
+    // the text instead.
+    await realClick(picture);
+    await expect
+        .poll(
+            async () =>
+                (await getInlineImage(page, groupSelector, languageTag, id))
+                    .handleCount,
+            {
+                timeout: 30000,
+                message: `Clicking inline image ${id} did not select it.`,
+            },
+        )
+        .toBe(4);
+}
+
+/**
+ * Put the block's scroll back at the top, so that what is at the top of its text is where a
+ * person would be looking at it.
+ *
+ * Typing leaves the caret at the end of the text, and a block too small for its text is
+ * scrolled to the caret, which puts the top of the block -- and any picture sitting there --
+ * out of sight. A gesture aimed at a picture that is scrolled out of view lands on whatever
+ * is showing instead, and reads as the picture refusing to move. This is setup, not a gesture
+ * under test, so it sets scrollTop rather than driving the wheel.
+ */
+export async function scrollBlockToTop(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+): Promise<void> {
+    await editablePageFrame(page)
+        .locator(`${groupSelector} .bloom-editable[lang="${languageTag}"]`)
+        .first()
+        .evaluate((block) => {
+            block.scrollTop = 0;
+        });
+}
+
+/**
+ * Drag an inline image UP the block, the way a person does, and return the offset it ends at.
+ *
+ * Separate from dragInlineImageDown because the failure it reports is a different one: an image
+ * that will not come back up is stuck, and a block too small for its text is exactly when that
+ * used to happen. Fails with the offset the image is still at rather than timing out.
+ */
+export async function dragInlineImageUp(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+    id: string,
+    pixels: number,
+): Promise<number> {
+    const before = await getInlineImage(page, groupSelector, languageTag, id);
+    const picture = await pictureRect(page, groupSelector, languageTag, id);
+    await dragInlineImageTo(page, groupSelector, languageTag, id, {
+        x: picture.x + picture.width / 2,
+        y: picture.y + picture.height / 2 - pixels,
+    });
+    await expect
+        .poll(
+            async () =>
+                (await getInlineImage(page, groupSelector, languageTag, id))
+                    .offsetPx,
+            {
+                timeout: 30000,
+                message:
+                    `Dragging inline image ${id} up ${pixels}px did not move it: it still ` +
+                    `starts ${before.offsetPx}px below the top of the block. An image that ` +
+                    `cannot be dragged back up is stuck where it sits.`,
+            },
+        )
+        .toBeLessThan(before.offsetPx);
+    return (await getInlineImage(page, groupSelector, languageTag, id))
+        .offsetPx;
+}
+
+/**
+ * How much more room the block's text needs than the block has, in layout pixels. Zero when the
+ * text fits. This is what Bloom's overflow warning is about, and a test that means to work on an
+ * overflowing block should assert it before it starts.
+ */
+export async function getBlockScrollOverflowPx(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+): Promise<number> {
+    return editablePageFrame(page)
+        .locator(`${groupSelector} .bloom-editable[lang="${languageTag}"]`)
+        .first()
+        .evaluate((block) => block.scrollHeight - block.clientHeight);
+}
+
+/**
+ * Whether Bloom has marked this block as holding more text than it can show -- the red marking
+ * and the warning the person sees, as opposed to the arithmetic getBlockScrollOverflowPx does.
+ * OverflowChecker puts the "overflow" class on, and checks every editable when the page loads
+ * (AddOverflowHandlers ends by scheduling a check for each one), so this reports the state a
+ * person arrives at a page to find.
+ */
+export async function blockIsMarkedOverflowing(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+): Promise<boolean> {
+    return editablePageFrame(page)
+        .locator(`${groupSelector} .bloom-editable[lang="${languageTag}"]`)
+        .first()
+        .evaluate((block) => block.classList.contains("overflow"));
+}
+
+/**
+ * Drag an inline image to a dock, the way a person does: press on the picture and move it into
+ * the part of the block that dock belongs to, then let go. Returns once every language's copy is
+ * in that dock.
+ *
+ * Which dock a drop means is decided from where the PICTURE ends up, not the cursor, and by
+ * thirds of the block's width: the outer thirds are the side docks and the middle third is the
+ * band. In the middle third the bottom dock takes over where the band can no longer fit the
+ * picture inside the block's content, and anything below the block is the bottom dock whatever
+ * the horizontal position (computeInlineImageDock). This aims at the middle of the region for
+ * the dock asked for, so a caller states an intent rather than a coordinate.
+ *
+ * Bloom refuses a move that would push the block into overflow, putting the image back where it
+ * started. When that happens this fails with the dock the image is still in, rather than timing
+ * out on a wait: the caller's block is too small for what it asked.
+ */
+export async function dragInlineImageToDock(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+    id: string,
+    dock: InlineImageDock,
+): Promise<void> {
+    const block = await blockRect(page, groupSelector, languageTag);
+    const picture = await pictureRect(page, groupSelector, languageTag, id);
+    // How many copies there are to check, counted before the drag: the point of this wait is
+    // that EVERY language ends up in the new dock, and a count taken afterwards could not tell
+    // "all of them" from "the one the drag happened in".
+    const copyCount = (
+        await getInlineImageInEveryLanguage(page, groupSelector, id)
+    ).length;
+    expect(
+        copyCount,
+        `inline image ${id} should exist in at least one language before the drag`,
+    ).toBeGreaterThan(0);
+    // The middle of the region that means this dock, horizontally; the picture keeps the height it
+    // already had, because moving it sideways is the whole intent here and a drop lower down the
+    // block would also change how far down the picture starts. The bottom dock is the exception:
+    // it is claimed just below the block, which is unambiguous however tall the block is and
+    // whatever else is in it.
+    const acrossFraction = {
+        left: 1 / 6,
+        middle: 0.5,
+        right: 5 / 6,
+        bottom: 0.5,
+    }[dock];
+    await dragInlineImageTo(page, groupSelector, languageTag, id, {
+        x: block.x + block.width * acrossFraction,
+        y:
+            dock === "bottom"
+                ? block.y + block.height * 1.05
+                : picture.y + picture.height / 2,
+    });
+    await expect
+        .poll(
+            async () =>
+                (
+                    await getInlineImageInEveryLanguage(page, groupSelector, id)
+                ).filter((image) => image.dock === dock).length,
+            {
+                timeout: 30000,
+                message:
+                    `Dragging inline image ${id} into the ${dock} region of the block did not ` +
+                    `dock it there in all ${copyCount} of the group's languages. Bloom puts a ` +
+                    `move back where it started when the move would make the block overflow, ` +
+                    `and syncs the languages only when the gesture commits.`,
+            },
+        )
+        .toBe(copyCount);
+}
+
+/**
+ * Drag an inline image down its block by `pixels`, the way a person does, and return how far
+ * below the top of the block it now starts. Dragging down within a side dock is how the picture
+ * is moved past the first lines of text, and the distance is kept in one custom property.
+ *
+ * Bloom clamps the distance so the whole picture stays inside the block, so what comes back may
+ * be less than what was asked for; that is the answer, not a failure. The wait is for the
+ * distance to change at all.
+ */
+export async function dragInlineImageDown(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+    id: string,
+    pixels: number,
+): Promise<number> {
+    const before = await getInlineImage(page, groupSelector, languageTag, id);
+    const picture = await pictureRect(page, groupSelector, languageTag, id);
+    await dragInlineImageTo(page, groupSelector, languageTag, id, {
+        x: picture.x + picture.width / 2,
+        y: picture.y + picture.height / 2 + pixels,
+    });
+    await expect
+        .poll(
+            async () =>
+                (await getInlineImage(page, groupSelector, languageTag, id))
+                    .offsetPx,
+            {
+                timeout: 30000,
+                message:
+                    `Dragging inline image ${id} down ${pixels}px did not move it: it still ` +
+                    `starts ${before.offsetPx}px below the top of the block. Bloom puts a move ` +
+                    `back where it started when the move would make the block overflow.`,
+            },
+        )
+        .not.toBe(before.offsetPx);
+    return (await getInlineImage(page, groupSelector, languageTag, id))
+        .offsetPx;
+}
+
+/**
+ * Drag an inline image down its block by `pixels` and report where that left it, without
+ * insisting that it moved anywhere.
+ *
+ * Separate from dragInlineImageDown, which fails when the picture does not move, because this is
+ * for sweeping a picture down the block a step at a time to find out which positions the block
+ * offers at all: a step that re-docks the picture, or that the picture refuses, is an answer here
+ * rather than a failure.
+ */
+export async function nudgeInlineImageDown(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+    id: string,
+    pixels: number,
+): Promise<{ dock: InlineImageDock; offsetPx: number; roomBelowPx: number }> {
+    const picture = await pictureRect(page, groupSelector, languageTag, id);
+    await dragInlineImageTo(page, groupSelector, languageTag, id, {
+        x: picture.x + picture.width / 2,
+        y: picture.y + picture.height / 2 + pixels,
+    });
+    const image = await getInlineImage(page, groupSelector, languageTag, id);
+    return {
+        dock: image.dock,
+        offsetPx: image.offsetPx,
+        roomBelowPx: await getRoomBelowInlineImagePx(
+            page,
+            groupSelector,
+            languageTag,
+            id,
+        ),
+    };
+}
+
+/**
+ * Press on the picture and hold, so a drag is under way and the button stays down. Pair it with
+ * moveInlineImageDragTo and endInlineImageDrag.
+ *
+ * The other drag helpers do a whole gesture and hand back the result, which cannot answer a
+ * question about what the page does WHILE the picture is being held -- whether the block scrolls
+ * to follow it, for one.
+ */
+export async function beginInlineImageDrag(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+    id: string,
+): Promise<void> {
+    const picture = await pictureRect(page, groupSelector, languageTag, id);
+    await page.mouse.move(
+        picture.x + picture.width / 2,
+        picture.y + picture.height / 2,
+    );
+    await page.mouse.down();
+}
+
+/** Move the pointer during a drag begun with beginInlineImageDrag, without letting go. */
+export async function moveInlineImageDragTo(
+    page: Page,
+    to: { x: number; y: number },
+): Promise<void> {
+    await page.mouse.move(to.x, to.y, { steps: 16 });
+}
+
+/** Let go, ending a drag begun with beginInlineImageDrag. */
+export async function endInlineImageDrag(page: Page): Promise<void> {
+    await page.mouse.up();
+}
+
+/**
+ * Whether the page still thinks a picture is being dragged. The drag puts a class on the page's
+ * body and takes it off when the gesture ends, so this is how a test asks whether a gesture that
+ * should have finished actually did.
+ */
+export async function inlineImageDragIsInProgress(
+    page: Page,
+): Promise<boolean> {
+    return editablePageFrame(page)
+        .locator("body")
+        .evaluate((body) =>
+            body.classList.contains("bloom-inlineImage-dragging"),
+        );
+}
+
+/**
+ * How far the block's text is scrolled down, in the page's own pixels. Zero when the top of the
+ * text is showing. A block only scrolls when its text does not fit it.
+ */
+export async function getBlockScrollTopPx(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+): Promise<number> {
+    return editablePageFrame(page)
+        .locator(`${groupSelector} .bloom-editable[lang="${languageTag}"]`)
+        .first()
+        .evaluate((block) => block.scrollTop);
+}
+
+/**
+ * How much room is left between the bottom of the picture and the end of everything its block
+ * holds, in the page's own pixels. That room is whatever text still follows the picture, so
+ * "less than one line" means the picture has reached the end of the block's content -- which is
+ * the question behind "can I put the picture as far down the block as I like".
+ *
+ * Measured against the block's CONTENT and not its rectangle: a block too small for its text
+ * scrolls, and the text below the window is still text the picture can be put after.
+ */
+export async function getRoomBelowInlineImagePx(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+    id: string,
+): Promise<number> {
+    return inlineImageWrapper(page, groupSelector, languageTag, id).evaluate(
+        (wrapper) => {
+            const block = wrapper.closest(".bloom-editable") as HTMLElement;
+            const blockBox = block.getBoundingClientRect();
+            // The page is drawn at some zoom, so the block's rectangle and its clientHeight
+            // measure the same edge in different units; their ratio converts between them.
+            const viewportPxPerLayoutPx = blockBox.height / block.clientHeight;
+            const contentBottomViewportPx =
+                blockBox.top +
+                (block.scrollHeight - block.scrollTop) * viewportPxPerLayoutPx;
+            return (
+                (contentBottomViewportPx -
+                    wrapper.getBoundingClientRect().bottom) /
+                viewportPxPerLayoutPx
+            );
+        },
+    );
+}
+
+/** The height of one line of the block's text, in the page's own pixels. */
+export async function getBlockLineHeightPx(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+): Promise<number> {
+    return editablePageFrame(page)
+        .locator(`${groupSelector} .bloom-editable[lang="${languageTag}"]`)
+        .first()
+        .evaluate((block) => {
+            const lineHeight = getComputedStyle(block).lineHeight;
+            // "normal" has no number in it; the ratio Chromium uses for it is close enough to
+            // 1.2 for a test that asks "is there a line's worth of room left".
+            return lineHeight.endsWith("px")
+                ? parseFloat(lineHeight)
+                : parseFloat(getComputedStyle(block).fontSize) * 1.2;
+        });
+}
+
+/**
+ * Make an inline image wider or narrower by dragging one of its corner handles, the way a person
+ * does, and return the width it reaches as a percentage of the block. Only the horizontal
+ * movement counts: the picture keeps its aspect ratio, so pulling a corner sideways is the whole
+ * gesture (computeInlineImageWidthPercent).
+ *
+ * `pixels` is how far the corner moves outward, which grows the picture; pass a negative number
+ * to shrink it. Bloom keeps the width between 10% and 95% of the block.
+ */
+export async function resizeInlineImage(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+    id: string,
+    corner: InlineImageCorner,
+    pixels: number,
+): Promise<number> {
+    await selectInlineImage(page, groupSelector, languageTag, id);
+    const before = await getInlineImage(page, groupSelector, languageTag, id);
+    const handle = inlineImageWrapper(page, groupSelector, languageTag, id)
+        .locator(`.${kHandleClass}-${corner}`)
+        .first();
+    await handle.waitFor({ state: "visible", timeout: 30000 });
+    const box = await handle.boundingBox({ timeout: 30000 });
+    if (!box)
+        throw new Error(
+            `The ${corner} handle of inline image ${id} has no box, so there is nowhere to ` +
+                `drag from.`,
+        );
+    // Outward is away from the picture: rightward for the eastern corners, leftward for the
+    // western ones (getInlineImageHandleHorizontalSign).
+    const outward = corner === "ne" || corner === "se" ? 1 : -1;
+    const x = box.x + box.width / 2;
+    const y = box.y + box.height / 2;
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+    await page.mouse.move(x + outward * pixels, y, { steps: 12 });
+    await page.mouse.up();
+    await expect
+        .poll(
+            async () =>
+                (await getInlineImage(page, groupSelector, languageTag, id))
+                    .widthPercent,
+            {
+                timeout: 30000,
+                message:
+                    `Dragging the ${corner} handle of inline image ${id} by ${pixels}px did not ` +
+                    `change its width: it is still ${before.widthPercent}% of the block.`,
+            },
+        )
+        .not.toBe(before.widthPercent);
+    return (await getInlineImage(page, groupSelector, languageTag, id))
+        .widthPercent;
+}
+
+/**
+ * Put the picture at `filePath` into an inline image, and wait until every language's copy shows
+ * it.
+ *
+ * This is SETUP, on the same footing as chooseImageFile in helpers/images.ts and for the same
+ * reason: the production route ends in a native file picker, which hangs a run
+ * (AUTOMATION-DEBT.md, "Native OS dialogs hang automation"). It takes the route the chooser takes
+ * once a picture has been chosen -- Bloom's imageGallery/imageGalleryResult endpoint copies the
+ * file into the book, and changeImageByElement applies it to the very img the chooser was opened
+ * on -- so everything Bloom does after a picture is chosen still runs, including the copying of
+ * the new picture onto the other languages' wrappers (handleInlineImageChanged).
+ */
+export async function changeInlineImagePicture(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+    id: string,
+    filePath: string,
+): Promise<void> {
+    const result = await apiPost(
+        page,
+        "imageGallery/imageGalleryResult",
+        JSON.stringify({ localPath: filePath, provider: "local-disk" }),
+        "application/json",
+    );
+    const info = JSON.parse(result.body) as { src: string };
+    const picture = inlineImagePicture(page, groupSelector, languageTag, id);
+    await picture.waitFor({ state: "attached", timeout: 30000 });
+    // As in dragInlineImageToDock: the number of copies to expect the new picture in, counted
+    // before the change, so that losing a copy cannot read as success.
+    const copyCount = (
+        await getInlineImageInEveryLanguage(page, groupSelector, id)
+    ).length;
+    expect(
+        copyCount,
+        `inline image ${id} should exist in at least one language before its picture changes`,
+    ).toBeGreaterThan(0);
+    await picture.evaluate(
+        (element, imageInfo) => {
+            const bundle = (
+                window as unknown as {
+                    editablePageBundle: {
+                        changeImageByElement: (
+                            img: HTMLElement,
+                            info: typeof imageInfo,
+                        ) => void;
+                    };
+                }
+            ).editablePageBundle;
+            bundle.changeImageByElement(element as HTMLElement, imageInfo);
+        },
+        { ...info, undoable: "false" },
+    );
+    const fileName = Path.basename(decodeURIComponent(info.src));
+    await expect
+        .poll(
+            async () => {
+                const copies = await getInlineImageInEveryLanguage(
+                    page,
+                    groupSelector,
+                    id,
+                );
+                return copies.filter((copy) => copy.fileName === fileName)
+                    .length;
+            },
+            {
+                timeout: 30000,
+                message:
+                    `${fileName} never reached all ${copyCount} of the languages' copies of ` +
+                    `inline image ${id}.`,
+            },
+        )
+        .toBe(copyCount);
+}
+
+/**
+ * True when the text of a block flows beside the picture rather than starting below it: some line
+ * of text has its top above the bottom of the picture, and lies to the side of it.
+ *
+ * This is the point of the whole feature, and it can only be seen in a real renderer -- the float
+ * and its wrap shape do nothing in jsdom. It measures the client rectangles of the text itself
+ * (one per line), not the paragraph box, which spans the full width of the block whether the text
+ * wraps or not.
+ */
+export async function textWrapsBesideInlineImage(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+    id: string,
+): Promise<boolean> {
+    const block = inlineImageBlock(page, groupSelector, languageTag);
+    return block.evaluate(
+        (element, markup) => {
+            const wrapper = element.querySelector(
+                `[${markup.idAttribute}="${markup.id}"]`,
+            ) as HTMLElement | null;
+            const picture = wrapper?.querySelector("img");
+            if (!picture) return false;
+            const pictureBox = picture.getBoundingClientRect();
+            // Every line box of the block's text, which is what a Range over a text node reports.
+            const lines: DOMRect[] = [];
+            const walker = document.createTreeWalker(
+                element,
+                NodeFilter.SHOW_TEXT,
+            );
+            while (walker.nextNode()) {
+                const node = walker.currentNode;
+                if (wrapper?.contains(node)) continue;
+                if (!node.textContent?.trim()) continue;
+                const range = document.createRange();
+                range.selectNodeContents(node);
+                lines.push(...Array.from(range.getClientRects()));
+            }
+            return lines.some(
+                (line) =>
+                    line.width > 0 &&
+                    line.top < pictureBox.bottom - 1 &&
+                    line.bottom > pictureBox.top + 1 &&
+                    (line.right <= pictureBox.left + 1 ||
+                        line.left >= pictureBox.right - 1),
+            );
+        },
+        { idAttribute: kIdAttribute, id },
+    );
+}
+
+/** One language's copy of one inline image, as the saved .htm file records it. */
+export interface ISavedInlineImage {
+    id: string;
+    languageTag: string;
+    /** The classes on the wrapper, which is where the dock lives. */
+    classes: string[];
+    /** The whole style attribute, which is where the geometry lives. */
+    style: string;
+    /** The picture's src, relative to the book folder. */
+    source: string;
+    contentEditable: string | null;
+    /** Which slot the wrapper holds among the block's children, and how many there are. */
+    slot: { index: number; childCount: number };
+}
+
+/**
+ * Every inline image in the saved book on disk, in markup order. This is the product's own record
+ * of the page, and the only place to check what survives a save: the editing DOM carries
+ * edit-time decoration that never reaches the file (the corner handles, the selection marker),
+ * and Bloom writes a page only when the book leaves it -- so call goToPage first.
+ *
+ * `page` is borrowed as an HTML parser only, the way helpers/bookHtml.ts borrows it.
+ */
+export async function readSavedInlineImages(
+    page: Page,
+    bookFolder: string,
+): Promise<ISavedInlineImage[]> {
+    const html = fs.readFileSync(bookHtmlPath(bookFolder), "utf8");
+    return page.evaluate(
+        ({ source, idAttribute, wrapperClass }) => {
+            const document = new DOMParser().parseFromString(
+                source,
+                "text/html",
+            );
+            return Array.from(
+                document.querySelectorAll("." + wrapperClass),
+            ).map((wrapper) => {
+                const block = wrapper.parentElement;
+                const children = Array.from(block?.children ?? []);
+                return {
+                    id: wrapper.getAttribute(idAttribute) ?? "",
+                    languageTag: block?.getAttribute("lang") ?? "",
+                    classes: Array.from(wrapper.classList),
+                    style: wrapper.getAttribute("style") ?? "",
+                    source:
+                        wrapper.querySelector("img")?.getAttribute("src") ?? "",
+                    contentEditable: wrapper.getAttribute("contenteditable"),
+                    slot: {
+                        index: children.indexOf(wrapper),
+                        childCount: children.length,
+                    },
+                };
+            });
+        },
+        {
+            source: html,
+            idAttribute: kIdAttribute,
+            wrapperClass: kWrapperClass,
+        },
+    );
+}
+
+/**
+ * Where the text block and one inline image's picture are on screen, in the page's own
+ * coordinates. A test uses these to say that the picture stays inside its block -- which is what
+ * Bloom promises about a drag, and what only a real renderer can answer.
+ */
+export async function getInlineImageRects(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+    id: string,
+): Promise<{ block: IRect; picture: IRect }> {
+    return {
+        block: await blockRect(page, groupSelector, languageTag),
+        picture: await pictureRect(page, groupSelector, languageTag, id),
+    };
+}
+
+/** The text of one language's block, with the inline images' markup left out. */
+export async function getBlockText(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+): Promise<string> {
+    return inlineImageBlock(page, groupSelector, languageTag).evaluate(
+        (block, wrapperClass) => {
+            const copy = block.cloneNode(true) as HTMLElement;
+            Array.from(copy.querySelectorAll("." + wrapperClass)).forEach(
+                (wrapper) => wrapper.remove(),
+            );
+            return copy.textContent?.trim() ?? "";
+        },
+        kWrapperClass,
+    );
+}
+
+/**
+ * Click on the TEXT of a block, clear of every inline image in it, the way a person puts the
+ * caret back in the text. That ends the picture's turn as the selected object, so its corner
+ * handles go away. Returns once no inline image in the group is selected.
+ */
+export async function clickInBlockText(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+): Promise<void> {
+    const point = await clearTextPoint(page, groupSelector, languageTag);
+    await realClickAt(page, point.x, point.y);
+    await expect
+        .poll(
+            async () =>
+                (await getInlineImages(page, groupSelector))
+                    .flatMap((block) => block.images)
+                    .filter((image) => image.selected).length,
+            {
+                timeout: 30000,
+                message:
+                    `Clicking the text of the "${languageTag}" block left an inline image ` +
+                    `selected.`,
+            },
+        )
+        .toBe(0);
+}
+
+// --- the parts a test does not call -----------------------------------------
+
+// The text context menu MUI puts into the page's own document (renderTextContextMenu), not into
+// the shell: it is anchored at the mouse position inside the page being edited.
+// The menu itself, and only the one that is actually showing. There is normally more than one
+// MUI menu in the page: the selected inline image's toolbar keeps its own "..." menu mounted
+// while closed (keepMounted in CanvasElementContextControls), and that one comes first in the
+// document, so a plain .first() would settle on a menu that can never become visible.
+const kMenuSelector = '.MuiMenu-root [role="menu"] >> visible=true';
+
+// The invisible layer a MUI menu puts over everything behind it. A click on it is how the menu is
+// dismissed; it also stops that click from reaching the page.
+const kMenuBackdropSelector = ".MuiMenu-root .MuiBackdrop-root >> visible=true";
+
+/** The wrapper div of one language's copy of one inline image. */
+function inlineImageWrapper(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+    id: string,
+): Locator {
+    return inlineImageBlock(page, groupSelector, languageTag).locator(
+        `[${kIdAttribute}="${id}"]`,
+    );
+}
+
+/** The picture inside one language's copy of one inline image. */
+function inlineImagePicture(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+    id: string,
+): Locator {
+    return inlineImageWrapper(page, groupSelector, languageTag, id)
+        .locator("img")
+        .first();
+}
+
+/** One language's text block of a translation group. */
+function inlineImageBlock(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+): Locator {
+    return editablePageFrame(page)
+        .locator(`${groupSelector} > .bloom-editable[lang="${languageTag}"]`)
+        .first();
+}
+
+/** Where one language's text block is on screen. */
+async function blockRect(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+): Promise<IRect> {
+    const block = inlineImageBlock(page, groupSelector, languageTag);
+    await block.waitFor({ state: "visible", timeout: 30000 });
+    const box = await block.boundingBox({ timeout: 30000 });
+    if (!box)
+        throw new Error(
+            `The "${languageTag}" block of "${groupSelector}" has no box on screen, so there is ` +
+                `nowhere to drag within it. Bloom may not be showing that language.`,
+        );
+    return box;
+}
+
+/** Where one inline image's picture is on screen. */
+async function pictureRect(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+    id: string,
+): Promise<IRect> {
+    const picture = inlineImagePicture(page, groupSelector, languageTag, id);
+    await picture.waitFor({ state: "visible", timeout: 30000 });
+    const box = await picture.boundingBox({ timeout: 30000 });
+    if (!box) {
+        // What the page itself says about the element, so that the failure names the reason
+        // rather than only the symptom.
+        const asThePageSeesIt = await picture.evaluate((element) => {
+            const style = getComputedStyle(element);
+            const rect = element.getBoundingClientRect();
+            return `display ${style.display}, visibility ${style.visibility}, rect ${Math.round(rect.width)}x${Math.round(rect.height)} at ${Math.round(rect.left)},${Math.round(rect.top)}, natural ${(element as HTMLImageElement).naturalWidth}x${(element as HTMLImageElement).naturalHeight}, src ${(element as HTMLImageElement).getAttribute("src")}`;
+        });
+        // The frame's own box too. A box measured through a frame is nothing when the frame
+        // itself has none, which is what an element that the page says has a good rectangle
+        // means; waitForEditablePage waits for that, and this says so when it has not held.
+        const frameBox = await page
+            .locator("iframe#page")
+            .boundingBox()
+            .catch(() => null);
+        throw new Error(
+            `Inline image ${id} in the "${languageTag}" block has no box on screen. The page ` +
+                `says: ${asThePageSeesIt}. The frame it is in has ` +
+                `${frameBox ? `a box ${Math.round(frameBox.width)}x${Math.round(frameBox.height)} at ${Math.round(frameBox.x)},${Math.round(frameBox.y)}` : "no box at all"}. ` +
+                `A picture with a rectangle of its own, in a frame with none, is a page that is ` +
+                `still being rebuilt; one with no rectangle either is hidden by the CSS, which ` +
+                `shows only the copy in the first visible language.`,
+        );
+    }
+    return box;
+}
+
+/**
+ * Press on the picture and move it to a point, then let go. The gesture has to begin with a real
+ * press on the picture, because that is what selects the image and records the undo point a drop
+ * commits; and it has to move in steps, because the dock and the offset are worked out from each
+ * pointermove.
+ */
+async function dragInlineImageTo(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+    id: string,
+    to: { x: number; y: number },
+): Promise<void> {
+    const picture = await pictureRect(page, groupSelector, languageTag, id);
+    const from = {
+        x: picture.x + picture.width / 2,
+        y: picture.y + picture.height / 2,
+    };
+    await page.mouse.move(from.x, from.y);
+    await page.mouse.down();
+    await page.mouse.move(to.x, to.y, { steps: 16 });
+    await page.mouse.up();
+}
+
+/** Right-click one language's copy of an inline image, and wait for the menu. */
+async function openInlineImageMenu(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+    id: string,
+): Promise<void> {
+    const picture = await pictureRect(page, groupSelector, languageTag, id);
+    await rightClickAt(
+        page,
+        picture.x + picture.width / 2,
+        picture.y + picture.height / 2,
+    );
+    await waitForInlineImageMenu(page, `inline image ${id}`);
+}
+
+/**
+ * Right-click in the TEXT of one language's block, clear of every inline image in it, and wait
+ * for the menu. Finding a clear spot is the whole difficulty: a docked picture covers part of its
+ * block, and a right-click that lands on it gets the picture's menu instead of the block's.
+ */
+async function openInlineImageMenuInText(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+): Promise<void> {
+    const clear = await clearTextPoint(page, groupSelector, languageTag);
+    await rightClickAt(page, clear.x, clear.y);
+    await waitForInlineImageMenu(
+        page,
+        `the text of the "${languageTag}" block`,
+    );
+}
+
+/**
+ * A point in one language's block that is on the text and clear of every inline image in it.
+ * Finding one is the whole difficulty of pointing at the text: a docked picture covers part of
+ * its block, and a click that lands on the picture means the picture, not the text.
+ */
+async function clearTextPoint(
+    page: Page,
+    groupSelector: string,
+    languageTag: string,
+): Promise<{ x: number; y: number }> {
+    const block = inlineImageBlock(page, groupSelector, languageTag);
+    const onScreen = await blockRect(page, groupSelector, languageTag);
+    const found = await block.evaluate(
+        (element, markup) => {
+            // Every line the block's text occupies, which is what a Range over a text node
+            // reports. The paragraph box is no use here: it spans the block's full width whether
+            // the text wraps or not, so its middle can be over the picture.
+            const lines: DOMRect[] = [];
+            const walker = document.createTreeWalker(
+                element,
+                NodeFilter.SHOW_TEXT,
+            );
+            while (walker.nextNode()) {
+                const node = walker.currentNode;
+                if (
+                    (node.parentElement as HTMLElement | null)?.closest(
+                        "." + markup.wrapperClass,
+                    )
+                )
+                    continue;
+                if (!node.textContent?.trim()) continue;
+                const range = document.createRange();
+                range.selectNodeContents(node);
+                lines.push(...Array.from(range.getClientRects()));
+            }
+            // Along each line, from its middle outward. A line beside a docked picture is partly
+            // over it, so several points per line are worth trying.
+            const candidates = lines
+                .filter((line) => line.width > 2 && line.height > 2)
+                .flatMap((line) =>
+                    [0.5, 0.25, 0.75, 0.1, 0.9].map((along) => ({
+                        x: line.left + line.width * along,
+                        y: line.top + line.height / 2,
+                    })),
+                );
+            const clear = candidates.find((point) => {
+                // The condition the production handler itself applies: what is under the pointer
+                // has to be part of this text block, and not the picture, and not a piece of
+                // editing furniture such as the format gear -- which sits at the bottom left
+                // corner of the focused block and would otherwise swallow the right-click.
+                const under = document.elementFromPoint(
+                    point.x,
+                    point.y,
+                ) as HTMLElement | null;
+                if (!under || !element.contains(under)) return false;
+                if (under.closest("." + markup.wrapperClass)) return false;
+                if (under.closest(".bloom-ui")) return false;
+                return true;
+            });
+            const rect = element.getBoundingClientRect();
+            return {
+                point: clear,
+                lineCount: lines.length,
+                blockLeft: rect.left,
+                blockTop: rect.top,
+            };
+        },
+        { wrapperClass: kWrapperClass },
+    );
+    if (!found.point)
+        throw new Error(
+            `No spot on the text of the "${languageTag}" block of "${groupSelector}" is clear of ` +
+                `its inline images and of the editing furniture, over ${found.lineCount} lines of ` +
+                `text. A block with no text has nowhere to point at, so type something first.`,
+        );
+    // The block's own document measures from the top left of the frame it is in; the mouse
+    // measures from the top left of Bloom's window. The two differ by where the frame sits, which
+    // is what comparing the same block in both coordinate systems gives.
+    return {
+        x: onScreen.x + (found.point.x - found.blockLeft),
+        y: onScreen.y + (found.point.y - found.blockTop),
+    };
+}
+
+/**
+ * A real right-click at a point in the page's own coordinates. Bloom's own menu replaces
+ * WebView2's, and it is raised from the contextmenu event, so the press has to be a real one.
+ */
+async function rightClickAt(page: Page, x: number, y: number): Promise<void> {
+    await page.mouse.move(x, y);
+    await page.mouse.click(x, y, { button: "right" });
+}
+
+async function waitForInlineImageMenu(page: Page, what: string): Promise<void> {
+    await editablePageFrame(page)
+        .locator(kMenuSelector)
+        .first()
+        .waitFor({ state: "visible", timeout: 30000 })
+        .catch(() => {
+            throw new Error(
+                `Right-clicking ${what} did not open Bloom's own context menu. When a click has ` +
+                    `nothing to offer, Bloom leaves the event alone and WebView2 shows its own ` +
+                    `menu, which is not in the page (setupTextContextMenu).`,
+            );
+        });
+}
+
+/** Choose one command from the open menu, by localization id, and wait until the menu closes. */
+async function clickInlineImageMenuCommand(
+    page: Page,
+    l10nId: string,
+): Promise<void> {
+    const frame = editablePageFrame(page);
+    const item = frame
+        .locator(`${kMenuSelector} >> li[data-testid="${l10nId}"]`)
+        .first();
+    if ((await item.count()) === 0) {
+        const offered = await frame
+            .locator(`${kMenuSelector} >> li[role="menuitem"]`)
+            .evaluateAll((items) =>
+                items.map((one) => one.getAttribute("data-testid") ?? "?"),
+            );
+        throw new Error(
+            `The open menu has no "${l10nId}" command. It offers: ` +
+                `${offered.join(", ") || "(nothing)"}.`,
+        );
+    }
+    await item.click();
+    await frame
+        .locator(kMenuSelector)
+        .first()
+        .waitFor({ state: "hidden", timeout: 30000 });
+}
+
+/**
+ * The text of every sentence that the Talking Book tool has marked for recording INSIDE an inline
+ * image wrapper, in the whole page. It must always be empty: the wrapper is
+ * contenteditable="false" content of the text field, so a recordable sentence in it would give the
+ * reader a picture to record and would put an audio-sentence span into saved picture markup.
+ *
+ * A caller must open the toolbox first (openToolboxWithTalkingBook), because the marking is that
+ * tool's work, not the page's.
+ */
+export async function getNarrationInsideInlineImages(
+    page: Page,
+): Promise<string[]> {
+    return editablePageFrame(page)
+        .locator(`.${kWrapperClass} .audio-sentence`)
+        .evaluateAll((elements) =>
+            elements.map((element) => element.textContent ?? "(empty)"),
+        );
+}
+
+/** One line per language block, for a failure message that says what the group does hold. */
+function describeBlocks(blocks: IBlockInlineImages[]): string {
+    if (blocks.length === 0) return "(no language blocks)";
+    return blocks
+        .map(
+            (block) =>
+                `${block.languageTag}: ${
+                    block.images
+                        .map((image) => `${image.id} (${image.dock})`)
+                        .join(", ") || "no inline images"
+                }`,
+        )
+        .join("; ");
+}
+
+export { kAddImageCommand, kChooseImageCommand, kDeleteCommand };

--- a/src/BloomE2E/helpers/keys.ts
+++ b/src/BloomE2E/helpers/keys.ts
@@ -11,9 +11,16 @@
 // text box raises no key events".)
 //
 // Every press goes through Playwright's keyboard, which sends the same CDP raw key events the
-// browser would build from a physical key. What it cannot do is send a key that Bloom's WinForms
-// shell claims as an accelerator: Ctrl+Z never reaches the page at all, which is why undo has its
-// own helper in workspace.ts rather than a press here.
+// browser would build from a physical key.
+//
+// Ctrl+Z DOES arrive in the page: nothing in src/BloomExe claims it as an accelerator (no
+// ProcessCmdKey case, no menu ShortcutKeys, and the UndoCommand's Implementer in
+// WebView2Browser.SetEditingCommands is an empty lambda), and pressing it undoes typing, which
+// only ckeditor's undo plugin does. Measured in tests/inline-images-undo-keyboard.spec.ts. So
+// press it here when the question is what the key does. undo() in workspace.ts is still the way
+// to exercise the top-bar Undo BUTTON, which is a different path (it posts
+// editView/topBarButtonClick and comes back into workspaceRoot.handleUndo) -- the two are not
+// interchangeable, and a feature with its own undo stack needs both asked.
 
 import { expect, type Locator, type Page } from "@playwright/test";
 

--- a/src/BloomE2E/helpers/pageThumbnails.ts
+++ b/src/BloomE2E/helpers/pageThumbnails.ts
@@ -284,7 +284,15 @@ export async function runPageMenuCommand(
 /**
  * The menu item for a command, in the shell page (the menu is portaled out of the iframe).
  * Exported so a test can assert on a command's enabled state without running it.
+ *
+ * A command whose menu entry carries addEllipsis (Choose Different Layout) is shown with "..."
+ * after it, so the match allows a trailing one rather than each caller having to know which
+ * commands open a dialog.
  */
 export function pageMenuItem(page: Page, command: PageMenuCommand): Locator {
-    return page.getByRole("menuitem", { name: command, exact: true });
+    // No PageMenuCommand contains a regular-expression metacharacter, so the label goes in as it
+    // is; the only latitude is the optional ellipsis.
+    return page.getByRole("menuitem", {
+        name: new RegExp("^" + command + "(\\.\\.\\.)?$"),
+    });
 }

--- a/src/BloomE2E/helpers/spreadsheet.ts
+++ b/src/BloomE2E/helpers/spreadsheet.ts
@@ -1,0 +1,227 @@
+// Exporting a book to a spreadsheet, and importing a spreadsheet back into it.
+//
+// Both commands are on the book's context menu in the Collection tab, and both used to be
+// undrivable. Export finished by opening the .xlsx in whatever the machine uses for a
+// spreadsheet, which put an Excel window on the developer's screen that no test could close.
+// Import opens a native file chooser, which hangs a run.
+//
+// Bloom answers both under --e2e now. The export records the path it wrote instead of opening the
+// file, and reports it at e2e/lastExportedSpreadsheet; the import's chooser takes its answer from
+// e2e/nextFileToChoose. See AUTOMATION-DEBT.md, "Exporting a spreadsheet launches Excel".
+//
+// Both features need a subscription tier of LocalCommunity or better (FeatureRegistry.cs), so a
+// test launches its collection with kEnterpriseSubscriptionCode.
+
+import * as fs from "node:fs";
+import * as Path from "node:path";
+import { expect, type Page } from "@playwright/test";
+import { apiGet, apiGetJson, apiPost } from "./api";
+import { waitForCollectionReady } from "./collection";
+import { switchTab } from "./workspace";
+
+/** One book as collections/books reports it. Only the fields used here. */
+interface IBookInCollection {
+    id: string;
+    folderPath: string;
+}
+
+/**
+ * Export the selected book to a spreadsheet under `parentFolder`, and return the path of the
+ * .xlsx file. Creates `parentFolder` if it is not there.
+ *
+ * SETUP, not a UI path, and the one step here that is: the Export dialog's Choose Folder and
+ * Export buttons carry no test id, so a test cannot click them. What this does drive is the same
+ * `spreadsheet/export` POST the dialog's Export button sends, so everything after the dialog --
+ * the exporter, the progress dialog, the images, and the finished file -- is Bloom's own work.
+ *
+ * Waits for the export to finish. That wait is what the returned path is for: the export runs in
+ * the background behind a progress dialog, and Bloom fills e2e/lastExportedSpreadsheet in only
+ * when the file is written.
+ */
+export async function exportBookToSpreadsheet(
+    page: Page,
+    parentFolder: string,
+): Promise<string> {
+    fs.mkdirSync(parentFolder, { recursive: true });
+    // The Collection tab has to be showing. The export reports its progress into a dialog embedded
+    // in that tab's document, and it waits for that dialog to say it is ready to receive messages
+    // before it does any work (BrowserProgressDialog). Started from another tab, the export simply
+    // never begins, with nothing on screen to say so.
+    await switchTab(page, "collection");
+    await waitForCollectionReady(page);
+    await apiPost(
+        page,
+        "spreadsheet/export",
+        JSON.stringify({ parentFolderPath: parentFolder }),
+        "application/json",
+    );
+    await expect
+        .poll(
+            async () =>
+                (await apiGet(page, "e2e/lastExportedSpreadsheet")).body,
+            {
+                timeout: 120000,
+                message:
+                    "The export never reported a finished spreadsheet. An export that fails " +
+                    "reports nothing at all, so look for a problem message in Bloom's progress " +
+                    `dialog. The target folder was ${parentFolder}.`,
+            },
+        )
+        .not.toBe("");
+    const path = (await apiGet(page, "e2e/lastExportedSpreadsheet")).body;
+    if (!fs.existsSync(path))
+        throw new Error(
+            `Bloom says it exported to ${path}, but there is no file there.`,
+        );
+    return path;
+}
+
+/**
+ * Import a spreadsheet into the book in `bookFolder`, the way a person does: right-click the book
+ * in the Collection tab, and choose "Import Content from Spreadsheet...". The native file chooser
+ * that command opens is pre-answered with `xlsxPath`, so no dialog appears.
+ *
+ * The import always leaves its progress dialog up for the reader (SpreadsheetImporter), so this
+ * closes it, which is also what makes Bloom re-read the book. Waits until the book on disk has
+ * been rewritten and the dialog is gone. The caller is left in the Collection tab with the book
+ * selected.
+ *
+ * Returns the book's folder, which is not always the one passed in: a spreadsheet that changes the
+ * title renames the folder and the .htm inside it (BringBookUpToDate ends in
+ * UpdateBookFileAndFolderName). So the book is followed by its id here rather than by its path,
+ * and a caller that goes back to the files afterwards should use what this returns.
+ */
+export async function importSpreadsheetIntoBook(
+    page: Page,
+    bookFolder: string,
+    xlsxPath: string,
+): Promise<string> {
+    const collectionFolder = Path.dirname(bookFolder);
+    const bookId = readBookInstanceId(bookFolder);
+    const before = fs.statSync(bookHtmlPath(bookFolder)).mtimeMs;
+
+    // Arm the chooser before the command opens it; see the note at the top of this file.
+    await apiPost(page, "e2e/nextFileToChoose", xlsxPath, "text/plain");
+
+    await switchTab(page, "collection");
+    await waitForCollectionReady(page);
+    const book = await findBookInCollection(page, bookFolder);
+    await page
+        .locator(`.book-button[data-book-id="${book.id}"] .bookButton`)
+        .click({ button: "right" });
+
+    // Both spreadsheet commands are on the menu's "More" submenu, which has to be opened first.
+    // Matching it by its English label is the weak point of this helper: a nested menu item is
+    // rendered by a third-party NestedMenuItem that carries no test id, unlike every other item
+    // in this menu (see AUTOMATION-DEBT.md, "The Edit tab's page thumbnail menu has no stable
+    // test ids").
+    const more = page
+        .locator('[role="menu"] li')
+        .filter({ hasText: /^More$/ })
+        .first();
+    await more.waitFor({ state: "visible", timeout: 30000 });
+    await more.click();
+
+    const command = page.locator(
+        '[data-testid="CollectionTab.BookMenu.ImportContentFromSpreadsheet"]',
+    );
+    await command.waitFor({ state: "visible", timeout: 30000 });
+    await command.click();
+
+    // Poll for the book's .htm having been rewritten, resolving the folder each time round: a
+    // spreadsheet that changes the title makes Bloom rename the folder and the file, and the
+    // rename is not atomic from out here, so a moment when neither name resolves is normal. Such
+    // a moment reports the mtime we started with, which reads as "nothing yet" and keeps the wait
+    // going; reporting anything else (or throwing) would end it, in the wrong direction.
+    const currentHtmlMtime = (): number => {
+        try {
+            return fs.statSync(
+                bookHtmlPath(findBookFolderById(collectionFolder, bookId)),
+            ).mtimeMs;
+        } catch {
+            return before;
+        }
+    };
+    await expect
+        .poll(currentHtmlMtime, {
+            timeout: 120000,
+            message:
+                `The import never rewrote the .htm of the book ${bookId} in ` +
+                `${collectionFolder}. An import that fails leaves the book alone and says so in ` +
+                "Bloom's progress dialog.",
+        })
+        .not.toBe(before);
+
+    // The import deliberately keeps its progress dialog up until the reader closes it, and Bloom
+    // re-reads the book only then (the doWhenProgressCloses callback). So a test that skipped this
+    // would go on to look at the book Bloom had before the import, and its click on anything else
+    // would land on the dialog's backdrop.
+    const close = page.getByTestId("Common.Close");
+    await close.waitFor({ state: "visible", timeout: 120000 });
+    await close.click();
+    await close.waitFor({ state: "hidden", timeout: 30000 });
+    return findBookFolderById(collectionFolder, bookId);
+}
+
+/** The book's id, from its meta.json: the one thing about it a rename cannot change. */
+function readBookInstanceId(bookFolder: string): string {
+    const metaPath = Path.join(bookFolder, "meta.json");
+    const id = JSON.parse(fs.readFileSync(metaPath, "utf8")).bookInstanceId;
+    if (!id) throw new Error(`${metaPath} has no bookInstanceId.`);
+    return id;
+}
+
+/**
+ * The folder the book with this id is in now. Every book folder of a collection holds a meta.json
+ * carrying its id, so this finds it wherever an import has renamed it to.
+ */
+function findBookFolderById(collectionFolder: string, bookId: string): string {
+    const folders = fs
+        .readdirSync(collectionFolder, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => Path.join(collectionFolder, entry.name))
+        .filter((folder) => fs.existsSync(Path.join(folder, "meta.json")));
+    const found = folders.filter(
+        (folder) => readBookInstanceId(folder) === bookId,
+    );
+    if (found.length !== 1)
+        throw new Error(
+            `Expected one book with id ${bookId} in ${collectionFolder}, found ` +
+                `${found.length}: ${found.join(", ") || "(none)"}.`,
+        );
+    return found[0];
+}
+
+/** The book's .htm file. Throws when the folder holds none, naming what it does hold. */
+function bookHtmlPath(bookFolder: string): string {
+    const names = fs
+        .readdirSync(bookFolder)
+        .filter((name) => name.endsWith(".htm"));
+    if (names.length !== 1)
+        throw new Error(
+            `Expected one .htm in ${bookFolder}, found ${names.length}: ` +
+                `${names.join(", ") || "(none)"}.`,
+        );
+    return Path.join(bookFolder, names[0]);
+}
+
+/** The book of the editable collection whose folder is `bookFolder`, as Bloom reports it. */
+async function findBookInCollection(
+    page: Page,
+    bookFolder: string,
+): Promise<IBookInCollection> {
+    const collectionId = Path.dirname(bookFolder);
+    const books = await apiGetJson<IBookInCollection[]>(
+        page,
+        `collections/books?collection-id=${encodeURIComponent(collectionId)}`,
+    );
+    const found = books.find(
+        (one) => Path.resolve(one.folderPath) === Path.resolve(bookFolder),
+    );
+    if (!found)
+        throw new Error(
+            `The collection has no book in ${bookFolder}. It holds: ` +
+                `${books.map((one) => one.folderPath).join(", ") || "(no books)"}.`,
+        );
+    return found;
+}

--- a/src/BloomE2E/helpers/workspace.ts
+++ b/src/BloomE2E/helpers/workspace.ts
@@ -159,12 +159,16 @@ export async function canUndo(page: Page): Promise<boolean> {
  * changes lands asynchronously, so wait for the state you expect (a text, a count, a class)
  * rather than reading the page straight after this.
  *
- * Ctrl+Z in the Edit tab is a WinForms accelerator: the key press never reaches the browser, so a
- * test cannot send it. What the shell does when the key is pressed is call the front end's
- * `workspaceBundle.handleUndo()`, which is exactly what this calls. So this is the production undo
- * path with only the key press missing, and it covers CKEditor undo and the canvas element
- * manager's undo alike, because handleUndo is the code that chooses between them.
- * (AUTOMATION-DEBT.md: "WinForms surfaces cannot be driven".)
+ * This is the top-bar Undo BUTTON's path, and only that. The button posts
+ * editView/topBarButtonClick, which EditingViewApi hands back to bloomEditing.topBarButtonClick,
+ * which calls `workspaceBundle.handleUndo()` -- exactly what this calls. handleUndo is the code
+ * that chooses between CKEditor's undo, the canvas element manager's, the toolbox's and the
+ * inline-image stack's, so this covers all of them.
+ *
+ * It is NOT what Ctrl+Z does. Nothing in the shell claims that key, so it arrives in the page and
+ * ckeditor's undo plugin runs it (measured in tests/inline-images-undo-keyboard.spec.ts). A
+ * feature with its own undo stack has to be asked both questions: press the key with
+ * pressKey(page, "Control+z") for one, call this for the other.
  */
 export async function undo(page: Page): Promise<void> {
     if (!(await canUndo(page)))

--- a/src/BloomE2E/tests/inline-images-aspect-ratio.spec.ts
+++ b/src/BloomE2E/tests/inline-images-aspect-ratio.spec.ts
@@ -1,0 +1,104 @@
+// Every copy of a picture has to know the picture's shape.
+//
+// WHAT THIS IS ABOUT. --inline-image-aspect-ratio is what gives the wrapper the shape of the
+// picture inside it, and it is written from the img's naturalWidth/naturalHeight once the file has
+// loaded (setAspectRatioFromNaturalSize, called from wireUpImage and again from the img's load
+// event). The copies of one picture live one per editable of the translation group, each with its
+// own img, and the comment on that load handler says each copy therefore records its own ratio
+// and there is nothing to sync.
+//
+// That leaves the copy whose load did not happen -- or happened before the src changed -- with no
+// ratio at all, and a wrapper with no ratio falls back to kDefaultInlineImageAspectRatio, 4 / 3.
+// The lang="z" prototype is the copy that matters most here: it is hidden, so nothing about it is
+// visible to the person, and it is what TranslationGroupManager clones when a language is added to
+// the collection later. A prototype with the wrong shape hands the wrong shape to every language
+// added from then on.
+//
+// Measured while probing paste: right after choosing bird.png (274 x 300), the "en" copy read
+// "274 / 300" and the "z" copy read "".
+
+import * as Path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "../fixtures/bloomTest";
+import {
+    addPage,
+    getContentPages,
+    goToPage,
+    makeBookFromTemplate,
+    typeInGroup,
+} from "../helpers/bookMaking";
+import {
+    addInlineImage,
+    changeInlineImagePicture,
+    getInlineImages,
+} from "../helpers/inlineImages";
+
+test.use({
+    collectionSpec: { name: "inline-images-aspect-ratio", languages: ["en"] },
+});
+
+test.describe.configure({ mode: "serial" });
+
+const BLOCK = ".bloom-translationGroup";
+const LANG = "en";
+
+const fixtureImage = (name: string) =>
+    Path.resolve(
+        Path.dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "fixtures",
+        "images",
+        name,
+    );
+
+test("every copy of a picture records the picture's shape, the hidden prototype included [Test Case ID 815]", async ({
+    page,
+}) => {
+    test.setTimeout(300000);
+    await makeBookFromTemplate(page, "Basic Book");
+    await typeInGroup(page, ".bookTitle", "en", "Inline Images Aspect Ratio");
+    await addPage(page, "Just Text");
+    const [contentPage] = await getContentPages(page);
+    await goToPage(page, contentPage.id);
+    await typeInGroup(
+        page,
+        BLOCK,
+        LANG,
+        "Some text for the picture to sit in.",
+    );
+
+    const imageId = await addInlineImage(page, BLOCK, LANG);
+
+    // THE ACTION UNDER TEST: choosing a real picture, which is what gives the wrapper a shape to
+    // record. Before this it holds a placeholder, which never loads and so keeps the default.
+    await changeInlineImagePicture(
+        page,
+        BLOCK,
+        LANG,
+        imageId,
+        fixtureImage("bird.png"),
+    );
+
+    const copies = (await getInlineImages(page, BLOCK))
+        .flatMap((block) => block.images)
+        .filter((image) => image.id === imageId);
+    expect(
+        copies.length,
+        "The group holds fewer than two copies of the picture, so this test is measuring nothing.",
+    ).toBeGreaterThan(1);
+    const shown = copies.find((copy) => copy.languageTag === LANG)!;
+    expect(
+        shown.aspectRatio,
+        "The copy the reader sees did not record the picture's shape at all.",
+    ).not.toBe("");
+
+    for (const copy of copies)
+        expect(
+            copy.aspectRatio,
+            `The "${copy.languageTag}" copy of the picture records its shape as ` +
+                `"${copy.aspectRatio}" while the "${LANG}" copy records "${shown.aspectRatio}". ` +
+                `A copy with no ratio falls back to 4 / 3, and the lang="z" prototype is what a ` +
+                `language added to the collection later is cloned from, so the wrong shape there ` +
+                `is handed to every language added from then on.`,
+        ).toBe(shown.aspectRatio);
+});

--- a/src/BloomE2E/tests/inline-images-change-layout.spec.ts
+++ b/src/BloomE2E/tests/inline-images-change-layout.spec.ts
@@ -1,0 +1,206 @@
+// What "Choose Different Layout" does to a picture the person has placed in a text block.
+//
+// WHAT THIS IS ABOUT. Choosing a different layout for a page does not rewrite the text: Bloom
+// imports the template page and MOVES the existing bloom-editable nodes into it
+// (HtmlDom.MigrateEditableData -> MigrateChildren), so the inline image wrapper arrives intact,
+// geometry and all, in a box that may be a different shape. That is the same stale-offset
+// problem as a page-size change, reached by a different route, and it is why MigrateChildren
+// already carries data-imgsizebasedon across for bloom-canvas: "or we don't get the right
+// adjustments for the probably changed size". An inline image's own baseline attribute
+// (data-inline-image-offset-basedon) sits on the wrapper inside the editable, so it travels with
+// the nodes that are moved, and the re-measure at page setup does the rest.
+//
+// The layouts here go from Just Text, whose one text block has the whole page, to Basic Text &
+// Image, whose text block gives half its height to a picture. That is the shape change a person
+// actually makes, and it shortens the block by more than the offset this test puts in it.
+//
+// NOT TESTED HERE, and not a defect of this feature: going to a layout with FEWER text blocks
+// discards the extra ones outright, picture and text alike (MigrateChildren stops at
+// Math.Min(template, old), and the single-page path passes allowDataLoss: true). Text is lost the
+// same way, so that is Bloom's existing answer for this menu item rather than anything to do with
+// inline images.
+
+import * as Path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Page } from "@playwright/test";
+import { expect, test } from "../fixtures/bloomTest";
+import { chooseDifferentLayout } from "../helpers/addPageDialog";
+import {
+    addPage,
+    getContentPages,
+    goToPage,
+    makeBookFromTemplate,
+    typeInGroup,
+} from "../helpers/bookMaking";
+import {
+    addInlineImage,
+    changeInlineImagePicture,
+    dragInlineImageDown,
+    dragInlineImageToDock,
+    getBlockLineHeightPx,
+    getBlockScrollOverflowPx,
+    getInlineImage,
+    getInlineImageRects,
+    getRoomBelowInlineImagePx,
+    scrollBlockToTop,
+} from "../helpers/inlineImages";
+import { runPageMenuCommand, selectPage } from "../helpers/pageThumbnails";
+
+test.use({
+    collectionSpec: { name: "inline-images-change-layout", languages: ["en"] },
+});
+
+test.describe.configure({ mode: "serial" });
+
+const BLOCK = ".bloom-translationGroup";
+const LANG = "en";
+
+// Short enough that the SHORTENED block can still hold it all. Any more and the layout change
+// overflows the block whatever the picture does -- half the height with the same text -- and
+// then the overflow this test asserts on says nothing about the picture's offset, which is what
+// it is here to watch. Plain text of that length overflows the same way, so that is Bloom's
+// answer for the menu item rather than a defect of inline images.
+const TEXT =
+    "The kingfisher waits on the branch above the pool, still enough that the water forgets it " +
+    "is there. It watches the shadows move under the surface.";
+
+const fixtureImage = (name: string) =>
+    Path.resolve(
+        Path.dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "fixtures",
+        "images",
+        name,
+    );
+
+let imageId: string;
+
+/** Everything about where the picture sits, in one reading, for comparing across layouts. */
+const wherePictureSits = async (page: Page) => {
+    const image = await getInlineImage(page, BLOCK, LANG, imageId);
+    const rects = await getInlineImageRects(page, BLOCK, LANG, imageId);
+    return {
+        dock: image.dock,
+        offsetPx: image.offsetPx,
+        widthPercent: image.widthPercent,
+        roomBelowPx: await getRoomBelowInlineImagePx(
+            page,
+            BLOCK,
+            LANG,
+            imageId,
+        ),
+        overflowPx: await getBlockScrollOverflowPx(page, BLOCK, LANG),
+        lineHeightPx: await getBlockLineHeightPx(page, BLOCK, LANG),
+        pictureTopInBlockPx: rects.picture.y - rects.block.y,
+        blockHeightPx: rects.block.height,
+        blockWidthPx: rects.block.width,
+    };
+};
+
+/**
+ * A page with the picture in the full-width band as far down the text as the drag will take it,
+ * which is the state a shorter block cannot hold. Returns the page's id.
+ */
+const makePageWithAPictureLowInItsText = async (
+    page: Page,
+    title: string,
+): Promise<string> => {
+    await makeBookFromTemplate(page, "Basic Book");
+    await typeInGroup(page, ".bookTitle", "en", title);
+    await addPage(page, "Just Text");
+    const [contentPage] = await getContentPages(page);
+    await goToPage(page, contentPage.id);
+    await typeInGroup(page, BLOCK, LANG, TEXT);
+
+    imageId = await addInlineImage(page, BLOCK, LANG);
+    await changeInlineImagePicture(
+        page,
+        BLOCK,
+        LANG,
+        imageId,
+        fixtureImage("bird.png"),
+    );
+    await scrollBlockToTop(page, BLOCK, LANG);
+    await dragInlineImageToDock(page, BLOCK, LANG, imageId, "middle");
+    const roomAtStartPx = await getRoomBelowInlineImagePx(
+        page,
+        BLOCK,
+        LANG,
+        imageId,
+    );
+    await dragInlineImageDown(
+        page,
+        BLOCK,
+        LANG,
+        imageId,
+        Math.max(
+            40,
+            roomAtStartPx - (await getBlockLineHeightPx(page, BLOCK, LANG)),
+        ),
+    );
+    return contentPage.id;
+};
+
+test("a picture survives choosing a different layout for its page, and keeps the text on the page [Test Case ID 815]", async ({
+    page,
+}) => {
+    test.setTimeout(300000);
+    const contentPageId = await makePageWithAPictureLowInItsText(
+        page,
+        "Inline Images Change Layout",
+    );
+
+    const before = await wherePictureSits(page);
+    expect(
+        before.dock,
+        "The setup did not leave the picture in the full-width band, so this test is measuring the wrong thing.",
+    ).toBe("middle");
+    expect(
+        before.offsetPx,
+        "The setup did not move the picture down the block, so there is no offset for a layout change to strand.",
+    ).toBeGreaterThan(40);
+    expect(
+        before.overflowPx,
+        "The block already held more text than it could show before the layout change.",
+    ).toBeLessThanOrEqual(0);
+
+    // THE ACTION UNDER TEST: the page menu's own command, and the dialog's own button.
+    await selectPage(page, contentPageId);
+    await runPageMenuCommand(page, contentPageId, "Choose Different Layout");
+    await chooseDifferentLayout(page, "Basic Text & Image", "Basic Book");
+
+    const after = await wherePictureSits(page);
+    // First that it is there at all. The wrapper is moved with the text, so losing it would mean
+    // the migration dropped content the person had put on the page.
+    expect(
+        after.widthPercent,
+        "The picture did not survive the layout change at all.",
+    ).toBeGreaterThan(0);
+    expect(
+        after.dock,
+        "The layout change moved the picture to a different dock.",
+    ).toBe(before.dock);
+    // And then the invariant a drag keeps: no text pushed off the end of the block.
+    expect(
+        after.overflowPx,
+        `Choosing the "Basic Text & Image" layout pushed ${Math.round(after.overflowPx)}px of ` +
+            `text -- about ${(after.overflowPx / after.lineHeightPx).toFixed(1)} lines -- off the ` +
+            `end of the block, which no drag could have done. The offset is ` +
+            `${Math.round(after.offsetPx)}px, measured when the block was ` +
+            `${Math.round(before.blockHeightPx)}px tall and ${Math.round(before.blockWidthPx)}px ` +
+            `wide, and it is now ${Math.round(after.blockHeightPx)}px by ` +
+            `${Math.round(after.blockWidthPx)}px.`,
+    ).toBeLessThanOrEqual(0);
+    expect(
+        after.roomBelowPx,
+        `Choosing the "Basic Text & Image" layout left the picture ` +
+            `${Math.round(-after.roomBelowPx)}px past the end of everything the block holds.`,
+    ).toBeGreaterThan(-2);
+    // And the person can still see it without hunting for it.
+    expect(
+        after.pictureTopInBlockPx,
+        `Choosing the "Basic Text & Image" layout put the top of the picture ` +
+            `${Math.round(after.pictureTopInBlockPx)}px down a block only ` +
+            `${Math.round(after.blockHeightPx)}px tall.`,
+    ).toBeLessThan(after.blockHeightPx);
+});

--- a/src/BloomE2E/tests/inline-images-cover-title.spec.ts
+++ b/src/BloomE2E/tests/inline-images-cover-title.spec.ts
@@ -1,0 +1,117 @@
+// "Add Image" is not offered in a field Bloom stores and rewrites for itself -- the book title
+// being the one every person meets first.
+//
+// WHAT THIS IS ABOUT. getInlineImageActionTarget decides where the command is offered, and what
+// it used to exclude was an editable inside a canvas element and an editable that is not a direct
+// child of a translation group. A data-book field is neither of those, so the command was offered
+// on the cover title, the credits page, and everywhere else in front and back matter. Nobody
+// decided that; it was what the two exclusions left behind.
+//
+// Front and back matter is not stored where it is shown. BringXmatterHtmlUpToDate deletes and
+// re-injects every xmatter page whenever the book is brought up to date, so cover content survives
+// only through the data div: GatherDataItemsFromXElement stores the field's InnerXml, and
+// SetNodeXml writes it back into EVERY element carrying the same data-book key. bookTitle is on
+// both the cover and the title page, so a picture put on one became markup stored in the data div
+// and written into both -- and the stored title is what names the book in the collection, the
+// title bar, and AllTitles.
+//
+// Measured, before the exclusion was added: one picture added to the cover title produced four
+// wrappers in the saved book, and the stored title read
+// `<div data-bloom-inline-image-id="..." class="bloom-inlineImage bloom-inlineImageRight ...">`
+// instead of the words the person typed.
+//
+// Bloom's own way to put a picture on a cover is a canvas element, which the person reaches from
+// the same page, so nothing is taken away by not offering this one.
+
+import * as fs from "node:fs";
+import { expect, test } from "../fixtures/bloomTest";
+import {
+    addPage,
+    findBookFolder,
+    getContentPages,
+    getPages,
+    goToPage,
+    makeBookFromTemplate,
+    typeInGroup,
+} from "../helpers/bookMaking";
+import { bookHtmlPath } from "../helpers/bookHtml";
+import { textBlockOffersAddImage } from "../helpers/inlineImages";
+
+test.use({
+    collectionSpec: { name: "inline-images-cover-title", languages: ["en"] },
+});
+
+test.describe.configure({ mode: "serial" });
+
+const TITLE_BLOCK = ".bookTitle";
+// The other data-book field a person meets on the front cover.
+const COVER_CREDITS_BLOCK = ".creditsRow .bloom-translationGroup";
+const LANG = "en";
+const BOOK_TITLE = "Inline Images Cover Title";
+
+/** What the saved book holds: any inline image wrapper at all, and the stored title. */
+const readFromDisk = (bookFolder: string) => {
+    const html = fs.readFileSync(bookHtmlPath(bookFolder), "utf8");
+    return {
+        wrappersInTheWholeFile: (
+            html.match(/data-bloom-inline-image-id/g) ?? []
+        ).length,
+        // The stored title, as the data div holds it: markup and all.
+        storedTitle: (html.match(
+            /<div[^>]*data-book="bookTitle"[^>]*lang="en"[^>]*>([\s\S]*?)<\/div>/,
+        ) ?? [, ""])[1]
+            .trim()
+            .slice(0, 400),
+    };
+};
+
+test("Bloom does not offer to put a picture in the book title or the credits [Test Case ID 815]", async ({
+    page,
+}) => {
+    test.setTimeout(300000);
+    await makeBookFromTemplate(page, "Basic Book");
+    await typeInGroup(page, TITLE_BLOCK, LANG, BOOK_TITLE);
+    // Somewhere to go afterwards: leaving the cover is what makes Bloom save it, and a book made
+    // from the Basic Book template starts with no content page to leave to.
+    await addPage(page, "Just Text");
+    const pagesAtStart = await getPages(page);
+    const coverId = pagesAtStart.find((p) => !p.isContentPage)!.id;
+    await goToPage(page, coverId);
+    // The cover credits start empty, and the menu is opened by pointing at a spot on the text.
+    await typeInGroup(page, COVER_CREDITS_BLOCK, LANG, "Written by someone");
+
+    // THE THING UNDER TEST: the command the person would reach for on the block they are in.
+    expect(
+        await textBlockOffersAddImage(page, TITLE_BLOCK, LANG),
+        `Bloom offered to put a picture in the book title. That field is stored in the data div ` +
+            `as markup and written back into every element with the same data-book key, so the ` +
+            `picture ends up on the title page as well and the wrapper's markup becomes the ` +
+            `book's stored title.`,
+    ).toBe(false);
+    expect(
+        await textBlockOffersAddImage(page, COVER_CREDITS_BLOCK, LANG),
+        `Bloom offered to put a picture in the cover credits, which is a data-book field on an ` +
+            `xmatter page and so has the same problem as the title.`,
+    ).toBe(false);
+
+    // And nothing about the front matter left inline image markup in the saved book. Leaving the
+    // page is what makes Bloom save it; the collection learns the title at the same moment, which
+    // is why findBookFolder comes after the navigation.
+    const [contentPage] = await getContentPages(page);
+    await goToPage(page, contentPage.id);
+    const onDisk = readFromDisk(await findBookFolder(page, BOOK_TITLE));
+    expect(
+        onDisk.wrappersInTheWholeFile,
+        `The saved book holds ${onDisk.wrappersInTheWholeFile} inline image wrappers, though no ` +
+            `picture was added anywhere.`,
+    ).toBe(0);
+    expect(
+        onDisk.storedTitle,
+        `The book's stored title holds inline image markup. It is what names this book in the ` +
+            `collection, the title bar and AllTitles, and it reads: ${onDisk.storedTitle}`,
+    ).not.toContain("bloom-inlineImage");
+    expect(
+        onDisk.storedTitle,
+        "The book's stored title is not the words that were typed on the cover.",
+    ).toContain(BOOK_TITLE);
+});

--- a/src/BloomE2E/tests/inline-images-duplicate-page.spec.ts
+++ b/src/BloomE2E/tests/inline-images-duplicate-page.spec.ts
@@ -1,0 +1,145 @@
+// Duplicating a page that has a picture in its text.
+//
+// WHAT THIS IS ABOUT. Duplicate Page goes through Book.InsertPageAfter, whose BookStarter.
+// UniqueifyIds renews only .//img[@id] -- so every copy of the page keeps the SAME
+// data-bloom-inline-image-id as the page it came from. That is deliberate and harmless, because
+// every lookup this feature does is scoped to a translation group: syncInlineImagesFromEditable,
+// getInlineImageById and normalizeInlineImages are all handed a group or an editable and never
+// search the page, let alone the book. But it is load-bearing and invisible, which is exactly the
+// kind of thing that gets broken by a later change that looks harmless -- a document-wide
+// querySelector would do it -- so this pins it down: changing one page's picture must leave the
+// other page's alone.
+//
+// The image FILE is copied by InsertPageAfter, but only `if (!RobustFile.Exists(path))`, so a
+// page pasted into a book that already has a different file of the same name silently takes the
+// other book's picture. That is how every picture in Bloom is copied, canvas elements included,
+// so it is not this feature's to fix; it is noted here so the next person reading this file knows
+// it was looked at.
+
+import * as Path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "../fixtures/bloomTest";
+import {
+    addPage,
+    getContentPages,
+    goToPage,
+    makeBookFromTemplate,
+    typeInGroup,
+} from "../helpers/bookMaking";
+import {
+    addInlineImage,
+    changeInlineImagePicture,
+    getInlineImages,
+    resizeInlineImage,
+} from "../helpers/inlineImages";
+import { duplicatePageWithContextMenu } from "../helpers/pageList";
+
+test.use({
+    collectionSpec: {
+        name: "inline-images-duplicate-page",
+        languages: ["en"],
+    },
+});
+
+test.describe.configure({ mode: "serial" });
+
+const BLOCK = ".bloom-translationGroup";
+const LANG = "en";
+
+const fixtureImage = (name: string) =>
+    Path.resolve(
+        Path.dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "fixtures",
+        "images",
+        name,
+    );
+
+test("a duplicated page's picture is independent of the original's [Test Case ID 815]", async ({
+    page,
+}) => {
+    test.setTimeout(300000);
+    await makeBookFromTemplate(page, "Basic Book");
+    await typeInGroup(page, ".bookTitle", "en", "Inline Images Duplicate Page");
+    await addPage(page, "Just Text");
+    const [firstPage] = await getContentPages(page);
+    await goToPage(page, firstPage.id);
+    await typeInGroup(
+        page,
+        BLOCK,
+        LANG,
+        "Some text for the picture to sit in.",
+    );
+
+    const imageId = await addInlineImage(page, BLOCK, LANG);
+    await changeInlineImagePicture(
+        page,
+        BLOCK,
+        LANG,
+        imageId,
+        fixtureImage("bird.png"),
+    );
+    const widthAtStart = (await getInlineImages(page, BLOCK)).flatMap(
+        (block) => block.images,
+    )[0].widthPercent;
+
+    // THE ACTION UNDER TEST.
+    await duplicatePageWithContextMenu(page, firstPage.id);
+    const contentPages = await getContentPages(page);
+    expect(
+        contentPages.length,
+        "Duplicate Page did not add a page, so this test is measuring nothing.",
+    ).toBe(2);
+    const copyId = contentPages.find((p) => p.id !== firstPage.id)!.id;
+
+    // The copy has the picture, and it has the same identity, which is what this pins down.
+    await goToPage(page, copyId);
+    const onTheCopy = (await getInlineImages(page, BLOCK)).flatMap(
+        (block) => block.images,
+    );
+    expect(
+        onTheCopy.length,
+        "The duplicated page has no picture in its text.",
+    ).toBeGreaterThan(0);
+    expect(
+        onTheCopy[0].fileName,
+        "The duplicated page's picture points at a different file from the original's.",
+    ).toBe("bird.png");
+    expect(
+        onTheCopy.every((image) => image.id === imageId),
+        `The duplicated page's picture has a different identity (${onTheCopy[0].id}) from the ` +
+            `original's (${imageId}). Nothing is wrong with that in itself, but the tests and ` +
+            `comments in this feature are written on the understanding that UniqueifyIds does ` +
+            `NOT renew this attribute, so a change here means those need rereading.`,
+    ).toBe(true);
+
+    // THE THING THAT MATTERS: changing the copy's picture leaves the original's alone. The two
+    // share an id, so anything that looked one up across the page, or across the book, would hit
+    // the wrong one.
+    const widened = await resizeInlineImage(
+        page,
+        BLOCK,
+        LANG,
+        imageId,
+        "se",
+        40,
+    );
+    expect(
+        widened,
+        "The resize did not change the copy's picture, so this test cannot say whether the change leaked.",
+    ).not.toBe(widthAtStart);
+
+    await goToPage(page, firstPage.id);
+    const backOnTheOriginal = (await getInlineImages(page, BLOCK)).flatMap(
+        (block) => block.images,
+    );
+    for (const image of backOnTheOriginal)
+        expect(
+            image.widthPercent,
+            `Resizing the duplicated page's picture changed the original page's too: the ` +
+                `"${image.languageTag}" copy there is now ${image.widthPercent}% instead of ` +
+                `${widthAtStart}%. The two pages' pictures share a ` +
+                `data-bloom-inline-image-id, so a lookup that is not scoped to one translation ` +
+                `group reaches across pages.`,
+        ).toBe(widthAtStart);
+});

--- a/src/BloomE2E/tests/inline-images-keyboard-delete.spec.ts
+++ b/src/BloomE2E/tests/inline-images-keyboard-delete.spec.ts
@@ -1,0 +1,181 @@
+// Deleting a picture with the keyboard rather than from its menu.
+//
+// WHAT THIS IS ABOUT. Two mechanisms meet here, and each is fine on its own.
+//
+// BloomField's PreventRemovalOfSomeElements is the guard: the wrapper carries
+// bloom-preventRemoval, and a keystroke that leaves the field with fewer of those than it had
+// before the keystroke gets document.execCommand("undo"). Ctrl+A DEL is what it exists for.
+//
+// The other is normalizeInlineImages at page setup, which stamps the canonical editable's images
+// over the group's other editables. getCanonicalInlineImageEditable only ever considers an
+// editable that HAS images, so an editable the person emptied is never the authority: the picture
+// comes back from whichever language still holds one. And nothing calls
+// syncInlineImagesFromEditable after ordinary typing or cutting -- its callers are all
+// inline-image operations -- so a keyboard deletion is never carried to the other languages in
+// the first place.
+//
+// So if the guard ever fails to restore, the person gets "I deleted the picture, saved, came back,
+// and it is here again", with no way to tell why. This test asks the browser which it is: does
+// Ctrl+A DEL leave the picture in place, and does it survive a save and a reload either way.
+
+import * as Path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "../fixtures/bloomTest";
+import {
+    addPage,
+    getContentPages,
+    getPages,
+    goToPage,
+    makeBookFromTemplate,
+    typeInGroup,
+} from "../helpers/bookMaking";
+import {
+    addInlineImage,
+    changeInlineImagePicture,
+    deleteInlineImage,
+    getInlineImages,
+} from "../helpers/inlineImages";
+
+test.use({
+    collectionSpec: {
+        name: "inline-images-keyboard-delete",
+        languages: ["en"],
+    },
+});
+
+test.describe.configure({ mode: "serial" });
+
+const BLOCK = ".bloom-translationGroup";
+const LANG = "en";
+
+const TEXT =
+    "The kingfisher waits on the branch above the pool, still enough that the water forgets it " +
+    "is there.";
+
+const fixtureImage = (name: string) =>
+    Path.resolve(
+        Path.dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "fixtures",
+        "images",
+        name,
+    );
+
+const countImages = async (page: import("@playwright/test").Page) =>
+    (await getInlineImages(page, BLOCK)).flatMap((block) => block.images)
+        .length;
+
+let imageId: string;
+let contentPageId: string;
+let coverId: string;
+
+test("Ctrl+A DEL does not take the picture out of the block [Test Case ID 815]", async ({
+    page,
+}) => {
+    test.setTimeout(300000);
+    await makeBookFromTemplate(page, "Basic Book");
+    await typeInGroup(
+        page,
+        ".bookTitle",
+        "en",
+        "Inline Images Keyboard Delete",
+    );
+    await addPage(page, "Just Text");
+    const pages = await getPages(page);
+    coverId = pages.find((p) => !p.isContentPage)!.id;
+    contentPageId = (await getContentPages(page))[0].id;
+    await goToPage(page, contentPageId);
+    await typeInGroup(page, BLOCK, LANG, TEXT);
+
+    imageId = await addInlineImage(page, BLOCK, LANG);
+    await changeInlineImagePicture(
+        page,
+        BLOCK,
+        LANG,
+        imageId,
+        fixtureImage("bird.png"),
+    );
+    // One copy per language's block, counted before the keystroke: what has to be true afterwards
+    // is that every one of them still has its copy, and a count taken afterwards could not tell
+    // that from a block having gone missing altogether.
+    const copiesBefore = (await getInlineImages(page, BLOCK)).map(
+        (editable) => editable.images.length,
+    );
+    expect(
+        copiesBefore.reduce((a, b) => a + b, 0),
+        "The group holds fewer than two copies of the picture, so this test is measuring nothing.",
+    ).toBeGreaterThan(1);
+
+    // THE ACTION UNDER TEST: the gesture bloom-preventRemoval exists for, with real keys.
+    const block = page
+        .frameLocator("#page")
+        .locator(`${BLOCK} > .bloom-editable[lang="${LANG}"]`)
+        .first();
+    await block.click();
+    await page.keyboard.press("Control+a");
+    await page.keyboard.press("Delete");
+
+    // What we are waiting for is the protection having run: BloomField takes the deletion back
+    // when it sees the wrapper count has dropped (PreventRemovalOfSomeElements, on keyup), and
+    // CKEditor's own work around a paste or a deletion is asynchronous. So the wait is for the
+    // picture to be there in every language -- the state under test -- rather than for a length
+    // of time. A protection that never runs polls to the timeout and fails with the message
+    // below.
+    await expect
+        .poll(
+            async () =>
+                (await getInlineImages(page, BLOCK)).map(
+                    (editable) => editable.images.length,
+                ),
+            {
+                timeout: 30000,
+                message:
+                    `Ctrl+A DEL did not leave every language's block holding its one copy of ` +
+                    `the picture. bloom-preventRemoval is supposed to undo a keystroke that ` +
+                    `removes the wrapper, and nothing carries such a removal to the other ` +
+                    `languages, so a block left empty here gets the picture stamped back into ` +
+                    `it by normalizeInlineImages at the next page setup -- which reads as "I ` +
+                    `deleted it, saved, and it came back".`,
+            },
+        )
+        .toEqual(copiesBefore);
+
+    const after = await getInlineImages(page, BLOCK);
+    for (const editable of after)
+        expect(
+            editable.images.length,
+            `Ctrl+A DEL left the "${editable.languageTag}" block with ` +
+                `${editable.images.length} copies of the picture instead of 1. ` +
+                `bloom-preventRemoval is supposed to undo a keystroke that removes the wrapper, ` +
+                `and nothing carries such a removal to the other languages, so a block left ` +
+                `empty here gets the picture stamped back into it by normalizeInlineImages at ` +
+                `the next page setup -- which reads as "I deleted it, saved, and it came back".`,
+        ).toBe(1);
+});
+
+test("a picture deleted from its own menu stays deleted through a save and a reload [Test Case ID 815]", async ({
+    page,
+}) => {
+    test.setTimeout(300000);
+    // The menu is the way to delete a picture, so this is the other half: the deletion has to
+    // reach every language, or normalizeInlineImages brings it back from the one it missed.
+    await goToPage(page, contentPageId);
+    await deleteInlineImage(page, BLOCK, LANG, imageId);
+    expect(
+        await countImages(page),
+        "The menu's Delete left copies of the picture in the group.",
+    ).toBe(0);
+
+    // Leave the page and come back, which is a save and a fresh page setup.
+    await goToPage(page, coverId);
+    await goToPage(page, contentPageId);
+
+    const after = await getInlineImages(page, BLOCK);
+    expect(
+        after.flatMap((block) => block.images).length,
+        `The picture came back after a save and a reload. normalizeInlineImages stamps the ` +
+            `canonical editable's images over the others, and getCanonicalInlineImageEditable ` +
+            `only considers an editable that HAS images, so one language still holding a copy ` +
+            `puts it back in all of them.`,
+    ).toBe(0);
+});

--- a/src/BloomE2E/tests/inline-images-multilingual.spec.ts
+++ b/src/BloomE2E/tests/inline-images-multilingual.spec.ts
@@ -1,0 +1,348 @@
+// Inline (Word-style) images in a book with more than one language. The feature is described in
+// INLINE-IMAGES-PLAN.md; inline-images.spec.ts covers one language.
+//
+// WHAT THIS FILE COVERS, AND WHY IT IS THE E2E PART. An inline image is not one element. A float
+// only wraps the text of the block it sits in, so the picture has to live inside each
+// bloom-editable of the translation group, and the copies are kept the same by edit-time
+// JavaScript. That design has three consequences that only a real Bloom can show:
+//
+//  - the copies exist in every language block at once, but the reader must see one picture, so the
+//    CSS shows the first showing language's copy and hides the rest with display: none;
+//  - the copy in the lang="z" prototype block is what a language added to the collection later
+//    inherits, and only Bloom's own C# builds that new block out of the prototype;
+//  - Bloom's language-stamping sweep (TranslationGroupManager.UpdateContentLanguageClasses) walks
+//    every div inside a translation group, the picture wrapper included, so turning a language on
+//    or off runs that sweep over the wrapper.
+//
+// The last test covers a separate collision: the Talking Book tool marks the sentences of a text
+// field for recording, and the wrapper is content of that field.
+//
+// The tests are serial: each starts from the book the one before it left behind. The second test
+// restarts Bloom on a collection with a second language, so every test after it takes the page
+// from the `page` fixture again rather than holding on to an old one.
+
+import * as Path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "../fixtures/bloomTest";
+import {
+    addPage,
+    findBookFolder,
+    getContentPages,
+    getPages,
+    goToPage,
+    makeBookFromTemplate,
+    setContentLanguages,
+    typeInGroup,
+} from "../helpers/bookMaking";
+import { selectBook } from "../helpers/collection";
+import { restartWithCollectionSettings } from "../helpers/collectionSettings";
+import {
+    addInlineImage,
+    changeInlineImagePicture,
+    deleteInlineImage,
+    dragInlineImageToDock,
+    getInlineImage,
+    getInlineImageInEveryLanguage,
+    getInlineImages,
+    getNarrationInsideInlineImages,
+} from "../helpers/inlineImages";
+import {
+    getNarrationSentences,
+    openToolboxWithTalkingBook,
+} from "../helpers/talkingBook";
+import { switchTab } from "../helpers/workspace";
+
+// The collection starts with one language, so that the second one is genuinely added later: the
+// French block does not exist in the page's markup until Bloom builds it out of the prototype.
+test.use({
+    collectionSpec: { name: "inline-images-multi", languages: ["en"] },
+});
+
+test.describe.configure({ mode: "serial" });
+
+// The only translation group of a Just Text page, the two languages, and the prototype block every
+// new language block is built from.
+const BLOCK = ".bloom-translationGroup";
+const FIRST_LANG = "en";
+const SECOND_LANG = "fr";
+const PROTOTYPE_LANG = "z";
+
+const BOOK_TITLE = "Inline Images Multilingual";
+
+// Enough text in each language that the block has several lines for the picture to displace.
+const ENGLISH_TEXT =
+    "The kingfisher waits on the branch above the pool, still enough that the water forgets " +
+    "it is there. When it drops, it drops straight, and the pool closes over the place where " +
+    "it went in. The children on the bank have learned to wait as well.";
+const FRENCH_TEXT =
+    "Le martin-pecheur attend sur la branche au-dessus du bassin, si tranquille que l'eau " +
+    "oublie qu'il est la. Quand il plonge, il plonge droit, et le bassin se referme sur " +
+    "l'endroit ou il est entre. Les enfants sur la rive ont appris a attendre aussi.";
+
+const fixtureImage = (name: string) =>
+    Path.resolve(
+        Path.dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "fixtures",
+        "images",
+        name,
+    );
+
+// The image the file works on, the page it is on, and the book's folder. Set by the first test.
+let imageId: string;
+let contentPageId: string;
+let bookFolder: string;
+
+test.describe("inline images in a book with two languages [Test Case ID 815]", () => {
+    test("with one language in the collection, the picture goes in that block and in the prototype", async ({
+        page,
+    }) => {
+        test.setTimeout(300000);
+        await makeBookFromTemplate(page, "Basic Book");
+        await typeInGroup(page, ".bookTitle", "en", BOOK_TITLE);
+        await addPage(page, "Just Text");
+        const [contentPage] = await getContentPages(page);
+        contentPageId = contentPage.id;
+        await goToPage(page, contentPageId);
+        await typeInGroup(page, BLOCK, FIRST_LANG, ENGLISH_TEXT);
+        bookFolder = await findBookFolder(page, BOOK_TITLE);
+
+        const before = await getInlineImages(page, BLOCK);
+        expect(
+            before.map((block) => block.languageTag).sort(),
+            "The group should hold the one language and the prototype, and no French block yet, " +
+                "or the test after this one proves nothing.",
+        ).toEqual([FIRST_LANG, PROTOTYPE_LANG]);
+
+        // THE ACTION UNDER TEST: a real right-click in the English text, and a real click on Add
+        // Image, in a book with one language.
+        imageId = await addInlineImage(page, BLOCK, FIRST_LANG);
+        await changeInlineImagePicture(
+            page,
+            BLOCK,
+            FIRST_LANG,
+            imageId,
+            fixtureImage("bird.png"),
+        );
+
+        const prototype = await getInlineImage(
+            page,
+            BLOCK,
+            PROTOTYPE_LANG,
+            imageId,
+        );
+        expect(prototype.dock).toBe("right");
+        expect(prototype.fileName).toBe("bird.png");
+        // The prototype block is never shown to anybody, so its copy is not painted either.
+        expect(prototype.shown).toBe(false);
+        // Load-bearing in the prototype above all: it is the only thing stopping Bloom's
+        // language-stamping sweep from treating the wrapper as a text box of the new language.
+        expect(prototype.contentEditable).toBe("false");
+    });
+
+    test("a language added to the collection later inherits the picture from the prototype", async ({
+        bloomApp,
+    }) => {
+        test.setTimeout(300000);
+        // The restart kills Bloom, and Bloom writes a page only when the book leaves it, so the
+        // book has to leave the page first or the picture is never saved at all.
+        const [firstXmatter] = (await getPages(bloomApp.page)).filter(
+            (one) => !one.isContentPage,
+        );
+        await goToPage(bloomApp.page, firstXmatter.id);
+
+        // THE ACTION UNDER TEST: a second collection language, which is what a person adds in the
+        // Settings dialog. Bloom restarts, and builds the book's French block out of the lang="z"
+        // prototype -- carrying whatever the prototype holds, the picture included.
+        const restarted = await restartWithCollectionSettings(bloomApp, {
+            languages: [FIRST_LANG, SECOND_LANG],
+        });
+        await selectBook(restarted, bookFolder);
+        await switchTab(restarted, "edit");
+        await goToPage(restarted, contentPageId);
+        await setContentLanguages(restarted, [FIRST_LANG, SECOND_LANG]);
+
+        const blocks = await getInlineImages(restarted, BLOCK);
+        expect(
+            blocks.map((block) => block.languageTag).sort(),
+            "Adding the language should have given the group a French block.",
+        ).toEqual([FIRST_LANG, SECOND_LANG, PROTOTYPE_LANG]);
+
+        const french = await getInlineImage(
+            restarted,
+            BLOCK,
+            SECOND_LANG,
+            imageId,
+        );
+        // The inherited copy is the same image, not a second one, and it comes with the geometry
+        // and the picture the prototype held.
+        expect(french.dock).toBe("right");
+        expect(french.widthPercent).toBe(40);
+        expect(french.fileName).toBe("bird.png");
+        expect(french.contentEditable).toBe("false");
+    });
+
+    test("the reader sees one picture: the outranked copies stay in the markup and are hidden", async ({
+        page,
+    }) => {
+        await typeInGroup(page, BLOCK, SECOND_LANG, FRENCH_TEXT);
+
+        const blocks = await getInlineImages(page, BLOCK);
+        const showing = blocks.filter((block) => block.visible);
+        expect(
+            showing.length,
+            "The book should be showing two languages at this point.",
+        ).toBe(2);
+
+        // Every block holds its copy, so nothing was moved or deleted.
+        for (const block of blocks) expect(block.images.length).toBe(1);
+
+        // Exactly one copy is painted, and it is the first showing language's.
+        const shownCopies = blocks
+            .flatMap((block) => block.images)
+            .filter((image) => image.shown);
+        expect(
+            shownCopies.map((image) => image.languageTag),
+            "The rule that shows the picture once per translation group " +
+                "(inlineImages.less) should leave exactly one copy painted.",
+        ).toEqual([showing[0].languageTag]);
+
+        // The hidden copy is hidden by that rule, not by its block being hidden: the French block
+        // is showing its text, and it contains the float like any other block holding a picture.
+        const french = blocks.find(
+            (block) => block.languageTag === SECOND_LANG,
+        );
+        expect(french!.visible).toBe(true);
+        expect(french!.display).toBe("flow-root");
+    });
+
+    test("dragging the one picture a reader can see moves the hidden copies too", async ({
+        page,
+    }) => {
+        const before = await getInlineImageInEveryLanguage(
+            page,
+            BLOCK,
+            imageId,
+        );
+        expect(
+            before.map((copy) => copy.dock),
+            "Every copy should start docked right, or this test cannot tell a move from a " +
+                "starting state.",
+        ).toEqual(before.map(() => "right"));
+
+        // THE ACTION UNDER TEST: a real drag of the copy the reader sees, to the left third of
+        // the block.
+        await dragInlineImageToDock(page, BLOCK, FIRST_LANG, imageId, "left");
+
+        const after = await getInlineImageInEveryLanguage(page, BLOCK, imageId);
+        expect(after.length).toBe(3);
+        // The hidden French copy and the prototype copy follow the shown one. A copy left behind
+        // would show the wrong side as soon as the book's language choice changed.
+        expect(after.map((copy) => copy.dock)).toEqual(after.map(() => "left"));
+    });
+
+    test("turning the second language off again leaves the picture where it was", async ({
+        page,
+    }) => {
+        // THE ACTION UNDER TEST: back to One Language, which runs Bloom's language sweep over the
+        // wrapper again and hides the French block.
+        await setContentLanguages(page, [FIRST_LANG]);
+
+        for (const copy of await getInlineImageInEveryLanguage(
+            page,
+            BLOCK,
+            imageId,
+        )) {
+            expect(copy.dock).toBe("left");
+            expect(copy.widthPercent).toBe(40);
+            expect(copy.fileName).toBe("bird.png");
+            expect(copy.contentEditable).toBe("false");
+        }
+        // English is showing alone now, so its copy is the painted one.
+        expect(
+            (await getInlineImage(page, BLOCK, FIRST_LANG, imageId)).shown,
+        ).toBe(true);
+    });
+
+    test("a second image in the same block keeps its own identity in every language", async ({
+        page,
+    }) => {
+        // THE ACTION UNDER TEST: a second real Add Image in a block that already has one.
+        const secondId = await addInlineImage(page, BLOCK, FIRST_LANG);
+        expect(
+            secondId,
+            "The second image should have an id of its own; sharing one would make the two " +
+                "images the same image in the eyes of every sync.",
+        ).not.toBe(imageId);
+
+        for (const block of await getInlineImages(page, BLOCK)) {
+            expect(
+                block.images.map((image) => image.id).sort(),
+                `The ${block.languageTag} block should hold both images.`,
+            ).toEqual([imageId, secondId].sort());
+        }
+
+        // A picture, because a drag has to grab something the reader can see: the placeholder an
+        // image starts with has no picture file in the book yet, so it has nothing to grab.
+        await changeInlineImagePicture(
+            page,
+            BLOCK,
+            FIRST_LANG,
+            secondId,
+            fixtureImage("bird.png"),
+        );
+
+        // Moving one leaves the other where it is, in every language.
+        await dragInlineImageToDock(
+            page,
+            BLOCK,
+            FIRST_LANG,
+            secondId,
+            "middle",
+        );
+        for (const copy of await getInlineImageInEveryLanguage(
+            page,
+            BLOCK,
+            secondId,
+        ))
+            expect(copy.dock).toBe("middle");
+        for (const copy of await getInlineImageInEveryLanguage(
+            page,
+            BLOCK,
+            imageId,
+        ))
+            expect(copy.dock).toBe("left");
+
+        // THE ACTION UNDER TEST: deleting one of the two. The other survives it, in every
+        // language.
+        await deleteInlineImage(page, BLOCK, FIRST_LANG, secondId);
+        for (const block of await getInlineImages(page, BLOCK)) {
+            expect(block.images.map((image) => image.id)).toEqual([imageId]);
+        }
+    });
+
+    test("the Talking Book tool marks no sentence inside the picture", async ({
+        page,
+    }) => {
+        // THE ACTION UNDER TEST: opening the toolbox, which puts the Talking Book tool to work on
+        // the page and makes it mark the recordable sentences of every text field.
+        await openToolboxWithTalkingBook(page);
+
+        const sentences = await getNarrationSentences(page);
+        expect(
+            sentences.length,
+            "The tool marked nothing at all, so this test would pass whatever the wrapper held.",
+        ).toBeGreaterThan(0);
+
+        expect(
+            await getNarrationInsideInlineImages(page),
+            "The tool marked something inside the picture wrapper. A recorder would be asked to " +
+                "read a picture, and an audio-sentence span would be saved into picture markup.",
+        ).toEqual([]);
+
+        // The tool left the image alone.
+        const shown = await getInlineImage(page, BLOCK, FIRST_LANG, imageId);
+        expect(shown.dock).toBe("left");
+        expect(shown.fileName).toBe("bird.png");
+    });
+});

--- a/src/BloomE2E/tests/inline-images-origami.spec.ts
+++ b/src/BloomE2E/tests/inline-images-origami.spec.ts
@@ -1,0 +1,176 @@
+// What cutting a text block in half in Change Layout mode does to a picture placed low in it.
+//
+// WHAT THIS IS ABOUT. Origami changes the shape of a block without any template or page size
+// being involved: splitting a section leaves the text in a fraction of the height it had. That is
+// the third route to the same stale offset as inline-images-page-size and the Choose Different
+// Layout test, and it is the one that needs no dialog at all.
+//
+// Nothing about the page is written while the person is arranging boxes. Leaving Change Layout
+// mode is what makes origami save the page and ask Bloom to rebuild it
+// (changeLayoutModeToggleClickHandler posts common/saveChangesAndRethinkPageEvent), so the
+// re-measure at page setup is what has to catch this, and there is no need for origami to call it
+// itself. This test is what says so.
+
+import * as Path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Page } from "@playwright/test";
+import { expect, test } from "../fixtures/bloomTest";
+import {
+    addPage,
+    getContentPages,
+    goToPage,
+    makeBookFromTemplate,
+    typeInGroup,
+} from "../helpers/bookMaking";
+import {
+    addInlineImage,
+    changeInlineImagePicture,
+    dragInlineImageDown,
+    dragInlineImageToDock,
+    getBlockLineHeightPx,
+    getBlockScrollOverflowPx,
+    getInlineImage,
+    getInlineImageRects,
+    getRoomBelowInlineImagePx,
+    scrollBlockToTop,
+} from "../helpers/inlineImages";
+import { setChangeLayoutMode, splitSection } from "../helpers/origami";
+
+test.use({
+    collectionSpec: { name: "inline-images-origami", languages: ["en"] },
+});
+
+test.describe.configure({ mode: "serial" });
+
+const BLOCK = ".bloom-translationGroup";
+const LANG = "en";
+
+// Short enough that the SHORTENED block can still hold it all. Any more and the layout change
+// overflows the block whatever the picture does -- half the height with the same text -- and
+// then the overflow this test asserts on says nothing about the picture's offset, which is what
+// it is here to watch. Plain text of that length overflows the same way, so that is Bloom's
+// answer for the menu item rather than a defect of inline images.
+const TEXT =
+    "The kingfisher waits on the branch above the pool, still enough that the water forgets it " +
+    "is there. It watches the shadows move under the surface.";
+
+const fixtureImage = (name: string) =>
+    Path.resolve(
+        Path.dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "fixtures",
+        "images",
+        name,
+    );
+
+let imageId: string;
+
+/** Everything about where the picture sits, in one reading, for comparing across layouts. */
+const wherePictureSits = async (page: Page) => {
+    const image = await getInlineImage(page, BLOCK, LANG, imageId);
+    const rects = await getInlineImageRects(page, BLOCK, LANG, imageId);
+    return {
+        dock: image.dock,
+        offsetPx: image.offsetPx,
+        widthPercent: image.widthPercent,
+        roomBelowPx: await getRoomBelowInlineImagePx(
+            page,
+            BLOCK,
+            LANG,
+            imageId,
+        ),
+        overflowPx: await getBlockScrollOverflowPx(page, BLOCK, LANG),
+        lineHeightPx: await getBlockLineHeightPx(page, BLOCK, LANG),
+        pictureTopInBlockPx: rects.picture.y - rects.block.y,
+        blockHeightPx: rects.block.height,
+        blockWidthPx: rects.block.width,
+    };
+};
+
+/**
+ * A page with the picture in the full-width band as far down the text as the drag will take it,
+ * which is the state a shorter block cannot hold. Returns the page's id.
+ */
+const makePageWithAPictureLowInItsText = async (
+    page: Page,
+    title: string,
+): Promise<string> => {
+    await makeBookFromTemplate(page, "Basic Book");
+    await typeInGroup(page, ".bookTitle", "en", title);
+    await addPage(page, "Just Text");
+    const [contentPage] = await getContentPages(page);
+    await goToPage(page, contentPage.id);
+    await typeInGroup(page, BLOCK, LANG, TEXT);
+
+    imageId = await addInlineImage(page, BLOCK, LANG);
+    await changeInlineImagePicture(
+        page,
+        BLOCK,
+        LANG,
+        imageId,
+        fixtureImage("bird.png"),
+    );
+    await scrollBlockToTop(page, BLOCK, LANG);
+    await dragInlineImageToDock(page, BLOCK, LANG, imageId, "middle");
+    const roomAtStartPx = await getRoomBelowInlineImagePx(
+        page,
+        BLOCK,
+        LANG,
+        imageId,
+    );
+    await dragInlineImageDown(
+        page,
+        BLOCK,
+        LANG,
+        imageId,
+        Math.max(
+            40,
+            roomAtStartPx - (await getBlockLineHeightPx(page, BLOCK, LANG)),
+        ),
+    );
+    return contentPage.id;
+};
+
+test("a picture survives having its block cut in half in Change Layout mode [Test Case ID 815]", async ({
+    page,
+}) => {
+    test.setTimeout(300000);
+    await makePageWithAPictureLowInItsText(page, "Inline Images Origami");
+
+    const before = await wherePictureSits(page);
+    expect(
+        before.overflowPx,
+        "The block already held more text than it could show before the layout was changed.",
+    ).toBeLessThanOrEqual(0);
+
+    // THE ACTION UNDER TEST: split the text block's section in two, which leaves the text in the
+    // lower half of the height it had. Nothing about the page is written until the person leaves
+    // Change Layout mode -- that is when origami saves the page and asks Bloom to rebuild it --
+    // so the re-measure at page setup is what has to catch this.
+    await setChangeLayoutMode(page, true);
+    await splitSection(page, "top");
+    await setChangeLayoutMode(page, false);
+
+    const after = await wherePictureSits(page);
+    expect(
+        after.widthPercent,
+        "The picture did not survive the split at all.",
+    ).toBeGreaterThan(0);
+    expect(
+        after.blockHeightPx,
+        "The split did not shorten the block, so this test is not measuring what it means to.",
+    ).toBeLessThan(before.blockHeightPx - 10);
+    expect(
+        after.overflowPx,
+        `Splitting the block pushed ${Math.round(after.overflowPx)}px of text -- about ` +
+            `${(after.overflowPx / after.lineHeightPx).toFixed(1)} lines -- off the end of it, ` +
+            `which no drag could have done. The offset is ${Math.round(after.offsetPx)}px, ` +
+            `measured when the block was ${Math.round(before.blockHeightPx)}px tall, and the ` +
+            `block is now ${Math.round(after.blockHeightPx)}px tall.`,
+    ).toBeLessThanOrEqual(0);
+    expect(
+        after.pictureTopInBlockPx,
+        `Splitting the block put the top of the picture ${Math.round(after.pictureTopInBlockPx)}px ` +
+            `down a block only ${Math.round(after.blockHeightPx)}px tall.`,
+    ).toBeLessThan(after.blockHeightPx);
+});

--- a/src/BloomE2E/tests/inline-images-overflow.spec.ts
+++ b/src/BloomE2E/tests/inline-images-overflow.spec.ts
@@ -1,0 +1,329 @@
+// An inline image in a text block whose text does NOT fit the block.
+//
+// WHY THIS IS ITS OWN FILE. Every other inline-image test works in a block with room to spare,
+// which is the case the feature was built against. This one is about the opposite case, and it
+// follows the steps a person took with a real book: a picture placed on a full page, the page
+// then changed to a smaller size so that the text needed scrolling, and from then on the picture
+// could not be moved -- "it was just stuck there".
+//
+// WHY THE GESTURE HAS TO BE REAL. The rule that froze the picture is measured on the block's
+// scroll overflow after each move of the drag, so it exists only in a real layout: jsdom lays
+// nothing out, reports every box as empty and never scrolls. The vitest suite covers the
+// decision itself (shouldRevertInlineImageMove in inlineImageInteractions.test.ts); only a real
+// mouse in a real WebView2 shows whether a person can move the picture.
+//
+// WHY A SWEEP OF DRAGS RATHER THAN ONE. Whether a single move adds scroll overflow depends on
+// where the lines of text happen to fall, so one drag can get through even while the block is
+// unusable. A run of moves down and back up is what "I can put it where I want it" means, and it
+// is what tells the two rules apart: with the old rule at least one of these moves is undone,
+// and the drag helper says which one.
+
+import * as Path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Page } from "@playwright/test";
+import { expect, test } from "../fixtures/bloomTest";
+import {
+    addPage,
+    getContentPages,
+    goToPage,
+    makeBookFromTemplate,
+    typeInGroup,
+} from "../helpers/bookMaking";
+import {
+    addInlineImage,
+    beginInlineImageDrag,
+    changeInlineImagePicture,
+    dragInlineImageDown,
+    dragInlineImageUp,
+    endInlineImageDrag,
+    getBlockLineHeightPx,
+    getBlockScrollOverflowPx,
+    getBlockScrollTopPx,
+    getInlineImage,
+    getInlineImageRects,
+    moveInlineImageDragTo,
+    scrollBlockToTop,
+} from "../helpers/inlineImages";
+import { expectInside, IRect } from "../helpers/geometry";
+import { setPageSize } from "../helpers/pageSize";
+
+test.use({
+    collectionSpec: { name: "inline-images-overflow", languages: ["en"] },
+});
+
+test.describe.configure({ mode: "serial" });
+
+const BLOCK = ".bloom-translationGroup";
+const LANG = "en";
+
+// Enough text to fill a Just Text page at A5 and to overflow it at A6, which is the change that
+// put the person's book into the state this test is about.
+const TEXT = (
+    "The kingfisher waits on the branch above the pool, still enough that the water forgets it " +
+    "is there. It watches the shadows move under the surface. When it drops, it drops straight, " +
+    "and the pool closes over the place where it went in. A moment later it is back on the " +
+    "branch with a fish, and the water is still again. The children on the bank have learned " +
+    "to wait as well, and they do not talk while the bird is fishing. "
+).repeat(2);
+
+// The picture both tests work on. The second carries on from where the first leaves off, in the
+// same book on the same page, because building an overflowing A6 block takes most of the run.
+let imageId: string;
+
+const fixtureImage = (name: string) =>
+    Path.resolve(
+        Path.dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "fixtures",
+        "images",
+        name,
+    );
+
+test("a picture in a block whose text overflows can still be moved [Test Case ID 815]", async ({
+    page,
+}) => {
+    test.setTimeout(300000);
+    await makeBookFromTemplate(page, "Basic Book");
+    await typeInGroup(page, ".bookTitle", "en", "Inline Images Overflow");
+    await addPage(page, "Just Text");
+    const [contentPage] = await getContentPages(page);
+    await goToPage(page, contentPage.id);
+    await typeInGroup(page, BLOCK, LANG, TEXT);
+
+    imageId = await addInlineImage(page, BLOCK, LANG);
+    await changeInlineImagePicture(
+        page,
+        BLOCK,
+        LANG,
+        imageId,
+        fixtureImage("bird.png"),
+    );
+
+    // Down the block once while it still fits, so the same gesture is known to work before the
+    // page is made smaller. A failure here is not the bug this test is about.
+    await scrollBlockToTop(page, BLOCK, LANG);
+    const offsetWhileItFitsPx = await dragInlineImageDown(
+        page,
+        BLOCK,
+        LANG,
+        imageId,
+        60,
+    );
+    expect(offsetWhileItFitsPx).toBeGreaterThan(0);
+
+    // The step that caused the trouble: a smaller page, so the same text no longer fits.
+    await setPageSize(page, "A6Portrait");
+    await scrollBlockToTop(page, BLOCK, LANG);
+
+    // Sanity check the state the rest of the test rests on. Without this the test could pass in
+    // a block with room to spare and prove nothing.
+    expect(
+        await getBlockScrollOverflowPx(page, BLOCK, LANG),
+        "The block's text still fits at A6, so this test is not exercising an overflowing block.",
+    ).toBeGreaterThan(0);
+
+    // And that the gestures below will land on the picture: in a block this small the picture is
+    // easily scrolled out of view, and a drag aimed at where it is not reads as the picture
+    // refusing to move.
+    const rects = await getInlineImageRects(page, BLOCK, LANG, imageId);
+    expectInside(rects.picture, rects.block, "the picture", "the block");
+
+    // THE ACTION UNDER TEST: move the picture down the block and back up again, a step at a
+    // time. Each step changes how much room the text below the picture needs, which is what the
+    // old rule read as "this move made the block overflow" and undid.
+    const kStepPx = 50;
+    const kSteps = 4;
+    let offsetPx = (await getInlineImage(page, BLOCK, LANG, imageId)).offsetPx;
+    for (let step = 1; step <= kSteps; step++) {
+        const moved = await dragInlineImageDown(
+            page,
+            BLOCK,
+            LANG,
+            imageId,
+            kStepPx,
+        );
+        expect(moved, `Down step ${step} of ${kSteps}`).toBeGreaterThan(
+            offsetPx,
+        );
+        offsetPx = moved;
+    }
+    for (let step = 1; step <= kSteps; step++) {
+        const moved = await dragInlineImageUp(
+            page,
+            BLOCK,
+            LANG,
+            imageId,
+            kStepPx,
+        );
+        expect(moved, `Up step ${step} of ${kSteps}`).toBeLessThan(offsetPx);
+        offsetPx = moved;
+    }
+
+    // It stays where the last drag left it rather than springing back once the gesture ends.
+    expect((await getInlineImage(page, BLOCK, LANG, imageId)).offsetPx).toBe(
+        offsetPx,
+    );
+
+    // The block still does not fit its text, which is the state the whole test is about: the
+    // change under test loosened a rule for such a block, it did not make the text fit.
+    expect(await getBlockScrollOverflowPx(page, BLOCK, LANG)).toBeGreaterThan(
+        0,
+    );
+});
+
+/**
+ * Assert that the middle of the picture -- the point a drag keeps at the pointer -- is inside
+ * the part of the block that is on the screen.
+ *
+ * Not that the whole picture is. A drag moves the picture's MIDDLE to the pointer, so a pointer
+ * held just inside an edge puts the picture's far half over that edge however the block
+ * scrolls, and demanding the whole picture would be demanding that the block scroll further
+ * than the person pointed, which would run the text away from the cursor. What must not happen
+ * is the picture sliding away under the edge altogether, and its middle staying on the screen
+ * is exactly that.
+ */
+/**
+ * Where the block's scroll comes to rest while the pointer is held still, in the page's own
+ * pixels: two readings a beat apart that agree.
+ *
+ * "It scrolled at all" is too weak a question. Something else in the page nudges a block's
+ * scroll when an image inside it moves, so a single pixel of scroll proves nothing about a drag
+ * being followed; where the scroll ENDS UP while the person goes on holding the picture at the
+ * edge is what says whether they can reach the end of the text.
+ */
+const scrollTopWhereItSettles = async (
+    page: Page,
+    stillMs = 700,
+): Promise<number> => {
+    let previous = -1;
+    for (let read = 0; read < 40; read++) {
+        const now = await getBlockScrollTopPx(page, BLOCK, LANG);
+        if (now === previous) return now;
+        previous = now;
+        await page.waitForTimeout(stillMs);
+    }
+    return previous;
+};
+
+const expectPictureMiddleShowing = (
+    picture: IRect,
+    block: IRect,
+    when: string,
+) => {
+    const middleY = picture.y + picture.height / 2;
+    const where =
+        `${when} the middle of the picture was at y ${Math.round(middleY)}, and the part of the ` +
+        `block on the screen runs from ${Math.round(block.y)} to ` +
+        `${Math.round(block.y + block.height)}.`;
+    expect(middleY, where).toBeGreaterThanOrEqual(block.y);
+    expect(middleY, where).toBeLessThanOrEqual(block.y + block.height);
+};
+
+test("the block scrolls to follow the picture when it is dragged past an edge", async ({
+    page,
+}) => {
+    test.setTimeout(300000);
+    // Carries on from the test above, in the block that test made too small for its text. A
+    // block that fits has nothing to scroll, so this only means anything here.
+    expect(
+        await getBlockScrollOverflowPx(page, BLOCK, LANG),
+        "The block's text fits, so there is no scrolling for a drag to follow.",
+    ).toBeGreaterThan(0);
+    await scrollBlockToTop(page, BLOCK, LANG);
+    expect(await getBlockScrollTopPx(page, BLOCK, LANG)).toBe(0);
+
+    const atStart = await getInlineImageRects(page, BLOCK, LANG, imageId);
+
+    // THE ACTION UNDER TEST: hold the picture just inside the bottom edge of the block. Most of
+    // the text is below what the block can show, so carrying the picture on down means the block
+    // has to scroll; if it does not, the picture goes under the edge and the person loses sight
+    // of the thing they are dragging.
+    await beginInlineImageDrag(page, BLOCK, LANG, imageId);
+    await moveInlineImageDragTo(page, {
+        x: atStart.block.x + atStart.block.width / 2,
+        y: atStart.block.y + atStart.block.height - 8,
+    });
+    await expect
+        .poll(async () => getBlockScrollTopPx(page, BLOCK, LANG), {
+            timeout: 15000,
+            message:
+                "Holding the picture at the bottom edge of the block never scrolled the block, " +
+                "so the picture is being dragged into text the person cannot see.",
+        })
+        .toBeGreaterThan(0);
+    // And it goes on scrolling for as long as the picture is held there, until the picture has
+    // reached the end of the text: a block that stops part way is a block whose later lines the
+    // picture cannot be dragged to.
+    const overflowPx = await getBlockScrollOverflowPx(page, BLOCK, LANG);
+    const lineHeightPx = await getBlockLineHeightPx(page, BLOCK, LANG);
+    const settledLowPx = await scrollTopWhereItSettles(page);
+    expect(
+        settledLowPx,
+        `Holding the picture at the bottom edge scrolled the block to ${Math.round(settledLowPx)} ` +
+            `and stopped, ${Math.round(overflowPx - settledLowPx)}px short of the end of the ` +
+            `text at ${Math.round(overflowPx)} -- so the last ` +
+            `${((overflowPx - settledLowPx) / lineHeightPx).toFixed(1)} lines are out of reach.`,
+    ).toBeGreaterThanOrEqual(overflowPx - lineHeightPx);
+    const whileHeldLow = await getInlineImageRects(page, BLOCK, LANG, imageId);
+    expectPictureMiddleShowing(
+        whileHeldLow.picture,
+        whileHeldLow.block,
+        "While the picture was held at the bottom edge of the block,",
+    );
+    await endInlineImageDrag(page);
+    // And letting go leaves it showing: the drag ends where the block was scrolled to, so the
+    // picture the person has just put down is in front of them, not off the screen.
+    const afterHeldLow = await getInlineImageRects(page, BLOCK, LANG, imageId);
+    expectPictureMiddleShowing(
+        afterHeldLow.picture,
+        afterHeldLow.block,
+        "After the drag to the bottom edge ended,",
+    );
+
+    // And the same at the other edge: with the block now scrolled down, holding the picture at
+    // the top edge has to bring the text back up.
+    const scrolledDownPx = await getBlockScrollTopPx(page, BLOCK, LANG);
+    expect(scrolledDownPx).toBeGreaterThan(0);
+    const beforeUp = await getInlineImageRects(page, BLOCK, LANG, imageId);
+    await beginInlineImageDrag(page, BLOCK, LANG, imageId);
+    await moveInlineImageDragTo(page, {
+        x: beforeUp.block.x + beforeUp.block.width / 2,
+        y: beforeUp.block.y + 8,
+    });
+    await expect
+        .poll(async () => getBlockScrollTopPx(page, BLOCK, LANG), {
+            timeout: 15000,
+            message:
+                "Holding the picture at the top edge of the block never scrolled the block back " +
+                "up, so a picture dragged off the top cannot be seen.",
+        })
+        .toBeLessThan(scrolledDownPx);
+    // And likewise all the way back to the top of the text. What settles here is the PICTURE's
+    // own position in the text, not the block's scroll: the two part company at the top, because
+    // once the picture is at the start of the text there is nothing above it for the block to
+    // scroll to, and the block can be showing the picture flush against its top edge with a line
+    // or so of the text still above the window. The offset is the thing the person is setting.
+    const settledHighPx = await scrollTopWhereItSettles(page);
+    const highOffsetPx = (await getInlineImage(page, BLOCK, LANG, imageId))
+        .offsetPx;
+    expect(
+        highOffsetPx,
+        `Holding the picture at the top edge brought it back to an offset of ` +
+            `${Math.round(highOffsetPx)}px, ${(highOffsetPx / lineHeightPx).toFixed(1)} lines ` +
+            `below the start of the text, so those lines cannot be put above the picture. The ` +
+            `block's scroll settled at ${Math.round(settledHighPx)}.`,
+    ).toBeLessThanOrEqual(lineHeightPx);
+    const whileHeldHigh = await getInlineImageRects(page, BLOCK, LANG, imageId);
+    expectPictureMiddleShowing(
+        whileHeldHigh.picture,
+        whileHeldHigh.block,
+        "While the picture was held at the top edge of the block,",
+    );
+    await endInlineImageDrag(page);
+    const afterHeldHigh = await getInlineImageRects(page, BLOCK, LANG, imageId);
+    expectPictureMiddleShowing(
+        afterHeldHigh.picture,
+        afterHeldHigh.block,
+        "After the drag to the top edge ended,",
+    );
+});

--- a/src/BloomE2E/tests/inline-images-page-size.spec.ts
+++ b/src/BloomE2E/tests/inline-images-page-size.spec.ts
@@ -1,0 +1,208 @@
+// What happens to a picture's position down its block when the book is drawn at another size.
+//
+// WHAT THIS IS ABOUT. Of the three things that record an inline image's geometry, two are
+// relative -- `--inline-image-width` is a percent of the block and `--inline-image-aspect-ratio`
+// is a ratio -- and one, `--inline-image-offset`, is absolute layout pixels. Changing the book's
+// page size only swaps classes on the page div: no HTML is rewritten and no inline style is
+// touched, and the offset's clamp runs only during a drag, so nothing re-measures the offset
+// against a block that has just become shorter and narrower.
+//
+// So this asks what the person sees afterwards. The invariant worth holding is the one the drag
+// itself maintains: a move that would push the block into overflow is put back where it started
+// (shouldOccupyInlineImageMove / FIT OR REVERT). A page-size change reaches the same state the
+// drag refuses to create, and nothing will ever correct it -- the offset holds the picture the
+// same distance below the start of the text however short the block becomes, so the text that
+// follows the picture is pushed off the end.
+//
+// Canvas elements solve the same problem with `data-imgsizebasedon` and
+// adjustCanvasElementChildrenIfSizeChanged; inline images have no equivalent, which is why this
+// test exists.
+
+import * as Path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Page } from "@playwright/test";
+import { expect, test } from "../fixtures/bloomTest";
+import {
+    addPage,
+    getContentPages,
+    goToPage,
+    makeBookFromTemplate,
+    typeInGroup,
+} from "../helpers/bookMaking";
+import {
+    addInlineImage,
+    changeInlineImagePicture,
+    dragInlineImageDown,
+    dragInlineImageToDock,
+    getBlockLineHeightPx,
+    getBlockScrollOverflowPx,
+    getInlineImage,
+    getInlineImageRects,
+    getRoomBelowInlineImagePx,
+    blockIsMarkedOverflowing,
+    scrollBlockToTop,
+} from "../helpers/inlineImages";
+import {
+    getPageSize,
+    getPageSizeChoices,
+    setPageSize,
+} from "../helpers/pageSize";
+
+test.use({
+    collectionSpec: { name: "inline-images-page-size", languages: ["en"] },
+});
+
+test.describe.configure({ mode: "serial" });
+
+const BLOCK = ".bloom-translationGroup";
+const LANG = "en";
+
+// Enough text to give the block lines all the way down at A5, so there is somewhere to put the
+// picture, and enough that a smaller page will have to rewrap it.
+const TEXT =
+    "The kingfisher waits on the branch above the pool, still enough that the water forgets it " +
+    "is there. It watches the shadows move under the surface. When it drops, it drops straight, " +
+    "and the pool closes over the place where it went in. A moment later it is back on the " +
+    "branch with a fish, and the water is still again. The children on the bank have learned " +
+    "to wait as well, and they do not talk while the bird is fishing.";
+
+const fixtureImage = (name: string) =>
+    Path.resolve(
+        Path.dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "fixtures",
+        "images",
+        name,
+    );
+
+let imageId: string;
+
+/** Everything about where the picture sits, in one reading, for comparing across page sizes. */
+const wherePictureSits = async (page: Page) => {
+    const image = await getInlineImage(page, BLOCK, LANG, imageId);
+    const rects = await getInlineImageRects(page, BLOCK, LANG, imageId);
+    const lineHeightPx = await getBlockLineHeightPx(page, BLOCK, LANG);
+    return {
+        pageSize: await getPageSize(page),
+        dock: image.dock,
+        offsetPx: image.offsetPx,
+        widthPercent: image.widthPercent,
+        roomBelowPx: await getRoomBelowInlineImagePx(
+            page,
+            BLOCK,
+            LANG,
+            imageId,
+        ),
+        overflowPx: await getBlockScrollOverflowPx(page, BLOCK, LANG),
+        markedOverflowing: await blockIsMarkedOverflowing(page, BLOCK, LANG),
+        lineHeightPx,
+        // How far down the block's own window the picture is drawn, which is what the person sees.
+        pictureTopInBlockPx: rects.picture.y - rects.block.y,
+        blockHeightPx: rects.block.height,
+        blockWidthPx: rects.block.width,
+    };
+};
+
+test("a picture stays inside its block when the book is drawn at another size [Test Case ID 815]", async ({
+    page,
+}) => {
+    test.setTimeout(300000);
+    await makeBookFromTemplate(page, "Basic Book");
+    await typeInGroup(page, ".bookTitle", "en", "Inline Images Page Size");
+    await addPage(page, "Just Text");
+    const [contentPage] = await getContentPages(page);
+    await goToPage(page, contentPage.id);
+    await typeInGroup(page, BLOCK, LANG, TEXT);
+
+    imageId = await addInlineImage(page, BLOCK, LANG);
+    await changeInlineImagePicture(
+        page,
+        BLOCK,
+        LANG,
+        imageId,
+        fixtureImage("bird.png"),
+    );
+
+    // The full-width band is the dock whose position down the block is a distance, so it is the
+    // one an absolute offset can strand.
+    await scrollBlockToTop(page, BLOCK, LANG);
+    await dragInlineImageToDock(page, BLOCK, LANG, imageId, "middle");
+    // As far down the block as the drag will take it. A person filling an A5 page puts the
+    // picture near the end of their text, which is the largest offset the block allows -- and an
+    // absolute offset measured against the tallest page is the one a shorter page cannot hold.
+    // A modest offset (145px) survived every size, because line height does not change with page
+    // size, so the same offset leaves the same number of lines above the picture; what runs out
+    // is the room below it, and only a large offset runs it out.
+    const roomAtStartPx = await getRoomBelowInlineImagePx(
+        page,
+        BLOCK,
+        LANG,
+        imageId,
+    );
+    await dragInlineImageDown(
+        page,
+        BLOCK,
+        LANG,
+        imageId,
+        Math.max(
+            40,
+            roomAtStartPx - (await getBlockLineHeightPx(page, BLOCK, LANG)),
+        ),
+    );
+
+    const atA5 = await wherePictureSits(page);
+    expect(
+        atA5.dock,
+        "The setup did not leave the picture in the full-width band, so this test is measuring the wrong thing.",
+    ).toBe("middle");
+    expect(
+        atA5.offsetPx,
+        "The setup did not move the picture down the block, so there is no offset for a size change to strand.",
+    ).toBeGreaterThan(40);
+    // Sanity check on the starting state: the drag's own clamp holds this, and it is the thing
+    // the size change is being asked not to break.
+    expect(
+        atA5.roomBelowPx,
+        "The picture was already past the end of the block's content before any size change, so the drag itself is at fault, not the size change.",
+    ).toBeGreaterThan(-2);
+    // The state every assertion below is about not losing. The drag guarantees this: it puts a
+    // move back where it started rather than let the block overflow.
+    expect(
+        atA5.overflowPx,
+        "The block already held more text than it could show before any size change, so there is nothing for the size change to be blamed for.",
+    ).toBeLessThanOrEqual(0);
+
+    // THE ACTION UNDER TEST, at each size this book offers that changes the block's shape.
+    const sizes = (await getPageSizeChoices(page)).choices.map((c) => c.id);
+    for (const size of ["A6Portrait", "A5Landscape"].filter((s) =>
+        sizes.includes(s),
+    )) {
+        await setPageSize(page, size);
+        await scrollBlockToTop(page, BLOCK, LANG);
+        const after = await wherePictureSits(page);
+        expect(
+            after.overflowPx,
+            `Drawing the book at ${size} pushed ${Math.round(after.overflowPx)}px of text -- ` +
+                `about ${(after.overflowPx / after.lineHeightPx).toFixed(1)} lines -- off the end ` +
+                `of the block, which no drag could have done: a move that would overflow the ` +
+                `block is put back where it started. The offset is still ` +
+                `${Math.round(after.offsetPx)}px, measured when the block was ` +
+                `${Math.round(atA5.blockHeightPx)}px tall and ${Math.round(atA5.blockWidthPx)}px ` +
+                `wide, and it is now ${Math.round(after.blockHeightPx)}px by ` +
+                `${Math.round(after.blockWidthPx)}px.`,
+        ).toBeLessThanOrEqual(0);
+        // markedOverflowing is in the reading above rather than asserted here because it comes
+        // back FALSE: Bloom does not warn about this. OverflowChecker treats a block it has
+        // allowed to scroll as not overflowing, so the person is given no sign that the lines
+        // after the picture have gone -- which is why the arithmetic above is what this asserts.
+        // And what the person actually sees: the picture is still somewhere in the block's window,
+        // not below it needing a scroll to find.
+        expect(
+            after.pictureTopInBlockPx,
+            `Drawing the book at ${size} put the top of the picture ` +
+                `${Math.round(after.pictureTopInBlockPx)}px down a block only ` +
+                `${Math.round(after.blockHeightPx)}px tall, so the person has to scroll to find ` +
+                `the picture they placed.`,
+        ).toBeLessThan(after.blockHeightPx);
+    }
+});

--- a/src/BloomE2E/tests/inline-images-paste.spec.ts
+++ b/src/BloomE2E/tests/inline-images-paste.spec.ts
@@ -1,0 +1,259 @@
+// Copying text that contains a picture, and pasting it.
+//
+// WHAT THIS IS ABOUT. Bloom's own paste handler bails out whenever the focus is in a
+// bloom-editable (bloomEditing.ts), so a paste inside a text block is CKEditor's. CKEditor's
+// pasteFilter (lib/ckeditor/config.js) applies only to content from OUTSIDE the editor; an
+// internal paste falls back to allowedContent = true. So the wrapper markup pastes through
+// unfiltered, and what arrives is a second element carrying the FIRST one's
+// data-bloom-inline-image-id.
+//
+// Identity is what the feature is built on. syncInlineImagesFromEditable matches the copies of a
+// picture across the group's editables by that id, and getInlineImageById returns the first match,
+// so a second element with the same id is a picture that can never be kept in step with its own
+// copies in the other languages: it diverges from the moment it exists, and nothing in the editor
+// will ever bring it back.
+//
+// Two pastes are worth asking about and they have different answers available: into the same
+// block, and into a different block on the same page. Either "no second picture appears" or "the
+// second picture gets its own id" would be a sound outcome; two elements sharing one id is not.
+
+import * as Path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "../fixtures/bloomTest";
+import * as fs from "node:fs";
+import {
+    addPage,
+    findBookFolder,
+    getContentPages,
+    getPages,
+    goToPage,
+    makeBookFromTemplate,
+    typeInGroup,
+} from "../helpers/bookMaking";
+import { bookHtmlPath } from "../helpers/bookHtml";
+import {
+    addInlineImage,
+    changeInlineImagePicture,
+    getInlineImages,
+} from "../helpers/inlineImages";
+
+test.use({
+    collectionSpec: { name: "inline-images-paste", languages: ["en"] },
+});
+
+test.describe.configure({ mode: "serial" });
+
+const BLOCK = ".bloom-translationGroup";
+const LANG = "en";
+
+const TEXT =
+    "The kingfisher waits on the branch above the pool, still enough that the water forgets it " +
+    "is there.";
+
+const fixtureImage = (name: string) =>
+    Path.resolve(
+        Path.dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "fixtures",
+        "images",
+        name,
+    );
+
+/** Every inline image in the group, flattened, with the block it is in. */
+const allImages = async (page: import("@playwright/test").Page) =>
+    (await getInlineImages(page, BLOCK)).flatMap((block) => block.images);
+
+test("pasting text that contains a picture does not produce two pictures with one identity [Test Case ID 815]", async ({
+    page,
+}) => {
+    test.setTimeout(300000);
+    await makeBookFromTemplate(page, "Basic Book");
+    await typeInGroup(page, ".bookTitle", "en", "Inline Images Paste");
+    await addPage(page, "Just Text");
+    const [contentPage] = await getContentPages(page);
+    await goToPage(page, contentPage.id);
+    await typeInGroup(page, BLOCK, LANG, TEXT);
+
+    const imageId = await addInlineImage(page, BLOCK, LANG);
+    await changeInlineImagePicture(
+        page,
+        BLOCK,
+        LANG,
+        imageId,
+        fixtureImage("bird.png"),
+    );
+    const before = await allImages(page);
+    expect(
+        before.length,
+        "The setup put no picture in the block, so there is nothing for the paste to copy.",
+    ).toBeGreaterThan(0);
+
+    // THE ACTION UNDER TEST: a paste of the block's own markup, wrapper included, delivered as
+    // the paste event CKEditor listens for. Real Ctrl+C / Ctrl+V key presses do not do it here:
+    // the keys arrive, but nothing lands, because the OS clipboard is not filled by CDP key
+    // events. What matters for this question is not the clipboard but the paste PIPELINE --
+    // Bloom's handler, which stands aside for a bloom-editable, and then CKEditor's pasteFilter,
+    // which treats internal content as unfiltered -- and that is exactly what this reaches.
+    const block = page
+        .frameLocator("#page")
+        .locator(`${BLOCK} > .bloom-editable[lang="${LANG}"]`)
+        .first();
+    await block.click();
+    const textBefore = ((await block.textContent()) ?? "").length;
+    const pastedHtml = await block.evaluate((editable) => editable.innerHTML);
+    expect(
+        pastedHtml,
+        "The markup about to be pasted holds no picture, so this test is measuring nothing.",
+    ).toContain("bloom-inlineImage");
+    await block.evaluate((editable, html) => {
+        const transfer = new DataTransfer();
+        transfer.setData("text/html", html);
+        transfer.setData("text/plain", editable.textContent ?? "");
+        // At the end of the text, which is where a person pastes when they mean "again".
+        const selection = editable.ownerDocument.getSelection()!;
+        const range = editable.ownerDocument.createRange();
+        range.selectNodeContents(editable);
+        range.collapse(false);
+        selection.removeAllRanges();
+        selection.addRange(range);
+        editable.dispatchEvent(
+            new ClipboardEvent("paste", {
+                bubbles: true,
+                cancelable: true,
+                clipboardData: transfer,
+            }),
+        );
+    }, pastedHtml);
+    // The paste is asynchronous in CKEditor, and so is anything the page does about it, so wait
+    // for the block's text to have grown: that is the paste having landed, and it is what the
+    // next assertion is about anyway.
+    await expect
+        .poll(async () => ((await block.textContent()) ?? "").length, {
+            timeout: 30000,
+            message:
+                `The paste never changed the block's text, so nothing was pasted and this test ` +
+                `is measuring nothing. Ctrl+A inside a contenteditable may not have selected ` +
+                `what was expected.`,
+        })
+        .toBeGreaterThan(textBefore);
+
+    const textAfter = ((await block.textContent()) ?? "").length;
+    expect(
+        textAfter,
+        `The paste did not change the block's text (still ${textAfter} characters), so nothing ` +
+            `was pasted and this test is measuring nothing. Ctrl+A inside a contenteditable may ` +
+            `not have selected what was expected.`,
+    ).toBeGreaterThan(textBefore);
+
+    const after = await allImages(page);
+    const byId = new Map<string, number>();
+    for (const image of after)
+        byId.set(image.id, (byId.get(image.id) ?? 0) + 1);
+    // One copy of the picture per editable of the group is the design: that is how a float can
+    // wrap the text of each language's block. So the count to watch is per editable.
+    const duplicatedWithinAnEditable = (
+        await getInlineImages(page, BLOCK)
+    ).flatMap((editable) => {
+        const seen = new Map<string, number>();
+        for (const image of editable.images)
+            seen.set(image.id, (seen.get(image.id) ?? 0) + 1);
+        return [...seen.entries()]
+            .filter(([, count]) => count > 1)
+            .map(([id, count]) => `${editable.languageTag}: ${count} of ${id}`);
+    });
+
+    expect(
+        duplicatedWithinAnEditable,
+        `Pasting text that contained the picture put more than one element with the same ` +
+            `data-bloom-inline-image-id into one block: ${duplicatedWithinAnEditable.join("; ")}. ` +
+            `That id is how the copies of a picture are matched across the group's languages, and ` +
+            `getInlineImageById returns the first match, so the second element can never be kept ` +
+            `in step with anything and nothing in the editor will repair it.`,
+    ).toEqual([]);
+});
+
+test("pasting a picture into a front-matter field does not put markup in the data div [Test Case ID 815]", async ({
+    page,
+}) => {
+    test.setTimeout(300000);
+    // The menu no longer offers "Add Image" in a data-book field, because that field is stored in
+    // the data div as markup and written back into every element with the same key -- which made
+    // the wrapper's markup the book's title. Hiding the command closes one door. A paste is the
+    // other, and it does not go through the menu at all, so it has to be asked separately.
+    const block = page
+        .frameLocator("#page")
+        .locator(`${BLOCK} > .bloom-editable[lang="${LANG}"]`)
+        .first();
+    const markupWithAPicture = await block.evaluate(
+        (editable) => editable.innerHTML,
+    );
+    expect(
+        markupWithAPicture,
+        "The markup to paste holds no picture, so this test is measuring nothing.",
+    ).toContain("bloom-inlineImage");
+
+    const coverId = (await getPages(page)).find((p) => !p.isContentPage)!.id;
+    await goToPage(page, coverId);
+    // The cover credits rather than the title: it is a data-book field on the same xmatter page,
+    // so it asks the same question, and pasting into it does not change the book's name, which
+    // the collection and the book's folder are both keyed on.
+    const title = page
+        .frameLocator("#page")
+        .locator(
+            `.creditsRow .bloom-translationGroup > .bloom-editable[lang="${LANG}"]`,
+        )
+        .first();
+    await title.click();
+    const creditsBefore = await title.evaluate((e) => e.innerHTML);
+    await title.evaluate((editable, html) => {
+        const transfer = new DataTransfer();
+        transfer.setData("text/html", html);
+        transfer.setData("text/plain", "pasted");
+        const selection = editable.ownerDocument.getSelection()!;
+        const range = editable.ownerDocument.createRange();
+        range.selectNodeContents(editable);
+        range.collapse(false);
+        selection.removeAllRanges();
+        selection.addRange(range);
+        editable.dispatchEvent(
+            new ClipboardEvent("paste", {
+                bubbles: true,
+                cancelable: true,
+                clipboardData: transfer,
+            }),
+        );
+    }, markupWithAPicture);
+    // As above: wait for the paste to have landed rather than for a length of time. The credits
+    // field's markup changing is that, whatever the paste turned into.
+    await expect
+        .poll(async () => await title.evaluate((e) => e.innerHTML), {
+            timeout: 30000,
+            message:
+                "The paste never changed the credits field, so nothing was pasted and this " +
+                "test is measuring nothing.",
+        })
+        .not.toBe(creditsBefore);
+
+    // Leaving the page is what makes Bloom save it, and the collection learns the title then.
+    const [contentPage] = await getContentPages(page);
+    await goToPage(page, contentPage.id);
+    const html = fs.readFileSync(
+        bookHtmlPath(await findBookFolder(page, "Inline Images Paste")),
+        "utf8",
+    );
+    const storedCredits = (html.match(
+        /<div[^>]*data-book="smallCoverCredits"[^>]*lang="en"[^>]*>([\s\S]*?)<\/div>/,
+    ) ?? [, ""])[1].trim();
+    expect(
+        storedCredits,
+        `Pasting a picture into a front-matter field put its markup into the data div, which is ` +
+            `where that field is stored and from which it is written back into every element ` +
+            `with the same data-book key. It reads: ${storedCredits.slice(0, 300)}`,
+    ).not.toContain("bloom-inlineImage");
+    // And nowhere else in the saved book either: the data div is written back into every element
+    // carrying the same key, so one wrapper stored there becomes several on the pages.
+    expect(
+        (html.match(/data-bloom-inline-image-id/g) ?? []).length,
+        "Pasting into front matter left inline image wrappers on the xmatter pages.",
+    ).toBe(2);
+});

--- a/src/BloomE2E/tests/inline-images-release-outside.spec.ts
+++ b/src/BloomE2E/tests/inline-images-release-outside.spec.ts
@@ -1,0 +1,148 @@
+// What happens when the person lets go of the mouse somewhere other than the page.
+//
+// WHAT THIS IS ABOUT. A drag of an inline image listens for pointermove and pointerup on the
+// PAGE IFRAME's document (addPointerListeners), and nothing in Bloom calls setPointerCapture. A
+// person dragging a picture upward runs out of page long before they run out of gesture: above
+// the page is Bloom's own toolbar, which is the top-level document, not the page's.
+//
+// WHAT THIS TEST MEASURED. The gesture survives it. Dragged to (8, 8) in the top-level document,
+// the drag is still under way -- so the pointermoves reached the page's document even though the
+// pointer was over a different one -- and the release there ends it, commits, and syncs the
+// copies. That is Chromium's mouse capture: while a button is down, the events go to the frame
+// where the press happened, whatever they are over. So the page iframe boundary, which is the one
+// boundary a person can cross with the button held inside Bloom's window, needs no
+// setPointerCapture.
+//
+// WHAT IT DOES NOT COVER, and cannot: a release outside the WebView2 window altogether. Playwright
+// drives the mouse through the browser, so there is no "outside the window" for it to release in
+// (AUTOMATION-DEBT.md: "WinForms surfaces cannot be driven"). What would be left behind there is
+// worth knowing: dragState still set, the body still carrying the dragging class, and the 50ms
+// edge-scroll interval still re-applying the move from a pointer position nothing updates.
+//
+// So this test is here as the guard on the boundary that IS reachable. If a later change moves
+// these listeners to the wrapper, or to the top-level document, this is what says so.
+
+import * as Path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "../fixtures/bloomTest";
+import {
+    addPage,
+    getContentPages,
+    goToPage,
+    makeBookFromTemplate,
+    typeInGroup,
+} from "../helpers/bookMaking";
+import {
+    addInlineImage,
+    beginInlineImageDrag,
+    changeInlineImagePicture,
+    dragInlineImageToDock,
+    getInlineImage,
+    getInlineImages,
+    inlineImageDragIsInProgress,
+    moveInlineImageDragTo,
+    scrollBlockToTop,
+} from "../helpers/inlineImages";
+
+test.use({
+    collectionSpec: {
+        name: "inline-images-release-outside",
+        languages: ["en"],
+    },
+});
+
+test.describe.configure({ mode: "serial" });
+
+const BLOCK = ".bloom-translationGroup";
+const LANG = "en";
+
+const TEXT =
+    "The kingfisher waits on the branch above the pool, still enough that the water forgets it " +
+    "is there. It watches the shadows move under the surface. When it drops, it drops straight, " +
+    "and the pool closes over the place where it went in.";
+
+const fixtureImage = (name: string) =>
+    Path.resolve(
+        Path.dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "fixtures",
+        "images",
+        name,
+    );
+
+test("letting go of the mouse outside the page still ends the drag [Test Case ID 815]", async ({
+    page,
+}) => {
+    test.setTimeout(300000);
+    await makeBookFromTemplate(page, "Basic Book");
+    await typeInGroup(
+        page,
+        ".bookTitle",
+        "en",
+        "Inline Images Release Outside",
+    );
+    await addPage(page, "Just Text");
+    const [contentPage] = await getContentPages(page);
+    await goToPage(page, contentPage.id);
+    await typeInGroup(page, BLOCK, LANG, TEXT);
+
+    const imageId = await addInlineImage(page, BLOCK, LANG);
+    await changeInlineImagePicture(
+        page,
+        BLOCK,
+        LANG,
+        imageId,
+        fixtureImage("bird.png"),
+    );
+    await scrollBlockToTop(page, BLOCK, LANG);
+    await dragInlineImageToDock(page, BLOCK, LANG, imageId, "middle");
+
+    // THE ACTION UNDER TEST. Take hold of the picture, drag it clear of the page iframe -- (8, 8)
+    // in the top-level document is Bloom's own chrome, well above where the page starts -- and let
+    // go there. The assertion in between is the interesting one: it says the moves are still
+    // arriving at the page's document while the pointer is over a different one.
+    await beginInlineImageDrag(page, BLOCK, LANG, imageId);
+    await moveInlineImageDragTo(page, { x: 8, y: 8 });
+    expect(
+        await inlineImageDragIsInProgress(page),
+        "Dragging the pointer out of the page iframe ended the drag on its own. While a mouse " +
+            "button is down Chromium delivers the events to the frame where the press happened, " +
+            "so the moves should still be reaching the page's document.",
+    ).toBe(true);
+    await page.mouse.up();
+
+    await expect
+        .poll(() => inlineImageDragIsInProgress(page), {
+            message:
+                "Letting go of the mouse outside the page left the drag running: the page still " +
+                "has the dragging class, so dragState is still set, the context controls are " +
+                "still in their moving state, and the 50ms edge-scroll interval is still " +
+                "re-applying the move. Nothing would ever end it, and the person's next click " +
+                "could reach a save. The pointerup needs to arrive at the document the " +
+                "listeners are on, which is the page's, not the one the pointer is over.",
+            timeout: 10000,
+        })
+        .toBe(false);
+
+    // And the gesture has to have finished properly, not just stopped: the change is committed to
+    // every copy of the picture. The copies are only ever synced at the end of a gesture, so if
+    // they agree, the end ran.
+    const settled = await getInlineImage(page, BLOCK, LANG, imageId);
+    const copies = (await getInlineImages(page, BLOCK))
+        .flatMap((block) => block.images)
+        .filter((image) => image.id === imageId);
+    for (const copy of copies)
+        expect(
+            copy.offsetPx,
+            `The "${copy.languageTag}" copy is at ${copy.offsetPx}px while the "${LANG}" copy is ` +
+                `at ${settled.offsetPx}px. The copies are synced at the end of a gesture, so ` +
+                `disagreeing copies mean the end never ran.`,
+        ).toBe(settled.offsetPx);
+
+    // And the picture stayed in the block, wherever the pointer went. A pointer above the page is
+    // asking for the top of the text, not for somewhere off it.
+    expect(
+        settled.offsetPx,
+        `The picture ended up at ${settled.offsetPx}px, which is above the start of its block.`,
+    ).toBeGreaterThanOrEqual(0);
+});

--- a/src/BloomE2E/tests/inline-images-spreadsheet.spec.ts
+++ b/src/BloomE2E/tests/inline-images-spreadsheet.spec.ts
@@ -1,0 +1,166 @@
+// An inline (Word-style) image has to survive a spreadsheet round trip. The feature is described
+// in INLINE-IMAGES-PLAN.md.
+//
+// WHY THIS IS WORTH AN E2E TEST. A spreadsheet holds one row per text block. An image inside a
+// text block is the one thing a round trip could silently drop, because there is no column for it:
+// the exporter writes an [inline image] row of its own and the geometry as JSON in a hidden
+// column, and the importer builds the wrapper again from those. That is covered in C# by
+// src/BloomTests/Spreadsheet/SpreadsheetInlineImageTests.cs, at the level of the exporter and the
+// importer. What is left, and what this file covers, is the two menu commands and the real file
+// passing between them: a real .xlsx that Bloom wrote, chosen through the real Import command.
+//
+// The identity attribute is deliberately NOT asserted across the round trip. The importer builds
+// a new wrapper and gives it a fresh data-bloom-inline-image-id, because nothing outside the page
+// refers to that id; what has to survive is the picture and its geometry.
+
+import * as Path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "../fixtures/bloomTest";
+import {
+    addPage,
+    findBookFolder,
+    getContentPages,
+    getPages,
+    goToPage,
+    makeBookFromTemplate,
+    typeInGroup,
+} from "../helpers/bookMaking";
+import { kEnterpriseSubscriptionCode } from "../helpers/collectionSettings";
+import {
+    addInlineImage,
+    changeInlineImagePicture,
+    deleteInlineImage,
+    dragInlineImageToDock,
+    getInlineImage,
+    getInlineImages,
+    resizeInlineImage,
+} from "../helpers/inlineImages";
+import {
+    exportBookToSpreadsheet,
+    importSpreadsheetIntoBook,
+} from "../helpers/spreadsheet";
+import { switchTab } from "../helpers/workspace";
+
+// Exporting and importing spreadsheets needs a subscription tier of LocalCommunity or better, so
+// the collection is launched with a subscription code.
+test.use({
+    collectionSpec: {
+        name: "inline-images-spreadsheet",
+        languages: ["en"],
+        subscriptionCode: kEnterpriseSubscriptionCode,
+    },
+});
+
+test.describe.configure({ mode: "serial" });
+
+const BLOCK = ".bloom-translationGroup";
+const LANG = "en";
+const BOOK_TITLE = "Inline Images Spreadsheet";
+const TEXT =
+    "The kingfisher waits on the branch above the pool, still enough that the water forgets " +
+    "it is there. When it drops, it drops straight, and the pool closes over the place where " +
+    "it went in. The children on the bank have learned to wait as well.";
+
+const fixtureImage = (name: string) =>
+    Path.resolve(
+        Path.dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "fixtures",
+        "images",
+        name,
+    );
+
+test("an inline image survives a spreadsheet round trip [Test Case ID 815]", async ({
+    page,
+    bloomApp,
+}) => {
+    test.setTimeout(300000);
+
+    await makeBookFromTemplate(page, "Basic Book");
+    await typeInGroup(page, ".bookTitle", "en", BOOK_TITLE);
+    await addPage(page, "Just Text");
+    const [contentPage] = await getContentPages(page);
+    await goToPage(page, contentPage.id);
+    await typeInGroup(page, BLOCK, LANG, TEXT);
+    const bookFolder = await findBookFolder(page, BOOK_TITLE);
+
+    // A picture with geometry of its own, so that a round trip which merely put a picture back
+    // could not pass: it is docked left, not at the default right, and it is wider than the
+    // default 40%.
+    const imageId = await addInlineImage(page, BLOCK, LANG);
+    await changeInlineImagePicture(
+        page,
+        BLOCK,
+        LANG,
+        imageId,
+        fixtureImage("bird.png"),
+    );
+    await dragInlineImageToDock(page, BLOCK, LANG, imageId, "left");
+    await resizeInlineImage(page, BLOCK, LANG, imageId, "se", 60);
+    const before = await getInlineImage(page, BLOCK, LANG, imageId);
+    expect(before.widthPercent).toBeGreaterThan(40);
+
+    // Bloom writes a page only when the book leaves it, so this is the save the export reads.
+    const [firstXmatter] = (await getPages(page)).filter(
+        (one) => !one.isContentPage,
+    );
+    await goToPage(page, firstXmatter.id);
+
+    // THE FIRST ACTION UNDER TEST: the export. Under --e2e it writes the file and says where it
+    // put it, instead of opening it in the machine's spreadsheet program.
+    const spreadsheet = await exportBookToSpreadsheet(
+        page,
+        Path.join(bloomApp.collectionDir, "spreadsheet-exports"),
+    );
+    expect(spreadsheet.endsWith(".xlsx")).toBe(true);
+
+    // Take the image out of the book, so that finding it afterwards can only mean the spreadsheet
+    // carried it. Without this step an import that changed nothing would pass. The export left the
+    // Collection tab showing, so go back to editing first.
+    await switchTab(page, "edit");
+    await goToPage(page, contentPage.id);
+    await deleteInlineImage(page, BLOCK, LANG, imageId);
+    expect(
+        (await getInlineImages(page, BLOCK)).flatMap((block) => block.images),
+    ).toEqual([]);
+    await goToPage(page, firstXmatter.id);
+
+    // THE SECOND ACTION UNDER TEST: a real "Import Content from Spreadsheet..." on the book's
+    // context menu, answering its file chooser with the file the export just wrote.
+    await importSpreadsheetIntoBook(page, bookFolder, spreadsheet);
+
+    await switchTab(page, "edit");
+    const [pageAfterImport] = await getContentPages(page);
+    await goToPage(page, pageAfterImport.id);
+
+    const blocks = await getInlineImages(page, BLOCK);
+    const copies = blocks.flatMap((block) => block.images);
+    expect(
+        copies.length,
+        "The import put no inline image back in the block. The spreadsheet's [inline image] row " +
+            "or its hidden geometry column did not survive the trip through the file.",
+    ).toBeGreaterThan(0);
+
+    // Every block of the group has one copy again, and they share one identity, which is what the
+    // edit-time sync needs. The id itself is a new one; see the note at the top of this file.
+    expect(blocks.map((block) => block.images.length)).toEqual(
+        blocks.map(() => 1),
+    );
+    expect(new Set(copies.map((copy) => copy.id)).size).toBe(1);
+
+    for (const copy of copies) {
+        expect(copy.dock, "The dock did not survive the round trip.").toBe(
+            "left",
+        );
+        expect(
+            copy.widthPercent,
+            "The width did not survive the round trip.",
+        ).toBe(before.widthPercent);
+        expect(copy.fileName).toBe("bird.png");
+        expect(copy.contentEditable).toBe("false");
+    }
+    // The text of the block came back as well, and the picture still leads it.
+    const shown = await getInlineImage(page, BLOCK, LANG, copies[0].id);
+    expect(shown.slot.index).toBe(0);
+    expect(shown.slot.childCount).toBeGreaterThan(1);
+});

--- a/src/BloomE2E/tests/inline-images-undo-keyboard.spec.ts
+++ b/src/BloomE2E/tests/inline-images-undo-keyboard.spec.ts
@@ -1,0 +1,165 @@
+// What Ctrl+Z does to an inline image, as opposed to what the top-bar Undo button does.
+//
+// WHAT THIS IS ABOUT. The inline-image undo stack is reached from workspaceRoot.handleUndo, and
+// the only thing that calls handleUndo is the top-bar Undo button (editTopBarControls posts
+// editView/topBarButtonClick, EditingViewApi passes it back to bloomEditing.topBarButtonClick) --
+// plus origami's own Ctrl+Z handler, which is bound only while Change Layout mode is on. So the
+// existing undo test, which calls handleUndo, takes the path a person does not take.
+//
+// Two claims in this harness say Ctrl+Z is a WinForms accelerator that never reaches the page
+// (helpers/keys.ts and helpers/workspace.ts). Nothing in src/BloomExe binds it: there is no
+// ProcessCmdKey case, no menu ShortcutKeys, and the UndoCommand's Implementer in
+// WebView2Browser.SetEditingCommands is an empty lambda. So this test asks the browser rather
+// than the comments, and it asks it twice: once about text, which says whether the key arrives at
+// all, and once about a picture, which is what the feature cares about.
+
+import * as Path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "../fixtures/bloomTest";
+import {
+    addPage,
+    getContentPages,
+    goToPage,
+    makeBookFromTemplate,
+    typeInGroup,
+} from "../helpers/bookMaking";
+import {
+    addInlineImage,
+    changeInlineImagePicture,
+    getInlineImage,
+    getInlineImages,
+    resizeInlineImage,
+    selectInlineImage,
+} from "../helpers/inlineImages";
+import { pressKey, typeWithKeys } from "../helpers/keys";
+
+test.use({
+    collectionSpec: { name: "inline-images-undo-keyboard", languages: ["en"] },
+});
+
+test.describe.configure({ mode: "serial" });
+
+const BLOCK = ".bloom-translationGroup";
+const LANG = "en";
+
+const TEXT =
+    "The kingfisher waits on the branch above the pool, still enough that the water forgets it " +
+    "is there. It watches the shadows move under the surface.";
+
+const fixtureImage = (name: string) =>
+    Path.resolve(
+        Path.dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "fixtures",
+        "images",
+        name,
+    );
+
+const blockLocator = (page: import("@playwright/test").Page) =>
+    page
+        .frameLocator("#page")
+        .locator(`${BLOCK} > .bloom-editable[lang="${LANG}"]`)
+        .first();
+
+test("Ctrl+Z reaches the page, and takes back the last change to a picture [Test Case ID 815]", async ({
+    page,
+}) => {
+    test.setTimeout(300000);
+    await makeBookFromTemplate(page, "Basic Book");
+    await typeInGroup(page, ".bookTitle", "en", "Inline Images Undo Keyboard");
+    await addPage(page, "Just Text");
+    const [contentPage] = await getContentPages(page);
+    await goToPage(page, contentPage.id);
+    await typeInGroup(page, BLOCK, LANG, TEXT);
+
+    // FIRST QUESTION: does the key arrive in the page at all? Real key presses, because CKEditor's
+    // undo plugin only ever sees a keystroke, and typeInGroup inserts text without one.
+    const block = blockLocator(page);
+    await block.click();
+    await page.keyboard.press("Control+End");
+    await typeWithKeys(page, " And then a word nobody wanted.");
+    const textWithTheExtraWords = (await block.textContent()) ?? "";
+    expect(
+        textWithTheExtraWords,
+        "The typing did not land, so this test cannot say what undoing it would do.",
+    ).toContain("nobody wanted");
+    await pressKey(page, "Control+z");
+    // CKEditor's undo plugin restores a saved snapshot of the editable, which it does after the
+    // keystroke rather than during it, so this waits for the words to go rather than for a time.
+    await expect
+        .poll(async () => (await block.textContent()) ?? "", {
+            message:
+                `Ctrl+Z did not take back the typing, so the key is not reaching the page's ` +
+                `CKEditor at all -- which is the premise of everything below.`,
+            timeout: 10000,
+        })
+        .not.toContain("nobody wanted");
+
+    // SECOND QUESTION: the one the feature cares about. Resize the picture, then press Ctrl+Z with
+    // the picture selected, which is the state a person is in right after changing it.
+    const imageId = await addInlineImage(page, BLOCK, LANG);
+    await changeInlineImagePicture(
+        page,
+        BLOCK,
+        LANG,
+        imageId,
+        fixtureImage("bird.png"),
+    );
+    const before = await getInlineImage(page, BLOCK, LANG, imageId);
+    const widened = await resizeInlineImage(
+        page,
+        BLOCK,
+        LANG,
+        imageId,
+        "se",
+        40,
+    );
+    expect(
+        widened,
+        "The resize did not change the picture's width, so there is nothing for undo to take back.",
+    ).not.toBe(before.widthPercent);
+
+    await selectInlineImage(page, BLOCK, LANG, imageId);
+    await pressKey(page, "Control+z");
+
+    await expect
+        .poll(
+            async () =>
+                (await getInlineImage(page, BLOCK, LANG, imageId)).widthPercent,
+            {
+                message:
+                    `Ctrl+Z did not take back the picture's resize (it is still ` +
+                    `${widened}%, and was ${before.widthPercent}% before). The inline-image undo ` +
+                    `stack is reached only from workspaceRoot.handleUndo, and the only thing that ` +
+                    `calls handleUndo is the top-bar Undo button. Ctrl+Z in the page belongs to ` +
+                    `CKEditor's undo plugin, and selecting a picture deliberately leaves the ` +
+                    `keyboard focus on the containing editable -- so the key undoes text, or ` +
+                    `nothing, and the person's last change to the picture cannot be taken back ` +
+                    `by the key everyone uses.`,
+                timeout: 10000,
+            },
+        )
+        .toBe(before.widthPercent);
+
+    // And it has to be the whole undo, not one block's worth of it. CKEditor's undo restores one
+    // editable's saved HTML, so it cannot know about the wrapper's copies in the other editables
+    // of the group -- including the lang="z" prototype, which is what a language added to the
+    // collection later is built from. If those are left at the width the person just undid, the
+    // book is in a state no operation produced, and it is the prototype that carries it forward.
+    const blocks = await getInlineImages(page, BLOCK);
+    const copies = blocks
+        .flatMap((b) => b.images)
+        .filter((i) => i.id === imageId);
+    expect(
+        copies.length,
+        "The group holds no copies of the picture at all, so this test is measuring nothing.",
+    ).toBeGreaterThan(1);
+    for (const copy of copies)
+        expect(
+            copy.widthPercent,
+            `Ctrl+Z put the "${LANG}" copy of the picture back to ${before.widthPercent}% but ` +
+                `left the "${copy.languageTag}" copy at ${copy.widthPercent}%. CKEditor's undo ` +
+                `restores the saved HTML of one editable, so it can only ever undo the copy in ` +
+                `the block that had the focus.`,
+        ).toBe(before.widthPercent);
+});

--- a/src/BloomE2E/tests/inline-images-vertical-position.spec.ts
+++ b/src/BloomE2E/tests/inline-images-vertical-position.spec.ts
@@ -1,0 +1,167 @@
+// How far down its block an inline image can be put.
+//
+// WHAT THIS IS ABOUT. A person moving a picture down a block expects to be able to stop
+// anywhere: with six lines above it, or seven, or with one last line below it. The docks are
+// the only thing that is supposed to be quantized -- left, right, the full-width band, and
+// below the text -- and how far down the band sits is a distance in pixels, not a choice from
+// a list. What made this a test is the report that it was a choice from a list: the picture
+// could go at the bottom, or about five lines higher, and nowhere in between (John, live
+// testing, with the ball picture in a full A6 block).
+//
+// WHY IT IS ITS OWN FILE. inline-images.spec.ts checks that each dock can be reached, one drag
+// per dock, which is a different question from what the space between two docks offers. This
+// one takes the picture to the far end of the block and then steps it down a line at a time, so
+// it needs a block whose text it knows and a page it does not share.
+//
+// WHY IT DOES NOT STEP THE WHOLE WAY DOWN. It used to, and a full A5 block is twenty-odd lines
+// of one drag each, which is most of a minute for the sake of the last two or three of them.
+// Every position in the middle of the block was reached by the same arithmetic and told us the
+// same thing. So one drag covers the distance -- which is also the gesture a person makes -- and
+// the stepping is spent only where the answer is in doubt: the few lines at the end, where the
+// bottom dock takes over and where the reported bug had the band giving out early.
+
+import * as Path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "../fixtures/bloomTest";
+import {
+    addPage,
+    getContentPages,
+    goToPage,
+    makeBookFromTemplate,
+    typeInGroup,
+} from "../helpers/bookMaking";
+import {
+    addInlineImage,
+    changeInlineImagePicture,
+    dragInlineImageDown,
+    dragInlineImageToDock,
+    getBlockLineHeightPx,
+    getRoomBelowInlineImagePx,
+    nudgeInlineImageDown,
+    scrollBlockToTop,
+} from "../helpers/inlineImages";
+
+test.use({
+    collectionSpec: {
+        name: "inline-images-vertical-position",
+        languages: ["en"],
+    },
+});
+
+test.describe.configure({ mode: "serial" });
+
+const BLOCK = ".bloom-translationGroup";
+const LANG = "en";
+
+// Enough text that the block has lines all the way down it, so that "how far down can the
+// picture go" is a question with a visible answer at every step.
+const TEXT =
+    "The kingfisher waits on the branch above the pool, still enough that the water forgets it " +
+    "is there. It watches the shadows move under the surface. When it drops, it drops straight, " +
+    "and the pool closes over the place where it went in. A moment later it is back on the " +
+    "branch with a fish, and the water is still again. The children on the bank have learned " +
+    "to wait as well, and they do not talk while the bird is fishing.";
+
+const fixtureImage = (name: string) =>
+    Path.resolve(
+        Path.dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "fixtures",
+        "images",
+        name,
+    );
+
+test("the picture can be put right down to the end of the block's text, not just in its upper part [Test Case ID 815]", async ({
+    page,
+}) => {
+    test.setTimeout(300000);
+    await makeBookFromTemplate(page, "Basic Book");
+    await typeInGroup(page, ".bookTitle", "en", "Inline Images Vertical");
+    await addPage(page, "Just Text");
+    const [contentPage] = await getContentPages(page);
+    await goToPage(page, contentPage.id);
+    await typeInGroup(page, BLOCK, LANG, TEXT);
+
+    const imageId = await addInlineImage(page, BLOCK, LANG);
+    await changeInlineImagePicture(
+        page,
+        BLOCK,
+        LANG,
+        imageId,
+        fixtureImage("bird.png"),
+    );
+
+    // The full-width band is the dock this is about: it is the one whose position down the
+    // block is a distance rather than a side.
+    await scrollBlockToTop(page, BLOCK, LANG);
+    await dragInlineImageToDock(page, BLOCK, LANG, imageId, "middle");
+
+    const lineHeightPx = await getBlockLineHeightPx(page, BLOCK, LANG);
+    expect(
+        lineHeightPx,
+        "The block reports no line height, so this test cannot say what a line's worth of room is.",
+    ).toBeGreaterThan(0);
+
+    // THE ACTION UNDER TEST, in two parts. First one drag that carries the picture down to
+    // within a few lines of the end of the text: a person moves a picture in one gesture, and a
+    // band that cannot be dragged this far down at all fails here rather than after twenty
+    // nudges. kLinesToStep is how much is left for the stepping to cover.
+    const kLinesToStep = 4;
+    const roomAtTopPx = await getRoomBelowInlineImagePx(
+        page,
+        BLOCK,
+        LANG,
+        imageId,
+    );
+    if (roomAtTopPx > kLinesToStep * lineHeightPx)
+        await dragInlineImageDown(
+            page,
+            BLOCK,
+            LANG,
+            imageId,
+            Math.round(roomAtTopPx - kLinesToStep * lineHeightPx),
+        );
+
+    // Then step it down a line at a time until the bottom dock takes over, remembering the
+    // lowest band position it reached. One line is the granularity the assertion below is in, so
+    // there is nothing to be had from finer steps. The limit is generous enough to cover a block
+    // whose text rewraps as the picture moves through it, and small enough to fail rather than
+    // grind if the band stops moving.
+    let deepestBandRoomBelowPx = await getRoomBelowInlineImagePx(
+        page,
+        BLOCK,
+        LANG,
+        imageId,
+    );
+    const positions: string[] = [];
+    for (let step = 1; step <= kLinesToStep + 4; step++) {
+        const at = await nudgeInlineImageDown(
+            page,
+            BLOCK,
+            LANG,
+            imageId,
+            Math.round(lineHeightPx),
+        );
+        positions.push(
+            `${at.dock} offset ${at.offsetPx} room below ${Math.round(at.roomBelowPx)}`,
+        );
+        if (at.dock === "bottom") break;
+        if (at.dock === "middle")
+            deepestBandRoomBelowPx = Math.min(
+                deepestBandRoomBelowPx,
+                at.roomBelowPx,
+            );
+    }
+
+    // The picture ran out of block before it ran out of positions: less than one line of the
+    // block's content is left below it. More than that is text the person could not get the
+    // picture past, which is the reported bug -- the band stopped several lines short and the
+    // next thing a drag offered was the bottom dock.
+    expect(
+        deepestBandRoomBelowPx,
+        `The lowest place the band would go left ${Math.round(deepestBandRoomBelowPx)}px of the ` +
+            `block below the picture, which is ${(deepestBandRoomBelowPx / lineHeightPx).toFixed(1)} ` +
+            `lines of text the picture cannot be put after. The last few of the ${positions.length} ` +
+            `places the sweep stopped at: ${positions.slice(-6).join("; ")}.`,
+    ).toBeLessThan(lineHeightPx);
+});

--- a/src/BloomE2E/tests/inline-images-zoom.spec.ts
+++ b/src/BloomE2E/tests/inline-images-zoom.spec.ts
@@ -1,0 +1,170 @@
+// Dragging a picture while the edit view is zoomed.
+//
+// WHAT THIS IS ABOUT. The drag arithmetic works in two units at once. getBoundingClientRect and
+// a pointer event's clientX/clientY are VIEWPORT pixels, while clientHeight, scrollTop and the
+// custom properties the picture's position is stored in are LAYOUT pixels. Bloom draws the zoom
+// by scaling a container around the page (SetupPageZoom / #page-scaling-container), so the two
+// differ by exactly the zoom, and computeViewportPxPerLayoutPx is where the drag reconciles them
+// -- measured once, at pointerdown.
+//
+// A wrong ratio does not fail quietly: the picture slides away from the cursor, by more the
+// further it is dragged. The zoom is a control people reach for constantly, so this is the
+// arithmetic most likely to be exercised at a value nobody tested.
+//
+// WHAT IS CHECKED. The pointer's own travel against the distance the picture actually moved, at
+// each of three zooms. That comparison is the whole question: at 100% a correct implementation and
+// one that ignores the ratio entirely give the same answer, so the smaller and larger zooms are
+// what have anything to say. The tolerance is a line of text, because the picture's position is
+// quantized by nothing but the block's own layout, and a float's arrival point can differ by a
+// line's worth as the text rewraps around it.
+
+import * as Path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Page } from "@playwright/test";
+import { expect, test } from "../fixtures/bloomTest";
+import {
+    addPage,
+    getContentPages,
+    goToPage,
+    makeBookFromTemplate,
+    typeInGroup,
+} from "../helpers/bookMaking";
+import {
+    addInlineImage,
+    beginInlineImageDrag,
+    changeInlineImagePicture,
+    dragInlineImageToDock,
+    endInlineImageDrag,
+    getBlockLineHeightPx,
+    getInlineImageRects,
+    moveInlineImageDragTo,
+    scrollBlockToTop,
+} from "../helpers/inlineImages";
+import { getZoom, setZoom } from "../helpers/workspace";
+
+test.use({
+    collectionSpec: { name: "inline-images-zoom", languages: ["en"] },
+});
+
+test.describe.configure({ mode: "serial" });
+
+const BLOCK = ".bloom-translationGroup";
+const LANG = "en";
+
+// Long enough that the block has lines all the way down it at every zoom, so a drag downward has
+// somewhere to go.
+const TEXT =
+    "The kingfisher waits on the branch above the pool, still enough that the water forgets it " +
+    "is there. It watches the shadows move under the surface. When it drops, it drops straight, " +
+    "and the pool closes over the place where it went in. A moment later it is back on the " +
+    "branch with a fish, and the water is still again. The children on the bank have learned " +
+    "to wait as well, and they do not talk while the bird is fishing.";
+
+const fixtureImage = (name: string) =>
+    Path.resolve(
+        Path.dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "fixtures",
+        "images",
+        name,
+    );
+
+let imageId: string;
+
+/**
+ * Drag the picture down by `pointerTravelViewportPx` of real pointer movement, and report how far
+ * the picture itself moved on the screen. Both are viewport pixels -- what the person's hand did
+ * and what their eye saw -- so they are comparable whatever the zoom is.
+ */
+const dragDownAndMeasure = async (
+    page: Page,
+    pointerTravelViewportPx: number,
+): Promise<{ pictureMovedViewportPx: number; blockHeightPx: number }> => {
+    const before = await getInlineImageRects(page, BLOCK, LANG, imageId);
+    await beginInlineImageDrag(page, BLOCK, LANG, imageId);
+    await moveInlineImageDragTo(page, {
+        x: before.picture.x + before.picture.width / 2,
+        y:
+            before.picture.y +
+            before.picture.height / 2 +
+            pointerTravelViewportPx,
+    });
+    await endInlineImageDrag(page);
+    const after = await getInlineImageRects(page, BLOCK, LANG, imageId);
+    return {
+        pictureMovedViewportPx: after.picture.y - before.picture.y,
+        blockHeightPx: after.block.height,
+    };
+};
+
+test("a drag follows the pointer at every zoom [Test Case ID 815]", async ({
+    page,
+}) => {
+    test.setTimeout(300000);
+    await makeBookFromTemplate(page, "Basic Book");
+    await typeInGroup(page, ".bookTitle", "en", "Inline Images Zoom");
+    await addPage(page, "Just Text");
+    const [contentPage] = await getContentPages(page);
+    await goToPage(page, contentPage.id);
+    await typeInGroup(page, BLOCK, LANG, TEXT);
+
+    imageId = await addInlineImage(page, BLOCK, LANG);
+    await changeInlineImagePicture(
+        page,
+        BLOCK,
+        LANG,
+        imageId,
+        fixtureImage("bird.png"),
+    );
+
+    const { zoom: zoomAtStart, minZoom, maxZoom } = await getZoom(page);
+    // The extremes Bloom itself allows, plus the middle, so the test asks about the values a
+    // person can actually reach rather than ones invented here.
+    const zoomsToTry = [zoomAtStart, minZoom, maxZoom];
+
+    try {
+        for (const zoom of zoomsToTry) {
+            await setZoom(page, zoom);
+            // Start each attempt from the same place: the full-width band at the top of the text.
+            await scrollBlockToTop(page, BLOCK, LANG);
+            await dragInlineImageToDock(page, BLOCK, LANG, imageId, "middle");
+
+            // getBlockLineHeightPx reads the block's CSS line-height, which is a LAYOUT pixel
+            // value and so is the same number at every zoom. On the screen a line is that
+            // multiplied by the zoom, and the pointer travels on the screen, so everything below
+            // is in the scaled units.
+            const lineHeightLayoutPx = await getBlockLineHeightPx(
+                page,
+                BLOCK,
+                LANG,
+            );
+            const lineHeightViewportPx = (lineHeightLayoutPx * zoom) / 100;
+            // Three lines. Measured in lines rather than as a fraction of the block because the
+            // block is three times as tall on screen at 300% as at 100%, and a quarter of THAT
+            // puts the pointer below everything the person can see -- a drag to somewhere the
+            // block has no room for is refused outright by the fit-or-revert rule, which says
+            // nothing about the arithmetic this test is asking about.
+            const pointerTravelViewportPx = Math.round(
+                3 * lineHeightViewportPx,
+            );
+            const { pictureMovedViewportPx } = await dragDownAndMeasure(
+                page,
+                pointerTravelViewportPx,
+            );
+
+            expect(
+                Math.abs(pictureMovedViewportPx - pointerTravelViewportPx),
+                `At ${zoom}% zoom the pointer travelled ${pointerTravelViewportPx}px down the ` +
+                    `screen and the picture moved ${Math.round(pictureMovedViewportPx)}px, which ` +
+                    `is ${Math.round(Math.abs(pictureMovedViewportPx - pointerTravelViewportPx) / lineHeightViewportPx)} ` +
+                    `lines away from the pointer. The drag converts between viewport pixels ` +
+                    `(clientY, getBoundingClientRect) and layout pixels (the offset it stores) ` +
+                    `using one ratio measured at pointerdown, and Bloom draws the zoom by ` +
+                    `scaling a container around the page, so that ratio IS the zoom.`,
+            ).toBeLessThanOrEqual(lineHeightViewportPx * 1.5);
+        }
+    } finally {
+        // Bloom saves the zoom as a user setting, so leave it as it was found.
+        await setZoom(page, zoomAtStart);
+    }
+});

--- a/src/BloomE2E/tests/inline-images.spec.ts
+++ b/src/BloomE2E/tests/inline-images.spec.ts
@@ -1,0 +1,494 @@
+// Inline (Word-style) images: a picture inside a text block, with the text of the block wrapping
+// around it. The feature is described in INLINE-IMAGES-PLAN.md.
+//
+// WHAT THIS FILE COVERS, AND WHY IT IS THE E2E PART. The logic of the feature -- which dock a
+// position means, how an offset is clamped, what a sync stamps onto the other languages -- is
+// covered by the vitest suites beside the code (bookEdit/js/inlineImages.test.ts and
+// inlineImageInteractions.test.ts), which run in jsdom. What jsdom cannot show is everything this
+// file is about:
+//
+//  - the real right-click menu in WebView2, which is the only way to add or delete an image;
+//  - real mouse gestures against real layout: the dock a drag lands in is decided from measured
+//    thirds of the block, and how far down the picture may go is measured from the block's height;
+//  - the CSS, which is half the feature: the float and its wrap shape are what make the text flow
+//    beside the picture, and display:flow-root is what keeps the picture inside its block;
+//  - what survives Bloom's save path to the .htm file, decoration stripped and
+//    contenteditable="false" intact;
+//  - undo through the real workspace undo chain, which the front end shares with CKEditor and the
+//    canvas element manager.
+//
+// The tests are serial: each starts from the book the one before it left behind, so the file reads
+// as one session with one text block, the way a person works.
+
+import * as Path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "../fixtures/bloomTest";
+import {
+    addPage,
+    findBookFolder,
+    getContentPages,
+    getPages,
+    goToPage,
+    makeBookFromTemplate,
+    typeInGroup,
+} from "../helpers/bookMaking";
+import {
+    addInlineImage,
+    changeInlineImagePicture,
+    deleteInlineImage,
+    getInlineImage,
+    getInlineImageInEveryLanguage,
+    getBlockText,
+    getInlineImageMenuCommands,
+    getInlineImageRects,
+    getInlineImageToolbarButtons,
+    getInlineImageToolbarRect,
+    getInlineImages,
+    clickInBlockText,
+    closeInlineImageMenu,
+    dragInlineImageDown,
+    dragInlineImageToDock,
+    readSavedInlineImages,
+    resizeInlineImage,
+    selectInlineImage,
+    textBlockOffersAddImage,
+    textWrapsBesideInlineImage,
+} from "../helpers/inlineImages";
+import { expectInside } from "../helpers/geometry";
+import { undo } from "../helpers/workspace";
+
+test.use({
+    collectionSpec: { name: "inline-images", languages: ["en"] },
+});
+
+test.describe.configure({ mode: "serial" });
+
+// The only translation group of a Just Text page, and the language the collection has. A Just Text
+// page is the right subject: its text block fills the page, so there is room to dock a picture on
+// any side and to drag it down without the block overflowing.
+const BLOCK = ".bloom-translationGroup";
+const LANG = "en";
+
+// The title the book is given, so that findBookFolder can name its folder on disk.
+const BOOK_TITLE = "Inline Images";
+
+// Enough text that the block has several lines for the picture to displace. Without text there is
+// nothing to wrap, and "the text flows beside the picture" could not be measured.
+const TEXT =
+    "The kingfisher waits on the branch above the pool, still enough that the water forgets " +
+    "it is there. It watches the shadows move under the surface. When it drops, it drops " +
+    "straight, and the pool closes over the place where it went in. A moment later it is back " +
+    "on the branch with a fish, and the water is still again. The children on the bank have " +
+    "learned to wait as well, and they do not talk while the bird is fishing.";
+
+// The picture the tests put in the image. It ships with the suite, so nothing outside this folder
+// is needed.
+const fixtureImage = (name: string) =>
+    Path.resolve(
+        Path.dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "fixtures",
+        "images",
+        name,
+    );
+
+// The image every test after the first one works on, and the book's folder. Set by the first test.
+let imageId: string;
+let bookFolder: string;
+
+test.describe("inline images in a text block [Test Case ID 815]", () => {
+    test("the right-click menu of a text block offers to add an inline image", async ({
+        page,
+    }) => {
+        test.setTimeout(300000);
+        await makeBookFromTemplate(page, "Basic Book");
+        await typeInGroup(page, ".bookTitle", "en", BOOK_TITLE);
+        await addPage(page, "Just Text");
+        const [contentPage] = await getContentPages(page);
+        await goToPage(page, contentPage.id);
+        await typeInGroup(page, BLOCK, LANG, TEXT);
+        bookFolder = await findBookFolder(page, BOOK_TITLE);
+
+        // Sanity check the block the whole file rests on: it has text and no inline image yet.
+        const blocks = await getInlineImages(page, BLOCK);
+        expect(
+            blocks.length,
+            "A Just Text page's translation group should have at least the shown language and " +
+                "the lang=z prototype.",
+        ).toBeGreaterThan(1);
+        expect(blocks.flatMap((block) => block.images)).toEqual([]);
+
+        expect(await textBlockOffersAddImage(page, BLOCK, LANG)).toBe(true);
+    });
+
+    test("Add Image puts a placeholder in every language, docked right", async ({
+        page,
+    }) => {
+        // THE ACTION UNDER TEST: a real right-click in the text, and a real click on Add Image.
+        imageId = await addInlineImage(page, BLOCK, LANG);
+
+        const blocks = await getInlineImages(page, BLOCK);
+        // Every block of the group has a copy, the lang="z" prototype included: that copy is how a
+        // language added later inherits the image with no C# involvement.
+        expect(blocks.map((block) => block.images.length)).toEqual(
+            blocks.map(() => 1),
+        );
+        for (const copy of blocks.flatMap((block) => block.images)) {
+            expect(copy.id).toBe(imageId);
+            expect(copy.dock).toBe("right");
+            expect(copy.widthPercent).toBe(40);
+            expect(copy.offsetPx).toBe(0);
+            expect(copy.fileName).toBe("placeHolder.png");
+            // Load-bearing in the saved markup: it is the only thing stopping Bloom's
+            // language-stamping sweep from treating the wrapper as a text box.
+            expect(copy.contentEditable).toBe("false");
+        }
+        // Adding the image does not open the image chooser; the picture is chosen afterwards.
+        // What it does do is select the image, which is what puts the corner handles on it.
+        const shown = await getInlineImage(page, BLOCK, LANG, imageId);
+        expect(shown.selected).toBe(true);
+        expect(shown.handleCount).toBe(4);
+        // Selecting it also puts up the toolbar, so the buttons are there the moment the image
+        // is, without the person having to click the picture first.
+        expect(
+            (await getInlineImageToolbarButtons(page)).map(
+                (button) => button.id,
+            ),
+        ).toContain("chooseImage");
+    });
+
+    test("the block's text flows beside the picture", async ({ page }) => {
+        await changeInlineImagePicture(
+            page,
+            BLOCK,
+            LANG,
+            imageId,
+            fixtureImage("bird.png"),
+        );
+        const shown = await getInlineImage(page, BLOCK, LANG, imageId);
+        expect(shown.float).toBe("right");
+        expect(
+            shown.wrapShape,
+            "Without a wrap shape the text would avoid the picture's whole box, including the " +
+                "transparent offset above it.",
+        ).not.toBe("none");
+        // The block contains its float, or the picture would hang out below the block over
+        // whatever follows it on the page.
+        const [firstBlock] = (await getInlineImages(page, BLOCK)).filter(
+            (block) => block.languageTag === LANG,
+        );
+        expect(firstBlock.display).toBe("flow-root");
+        expect(
+            await textWrapsBesideInlineImage(page, BLOCK, LANG, imageId),
+            "No line of the block's text sits beside the picture, so the text is not wrapping " +
+                "around it.",
+        ).toBe(true);
+    });
+
+    test("clicking the picture selects it, and clicking the text lets it go", async ({
+        page,
+    }) => {
+        await clickInBlockText(page, BLOCK, LANG);
+        expect(
+            (await getInlineImage(page, BLOCK, LANG, imageId)).handleCount,
+        ).toBe(0);
+
+        // THE ACTION UNDER TEST: a real click on the picture. It has to stick on the FIRST click:
+        // the click inevitably lands keyboard focus on the block that contains the picture, and
+        // the code has to tell that apart from the caret going back to the text.
+        await selectInlineImage(page, BLOCK, LANG, imageId);
+        const selected = await getInlineImage(page, BLOCK, LANG, imageId);
+        expect(selected.selected).toBe(true);
+        expect(selected.handleCount).toBe(4);
+
+        // Only the copy the person clicked is selected; the other languages' copies are not.
+        const copies = await getInlineImageInEveryLanguage(
+            page,
+            BLOCK,
+            imageId,
+        );
+        expect(copies.filter((copy) => copy.selected).length).toBe(1);
+    });
+
+    test("the picture carries the toolbar an image has on a canvas", async ({
+        page,
+    }) => {
+        // Letting the picture go takes the toolbar down with the handles.
+        await clickInBlockText(page, BLOCK, LANG);
+        expect(await getInlineImageToolbarButtons(page)).toEqual([]);
+
+        // THE ACTION UNDER TEST: a click on the picture brings the toolbar back.
+        await selectInlineImage(page, BLOCK, LANG, imageId);
+        const buttons = await getInlineImageToolbarButtons(page);
+        const ids = buttons.map((button) => button.id);
+        // The same buttons an image has on a canvas, so a person meets one set of controls for
+        // pictures wherever a picture is.
+        expect(ids).toContain("chooseImage");
+        expect(ids).toContain("pasteImage");
+        expect(ids).toContain("delete");
+        // Two are left out because they would turn the picture into canvas furniture, which a
+        // picture inside a text block cannot become.
+        expect(ids).not.toContain("becomeBackground");
+        expect(ids).not.toContain("duplicate");
+        expect(buttons.find((button) => button.id === "delete")?.enabled).toBe(
+            true,
+        );
+
+        // The bar belongs to this picture: it sits under it, not under some other one.
+        const rects = await getInlineImageRects(page, BLOCK, LANG, imageId);
+        const bar = await getInlineImageToolbarRect(page);
+        expect(bar, "The toolbar is not on the screen.").toBeDefined();
+        expect(bar!.y).toBeGreaterThanOrEqual(rects.picture.y);
+        expect(bar!.x + bar!.width).toBeGreaterThan(rects.picture.x);
+        expect(bar!.x).toBeLessThan(rects.picture.x + rects.picture.width);
+    });
+
+    test("choosing a picture puts it in every language's copy", async ({
+        page,
+    }) => {
+        const copies = await getInlineImageInEveryLanguage(
+            page,
+            BLOCK,
+            imageId,
+        );
+        expect(copies.length).toBeGreaterThan(1);
+        for (const copy of copies) expect(copy.fileName).toBe("bird.png");
+    });
+
+    test("the picture's own menu offers the standard image commands and Delete", async ({
+        page,
+    }) => {
+        const commands = await getInlineImageMenuCommands(
+            page,
+            BLOCK,
+            LANG,
+            imageId,
+        );
+        const ids = commands.map((command) => command.id);
+        // The same commands an image offers anywhere else in Bloom, so that a person meets one
+        // vocabulary for pictures, plus a Delete that knows about the per-language copies.
+        expect(ids).toContain("EditTab.Image.ChooseImage");
+        expect(ids).toContain("EditTab.Image.CopyImage");
+        expect(ids).toContain("Common.Delete");
+        // Two commands are excluded because they would turn the picture into canvas furniture,
+        // which a picture inside a text block cannot become.
+        expect(ids).not.toContain("EditTab.Image.BecomeBackground");
+        expect(
+            commands.find((command) => command.id === "Common.Delete")?.enabled,
+        ).toBe(true);
+        await closeInlineImageMenu(page);
+    });
+
+    test("dragging the picture to the left of the block docks it left", async ({
+        page,
+    }) => {
+        // THE ACTION UNDER TEST: a real drag of the picture into the left third of the block.
+        await dragInlineImageToDock(page, BLOCK, LANG, imageId, "left");
+
+        const copies = await getInlineImageInEveryLanguage(
+            page,
+            BLOCK,
+            imageId,
+        );
+        for (const copy of copies) expect(copy.dock).toBe("left");
+        const shown = await getInlineImage(page, BLOCK, LANG, imageId);
+        expect(shown.float).toBe("left");
+        expect(
+            await textWrapsBesideInlineImage(page, BLOCK, LANG, imageId),
+            "The text stopped wrapping when the picture moved to the left dock.",
+        ).toBe(true);
+    });
+
+    test("dragging the picture down moves it past the first lines, and stays inside the block", async ({
+        page,
+    }) => {
+        const { block } = await getInlineImageRects(page, BLOCK, LANG, imageId);
+        // THE ACTION UNDER TEST: a real drag straight down.
+        const offset = await dragInlineImageDown(
+            page,
+            BLOCK,
+            LANG,
+            imageId,
+            60,
+        );
+        expect(offset).toBeGreaterThan(0);
+
+        // The distance is one number in one custom property, and it reaches every language.
+        const copies = await getInlineImageInEveryLanguage(
+            page,
+            BLOCK,
+            imageId,
+        );
+        for (const copy of copies) expect(copy.offsetPx).toBe(offset);
+
+        // Whatever the drag asked for, the whole picture stays inside the block: nothing may hang
+        // below it. The offset is clamped against the block measured live, which is the part of
+        // this that only a real renderer can answer.
+        const { picture } = await getInlineImageRects(
+            page,
+            BLOCK,
+            LANG,
+            imageId,
+        );
+        expectInside(picture, block, "the picture", "its text block");
+    });
+
+    test("dragging a corner handle makes the picture wider, in every language", async ({
+        page,
+    }) => {
+        const before = await getInlineImage(page, BLOCK, LANG, imageId);
+        // THE ACTION UNDER TEST: a real drag of the south-east handle, outward.
+        const widthPercent = await resizeInlineImage(
+            page,
+            BLOCK,
+            LANG,
+            imageId,
+            "se",
+            60,
+        );
+        expect(widthPercent).toBeGreaterThan(before.widthPercent);
+        // Bloom keeps a width usable for both the picture and the text beside it.
+        expect(widthPercent).toBeLessThanOrEqual(95);
+
+        const copies = await getInlineImageInEveryLanguage(
+            page,
+            BLOCK,
+            imageId,
+        );
+        for (const copy of copies) expect(copy.widthPercent).toBe(widthPercent);
+    });
+
+    test("Undo takes back the last change to the image", async ({ page }) => {
+        const before = await getInlineImage(page, BLOCK, LANG, imageId);
+        const widened = await resizeInlineImage(
+            page,
+            BLOCK,
+            LANG,
+            imageId,
+            "se",
+            40,
+        );
+        expect(widened).not.toBe(before.widthPercent);
+
+        // THE ACTION UNDER TEST: the workspace's own undo, which is what Ctrl+Z reaches.
+        await undo(page);
+
+        await expect
+            .poll(
+                async () =>
+                    (await getInlineImage(page, BLOCK, LANG, imageId))
+                        .widthPercent,
+                {
+                    message:
+                        "Undo did not put the picture's width back. Inline images keep their own " +
+                        "undo stack, because CKEditor's cannot see a change made to the DOM by " +
+                        "code (inlineImages.ts).",
+                },
+            )
+            .toBe(before.widthPercent);
+        // Undo rebuilds the wrapper from saved markup in every language, so every copy comes back
+        // to the same width, and the restored copy keeps its handles.
+        const copies = await getInlineImageInEveryLanguage(
+            page,
+            BLOCK,
+            imageId,
+        );
+        for (const copy of copies)
+            expect(copy.widthPercent).toBe(before.widthPercent);
+        expect(
+            (await getInlineImage(page, BLOCK, LANG, imageId)).handleCount,
+        ).toBe(4);
+    });
+
+    test("the image and its geometry survive leaving the page and coming back", async ({
+        page,
+    }) => {
+        const before = await getInlineImage(page, BLOCK, LANG, imageId);
+        const [contentPage] = await getContentPages(page);
+        // Bloom writes a page only when the book leaves it, so this is the save.
+        const [firstXmatter] = (await getPages(page)).filter(
+            (one) => !one.isContentPage,
+        );
+        await goToPage(page, firstXmatter.id);
+
+        const saved = await readSavedInlineImages(page, bookFolder);
+        expect(
+            saved.length,
+            "The saved book has no inline image, so nothing reached the file.",
+        ).toBeGreaterThan(1);
+        for (const copy of saved.filter((one) => one.id === imageId)) {
+            expect(copy.classes).toContain("bloom-inlineImageLeft");
+            expect(copy.contentEditable).toBe("false");
+            expect(copy.source).toContain("bird.png");
+            // KNOWN DEFECT, and the reason this test does not assert the absence of
+            // "bloom-inlineImage-selected" here: the edit-time selection marker reaches the
+            // saved file. deselectAllInlineImages() runs from cleanupInlineImageInteractions(),
+            // which bloomEditing.ts calls from Cleanup() at page bootstrap. The save path is
+            // extractAndStripPageContentForSave(), which calls removeEditingDebris() and
+            // getBodyContentForSavePage(), and neither of those touches the wrapper. The next
+            // load strips the marker, so a reader never sees a selected image. The test below
+            // asserts that user-visible part.
+            expect(copy.style).toContain("--inline-image-width");
+            // A floating image is the first thing in its block, so the required paragraph of text
+            // follows it (bloom-keepFirstInField).
+            expect(copy.slot.index).toBe(0);
+            expect(copy.slot.childCount).toBeGreaterThan(1);
+        }
+
+        // Coming back shows what was saved.
+        await goToPage(page, contentPage.id);
+        const after = await getInlineImage(page, BLOCK, LANG, imageId);
+        // Nothing comes back selected, whatever the file holds.
+        expect(after.selected).toBe(false);
+        expect(after.dock).toBe(before.dock);
+        expect(after.widthPercent).toBe(before.widthPercent);
+        expect(after.offsetPx).toBe(before.offsetPx);
+        expect(after.fileName).toBe("bird.png");
+    });
+
+    test("dragging the picture below the text docks it at the bottom, as the last thing in the block", async ({
+        page,
+    }) => {
+        // THE ACTION UNDER TEST: a real drag to below the block. This is the one dock that moves
+        // the wrapper in the markup: it becomes the last child instead of the first.
+        await dragInlineImageToDock(page, BLOCK, LANG, imageId, "bottom");
+
+        const copies = await getInlineImageInEveryLanguage(
+            page,
+            BLOCK,
+            imageId,
+        );
+        for (const copy of copies) {
+            expect(copy.dock).toBe("bottom");
+            expect(copy.slot.index).toBe(copy.slot.childCount - 1);
+        }
+        const shown = await getInlineImage(page, BLOCK, LANG, imageId);
+        // Not a float any more: the bottom dock is simply the last block of the field.
+        expect(shown.float).toBe("none");
+    });
+
+    test("dragging it back out of the bottom dock puts it first again", async ({
+        page,
+    }) => {
+        await dragInlineImageToDock(page, BLOCK, LANG, imageId, "right");
+        const copies = await getInlineImageInEveryLanguage(
+            page,
+            BLOCK,
+            imageId,
+        );
+        for (const copy of copies) {
+            expect(copy.dock).toBe("right");
+            expect(copy.slot.index).toBe(0);
+        }
+    });
+
+    test("Delete takes the image out of every language", async ({ page }) => {
+        // THE ACTION UNDER TEST: a real right-click on the picture, and Delete.
+        await deleteInlineImage(page, BLOCK, LANG, imageId);
+
+        const blocks = await getInlineImages(page, BLOCK);
+        expect(blocks.flatMap((block) => block.images)).toEqual([]);
+        // The block keeps its text: deleting the picture is not deleting the paragraph.
+        expect(await getBlockText(page, BLOCK, LANG)).toContain("kingfisher");
+    });
+});

--- a/src/BloomExe/Spreadsheet/SpreadsheetApi.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetApi.cs
@@ -52,8 +52,20 @@ namespace Bloom.Spreadsheet
             _webSocketServer.LaunchDialog("SpreadsheetExportDialog", messageBundle);
         }
 
+        /// <summary>
+        /// Under --e2e only: the path of the .xlsx the last export wrote, or null if no export has
+        /// finished since the last one started. Under --e2e the export does not open the finished
+        /// file (see the resultCallback below), so this is the only way a test can find out where
+        /// the file went. E2eTestingApi serves it as e2e/lastExportedSpreadsheet.
+        /// </summary>
+        public static string LastExportedSpreadsheetPathForE2eTests;
+
         private void ExportToSpreadsheet(ApiRequest request)
         {
+            // Clear it before the export starts, so that a test polling for the path cannot read
+            // the answer an earlier export left there.
+            LastExportedSpreadsheetPathForE2eTests = null;
+
             var book = _bookSelection.CurrentSelection;
             var bookPath = book.GetPathHtmlFile();
             try
@@ -78,7 +90,15 @@ namespace Bloom.Spreadsheet
                     outputFolder,
                     outputFilePath =>
                     {
-                        if (outputFilePath != null)
+                        if (outputFilePath == null)
+                            return;
+                        // Do not hand the file to whatever the machine opens .xlsx files with when
+                        // a test did the export: nothing in the test can close the Excel window
+                        // that would appear, and it would land on the developer's screen. The test
+                        // reads the path instead, through e2e/lastExportedSpreadsheet.
+                        if (Program.RunningE2eTests)
+                            LastExportedSpreadsheetPathForE2eTests = outputFilePath;
+                        else
                             ProcessExtra.SafeStartInFront(outputFilePath);
                     }
                 );
@@ -195,6 +215,12 @@ namespace Bloom.Spreadsheet
         private void SetSpreadsheetFolder(Book.Book book, string folder)
         {
             book.UserPrefs.SpreadsheetFolder = folder;
+            // Not under --e2e: Settings.Default is machine-wide and shared with the developer's own
+            // Bloom, and a test's temp folder has no business becoming the folder their next export
+            // offers. The book's own UserPrefs above stay, because they live in the temp collection
+            // and die with it. (Same reasoning as FileIOApi.SelectFileUsingDialog and FilePathMemory.)
+            if (Program.RunningE2eTests)
+                return;
             // We go up a level since the input folder is specific to this book, while the parent of that
             // is a likely place to do future exports and imports of books that have not previously
             // been imported or exported.

--- a/src/BloomExe/web/controllers/E2eTestingApi.cs
+++ b/src/BloomExe/web/controllers/E2eTestingApi.cs
@@ -177,6 +177,31 @@ namespace Bloom.web.controllers
                 HandleSetNextFileToChoose,
                 false // does not need the UI thread
             );
+
+            // GET replies with the path of the .xlsx the last spreadsheet export wrote, or an
+            // empty string while no export has finished since the last one started. Exporting
+            // normally ends by opening the file in the machine's spreadsheet program, which a test
+            // cannot close and must not leave on the developer's screen, so under --e2e the export
+            // records the path here instead of opening it (SpreadsheetApi.ExportToSpreadsheet).
+            // That makes the path the test's completion signal as well: the export runs in the
+            // background behind a progress dialog, and a test polls this to know it has finished.
+            // Read-only; safe off the UI thread.
+            apiHandler.RegisterEndpointHandler(
+                kApiUrlPart + "lastExportedSpreadsheet",
+                HandleGetLastExportedSpreadsheet,
+                false // does not need the UI thread
+            );
+        }
+
+        /// <summary>
+        /// GET e2e/lastExportedSpreadsheet: where the last export put its file (see the
+        /// registration above), or an empty string if none has finished.
+        /// </summary>
+        private void HandleGetLastExportedSpreadsheet(ApiRequest request)
+        {
+            request.ReplyWithText(
+                Spreadsheet.SpreadsheetApi.LastExportedSpreadsheetPathForE2eTests ?? ""
+            );
         }
 
         /// <summary>


### PR DESCRIPTION
39 Playwright tests across 16 spec files, driving a real Bloom. They are the last
commit in this stack because they are the check on everything before it, and because
they are what a person reading the feature should be able to read as its
specification: each file's header says what the test is about, what mechanism made it
worth writing, and what was measured.

Beyond the feature's own behaviour (add, select, dock, resize, undo, delete, the copy
in every language, a save and a reload), the suite puts the feature in the path of
what people do to books: change the page size, choose a different layout, cut the
block in half in Change Layout mode, overflow the text, duplicate the page, add a
language to the collection, paste text containing a picture, press ctrl+z, zoom to
30% and 300%, select-all-delete, and let go of the mouse outside the page. Six
defects found that way are fixed in the commits before this one.

Two things Bloom does differently under --e2e, both so a test cannot leave something
on the developer's screen or in their settings:

- A spreadsheet export records the path it wrote, served at
  e2e/lastExportedSpreadsheet, instead of handing the .xlsx to whatever opens
  spreadsheets on the machine. Nothing in a test could close that window.
- It no longer writes the machine-wide export folder setting, which is shared with
  the developer's own Bloom. The book's own UserPrefs still get it; they live in the
  temp collection and die with it.

BloomButton now carries its l10n key as a data-testid. That key is the only stable
name such a button has -- its text is localized and most callers give it neither an id
nor a class -- and localizableMenuItem already does the same. A caller passing its own
data-testid still wins.

AUTOMATION-DEBT.md records the three things the suite cannot drive: the Export
dialog's two buttons and the book menu's More submenu carry no test id, and releasing
the mouse outside the WebView2 window cannot be reached by Playwright at all.

Notion test case 815 tracks what is covered.

Card: https://issues.bloomlibrary.org/youtrack/issue/BL-16822

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DCBGajN5YyAYPBenEf1yy


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8324)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8324)
<!-- Reviewable:end -->
