### PR TITLE
BL-16818 Tables 3/6: video as a cell content type

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/bloomVideo.ts
+++ b/src/BloomBrowserUI/bookEdit/js/bloomVideo.ts
@@ -169,7 +169,12 @@ function SetupClickToShowSignLanguageTool(videoContainerDiv: Element) {
             toolbox?.toolboxIsShowing() &&
             (currentToolId === kCanvasToolId ||
                 currentToolId === kGameToolId) &&
-            videoContainerDiv.closest(kCanvasElementSelector) // only ones actually in a canvas element
+            videoContainerDiv.closest(kCanvasElementSelector) && // only ones actually in a canvas element
+            // A video in a table cell is not one of the canvas elements those
+            // tools arrange, even though the table it sits in may itself be a
+            // canvas element. Suppressing its click would leave the user no way
+            // to reach the tool that records into it.
+            !videoContainerDiv.closest(".bloom-cell")
         ) {
             // Looks like a video-over-picture, and we're showing the canvas element or game tool. Don't switch to SL tool.
             return;

--- a/src/BloomBrowserUI/bookEdit/js/tableEditing.test.ts
+++ b/src/BloomBrowserUI/bookEdit/js/tableEditing.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi } from "vitest";
-import { addRow, getTableInfo } from "bloom-table";
+import { addRow, getTableInfo, setupContentsOfCell } from "bloom-table";
+// A new video cell asks the server to put the video placeholder in the book
+// folder; there is no server here, and the call is also what proves the wiring
+// ran.
+const postMock = vi.fn();
 vi.mock("../../utils/bloomApi", async (importOriginal) => ({
     ...((await importOriginal()) as object),
+    post: (...args: unknown[]) => postMock(...args),
     // SetupTableEditing asks the server for the table feature's status. There is no
     // server here, and never calling the callback is what these tests want: the
     // remembered answer stays whatever setTablesMayBeRestructuredForTests set, rather
@@ -158,5 +163,48 @@ describe("cells the library builds after the page has loaded", () => {
         nested.removeAttribute("data-table-attached");
         TeardownTableEditing(document.body);
         expect(nested.getAttribute("data-table-attached")).toBeNull();
+    });
+});
+
+describe("video cells", () => {
+    it("hold Bloom's own video container, wired for editing", () => {
+        document.body.innerHTML = "";
+        postMock.mockClear();
+        const tableDiv = document.createElement("div");
+        tableDiv.classList.add("bloom-table");
+        document.body.appendChild(tableDiv);
+        SetupTableEditing(document.body);
+        AttachNewTable(tableDiv);
+        const cell = tableDiv.querySelector<HTMLElement>(".bloom-cell")!;
+        // Sanity check: it starts as a text cell, and nothing has asked for the
+        // placeholder yet.
+        expect(cell.dataset.contentType).toBe("text");
+        expect(postMock).not.toHaveBeenCalled();
+
+        // What picking Video in the cell menu does.
+        setupContentsOfCell(cell, "video");
+
+        expect(cell.dataset.contentType).toBe("video");
+        // The library's own template would put a bare <video> here, which none
+        // of Bloom's video tooling knows about.
+        expect(cell.querySelector("video")).toBeNull();
+        const container = cell.querySelector(".bloom-videoContainer");
+        expect(container).not.toBeNull();
+        // Until a video is recorded or chosen, this is what shows the placeholder.
+        expect(container!.classList.contains("bloom-noVideoSelected")).toBe(
+            true,
+        );
+        expect(postMock).toHaveBeenCalledWith(
+            "edit/pageControls/requestVideoPlaceHolder",
+        );
+
+        // Wiring the same table again (which every later table operation does)
+        // must not treat the container as new a second time: that would add the
+        // click that opens the Sign Language tool over and over.
+        postMock.mockClear();
+        addRow(tableDiv);
+        expect(postMock).not.toHaveBeenCalled();
+
+        TeardownTableEditing(document.body);
     });
 });

--- a/src/BloomBrowserUI/bookEdit/js/tableEditing.ts
+++ b/src/BloomBrowserUI/bookEdit/js/tableEditing.ts
@@ -20,6 +20,8 @@ import {
 // bloom-table.css, which basePage.less inlines so they ship everywhere.
 import "bloom-table/bloom-table-edit.css";
 import { SetupImagesInContainer } from "./bloomImages";
+import { SetupVideoEditing } from "./bloomVideo";
+import { post } from "../../utils/bloomApi";
 import $ from "jquery";
 import BloomField from "../bloomField/BloomField";
 import { theOneCanvasElementManager } from "./canvasElementManager/CanvasElementManager";
@@ -103,6 +105,19 @@ function ensureContentTypesRegistered(): void {
         false,
     );
 
+    // Video cells hold a bloom-videoContainer, which is what Bloom's video
+    // tooling works on: the Sign Language tool records into it, the hover
+    // controls play what it holds, and Bloom's publishing code collects the
+    // videos it finds in one. The markup matches what origami's Video link
+    // creates, minus the placeholder graphic, which the server is asked for
+    // when a video cell is actually made (see wireBloomContentOfNewCells).
+    replaceCellContentType(
+        "video",
+        "<div class='bloom-videoContainer bloom-leadingElement bloom-noVideoSelected'></div>",
+        /bloom-videoContainer/,
+        false,
+    );
+
     setDefaultCellContentTypeId("text");
     installHostHooks();
 }
@@ -177,6 +192,39 @@ function wireBloomContentOfNewCells(root: HTMLElement): void {
     if (root.matches(imageCellSelector)) imageCells.push(root);
     imageCells.forEach((cell) => SetupImagesInContainer(cell));
     observeImageCells(root);
+    wireVideoContainersOfNewCells(root);
+}
+
+// The video containers this has already wired. SetupVideoEditing adds a click
+// handler to the container itself (the one that opens the Sign Language tool)
+// without any guard against being called twice, and we run over a whole table
+// again after every table operation, so remembering what we have done is what
+// keeps one click from opening the tool several times.
+const wiredVideoContainers = new WeakSet<HTMLElement>();
+
+/**
+ * Give the video container of every video cell within `root` the wiring Bloom's
+ * page-load pass would have given it: the play/pause/replay controls that appear
+ * on hover, and the click that opens the Sign Language tool to record into it.
+ */
+function wireVideoContainersOfNewCells(root: HTMLElement): void {
+    const containers = Array.from(
+        // `root` is a cell or a table, so every video container below it is the
+        // content of some cell.
+        root.querySelectorAll<HTMLElement>(".bloom-videoContainer"),
+    ).filter((container) => !wiredVideoContainers.has(container));
+    if (containers.length === 0) return;
+    containers.forEach((container) => {
+        wiredVideoContainers.add(container);
+        // SetupVideoEditing looks for containers inside what it is given, so it
+        // gets the cell rather than the container itself.
+        SetupVideoEditing(container.parentElement!);
+    });
+    // The placeholder graphic is not among the files Bloom copies into every
+    // book, so the server has to be asked to put this book's copy in place;
+    // origami's Video link does the same. Without it the placeholder is missing
+    // when the book is opened by anything but Bloom itself.
+    post("edit/pageControls/requestVideoPlaceHolder");
 }
 
 /** Handle a cell's content being (re)initialised. Attached via SetupTableEditing. */

--- a/src/BloomBrowserUI/bookEdit/toolbox/signLanguage/signLanguageTool.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/signLanguage/signLanguageTool.tsx
@@ -891,9 +891,8 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
             return undefined;
         }
 
-        const activeVideoContainer = activeCanvasElement.querySelector(
-            ".bloom-videoContainer",
-        ) as HTMLElement | null;
+        const activeVideoContainer =
+            SignLanguageTool.videoContainerToRecordInto(activeCanvasElement);
         if (
             !activeVideoContainer ||
             activeVideoContainer.closest("[data-target-of]")
@@ -902,6 +901,24 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
         }
 
         return activeVideoContainer;
+    }
+
+    /**
+     * The video container inside `canvasElement` that the user means. A canvas
+     * element normally holds one, but a table in a canvas element can have a
+     * video in any number of its cells, and there the first one in the markup is
+     * usually the wrong one: clicking a cell's video selects it, so an already
+     * selected container is the answer whenever there is one.
+     */
+    private static videoContainerToRecordInto(
+        canvasElement: HTMLElement,
+    ): HTMLElement | null {
+        return (
+            canvasElement.querySelector<HTMLElement>(
+                ".bloom-videoContainer.bloom-selected",
+            ) ??
+            canvasElement.querySelector<HTMLElement>(".bloom-videoContainer")
+        );
     }
 
     private updateEnabledStateForSelectedVideo(): void {
@@ -946,9 +963,8 @@ export class SignLanguageTool extends ToolboxToolReactAdaptor {
             return;
         }
 
-        const activeVideoContainer = activeCanvasElement.querySelector(
-            ".bloom-videoContainer",
-        ) as HTMLElement | null;
+        const activeVideoContainer =
+            SignLanguageTool.videoContainerToRecordInto(activeCanvasElement);
         if (
             !activeVideoContainer ||
             activeVideoContainer.closest("[data-target-of]")


### PR DESCRIPTION
Third of six stacked PRs splitting #8315. **Base is `BL-16818-table-on-canvas` (#8326).**

Small one. A table cell can hold a video, the way it already holds text or a picture.

`tableEditing` registers `video` as a content type, so the cell menu offers it, and wires the video container of any cell the library builds after the page has loaded. The sign language tool and `bloomVideo` learn to work on a container inside a cell rather than assuming the page's own video container.

## What to try

In a table cell's content menu, choose Video, then record or choose one with the Sign Language tool.

## Checks

`pnpm typecheck` green; `tableEditing.test.ts` and `bloomVideo.spec.ts` pass (8 tests).

[Claude Opus 5 following a prompt from Hatton]


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8327)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8327)
<!-- Reviewable:end -->
