### PR TITLE
BL-16818 Tables 4/6: the e2e step caption, and test ids

### DIFF
--- a/.github/skills/add-e2e-test/SKILL.md
+++ b/.github/skills/add-e2e-test/SKILL.md
@@ -217,6 +217,40 @@ Rules that hold regardless of the final API:
   a "Bloom had a problem" dialog appears; do not loop-dismiss it.
 - Waits are event/state-based (poll an API, await a selector), never fixed sleeps.
 
+## A gated feature's books must be tested in the hands of a non-subscriber
+
+Whenever the feature under test is behind a subscription tier, the test plan is not complete
+until it covers what happens to the books that feature produces when someone **without** that
+subscription opens them. This is a top priority for the Bloom project: subscribers make books,
+and the people who reuse those books, above all to translate them into their own languages, very
+often have no subscription. They cannot be blocked from that reuse. They will not be able to
+create new instances of the gated thing or restructure it, and that is fine, but they must be
+able to localize what is there.
+
+So for every gated feature, write tests for each of these, with Bloom relaunched into the lower
+tier (see `bloomApp.restart` and the relaunch options in `fixtures/launchBloom.ts`; the Pro and
+Enterprise code the suite uses is `Test-727011-1339`, never a new one):
+
+- **A derivative made below the tier from a subscriber's book.** Every text the subscriber
+  wrote can be translated: the text boxes take typing, show their language tags, and the
+  format gear works. Pictures can be replaced, audio can be recorded, the book publishes to
+  BloomPUB, ePUB and PDF. Nothing errors, nothing is hidden or garbled.
+- **What is frozen, precisely.** List the affordances the lower tier does not get (add, delete,
+  restructure, duplicate, the feature's palette icon, its Add Page entries) and assert each
+  one is absent or shows the subscription dialog, while the content itself stays editable.
+- **The original book opened below the tier.** Publishing an original that uses the gated
+  feature is normally blocked (`PreventPublishingInOriginalBooks` in `FeatureRegistry.cs`);
+  assert the Publish tab shows that block, and that the derivative from the bullet above does
+  not.
+- **The feature's experimental switch off, if it has one**, at the subscriber's tier: the
+  content still renders and localizes, with no badge, dialog or chrome.
+
+The expected behaviour for each of these is a product decision, not something to infer from the
+code. Ask the developer, item by item, what a non-subscriber should be able to do with this
+feature's content, and record the answers in the plan or the card before writing the test. Where
+the product does not yet do what they said, write the test as `test.fixme` with the observed and
+expected behaviour, and report the gap: it is a bug, and a high-priority one.
+
 ## Every step is a helper call
 
 This suite will grow to a few thousand tests. It stays maintainable only if the knowledge
@@ -510,6 +544,9 @@ The last message of the run is short (about 200 words) and stands on its own. In
 - [ ] The test passes locally, launched from a clean state (no Bloom running).
 - [ ] No Bloom.exe process survives the run.
 - [ ] New inputs: PR merged in bloom-testing-inputs, pin advanced here, both green.
+- [ ] If the feature is behind a subscription tier, tests cover a non-subscriber's use of the
+      books it makes: localizing a derivative, what is frozen, the original's publish block,
+      the experimental switch off. The expected behaviour came from the developer, not the code.
 - [ ] Anything you could not automate cleanly is recorded in `AUTOMATION-DEBT.md`.
 - [ ] The PR is open against `master`, CI is green, and it is marked ready unless something is
       deferred to the developer.

--- a/.github/skills/bloom-automation/SKILL.md
+++ b/.github/skills/bloom-automation/SKILL.md
@@ -431,3 +431,61 @@ Report:
 
 ## Debugging tips
 Use node or bash scripts. Avoid powershell. Use the "dev-browser" cli instead of playwright for interactive debugging/driving Bloom. Use "dev-browser --help" to see the available commands and options. If the user hasn't installed dev-browser, ask them for permission to install it (https://github.com/SawyerHood/dev-browser).
+
+## Driving the editable page over CDP (DOM interaction)
+
+These patterns were verified driving the real Bloom.exe WebView2 via `dev-browser --connect http://localhost:<cdpPort>`. Pages returned by `browser.getPage(...)` are full Playwright Page objects.
+
+- **Frames.** The Edit screen is several sibling iframes under the workspace root. Get them with Playwright by name/url, not by index:
+    - page (editable content): `page.frames().find(f => f.name() === 'page')`
+    - toolbox: `page.frames().find(f => (f.url()||'').includes('toolbox'))`
+    - others: `pageList`, plus the top/anon root.
+  After a tab switch or page change the page frame reloads; re-find it and poll until your target selector exists (e.g. `.bloom-page`) before acting.
+- **Clicking inside a frame: use `elementHandle.click({force:true})`, not `page.mouse.click(x,y)`.** `boundingBox()` for an element inside an iframe returns *frame-relative* coords, but `page.mouse` uses *top-level viewport* coords — so computed clicks land in the wrong place. `elementHandle.click()` is frame-aware. `{force:true}` is also needed because Bloom overlays a format-gear (`#formatButton`, `.bloom-ui`) on focused editables that intercepts normal clicks ("subtree intercepts pointer events").
+- **Typing into a cell/text box.** Click the `.bloom-editable` with `{force:true}`, then `page.keyboard.type(...)`. To replace existing text: `Control+A` then `Delete` first. Re-query the editables array between cells (the DOM can re-render).
+- **Saving a page.** There is no save button; navigating away persists the page. Switching workspace tabs (Collections → Edit) forces a save+reload — handy for a round-trip test. The saved book HTML is the book folder's main `<BookName>.htm`; ignore the `*-memsim-*` and `*Pagelist*` temp files. Find the book folder from a page-frame iframe `src` (e.g. `…/Bloom/<collection>/Book-xxxx/`).
+- **Undo is a C# accelerator — synthetic Ctrl+Z over CDP does NOT reach it.** Instead call the exact entry points C# uses, from the *top* frame: `window.workspaceBundle.handleUndo()` and `window.workspaceBundle.canUndo()` (returns `"yes"`/`"fail"`).
+- **Cross-frame bundle calls.** Page-frame functions are on `window.editablePageBundle.*` (read it inside the page frame); workspace/root functions on `window.workspaceBundle.*` (top frame). Useful for asserting state without scraping the DOM.
+- **Toolbox tools.** Optional/experimental tools must first be enabled via the "More…" settings checkbox (e.g. `#<toolname>Check`, which calls `toolboxBundle.showOrHideTool_click(this)`), then activated by clicking their accordion header `[data-toolId="<id>Tool"]`. Tool buttons expose `title`/`aria-label` (e.g. `button[title="Insert Row Below"]`), not `alt`.
+- **Capture console errors** while exercising React UI: `page.on('console', m => { if (m.type()==='error') errors.push(m.text()); })` — the cheapest check for "multiple React"/hook/MUI problems.
+- **dev-browser script gotchas.** Scripts run in a QuickJS sandbox (no Node/`require`/`fs`). Keep them small and single-purpose; end by logging the state you need. Bump `--timeout` (e.g. 40–50) for multi-step scripts. Avoid stray bare expressions (e.g. a lone `window` line) — they can abort the script.
+- **After relinking/rebuilding a linked front-end dependency**, restart the whole `go.sh` session rather than relying on hot reload; otherwise the page runs the stale copy. A launcher `/restart` is *not* enough: it restarts Bloom.exe but the Vite dev server started by the first `go.sh` keeps running and keeps serving the module it transformed at startup (`curl http://localhost:<vitePort>/@id/<dep>` and grep for your change to confirm). Do not kill the Vite process on its own either, because that takes the launcher down with it and the control API disappears. Stop the session and start `./go.sh` again; the new session picks new Vite and control ports, so re-read `output/bloom-launcher.json`.
+- **Locator coordinates are top-level, not frame-relative.** `locator.boundingBox()` on an element inside the page iframe already returns main-frame viewport coordinates, so `appPage.mouse.click(box.x + box.width/2, box.y + box.height/2)` lands on the element. Adding the iframe's own offset makes the click miss.
+
+## Change Layout (adding a section to a custom page)
+
+The Change Layout toggle turns on origami layout mode, which is the only place the
+section chooser ("Image, Video, Table, or Text") appears. So to give yourself a
+table, an image or a video to work with: turn the toggle on, click the section you
+want, then turn the toggle off.
+
+The toggle is **inside the page iframe**, not the shell: `AbovePageControls.tsx`
+renders a visually hidden checkbox `#changeLayoutToggle` with a visible
+`<label class="onoffswitch-label" for="changeLayoutToggle">`. Click the label; the
+checkbox itself is not clickable.
+
+```js
+const f = appPage.frames().find((fr) => fr.name() === "page");
+const state = () =>
+    f.evaluate(() => ({
+        checked: document.getElementById("changeLayoutToggle")?.checked,
+        marginBox: document.querySelector(".marginBox")?.className,
+    }));
+await f.locator('label.onoffswitch-label[for="changeLayoutToggle"]').click();
+// Layout mode adds a class, so the marginBox reads
+// "marginBox origami-layout-mode" while the toggle is on.
+```
+
+Two gotchas:
+
+- Allow about two seconds after the click. The page rebuilds its controls, and
+  `state()` right after the click still reports the old value.
+- **The chooser links exist twice.** A hidden `.origami-template-container` holds a
+  prototype copy of every link, and a plain locator matches that one first. Ask for
+  the visible one:
+  `f.locator('a[data-i18n="EditTab.CustomPage.Table"]:visible').first().click()`.
+
+The link's `data-i18n` values are `EditTab.CustomPage.Image`, `.Video`, `.Table`
+and `.Text`. A link only appears when its feature is on, so a missing Table link
+usually means the "Tables" experiment is off in Collection Settings, not that the
+click failed.

--- a/src/BloomBrowserUI/app/App.tsx
+++ b/src/BloomBrowserUI/app/App.tsx
@@ -15,6 +15,7 @@ import { PublishTabPane } from "../publish/PublishTab/PublishTabPane";
 import { kPanelBackground } from "../bloomMaterialUITheme";
 import { EditTabPane } from "./EditTabPane";
 import { ToastHost } from "../toast/ToastHost";
+import { E2eStepCaption } from "./e2eCaption/E2eStepCaption";
 
 export const App: React.FunctionComponent = () => {
     // Eventually the source of truth of what tab is active will be on the
@@ -66,6 +67,9 @@ export const App: React.FunctionComponent = () => {
             </div>
             <div id="modal-dialog-container" />
             <ToastHost />
+            {/* Says what an end-to-end test is doing. Renders nothing unless Bloom was
+                launched with --e2e. */}
+            <E2eStepCaption />
         </div>
     );
 };

--- a/src/BloomBrowserUI/app/e2eCaption/E2eStepCaption.test.tsx
+++ b/src/BloomBrowserUI/app/e2eCaption/E2eStepCaption.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+// The one thing the component asks the server: whether this Bloom is running under --e2e. Each
+// test sets the answer before rendering.
+let runningE2eTests = false;
+vi.mock("../../utils/bloomApi", () => ({
+    useApiObject: () => ({ runningE2eTests }),
+}));
+
+import { E2eStepCaption } from "./E2eStepCaption";
+
+let container: HTMLDivElement;
+let root: Root;
+
+const render = () => {
+    act(() => {
+        root.render(React.createElement(E2eStepCaption));
+    });
+};
+
+const caption = () =>
+    container.querySelector('[data-testid="e2e-step-caption"]');
+
+beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+});
+
+afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    delete window.bloomE2eCaption;
+});
+
+describe("E2eStepCaption", () => {
+    it("is not in the DOM, and installs nothing on window, in a normal run", () => {
+        runningE2eTests = false;
+        render();
+        expect(caption()).toBeNull();
+        expect(window.bloomE2eCaption).toBeUndefined();
+    });
+
+    it("stays out of the DOM under --e2e until a test begins", () => {
+        runningE2eTests = true;
+        render();
+        // Sanity check: the API is there to be called, but nothing is drawn yet.
+        expect(window.bloomE2eCaption).toBeDefined();
+        expect(caption()).toBeNull();
+    });
+
+    it("shows the test, then its steps, and never intercepts a click", () => {
+        runningE2eTests = true;
+        render();
+        act(() => {
+            window.bloomE2eCaption!.begin("tables-core", "add a table");
+        });
+        const strip = caption();
+        if (!strip) throw new Error("The caption did not appear.");
+        expect(strip.textContent).toContain("tables-core");
+        expect(strip.textContent).toContain("add a table");
+        expect(getComputedStyle(strip).pointerEvents).toBe("none");
+
+        act(() => {
+            window.bloomE2eCaption!.step("Open the toolbox");
+        });
+        expect(caption()!.textContent).toContain("Open the toolbox");
+        // The step counter, with no total because the test side did not know one.
+        expect(caption()!.textContent).toContain("1 ·");
+
+        act(() => {
+            window.bloomE2eCaption!.end("passed", 2100);
+            window.bloomE2eCaption!.step("Type into a cell");
+        });
+        expect(caption()!.textContent).toContain("2.1s");
+        expect(caption()!.textContent).toContain("Type into a cell");
+    });
+
+    it("shows only the last three steps", () => {
+        runningE2eTests = true;
+        render();
+        act(() => {
+            window.bloomE2eCaption!.begin("s", "t");
+            ["one", "two", "three", "four"].forEach((title) => {
+                window.bloomE2eCaption!.step(title);
+                window.bloomE2eCaption!.end("passed", 100);
+            });
+        });
+        expect(caption()!.textContent).not.toContain("one");
+        expect(caption()!.textContent).toContain("four");
+    });
+
+    it("takes its API back off window when it unmounts", () => {
+        runningE2eTests = true;
+        render();
+        expect(window.bloomE2eCaption).toBeDefined();
+        act(() => root.unmount());
+        expect(window.bloomE2eCaption).toBeUndefined();
+        // The afterEach unmount must still be safe.
+        root = createRoot(container);
+    });
+});

--- a/src/BloomBrowserUI/app/e2eCaption/E2eStepCaption.tsx
+++ b/src/BloomBrowserUI/app/e2eCaption/E2eStepCaption.tsx
@@ -1,0 +1,275 @@
+// A caption strip at the middle bottom of the Bloom shell saying what an end-to-end test is
+// doing: the spec file and test title, a clock, and the last three steps with their times.
+//
+// It exists only while Bloom runs under --e2e (see common/instanceInfo's runningE2eTests, set in
+// CommonApi.cs). In any other run this component renders nothing and installs nothing on window,
+// so a person using Bloom can neither see it nor find it in the DOM.
+//
+// The test side drives it through window.bloomE2eCaption, from src/BloomE2E/helpers/caption.ts.
+// It is cosmetic: nothing here may throw into the page, and a test whose page reloads mid-run
+// simply loses the caption until the next call.
+
+import * as React from "react";
+import { css } from "@emotion/react";
+import { useApiObject } from "../../utils/bloomApi";
+import {
+    beginStep,
+    beginTest,
+    emptyE2eCaptionState,
+    endStep,
+    finishTest,
+    formatClock,
+    formatStepTime,
+    IE2eCaptionState,
+    IE2eStep,
+    kSlowStepMs,
+    stepCounterText,
+    stepElapsedMs,
+    testElapsedMs,
+    visibleSteps,
+} from "./e2eCaptionModel";
+
+/** The imperative API a test drives the caption with, over CDP. */
+export interface IE2eCaptionApi {
+    /** Start a test: its spec file, its title, and how many steps it will run if that is known. */
+    begin(specName: string, testTitle: string, totalSteps?: number): void;
+    /** Start a step. */
+    step(title: string): void;
+    /** Say how the current step ended, and how long the test side measured it taking. */
+    end(status: "passed" | "failed" | "fixme", durationMs?: number): void;
+    /** The test is over: stop the clock and leave the last steps showing. */
+    finish(): void;
+}
+
+declare global {
+    interface Window {
+        bloomE2eCaption?: IE2eCaptionApi;
+    }
+}
+
+// How often the live timers repaint. Fast enough that the tenths in "2.1s" move, cheap enough
+// that it costs nothing next to what the test itself is doing.
+const kTickMs = 100;
+
+const strip = "rgba(22, 32, 36, 0.86)";
+const stripInk = "#f2f6f7";
+const stripDim = "rgba(242, 246, 247, 0.55)";
+const okColor = "#7dd6a4";
+const failColor = "#ff8f80";
+const slowColor = "#ffd08a";
+const monospace = `Consolas, "Roboto Mono", "Courier New", monospace`;
+
+export const E2eStepCaption: React.FunctionComponent = () => {
+    const instanceInfo = useApiObject<{ runningE2eTests?: boolean }>(
+        "common/instanceInfo",
+        {},
+    );
+    const runningE2eTests = !!instanceInfo.runningE2eTests;
+    const [state, setState] =
+        React.useState<IE2eCaptionState>(emptyE2eCaptionState);
+    const [now, setNow] = React.useState<number>(() => Date.now());
+
+    // Install the API the test drives. Only under --e2e, so nothing about the caption exists on
+    // window in a normal run.
+    React.useEffect(() => {
+        if (!runningE2eTests) return undefined;
+        const api: IE2eCaptionApi = {
+            begin: (specName, testTitle, totalSteps) =>
+                setState(
+                    beginTest(specName, testTitle, Date.now(), totalSteps),
+                ),
+            step: (title) =>
+                setState((previous) => beginStep(previous, title, Date.now())),
+            end: (status, durationMs) =>
+                setState((previous) =>
+                    endStep(previous, status, Date.now(), durationMs),
+                ),
+            finish: () =>
+                setState((previous) => finishTest(previous, Date.now())),
+        };
+        window.bloomE2eCaption = api;
+        return () => {
+            if (window.bloomE2eCaption === api) delete window.bloomE2eCaption;
+        };
+    }, [runningE2eTests]);
+
+    // Tick the live timers while a test is running. A finished test keeps its numbers, so we stop.
+    const testIsRunning =
+        !!state.testStartedAt && state.testDurationMs === undefined;
+    React.useEffect(() => {
+        if (!runningE2eTests || !testIsRunning) return undefined;
+        const timer = window.setInterval(() => setNow(Date.now()), kTickMs);
+        return () => window.clearInterval(timer);
+    }, [runningE2eTests, testIsRunning]);
+
+    if (!runningE2eTests || !state.testStartedAt) return null;
+
+    const counter = stepCounterText(state);
+    const shown = visibleSteps(state);
+
+    return (
+        <div
+            data-testid="e2e-step-caption"
+            aria-live="polite"
+            css={css`
+                position: fixed;
+                left: 50%;
+                bottom: 14px;
+                transform: translateX(-50%);
+                width: 560px;
+                max-width: calc(100% - 40px);
+                /* Never intercept a click: the test is driving the UI underneath it. */
+                pointer-events: none;
+                z-index: 2147483000;
+                background: ${strip};
+                color: ${stripInk};
+                border-radius: 6px;
+                padding: 7px 12px 8px;
+                box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+                font-size: 12.5px;
+                line-height: 18px;
+                backdrop-filter: blur(3px);
+            `}
+        >
+            <div
+                css={css`
+                    display: flex;
+                    justify-content: space-between;
+                    gap: 12px;
+                    font: 500 11px/16px ${monospace};
+                    color: ${stripDim};
+                    letter-spacing: 0.02em;
+                    margin-bottom: 3px;
+                `}
+            >
+                <span
+                    css={css`
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
+                    `}
+                >
+                    <b
+                        css={css`
+                            color: ${stripInk};
+                            font-weight: 500;
+                        `}
+                    >
+                        {state.specName}
+                    </b>
+                    {state.testTitle ? ` · ${state.testTitle}` : ""}
+                </span>
+                <span
+                    css={css`
+                        white-space: nowrap;
+                        font-variant-numeric: tabular-nums;
+                    `}
+                >
+                    {counter ? `${counter} · ` : ""}
+                    {formatClock(testElapsedMs(state, now))}
+                </span>
+            </div>
+            <div
+                css={css`
+                    height: 54px;
+                    overflow: hidden;
+                    display: flex;
+                    flex-direction: column;
+                    justify-content: flex-end;
+                `}
+            >
+                {shown.map((step, index) => (
+                    <StepLine
+                        // Steps scroll up a fixed window, so identify a line by where the step
+                        // sits in the whole run, not by its title, which can repeat.
+                        key={state.steps.length - shown.length + index}
+                        step={step}
+                        now={now}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+};
+
+/** One step line: marker, title, and the step's time. */
+const StepLine: React.FunctionComponent<{
+    step: IE2eStep;
+    now: number;
+}> = (props) => {
+    const running = props.step.status === "running";
+    const failed = props.step.status === "failed";
+    const fixme = props.step.status === "fixme";
+    const elapsed = stepElapsedMs(props.step, props.now);
+
+    let markColor = okColor;
+    if (running) markColor = stripInk;
+    if (failed) markColor = failColor;
+    if (fixme) markColor = stripDim;
+
+    let mark = "✓";
+    if (running) mark = "▸";
+    if (failed) mark = "✗";
+    if (fixme) mark = "–";
+
+    let lineColor = stripDim;
+    if (running) lineColor = stripInk;
+    if (failed) lineColor = failColor;
+
+    let timeColor = stripDim;
+    if (running) timeColor = stripInk;
+    if (!running && elapsed > kSlowStepMs) timeColor = slowColor;
+
+    return (
+        <div
+            css={css`
+                display: grid;
+                grid-template-columns: 16px 1fr auto;
+                gap: 8px;
+                align-items: baseline;
+                white-space: nowrap;
+                overflow: hidden;
+                color: ${lineColor};
+                font-style: ${fixme ? "italic" : "normal"};
+            `}
+        >
+            <span
+                css={css`
+                    font-family: ${monospace};
+                    text-align: center;
+                    color: ${markColor};
+                    ${running
+                        ? "animation: bloomE2eCaptionPulse 1.1s ease-in-out infinite;"
+                        : ""}
+                    @keyframes bloomE2eCaptionPulse {
+                        50% {
+                            opacity: 0.35;
+                        }
+                    }
+                    @media (prefers-reduced-motion: reduce) {
+                        animation: none;
+                    }
+                `}
+            >
+                {mark}
+            </span>
+            <span
+                css={css`
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                `}
+            >
+                {props.step.title}
+            </span>
+            <span
+                css={css`
+                    font: 11.5px/18px ${monospace};
+                    font-variant-numeric: tabular-nums;
+                    color: ${timeColor};
+                `}
+            >
+                {fixme ? "–" : formatStepTime(elapsed)}
+            </span>
+        </div>
+    );
+};

--- a/src/BloomBrowserUI/app/e2eCaption/e2eCaptionModel.test.ts
+++ b/src/BloomBrowserUI/app/e2eCaption/e2eCaptionModel.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import {
+    beginStep,
+    beginTest,
+    emptyE2eCaptionState,
+    endStep,
+    finishTest,
+    formatClock,
+    formatStepTime,
+    stepCounterText,
+    stepElapsedMs,
+    testElapsedMs,
+    visibleSteps,
+} from "./e2eCaptionModel";
+
+// The caption's state, exercised without a DOM. Times are handed in rather than read from the
+// clock, so these tests say exactly what the strip shows at a given moment.
+
+const t0 = 1_000_000;
+
+describe("e2e caption state", () => {
+    it("starts empty", () => {
+        expect(emptyE2eCaptionState.steps).toHaveLength(0);
+        expect(emptyE2eCaptionState.testStartedAt).toBe(0);
+        expect(stepCounterText(emptyE2eCaptionState)).toBe("");
+    });
+
+    it("a begun test carries its spec, title and start", () => {
+        const state = beginTest("tables-core", "add a table", t0);
+        expect(state.specName).toBe("tables-core");
+        expect(state.testTitle).toBe("add a table");
+        expect(state.testStartedAt).toBe(t0);
+        expect(state.steps).toHaveLength(0);
+    });
+
+    it("running a step then ending it records the measured duration", () => {
+        let state = beginTest("tables-core", "add a table", t0);
+        state = beginStep(state, "Open the toolbox", t0 + 500);
+        expect(state.steps[0].status).toBe("running");
+        // Sanity check the live timer before the step ends.
+        expect(stepElapsedMs(state.steps[0], t0 + 2500)).toBe(2000);
+
+        state = endStep(state, "passed", t0 + 3000, 2100);
+        expect(state.steps[0].status).toBe("passed");
+        expect(state.steps[0].durationMs).toBe(2100);
+        // A finished step's time no longer moves with the clock.
+        expect(stepElapsedMs(state.steps[0], t0 + 99999)).toBe(2100);
+    });
+
+    it("falls back to its own clock when the test side reports no duration", () => {
+        let state = beginTest("s", "t", t0);
+        state = beginStep(state, "Type into a cell", t0 + 1000);
+        state = endStep(state, "passed", t0 + 1900);
+        expect(state.steps[0].durationMs).toBe(900);
+    });
+
+    it("keeps a failed step failed, and a fixme step fixme", () => {
+        let state = beginTest("s", "t", t0);
+        state = beginStep(state, "Drag a column boundary", t0);
+        state = endStep(state, "failed", t0 + 100);
+        state = beginStep(state, "Skipped one", t0 + 200);
+        state = endStep(state, "fixme", t0 + 300);
+        expect(state.steps.map((step) => step.status)).toEqual([
+            "failed",
+            "fixme",
+        ]);
+    });
+
+    it("closes a forgotten running step when the next one starts", () => {
+        let state = beginTest("s", "t", t0);
+        state = beginStep(state, "First", t0);
+        state = beginStep(state, "Second", t0 + 700);
+        expect(state.steps[0].status).toBe("passed");
+        expect(state.steps[0].durationMs).toBe(700);
+        expect(state.steps[1].status).toBe("running");
+    });
+
+    it("ending a step with none running changes nothing", () => {
+        const state = beginTest("s", "t", t0);
+        expect(endStep(state, "passed", t0 + 5)).toBe(state);
+    });
+
+    it("shows only the last three steps", () => {
+        let state = beginTest("s", "t", t0);
+        ["a", "b", "c", "d"].forEach((title, index) => {
+            state = beginStep(state, title, t0 + index * 10);
+            state = endStep(state, "passed", t0 + index * 10 + 5);
+        });
+        expect(state.steps).toHaveLength(4);
+        expect(visibleSteps(state).map((step) => step.title)).toEqual([
+            "b",
+            "c",
+            "d",
+        ]);
+    });
+
+    it("counts steps, with the total only when the caller knew it", () => {
+        let state = beginTest("s", "t", t0);
+        state = beginStep(state, "one", t0);
+        expect(stepCounterText(state)).toBe("1");
+        let withTotal = beginTest("s", "t", t0, 10);
+        withTotal = beginStep(withTotal, "one", t0);
+        expect(stepCounterText(withTotal)).toBe("1 / 10");
+    });
+
+    it("stops the test clock when the test finishes", () => {
+        let state = beginTest("s", "t", t0);
+        state = beginStep(state, "one", t0 + 100);
+        expect(testElapsedMs(state, t0 + 5000)).toBe(5000);
+        state = finishTest(state, t0 + 6000);
+        expect(state.steps[0].status).toBe("passed");
+        expect(testElapsedMs(state, t0 + 999999)).toBe(6000);
+    });
+});
+
+describe("e2e caption formatting", () => {
+    it("prints a step's time in tenths below ten seconds and whole seconds above", () => {
+        expect(formatStepTime(0)).toBe("0.0s");
+        expect(formatStepTime(2100)).toBe("2.1s");
+        expect(formatStepTime(9999)).toBe("10.0s");
+        expect(formatStepTime(11200)).toBe("11s");
+    });
+
+    it("prints the header clock as mm:ss", () => {
+        expect(formatClock(0)).toBe("00:00");
+        expect(formatClock(72000)).toBe("01:12");
+        expect(formatClock(3_600_000)).toBe("60:00");
+    });
+});

--- a/src/BloomBrowserUI/app/e2eCaption/e2eCaptionModel.ts
+++ b/src/BloomBrowserUI/app/e2eCaption/e2eCaptionModel.ts
@@ -1,0 +1,168 @@
+// The state behind the end-to-end step caption, kept separate from the React component so it can
+// be unit tested without a DOM. See E2eStepCaption.tsx for what it looks like, and
+// src/BloomE2E/helpers/caption.ts for the test-side helper that drives it.
+
+/** What has become of a step. A step is "running" until the helper reports how it ended. */
+export type E2eStepStatus = "running" | "passed" | "failed" | "fixme";
+
+/** One step line in the caption. */
+export interface IE2eStep {
+    title: string;
+    status: E2eStepStatus;
+    /** Date.now() when the step started. */
+    startedAt: number;
+    /** How long the step took, once it has finished. */
+    durationMs?: number;
+}
+
+/** Everything the caption draws. */
+export interface IE2eCaptionState {
+    /** The spec file the running test came from, e.g. "tables-core". Empty means nothing to show. */
+    specName: string;
+    /** The test's title. */
+    testTitle: string;
+    /** Date.now() when the test started. */
+    testStartedAt: number;
+    /** How long the whole test took, once it has finished; undefined while it is still running. */
+    testDurationMs?: number;
+    /** How many steps the test will run, when that is known ahead of time. */
+    totalSteps?: number;
+    steps: IE2eStep[];
+}
+
+/** A caption with nothing in it: what the component holds before any test starts. */
+export const emptyE2eCaptionState: IE2eCaptionState = {
+    specName: "",
+    testTitle: "",
+    testStartedAt: 0,
+    steps: [],
+};
+
+/** How many step lines the strip shows at once. */
+export const kVisibleStepCount = 3;
+
+/** A step whose time passes this turns its timer amber: in this suite that usually means a wait
+ * is about to time out. */
+export const kSlowStepMs = 10000;
+
+/**
+ * Start a test. Everything from the previous test is dropped, because the strip shows one test.
+ */
+export const beginTest = (
+    specName: string,
+    testTitle: string,
+    now: number,
+    totalSteps?: number,
+): IE2eCaptionState => ({
+    specName,
+    testTitle,
+    testStartedAt: now,
+    totalSteps,
+    steps: [],
+});
+
+/**
+ * Start a step. Any step still marked running is taken to have passed, so a caller that forgets
+ * to end one does not leave two pulsing lines.
+ */
+export const beginStep = (
+    state: IE2eCaptionState,
+    title: string,
+    now: number,
+): IE2eCaptionState => ({
+    ...state,
+    steps: [
+        ...closeRunningSteps(state.steps, now),
+        { title, status: "running", startedAt: now },
+    ],
+});
+
+/**
+ * Report how the current step ended. `durationMs` is the test side's own measurement; when it is
+ * not given we fall back to the clock we started.
+ */
+export const endStep = (
+    state: IE2eCaptionState,
+    status: Exclude<E2eStepStatus, "running">,
+    now: number,
+    durationMs?: number,
+): IE2eCaptionState => {
+    const lastRunning = lastRunningIndex(state.steps);
+    if (lastRunning < 0) return state;
+    const steps = state.steps.slice();
+    const step = steps[lastRunning];
+    steps[lastRunning] = {
+        ...step,
+        status,
+        durationMs: durationMs ?? now - step.startedAt,
+    };
+    return { ...state, steps };
+};
+
+/**
+ * The test is over. The clock stops, and whatever the last step was stays on screen.
+ */
+export const finishTest = (
+    state: IE2eCaptionState,
+    now: number,
+): IE2eCaptionState => ({
+    ...state,
+    steps: closeRunningSteps(state.steps, now),
+    testDurationMs: state.testStartedAt ? now - state.testStartedAt : undefined,
+});
+
+/** The last three steps: the window the strip shows. */
+export const visibleSteps = (state: IE2eCaptionState): IE2eStep[] =>
+    state.steps.slice(Math.max(0, state.steps.length - kVisibleStepCount));
+
+/**
+ * The right-hand side of the header: "4 / 10" when the total is known, "4" when it is not, and
+ * nothing at all before the first step.
+ */
+export const stepCounterText = (state: IE2eCaptionState): string => {
+    if (state.steps.length === 0) return "";
+    if (state.totalSteps === undefined) return `${state.steps.length}`;
+    return `${state.steps.length} / ${state.totalSteps}`;
+};
+
+/** A step's own time, as the strip prints it: "2.1s" under ten seconds, "11s" over. */
+export const formatStepTime = (ms: number): string =>
+    ms < kSlowStepMs
+        ? `${(ms / 1000).toFixed(1)}s`
+        : `${Math.round(ms / 1000)}s`;
+
+/** The header clock: mm:ss of the test's elapsed time. */
+export const formatClock = (ms: number): string => {
+    const seconds = Math.max(0, Math.floor(ms / 1000));
+    const minutes = Math.floor(seconds / 60);
+    return `${String(minutes).padStart(2, "0")}:${String(seconds % 60).padStart(2, "0")}`;
+};
+
+/** How long the test has been going: frozen once it has finished. */
+export const testElapsedMs = (state: IE2eCaptionState, now: number): number => {
+    if (state.testDurationMs !== undefined) return state.testDurationMs;
+    if (!state.testStartedAt) return 0;
+    return now - state.testStartedAt;
+};
+
+/** How long a step has been going, or took. */
+export const stepElapsedMs = (step: IE2eStep, now: number): number =>
+    step.durationMs ?? now - step.startedAt;
+
+const lastRunningIndex = (steps: IE2eStep[]): number => {
+    for (let i = steps.length - 1; i >= 0; i--) {
+        if (steps[i].status === "running") return i;
+    }
+    return -1;
+};
+
+const closeRunningSteps = (steps: IE2eStep[], now: number): IE2eStep[] =>
+    steps.map((step) =>
+        step.status === "running"
+            ? {
+                  ...step,
+                  status: "passed" as const,
+                  durationMs: now - step.startedAt,
+              }
+            : step,
+    );

--- a/src/BloomBrowserUI/bookEdit/toolbox/settings/SettingsToolControls.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/settings/SettingsToolControls.tsx
@@ -29,6 +29,9 @@ const ToolboxCheckbox: FunctionComponent<{
                 margin-bottom: -6px;
                 padding-top: 0;
             `}
+            // The tool's own id, so a test can turn a tool on without matching its localized
+            // label. See BloomE2E/helpers/toolbox.ts.
+            data-testid={`toolbox-tool-${props.tool}`}
         >
             <BloomCheckbox
                 css={css`

--- a/src/BloomBrowserUI/publish/PublishTab/PublishingBookRequiresHigherTierNotice.tsx
+++ b/src/BloomBrowserUI/publish/PublishTab/PublishingBookRequiresHigherTierNotice.tsx
@@ -52,6 +52,10 @@ export const PublishingBookRequiresHigherTierNotice: React.FunctionComponent<{
 
     return (
         <div
+            // How an automated test tells that publishing is blocked: everything else on this
+            // notice is localized text. It replaces the whole tab, so its presence also means
+            // no publish destination is reachable.
+            data-testid="publishing-blocked-notice"
             css={css`
                 background-color: ${kBloomUnselectedTabBackground};
                 margin: 0;

--- a/src/BloomBrowserUI/react_components/requiresSubscription.tsx
+++ b/src/BloomBrowserUI/react_components/requiresSubscription.tsx
@@ -513,7 +513,10 @@ export const RequiresSubscriptionDialog: React.FunctionComponent<{
 
     return (
         <BloomDialog {...propsForBloomDialog}>
-            <div>
+            {/* The test id is how an automated test can tell that this dialog, rather than some
+                other one, is showing: its title is localized, and MUI unmounts the children of a
+                closed dialog, so the id is present only while it is open. */}
+            <div data-testid="requires-subscription-dialog">
                 <DialogTitle
                     title={dialogTitle}
                     css={css`

--- a/src/BloomExe/web/controllers/CommonApi.cs
+++ b/src/BloomExe/web/controllers/CommonApi.cs
@@ -297,6 +297,10 @@ namespace Bloom.web.controllers
                     // Control port of the dev launcher that started us (null when not
                     // launched via go.sh); see .github/skills/bloom-automation.
                     launcherControlPort = Program.StartupLauncherPort,
+                    // True when this Bloom was launched with --e2e. The workspace shell reads
+                    // this to decide whether to show the end-to-end step caption; nothing about
+                    // that caption exists in a normal run.
+                    runningE2eTests = Program.RunningE2eTests,
                 }
             );
         }


### PR DESCRIPTION
Fourth of six stacked PRs splitting #8315. **Base is `BL-16818-table-video-cells` (#8327).**

This is the only production code in the end-to-end half of that work, split out so that it gets read rather than skimmed past several thousand lines of test code. None of it is about tables.

**The step caption** is a strip the workspace shell shows only under `--e2e`, naming the step a test is on. Watching a run without it is watching Bloom do things for no stated reason; with it, a recording explains itself. `CommonApi` reports `runningE2eTests` so the shell knows whether to mount it.

**Test ids** on three places where the only other handle is a localized label: the subscription dialog, the higher-tier publish notice, and the toolbox tool checkboxes.

**The `add-e2e-test` skill** gains a section on what a gated feature's test plan owes a non-subscriber. Subscribers make books; the people who reuse them, above all to translate them, often have no subscription, and must still be able to localize what is there. Worth reading on its own — it applies to every gated feature, not just tables.

Note for reviewers: the version of this work on #8315 also carried an `ExperimentalFeatures` environment variable and a `nextVideoFileToChoose` endpoint. Both were superseded on `master` by the `--experimental-features` command line and the general `nextFileToChoose`, so neither is here.

## Checks

`pnpm typecheck`, the caption's own 17 tests, `build/agent-vite.sh`, and a `BloomExe` build all green.

[Claude Opus 5 following a prompt from Hatton]


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8328)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8328)
<!-- Reviewable:end -->
