### PR TITLE
BL-16818 Tables 6/6: spreadsheet export and import

### DIFF
--- a/src/BloomExe/Spreadsheet/InternalSpreadsheet.cs
+++ b/src/BloomExe/Spreadsheet/InternalSpreadsheet.cs
@@ -39,6 +39,13 @@ namespace Bloom.Spreadsheet
         public const string WidgetSourceColumnLabel = "[activities source]";
         public const string PageTypeColumnLabel = "[page type]";
         public const string AttributeColumnLabel = "[attribute]";
+
+        // A hidden column holding a JSON object with whatever non-textual state a row's
+        // object needs to be reconstructed on import. Used by [table] and [table cell]
+        // rows. Its presence anywhere in a spreadsheet marks that spreadsheet as the
+        // authority on the objects whose rows use it.
+        public const string DetailsColumnLabel = "[details]";
+        public const string DetailsColumnFriendlyName = "Details";
         public const string ImageSourceColumnFriendlyName = "Image File Path";
 
         public const string BlankContentIndicator = "[blank]";
@@ -47,6 +54,17 @@ namespace Bloom.Spreadsheet
         public const string CoverImageRowLabel = "[cover image]";
         public const string PageContentRowLabel = "[page content]";
         public const string ImageDescriptionRowLabel = "[image description]";
+
+        // A row for one bloom-table. It holds no text of its own: the whole table element,
+        // with every attribute of the table and of each of its cells, rides in [details]
+        // as JSON. It is followed immediately by one [table cell] row per visible cell.
+        public const string TableRowLabel = "[table]";
+
+        // A row for one visible (non bloom-skip) cell of the table whose [table] row it
+        // follows. Which cell it is rides in [details] as JSON; the cell's content rides
+        // in the ordinary columns -- the language columns for a text cell, [image source]
+        // for a picture cell, [video source] for a video cell.
+        public const string TableCellRowLabel = "[table cell]";
 
         internal static string MapRowLabelToDataBookLabel(string rowTypeLabel)
         {
@@ -350,7 +368,10 @@ namespace Bloom.Spreadsheet
             {
                 GetColumnForTag(PageNumberColumnLabel),
                 GetColumnForTag(ImageSourceColumnLabel),
-            };
+                GetColumnForTag(DetailsColumnLabel),
+            }
+                .Where(i => i >= 0) // optional columns may be absent
+                .ToList();
 
         public void SortHiddenContentRowsToTheBottom()
         {

--- a/src/BloomExe/Spreadsheet/SpreadsheetExporter.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetExporter.cs
@@ -18,6 +18,7 @@ using Bloom.Publish;
 using Bloom.SafeXml;
 using Bloom.web;
 using L10NSharp;
+using Newtonsoft.Json.Linq;
 using SIL.IO;
 using SIL.Reporting;
 
@@ -183,42 +184,94 @@ namespace Bloom.Spreadsheet
             Color colorForPage
         )
         {
-            var imageContainers = GetImageContainersAndBloomCanvases(page);
+            // A table's own translation groups, canvases and video containers belong to the
+            // table, which gets its own rows below; they must not also become [page content]
+            // rows, or a nine-by-six table would fill the sheet with dozens of positional
+            // rows that no importer could put back where they came from.
+            var tables = SpreadsheetTables.TopLevelTables(page);
+            var imageContainers = GetImageContainersAndBloomCanvases(page)
+                .Where(x => !SpreadsheetTables.IsInsideTable(x))
+                .ToList();
             var allGroups = TranslationGroupManager.SortedGroupsOnPage(page, true);
             var groups = allGroups
-                .Where(x => !x.GetAttribute("class").Contains("bloom-imageDescription"))
+                .Where(x =>
+                    !x.GetAttribute("class").Contains("bloom-imageDescription")
+                    && !SpreadsheetTables.IsInsideTable(x)
+                )
                 .ToList();
             var videoContainers = page.SafeSelectNodes(
                     ".//*[contains(@class,'bloom-videoContainer')]"
                 )
                 .Cast<SafeXmlElement>()
+                .Where(x => !SpreadsheetTables.IsInsideTable(x))
                 .ToList();
             var widgetContainers = page.SafeSelectNodes(
                     ".//*[contains(@class,'bloom-widgetContainer')]"
                 )
                 .Cast<SafeXmlElement>()
+                .Where(x => !SpreadsheetTables.IsInsideTable(x))
                 .ToList();
 
             var pageType = SpreadsheetImporter.GetLabelFromPage(page);
 
+            // Puts the page type on the first row we make for the page, whatever kind of row
+            // that is. If we make more rows for this page, we don't specify a type; that
+            // allows subsequent rows to go onto the same page if there is room.
+            void SetPageTypeIfNeeded(ContentRow rowNeedingType)
+            {
+                if (string.IsNullOrEmpty(pageType))
+                    return;
+                var pageTypeIndex = _spreadsheet.AddColumnForTag(
+                    InternalSpreadsheet.PageTypeColumnLabel,
+                    "Page Type"
+                );
+                rowNeedingType.SetCell(pageTypeIndex, pageType);
+                pageType = null;
+            }
+
             // Each of these will result in one row in the output.
-            var rowContentSources = Extensions.MapUnevenLists(
+            var rowContentSources = Extensions
+                .MapUnevenLists(
+                    new[] { groups, imageContainers, videoContainers, widgetContainers }
+                )
+                .ToList();
+
+            // Where each table's rows go among the page's [page content] rows: after as many
+            // of them as hold something that precedes the table in the document. Row k holds
+            // groups[k], imageContainers[k] and so on, so everything before the table has
+            // been written once we have written that many rows.
+            var pageContentRowsBeforeTable = RowsBeforeEachTable(
+                page,
+                tables,
                 new[] { groups, imageContainers, videoContainers, widgetContainers }
             );
+            var tablesWritten = 0;
+            void WriteTablesDueBefore(int pageContentRowsWritten)
+            {
+                while (
+                    tablesWritten < tables.Count
+                    && pageContentRowsBeforeTable[tablesWritten] <= pageContentRowsWritten
+                )
+                {
+                    ExportTableRows(
+                        tables[tablesWritten],
+                        pageNumber,
+                        colorForPage,
+                        bookFolderPath,
+                        null,
+                        SetPageTypeIfNeeded
+                    );
+                    tablesWritten++;
+                }
+            }
+
+            var pageContentRowsSoFar = 0;
             foreach (var pageContent in rowContentSources)
             {
+                WriteTablesDueBefore(pageContentRowsSoFar);
+                pageContentRowsSoFar++;
                 var row = new ContentRow(_spreadsheet);
-                if (!string.IsNullOrEmpty(pageType))
-                {
-                    var pageTypeIndex = _spreadsheet.AddColumnForTag(
-                        InternalSpreadsheet.PageTypeColumnLabel,
-                        "Page Type"
-                    );
-                    row.SetCell(pageTypeIndex, pageType);
-                    // If we make more rows for this page, don't specify a type.
-                    // This allows subsequent rows to go onto the same page if there is room.
-                    pageType = null;
-                }
+                SetPageTypeIfNeeded(row);
                 row.SetCell(
                     InternalSpreadsheet.RowTypeColumnLabel,
                     InternalSpreadsheet.PageContentRowLabel
@@ -278,6 +331,243 @@ namespace Bloom.Spreadsheet
                 }
 
                 row.BackgroundColor = colorForPage;
+            }
+            // Any tables that come after everything else on the page (including the case of
+            // a page whose only content is a table, where there are no [page content] rows).
+            WriteTablesDueBefore(int.MaxValue);
+        }
+
+        /// <summary>
+        /// For each table, how many [page content] rows must be written before it: the
+        /// largest number of items that precede it in document order in any one of the
+        /// lists those rows are made from.
+        /// </summary>
+        private static List<int> RowsBeforeEachTable(
+            SafeXmlElement page,
+            List<SafeXmlElement> tables,
+            List<SafeXmlElement>[] rowContentLists
+        )
+        {
+            if (tables.Count == 0)
+                return new List<int>();
+            var documentOrder = GetDocumentOrder(page);
+            int OrderOf(SafeXmlElement element) =>
+                documentOrder.TryGetValue(element, out var order) ? order : int.MaxValue;
+            return tables
+                .Select(table =>
+                {
+                    var tableOrder = OrderOf(table);
+                    return rowContentLists
+                        .Select(list => list.Count(item => OrderOf(item) < tableOrder))
+                        .Max();
+                })
+                .ToList();
+        }
+
+        /// <summary>
+        /// Every element at or under the page, numbered in document order, so that two
+        /// elements found by different searches can be told which comes first.
+        /// </summary>
+        private static Dictionary<SafeXmlElement, int> GetDocumentOrder(SafeXmlElement page)
+        {
+            var result = new Dictionary<SafeXmlElement, int>();
+            var next = 0;
+            void Walk(SafeXmlNode node)
+            {
+                if (node is SafeXmlElement element)
+                    result[element] = next++;
+                foreach (var child in node.ChildNodes)
+                    Walk(child);
+            }
+            Walk(page);
+            return result;
+        }
+
+        /// <summary>
+        /// Writes one bloom-table as a [table] row followed by one [table cell] row per
+        /// visible cell, row-major. The [table] row holds no text of its own: the table
+        /// element and all its cells go into the hidden [details] column as JSON,
+        /// attributes and inline styles verbatim, e.g.
+        /// {"kind":"table","attributes":{"class":"bloom-table bloom-leadingElement",
+        /// "data-column-widths":"hug,fill","style":"grid-template-columns: ...;"},
+        /// "cells":[{"row":0,"col":0,"attributes":{"class":"bloom-cell",
+        /// "data-content-type":"text"}}, ...]}. Copying attributes rather than
+        /// interpreting them means C# never has to understand a column width or a border
+        /// matrix, and an imported book renders correctly even if it is published without
+        /// ever being opened in the Edit tab.
+        ///
+        /// A cell's own content rides in the ordinary columns of its [table cell] row, so
+        /// that a translator sees a table's text in the same language columns as any other
+        /// text: {"kind":"table-cell","row":0,"col":1,"type":"text"}. Covered (bloom-skip)
+        /// cells get no row of their own; they are in the [table] row's cell list as
+        /// attributes, which is all there is to them.
+        ///
+        /// A cell whose type is "table" holds a nested table, whose own [table] and
+        /// [table cell] rows follow that cell's row and carry "parent":{"row":r,"col":c}
+        /// naming the cell of this table that holds them.
+        /// </summary>
+        /// <param name="parent">null for a table on the page; for a nested table, the row
+        /// and column of the cell of the containing table that holds it.</param>
+        private void ExportTableRows(
+            SafeXmlElement table,
+            string pageNumber,
+            Color colorForPage,
+            string bookFolderPath,
+            JObject parent,
+            Action<ContentRow> setPageTypeIfNeeded
+        )
+        {
+            // Make sure the details column exists; its presence is what tells the importer
+            // that this spreadsheet is the authority on the tables it describes.
+            _spreadsheet.AddColumnForTag(
+                InternalSpreadsheet.DetailsColumnLabel,
+                InternalSpreadsheet.DetailsColumnFriendlyName
+            );
+
+            var cells = SpreadsheetTables.CellsOf(table);
+            var columnCount = SpreadsheetTables.ColumnCount(table);
+
+            var tableDetails = new JObject { ["kind"] = SpreadsheetTables.TableKind };
+            if (parent != null)
+                tableDetails["parent"] = parent.DeepClone();
+            tableDetails["attributes"] = SpreadsheetTables.GetAttributesForExport(table);
+            var cellList = new JArray();
+            for (var i = 0; i < cells.Count; i++)
+            {
+                cellList.Add(
+                    new JObject
+                    {
+                        ["row"] = i / columnCount,
+                        ["col"] = i % columnCount,
+                        ["attributes"] = SpreadsheetTables.GetAttributesForExport(cells[i]),
+                    }
+                );
+            }
+            tableDetails["cells"] = cellList;
+
+            var tableRow = new ContentRow(_spreadsheet);
+            setPageTypeIfNeeded(tableRow);
+            tableRow.SetCell(
+                InternalSpreadsheet.RowTypeColumnLabel,
+                InternalSpreadsheet.TableRowLabel
+            );
+            tableRow.SetCell(InternalSpreadsheet.PageNumberColumnLabel, pageNumber);
+            tableRow.SetCell(
+                InternalSpreadsheet.DetailsColumnLabel,
+                tableDetails.ToString(Newtonsoft.Json.Formatting.None)
+            );
+            tableRow.BackgroundColor = colorForPage;
+
+            for (var i = 0; i < cells.Count; i++)
+            {
+                var cell = cells[i];
+                if (cell.HasClass(SpreadsheetTables.SkipClass))
+                    continue;
+                var cellRowNumber = i / columnCount;
+                var cellColumnNumber = i % columnCount;
+                var contentType = SpreadsheetTables.ContentTypeOf(cell);
+
+                var cellDetails = new JObject
+                {
+                    ["kind"] = SpreadsheetTables.TableCellKind,
+                    ["row"] = cellRowNumber,
+                    ["col"] = cellColumnNumber,
+                    ["type"] = contentType,
+                };
+                if (parent != null)
+                    cellDetails["parent"] = parent.DeepClone();
+
+                var cellRow = new ContentRow(_spreadsheet);
+                cellRow.SetCell(
+                    InternalSpreadsheet.RowTypeColumnLabel,
+                    InternalSpreadsheet.TableCellRowLabel
+                );
+                cellRow.SetCell(InternalSpreadsheet.PageNumberColumnLabel, pageNumber);
+                cellRow.SetCell(
+                    InternalSpreadsheet.DetailsColumnLabel,
+                    cellDetails.ToString(Newtonsoft.Json.Formatting.None)
+                );
+                cellRow.BackgroundColor = colorForPage;
+
+                switch (contentType)
+                {
+                    case SpreadsheetTables.TextContentType:
+                        var group = SafeXmlElement
+                            .GetAllDivsWithClass(cell, "bloom-translationGroup")
+                            .FirstOrDefault(g =>
+                                !g.HasClass("bloom-imageDescription")
+                                && SpreadsheetTables.ParentCellOf(g) == cell
+                            );
+                        if (group != null)
+                            WriteTranslationGroup(group, cellRow, bookFolderPath);
+                        break;
+                    case SpreadsheetTables.ImageContentType:
+                        WriteCellImage(cell, cellRow, pageNumber, colorForPage, bookFolderPath);
+                        break;
+                    case SpreadsheetTables.VideoContentType:
+                        var videoContainer = SpreadsheetTables.FindDescendantWithClass(
+                            cell,
+                            "bloom-videoContainer"
+                        );
+                        if (videoContainer != null)
+                            WriteVideo(videoContainer, cellRow, bookFolderPath);
+                        break;
+                    case SpreadsheetTables.TableContentType:
+                        var nested = SpreadsheetTables.FindNestedTable(cell);
+                        if (nested != null)
+                            ExportTableRows(
+                                nested,
+                                pageNumber,
+                                colorForPage,
+                                bookFolderPath,
+                                new JObject { ["row"] = cellRowNumber, ["col"] = cellColumnNumber },
+                                setPageTypeIfNeeded
+                            );
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Writes a picture cell's image into its [table cell] row, the same way a page's
+        /// image goes into a [page content] row: the file is copied into the spreadsheet's
+        /// images folder, its path goes in [image source] (so it also gets a thumbnail),
+        /// and any image description follows in an [image description] row.
+        /// </summary>
+        private void WriteCellImage(
+            SafeXmlElement cell,
+            ContentRow cellRow,
+            string pageNumber,
+            Color colorForPage,
+            string bookFolderPath
+        )
+        {
+            var image = cell.SafeSelectNodes(".//img").Cast<SafeXmlElement>().FirstOrDefault();
+            var imagePath = ImagePath(
+                bookFolderPath,
+                image?.GetAttribute("src") ?? "placeHolder.png"
+            );
+            var fileName = Path.GetFileName(imagePath);
+            var outputPath = Path.Combine("images", fileName);
+            if (ImageUtils.IsPlaceholderImageFilename(fileName))
+                outputPath = InternalSpreadsheet.BlankContentIndicator;
+            cellRow.SetCell(InternalSpreadsheet.ImageSourceColumnLabel, outputPath);
+            CopyImageFileToSpreadsheetFolder(imagePath);
+
+            foreach (
+                var description in SafeXmlElement
+                    .GetAllDivsWithClass(cell, "bloom-imageDescription")
+                    .Where(d => SpreadsheetTables.ParentCellOf(d) == cell)
+            ) // typically at most one
+            {
+                var descriptionRow = new ContentRow(_spreadsheet);
+                descriptionRow.SetCell(
+                    InternalSpreadsheet.RowTypeColumnLabel,
+                    InternalSpreadsheet.ImageDescriptionRowLabel
+                );
+                descriptionRow.SetCell(InternalSpreadsheet.PageNumberColumnLabel, pageNumber);
+                descriptionRow.BackgroundColor = colorForPage;
+                WriteTranslationGroup(description, descriptionRow, bookFolderPath);
             }
         }
 

--- a/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetIO.cs
@@ -379,8 +379,12 @@ namespace Bloom.Spreadsheet
             // PageType column holds what is basically the InnerText of an element;
             // the InnerText property handles any XML escaping.
             // Image source column holds the actual path to the file; it will be url encoded when set as the src.
+            // The details column holds JSON, which we must get back byte for byte: escaping
+            // its ampersands (e.g. in a url inside an attribute value) would corrupt the
+            // attributes we are copying verbatim.
             return key != InternalSpreadsheet.PageTypeColumnLabel
-                && key != InternalSpreadsheet.ImageSourceColumnLabel;
+                && key != InternalSpreadsheet.ImageSourceColumnLabel
+                && key != InternalSpreadsheet.DetailsColumnLabel;
         }
 
         private static bool IsWysiwygFormattedColumn(SpreadsheetRow row, int index)
@@ -392,6 +396,7 @@ namespace Bloom.Spreadsheet
                 || key == InternalSpreadsheet.WidgetSourceColumnLabel
                 || key == InternalSpreadsheet.PageTypeColumnLabel
                 || key == InternalSpreadsheet.AttributeColumnLabel
+                || key == InternalSpreadsheet.DetailsColumnLabel
             )
                 return false;
             return !nonWysiwygColumns.Contains(key);

--- a/src/BloomExe/Spreadsheet/SpreadsheetImporter.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetImporter.cs
@@ -19,6 +19,7 @@ using Bloom.TeamCollection;
 using Bloom.Utils;
 using Bloom.web;
 using Bloom.web.controllers;
+using Newtonsoft.Json.Linq;
 using SIL.Extensions;
 using SIL.IO;
 using SIL.Progress;
@@ -39,16 +40,22 @@ namespace Bloom.Spreadsheet
         private SafeXmlElement _currentPage;
         private List<SafeXmlElement> _pages;
 
-        // text, image, video, widget
-        const int blockTypeCount = 4;
+        // text, image, video, widget, table
+        const int blockTypeCount = 5;
 
         // lists of translation groups (other than image descriptions),
-        // bloom-canvases, video containers, and widget containers.
+        // bloom-canvases, video containers, widget containers, and top-level tables.
         List<SafeXmlElement>[] _blocksOnPage = new List<SafeXmlElement>[blockTypeCount];
         public const int translationGroupIndex = 0;
         public const int bloomCanvasIndex = 1;
         public const int videoContainerIndex = 2;
         public const int widgetContainerIndex = 3;
+
+        // A bloom-table is a block in its own right, so that a [table] row can advance the
+        // importer onto its page and pick the right table there just as a [page content]
+        // row does for text and pictures. A page whose only content is a table has no
+        // [page content] row at all, so nothing else would get us there.
+        public const int tableIndex = 4;
 
         // for each kind of block, this gives the index in the corresponding list in blocksOnPage
         // of the next block we should import into. May be -1 or too large if there are no more
@@ -276,6 +283,7 @@ namespace Bloom.Spreadsheet
             _currentPageIndex = -1;
             _blocksOnPage[translationGroupIndex] = new List<SafeXmlElement>();
             _blocksOnPage[bloomCanvasIndex] = new List<SafeXmlElement>();
+            _blocksOnPage[tableIndex] = new List<SafeXmlElement>();
             _destLayout = Layout.FromDom(_destinationDom, Layout.A5Portrait);
             var pageTypeIndex = sheet.GetColumnForTag(InternalSpreadsheet.PageTypeColumnLabel);
             while (_currentRowIndex < _inputRows.Count)
@@ -377,6 +385,18 @@ namespace Bloom.Spreadsheet
                         // not have all the required slots.
                         typesInRow &= ~typesToPut;
                     }
+                }
+                else if (rowTypeLabel == InternalSpreadsheet.TableRowLabel)
+                {
+                    await ImportTableAsync(pageType);
+                }
+                else if (rowTypeLabel == InternalSpreadsheet.TableCellRowLabel)
+                {
+                    // Normally consumed by the [table] handling above; one can only reach
+                    // the main loop this way if it was separated from its table's row.
+                    Warn(
+                        $"Row {CurrentRowIndexForMessages} is a {InternalSpreadsheet.TableCellRowLabel} row that does not follow a {InternalSpreadsheet.TableRowLabel} row, so Bloom could not use it."
+                    );
                 }
                 else if (rowTypeLabel.StartsWith("[") && rowTypeLabel.EndsWith("]")) //This row is xmatter
                 {
@@ -1655,6 +1675,22 @@ namespace Bloom.Spreadsheet
                 );
             }
 
+            // None of Bloom's default pages holds a table, so there is no page we could
+            // generate that would satisfy a table. Drop the flag and let the caller decide
+            // what to do with the page we have: either it can hold the rest of what the row
+            // needs, or (for a row that needs only a table) ImportTableAsync reports that
+            // the page has no table for it and skips those rows. We must not invent a table:
+            // it would be a table of a shape nothing in the spreadsheet asked for.
+            if (string.IsNullOrEmpty(guid) && (blocksNeeded & BlockTypes.Table) == BlockTypes.Table)
+            {
+                return InsertDefaultPageIfNeeded(
+                    blocksNeeded & ~BlockTypes.Table,
+                    blocksWeHave,
+                    pageTypeNeeded,
+                    _pageTypeOfLastPage
+                );
+            }
+
             if (string.IsNullOrEmpty(guid))
             {
                 throw new ApplicationException("Failed to find a default page type");
@@ -1695,6 +1731,387 @@ namespace Bloom.Spreadsheet
                 .Contains(className);
         }
 
+        /// <summary>
+        /// Imports the table whose [table] row we are on, and everything that belongs to
+        /// it: its [table cell] rows, any [image description] rows those carry, and the
+        /// [table] and [table cell] rows of a table nested in one of its cells. Leaves
+        /// _currentRowIndex on the last row it consumed, since the main loop advances past
+        /// that.
+        ///
+        /// When the spreadsheet has the hidden [details] column, a [table] row is the
+        /// authority on its table: the table element is rebuilt from the JSON (attributes
+        /// and inline styles verbatim, so Bloom never has to interpret a column width or a
+        /// border matrix) and put in place of the table the target page has, keeping its
+        /// parent. Its cells are then filled through the same code that fills [page
+        /// content] rows.
+        ///
+        /// The table it replaces is found the same way a [page content] row finds its
+        /// translation group: a table is one of the page's blocks, so the row advances onto
+        /// the page it belongs to (which for a page whose only content is a table is the
+        /// only thing that could) and takes that page's next unused table. A page that has
+        /// no table left for the row gets a warning naming the row, and the table's rows
+        /// are skipped.
+        /// </summary>
+        /// <param name="pageType">The page type named in this row's [page type] cell, which
+        /// export writes on the first row it makes for a page. As for a [page content] row,
+        /// a page type means "start a new page of that type".</param>
+        private async Task ImportTableAsync(string pageType)
+        {
+            var rows = CollectRowsOfTable();
+            var lastRowIndex = _currentRowIndex + rows.Count - 1;
+            var tableDetails = GetDetailsOfRow(rows[0]);
+
+            if (_sheet.GetColumnForTag(InternalSpreadsheet.DetailsColumnLabel) < 0)
+            {
+                // Nothing but the [details] column can tell us what a table looks like, so
+                // there is nothing we can do with these rows but leave the book's own table
+                // alone. (Export always writes the column when it writes a [table] row, so
+                // this means the spreadsheet was edited into this state.)
+                Warn(
+                    $"Row {CurrentRowIndexForMessages} is a {InternalSpreadsheet.TableRowLabel} row, but this spreadsheet has no {InternalSpreadsheet.DetailsColumnLabel} column, so Bloom could not use it."
+                );
+                _currentRowIndex = lastRowIndex;
+                return;
+            }
+
+            // Check first that advancing could actually find a table. Bloom has no default
+            // page that holds one, and it must not invent a table (that would be a table of
+            // a shape nothing in the spreadsheet asked for), so if there is none to be had
+            // we say so and skip rather than advancing off the end of the book and adding a
+            // page that still has no table for us.
+            // A row whose details cannot be read (handled below) may use up a table the
+            // book already has, but must not be the reason a page gets added.
+            if (!ATableIsStillAvailable(mayAddAPage: tableDetails != null))
+            {
+                Warn(
+                    $"Row {CurrentRowIndexForMessages} is a {InternalSpreadsheet.TableRowLabel} row, but Bloom found no table on the page for it, so it was skipped."
+                );
+                _currentRowIndex = lastRowIndex;
+                return;
+            }
+
+            // This is what gets us onto the page the table belongs to, and picks which of
+            // that page's tables this row is for.
+            var typesFound = AdvanceToNextSetOfBlocks(BlockTypes.Table, pageType);
+            if ((typesFound & BlockTypes.Table) != BlockTypes.Table)
+            {
+                Warn(
+                    $"Row {CurrentRowIndexForMessages} is a {InternalSpreadsheet.TableRowLabel} row, but Bloom found no table on the page for it, so it was skipped."
+                );
+                _currentRowIndex = lastRowIndex;
+                return;
+            }
+
+            var oldTable = _blocksOnPage[tableIndex][_blockOnPageIndexes[tableIndex]];
+            if (tableDetails == null)
+            {
+                // The column is there but this row's cell is empty or not valid JSON (again,
+                // something an edit did to the spreadsheet). Building a table from nothing
+                // would replace the book's table with an empty one, so leave it alone. This
+                // comes after the advance above so that the book's table still counts as
+                // used up: the next [table] row belongs to the table after it.
+                Warn(
+                    $"Row {CurrentRowIndexForMessages} is a {InternalSpreadsheet.TableRowLabel} row, but Bloom could not read its {InternalSpreadsheet.DetailsColumnLabel} cell, so the book's table was left alone."
+                );
+                _currentRowIndex = lastRowIndex;
+                return;
+            }
+            var newTable = BuildTableFromDetails(tableDetails);
+            oldTable.ParentNode.ReplaceChild(newTable, oldTable);
+
+            // Fill the cells. A row with no "parent" belongs to this table; one with a
+            // parent belongs to the table nested in that cell of this table.
+            SafeXmlElement nestedTable = null;
+            JObject nestedTableParent = null;
+            SafeXmlElement cellAwaitingDescription = null;
+            for (var i = 1; i < rows.Count; i++)
+            {
+                // Messages about these rows should name the row they are really about.
+                _currentRowIndex = _currentRowIndex + 1;
+                var row = rows[i];
+                var details = GetDetailsOfRow(row);
+                var parent = details?["parent"] as JObject;
+                if (row.MetadataKey == InternalSpreadsheet.ImageDescriptionRowLabel)
+                {
+                    if (cellAwaitingDescription != null)
+                        await PutDescriptionRowInCellAsync(row, cellAwaitingDescription);
+                    continue;
+                }
+                cellAwaitingDescription = null;
+                if (row.MetadataKey == InternalSpreadsheet.TableRowLabel)
+                {
+                    // A table nested in one of this table's cells.
+                    var host = CellOfTableAt(newTable, parent);
+                    if (host == null)
+                    {
+                        Warn(
+                            $"Row {CurrentRowIndexForMessages} describes a table nested in a cell that Bloom could not find, so it was skipped."
+                        );
+                        continue;
+                    }
+                    nestedTable = BuildTableFromDetails(details);
+                    nestedTableParent = parent;
+                    host.InnerXml = "";
+                    host.AppendChild(nestedTable);
+                    continue;
+                }
+
+                // A [table cell] row.
+                var owningTable = parent == null ? newTable : nestedTable;
+                if (parent != null && !SameCell(parent, nestedTableParent))
+                    owningTable = null;
+                var cell =
+                    owningTable == null ? null : CellOfTableAt(owningTable, details as JObject);
+                if (cell == null)
+                {
+                    Warn(
+                        $"Row {CurrentRowIndexForMessages} is a {InternalSpreadsheet.TableCellRowLabel} row for a cell Bloom could not find, so it was skipped."
+                    );
+                    continue;
+                }
+                var filledImage = await PutRowInCellAsync(row, cell, details?["type"]?.ToString());
+                if (filledImage)
+                    cellAwaitingDescription = cell;
+            }
+            _currentRowIndex = lastRowIndex;
+        }
+
+        /// <summary>
+        /// Whether there is still a table somewhere for another [table] row to fill: one on
+        /// the current page that we have not used yet, one on a page we have not reached,
+        /// or, if mayAddAPage, one on the last content page, since a copy of that page is
+        /// what import adds when it runs out of pages.
+        /// </summary>
+        private bool ATableIsStillAvailable(bool mayAddAPage)
+        {
+            var tablesOnCurrentPage = _blocksOnPage[tableIndex];
+            if (
+                tablesOnCurrentPage != null
+                && _blockOnPageIndexes[tableIndex] + 1 < tablesOnCurrentPage.Count
+            )
+                return true;
+            for (var i = Math.Max(_currentPageIndex + 1, 0); i < _pages.Count; i++)
+            {
+                if (SpreadsheetTables.TopLevelTables(_pages[i]).Count > 0)
+                    return true;
+            }
+            return mayAddAPage
+                && _lastContentPage != null
+                && SpreadsheetTables.TopLevelTables(_lastContentPage).Count > 0;
+        }
+
+        /// <summary>
+        /// The run of rows that belong to the [table] row we are on: itself, then every
+        /// following [table cell], [image description] and nested [table] row, stopping at
+        /// the next [table] row that is not nested (or at any other kind of row).
+        /// </summary>
+        private List<ContentRow> CollectRowsOfTable()
+        {
+            var rows = new List<ContentRow> { _inputRows[_currentRowIndex] };
+            for (var i = _currentRowIndex + 1; i < _inputRows.Count; i++)
+            {
+                var key = _inputRows[i].MetadataKey;
+                if (key == InternalSpreadsheet.TableRowLabel)
+                {
+                    // A nested table's row carries the cell of the outer table that holds
+                    // it; one without that starts a new table of its own.
+                    if (GetDetailsOfRow(_inputRows[i])?["parent"] == null)
+                        break;
+                }
+                else if (
+                    key != InternalSpreadsheet.TableCellRowLabel
+                    && key != InternalSpreadsheet.ImageDescriptionRowLabel
+                )
+                {
+                    break;
+                }
+                rows.Add(_inputRows[i]);
+            }
+            return rows;
+        }
+
+        /// <summary>
+        /// The JSON object in a row's [details] cell, or null if there is none or it will
+        /// not parse (which is reported).
+        /// </summary>
+        private JObject GetDetailsOfRow(ContentRow row)
+        {
+            var details = row.GetCell(InternalSpreadsheet.DetailsColumnLabel).Content;
+            if (string.IsNullOrWhiteSpace(details))
+                return null;
+            try
+            {
+                return JObject.Parse(details);
+            }
+            catch (Newtonsoft.Json.JsonReaderException)
+            {
+                Warn(
+                    $"Bloom could not read the {InternalSpreadsheet.DetailsColumnLabel} cell of row {CurrentRowIndexForMessages} (\"{details}\")."
+                );
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Builds a bloom-table element from a [table] row's JSON: the table's attributes
+        /// verbatim, then one cell per entry in its "cells" list (in row-major order),
+        /// each with its own attributes verbatim and, unless it is a covered
+        /// (bloom-skip) cell, the default content for its content type, which the
+        /// [table cell] rows then fill.
+        /// </summary>
+        private SafeXmlElement BuildTableFromDetails(JObject tableDetails)
+        {
+            var table = _destinationDom.RawDom.CreateElement("div");
+            SpreadsheetTables.ApplyAttributes(table, tableDetails?["attributes"] as JObject);
+            // Belt and braces: a table with no bloom-table class would not be a table at all.
+            table.AddClass(SpreadsheetTables.TableClass);
+            var cells = (tableDetails?["cells"] as JArray) ?? new JArray();
+            foreach (
+                var cellDetails in cells
+                    .OfType<JObject>()
+                    .OrderBy(c => (int?)c["row"] ?? 0)
+                    .ThenBy(c => (int?)c["col"] ?? 0)
+            )
+            {
+                var cell = _destinationDom.RawDom.CreateElement("div");
+                SpreadsheetTables.ApplyAttributes(cell, cellDetails["attributes"] as JObject);
+                cell.AddClass(SpreadsheetTables.CellClass);
+                table.AppendChild(cell);
+                if (cell.HasClass(SpreadsheetTables.SkipClass))
+                    continue;
+                switch (SpreadsheetTables.ContentTypeOf(cell))
+                {
+                    case SpreadsheetTables.ImageContentType:
+                        cell.InnerXml = SpreadsheetTables.ImageCellContent;
+                        break;
+                    case SpreadsheetTables.VideoContentType:
+                        cell.InnerXml = SpreadsheetTables.VideoCellContent;
+                        break;
+                    case SpreadsheetTables.TableContentType:
+                        // Left empty; the nested table's own [table] row builds its content.
+                        break;
+                    default:
+                        cell.InnerXml = SpreadsheetTables.TextCellContent;
+                        break;
+                }
+            }
+            return table;
+        }
+
+        /// <summary>
+        /// The cell of a table at the "row" and "col" of the given JSON object, or null if
+        /// the table has no such cell. The cells of a table are always
+        /// rowCount * columnCount of them in row-major order, covered ones included, so
+        /// the position is just index arithmetic.
+        /// </summary>
+        private static SafeXmlElement CellOfTableAt(SafeXmlElement table, JObject position)
+        {
+            if (table == null || position == null)
+                return null;
+            var row = (int?)position["row"];
+            var column = (int?)position["col"];
+            if (row == null || column == null)
+                return null;
+            var cells = SpreadsheetTables.CellsOf(table);
+            var index = row.Value * SpreadsheetTables.ColumnCount(table) + column.Value;
+            if (index < 0 || index >= cells.Count)
+                return null;
+            return cells[index];
+        }
+
+        /// <summary>
+        /// True if two [details] positions name the same cell.
+        /// </summary>
+        private static bool SameCell(JObject one, JObject other)
+        {
+            if (one == null || other == null)
+                return false;
+            return (int?)one["row"] == (int?)other["row"] && (int?)one["col"] == (int?)other["col"];
+        }
+
+        /// <summary>
+        /// Puts a [table cell] row's content into the cell, through the same code that
+        /// fills a [page content] row: text into the cell's translation group, an image
+        /// into the cell's bloom-canvas, a video into the cell's bloom-videoContainer.
+        /// Returns true if it filled an image, in which case an [image description] row
+        /// may follow for the same cell.
+        /// </summary>
+        private async Task<bool> PutRowInCellAsync(
+            ContentRow row,
+            SafeXmlElement cell,
+            string contentType
+        )
+        {
+            switch (contentType ?? SpreadsheetTables.ContentTypeOf(cell))
+            {
+                case SpreadsheetTables.ImageContentType:
+                    var canvas = SpreadsheetTables.FindDescendantWithClass(cell, "bloom-canvas");
+                    if (canvas == null)
+                    {
+                        cell.InnerXml = SpreadsheetTables.ImageCellContent;
+                        canvas = SpreadsheetTables.FindDescendantWithClass(cell, "bloom-canvas");
+                    }
+                    await PutRowInImageAsync(row, null, canvas);
+                    return true;
+                case SpreadsheetTables.VideoContentType:
+                    if (
+                        string.IsNullOrWhiteSpace(
+                            row.GetCell(InternalSpreadsheet.VideoSourceColumnLabel).Text
+                        )
+                    )
+                        return false;
+                    var videoContainer = SpreadsheetTables.FindDescendantWithClass(
+                        cell,
+                        "bloom-videoContainer"
+                    );
+                    if (videoContainer == null)
+                    {
+                        cell.InnerXml = SpreadsheetTables.VideoCellContent;
+                        videoContainer = SpreadsheetTables.FindDescendantWithClass(
+                            cell,
+                            "bloom-videoContainer"
+                        );
+                    }
+                    PutRowInVideo(row, videoContainer);
+                    return false;
+                case SpreadsheetTables.TableContentType:
+                    // A nested table has no content of its own; its cells have their own rows.
+                    return false;
+                default:
+                    var group = SafeSelectNodesByClassName(cell, ".//div", "bloom-translationGroup")
+                        .FirstOrDefault(g => !HasExactClassName(g, "bloom-imageDescription"));
+                    if (group == null)
+                    {
+                        cell.InnerXml = SpreadsheetTables.TextCellContent;
+                        group = SafeSelectNodesByClassName(cell, ".//div", "bloom-translationGroup")
+                            .First();
+                    }
+                    await PutRowInGroupAsync(row, group);
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Puts an [image description] row that followed a picture cell's row into that
+        /// cell's image description group, creating the group if the cell has none.
+        /// </summary>
+        private async Task PutDescriptionRowInCellAsync(ContentRow row, SafeXmlElement cell)
+        {
+            var canvas = SpreadsheetTables.FindDescendantWithClass(cell, "bloom-canvas") ?? cell;
+            var group = SafeSelectNodesByClassName(canvas, ".//div", "bloom-imageDescription")
+                .FirstOrDefault();
+            if (group == null)
+            {
+                group = canvas.OwnerDocument.CreateElement("div");
+                group.SetAttribute(
+                    "class",
+                    "bloom-translationGroup bloom-imageDescription bloom-trailingElement"
+                );
+                canvas.AppendChild(group);
+            }
+            await PutRowInGroupAsync(row, group);
+        }
+
         private List<SafeXmlElement> GetBloomCanvases(SafeXmlElement ancestor)
         {
             return SafeSelectNodesByClassName(ancestor, ".//div", "bloom-canvas").ToList();
@@ -1720,15 +2137,30 @@ namespace Bloom.Spreadsheet
             List<SafeXmlElement>[] blocksOnPageCollector
         )
         {
-            blocksOnPageCollector[bloomCanvasIndex] = GetBloomCanvases(currentPage);
+            // Anything inside a bloom-table belongs to that table, which is filled from its
+            // own [table] and [table cell] rows, so it must not be a destination for the
+            // page's positionally-matched [page content] rows.
+            blocksOnPageCollector[bloomCanvasIndex] = GetBloomCanvases(currentPage)
+                .Where(x => !SpreadsheetTables.IsInsideTable(x))
+                .ToList();
             // We don't want image description slots as possible destinations for text.
             // They are handled by special extra rows inserted after the row that has the image.
             var allGroups = TranslationGroupManager.SortedGroupsOnPage(currentPage, true);
             blocksOnPageCollector[translationGroupIndex] = allGroups
-                .Where(x => !HasExactClassName(x, "bloom-imageDescription"))
+                .Where(x =>
+                    !HasExactClassName(x, "bloom-imageDescription")
+                    && !SpreadsheetTables.IsInsideTable(x)
+                )
                 .ToList();
-            blocksOnPageCollector[videoContainerIndex] = GetVideoContainers(currentPage);
-            blocksOnPageCollector[widgetContainerIndex] = GetWidgetContainers(currentPage);
+            blocksOnPageCollector[videoContainerIndex] = GetVideoContainers(currentPage)
+                .Where(x => !SpreadsheetTables.IsInsideTable(x))
+                .ToList();
+            blocksOnPageCollector[widgetContainerIndex] = GetWidgetContainers(currentPage)
+                .Where(x => !SpreadsheetTables.IsInsideTable(x))
+                .ToList();
+            // A table nested in a cell is not a block of the page; it is filled from the
+            // rows that hang off the cell holding it.
+            blocksOnPageCollector[tableIndex] = SpreadsheetTables.TopLevelTables(currentPage);
         }
 
         // This helper method supports various tasks that have to be done for each block type
@@ -2378,7 +2810,8 @@ namespace Bloom.Spreadsheet
         Image = 1 << SpreadsheetImporter.bloomCanvasIndex,
         Video = 1 << SpreadsheetImporter.videoContainerIndex,
         Widget = 1 << SpreadsheetImporter.widgetContainerIndex,
-        All = 15, // deliberately not including landscape!
+        Table = 1 << SpreadsheetImporter.tableIndex,
+        All = 31, // deliberately not including landscape!
 
         // This is special. A combination of the above flags may be used as an index
         // to look up a page guid that should be inserted when we need that combination

--- a/src/BloomExe/Spreadsheet/SpreadsheetTables.cs
+++ b/src/BloomExe/Spreadsheet/SpreadsheetTables.cs
@@ -1,0 +1,327 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Bloom.SafeXml;
+using Newtonsoft.Json.Linq;
+
+namespace Bloom.Spreadsheet
+{
+    /// <summary>
+    /// What the spreadsheet export and import of bloom-table elements have in common: the
+    /// class and attribute names of the saved table markup (see the bloom-table library's
+    /// README and table-renderer.ts), the list of edit-time artifacts that must not be
+    /// written to a spreadsheet, and the default content of a cell of each type.
+    ///
+    /// A table goes into a spreadsheet verbatim rather than semantically: one JSON object
+    /// holding every attribute of the table element and of each of its cells, exactly as
+    /// they are written in the book. Nothing here interprets a column width, a border
+    /// matrix or an inline grid-template style, so a table that comes back from a
+    /// spreadsheet renders the same as the one that went in -- including in a book that is
+    /// published without ever being opened in the Edit tab, where the read-time CSS relies
+    /// on the inline grid styles the renderer wrote.
+    /// </summary>
+    public static class SpreadsheetTables
+    {
+        // The "kind" of the JSON in a [details] cell. The kind comes first in the object,
+        // so the blob identifies itself even apart from the row it sits in.
+        public const string TableKind = "table";
+        public const string TableCellKind = "table-cell";
+
+        public const string TableClass = "bloom-table";
+        public const string CellClass = "bloom-cell";
+
+        // A cell that a merge has covered. It stays in the DOM (the cells of a table are
+        // always rowCount * columnCount of them, row-major) but shows nothing and holds
+        // no content, so it goes into the spreadsheet as attributes only, with no row of
+        // its own.
+        public const string SkipClass = "bloom-skip";
+
+        public const string ContentTypeAttribute = "data-content-type";
+        public const string ColumnWidthsAttribute = "data-column-widths";
+
+        public const string TextContentType = "text";
+        public const string ImageContentType = "image";
+        public const string VideoContentType = "video";
+        public const string TableContentType = "table";
+
+        // Attributes the table editing UI puts on a table or a cell for the duration of an
+        // editing session. prepare-for-save.ts strips these before Bloom saves the page;
+        // we strip them again here so that a spreadsheet made from a page that somehow
+        // still has them does not carry them into another book.
+        private static readonly string[] kEditOnlyAttributes = new[]
+        {
+            "data-table-attached",
+            "data-btable-anchor-name",
+            "data-table-overlay",
+        };
+
+        // Classes that mean "this is the table or cell the user is working on right now".
+        private static readonly string[] kEditOnlyClasses = new[]
+        {
+            "cell--selected",
+            "table--selected",
+            "bloom-pointer-near",
+            "bloom-current-table",
+        };
+
+        // The pulse highlight uses several classes (bloom-pulse-fill, bloom-pulse-border);
+        // all of them start this way.
+        private const string kEditOnlyClassPrefix = "bloom-pulse-";
+
+        // Style properties that only mean something within the session that wrote them:
+        // the anchor name minted for a cell so the menu pills can be positioned against
+        // it, and the boundary hint colors an older renderer wrote inline.
+        private static readonly string[] kEditOnlyStyleProperties = new[]
+        {
+            "anchor-name",
+            "--hint-top-color",
+            "--hint-right-color",
+            "--hint-bottom-color",
+            "--hint-left-color",
+        };
+
+        /// <summary>
+        /// The default content of a text cell: a translation group, as
+        /// ensureContentTypesRegistered in tableEditing.ts makes one, so that text in a
+        /// table participates in Bloom's multilingual system and its styles. The lang="z"
+        /// editable is the prototype the importer's per-language editables are cloned from.
+        /// </summary>
+        public const string TextCellContent =
+            "<div class=\"bloom-translationGroup bloom-trailingElement normal-style\">"
+            + "<div class=\"bloom-editable normal-style\" lang=\"z\" contenteditable=\"true\"><p></p></div>"
+            + "</div>";
+
+        /// <summary>
+        /// The default content of a picture cell: a bloom-canvas holding a background image
+        /// canvas element, so Bloom's image tooling works inside a cell. Same markup as
+        /// tableEditing.ts registers, and as origami's Image link creates.
+        /// </summary>
+        public const string ImageCellContent =
+            "<div class=\"bloom-canvas bloom-has-canvas-element bloom-leadingElement\">"
+            + "<div class=\"bloom-canvas-element bloom-backgroundImage\" style=\"width:100%;height:100%;\">"
+            + "<div class=\"bloom-imageContainer\"><img src=\"placeHolder.png\"></img></div>"
+            + "</div></div>";
+
+        /// <summary>
+        /// The default content of a video cell. Same markup as tableEditing.ts registers,
+        /// and as origami's Video link creates.
+        /// </summary>
+        public const string VideoCellContent =
+            "<div class=\"bloom-videoContainer bloom-leadingElement bloom-noVideoSelected\"></div>";
+
+        /// <summary>
+        /// True if the element is a bloom-table.
+        /// </summary>
+        public static bool IsTable(SafeXmlElement element)
+        {
+            return element != null && element.HasClass(TableClass);
+        }
+
+        /// <summary>
+        /// True if the element is inside a bloom-table, and so belongs to that table
+        /// rather than to the page. The generic collectors that turn a page's translation
+        /// groups, canvases and video containers into [page content] rows must skip these.
+        /// </summary>
+        public static bool IsInsideTable(SafeXmlElement element)
+        {
+            for (var parent = element?.ParentNode as SafeXmlElement; parent != null; )
+            {
+                if (IsTable(parent))
+                    return true;
+                parent = parent.ParentNode as SafeXmlElement;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// The tables on a page that are not nested inside another table, in document order.
+        /// These are the ones that get a [table] row of their own; a nested table's rows
+        /// hang off the cell that holds it.
+        /// </summary>
+        public static List<SafeXmlElement> TopLevelTables(SafeXmlElement pageOrCell)
+        {
+            return SafeXmlElement
+                .GetAllDivsWithClass(pageOrCell, TableClass)
+                .Where(table => !IsInsideTable(table))
+                .ToList();
+        }
+
+        /// <summary>
+        /// All the cells of a table, in DOM (row-major) order, including the bloom-skip
+        /// ones. Same rule as the library's cellsOf: direct children carrying bloom-cell.
+        /// </summary>
+        public static List<SafeXmlElement> CellsOf(SafeXmlElement table)
+        {
+            return table
+                .ChildNodes.OfType<SafeXmlElement>()
+                .Where(child => child.HasClass(CellClass))
+                .ToList();
+        }
+
+        /// <summary>
+        /// How many columns a table has, read off its data-column-widths attribute (one
+        /// entry per column). Falls back to the number of cells, which is right for the
+        /// single-row table that is all we could sensibly assume without the attribute.
+        /// </summary>
+        public static int ColumnCount(SafeXmlElement table)
+        {
+            var widths = table.GetAttribute(ColumnWidthsAttribute) ?? "";
+            var count = widths.Split(',').Count(entry => !string.IsNullOrWhiteSpace(entry));
+            if (count > 0)
+                return count;
+            return Math.Max(1, CellsOf(table).Count);
+        }
+
+        /// <summary>
+        /// What kind of content a cell holds: its data-content-type if it has one,
+        /// otherwise worked out from what is actually in it (a table built by hand, e.g.
+        /// in a page template, may not carry the attribute). Text is the default, which is
+        /// also the library's default content type.
+        /// </summary>
+        public static string ContentTypeOf(SafeXmlElement cell)
+        {
+            var declared = cell.GetAttribute(ContentTypeAttribute);
+            if (!string.IsNullOrWhiteSpace(declared))
+                return declared;
+            if (FindNestedTable(cell) != null)
+                return TableContentType;
+            if (FindDescendantWithClass(cell, "bloom-videoContainer") != null)
+                return VideoContentType;
+            if (
+                FindDescendantWithClass(cell, "bloom-canvas") != null
+                || FindDescendantWithClass(cell, "bloom-imageContainer") != null
+            )
+                return ImageContentType;
+            return TextContentType;
+        }
+
+        /// <summary>
+        /// The table nested directly in a cell (the content of a cell whose type is
+        /// "table"), or null.
+        /// </summary>
+        public static SafeXmlElement FindNestedTable(SafeXmlElement cell)
+        {
+            return SafeXmlElement
+                .GetAllDivsWithClass(cell, TableClass)
+                .FirstOrDefault(table => ParentCellOf(table) == cell);
+        }
+
+        /// <summary>
+        /// The cell a nested table sits in, or null if the table is not in a cell.
+        /// </summary>
+        public static SafeXmlElement ParentCellOf(SafeXmlElement table)
+        {
+            for (var parent = table.ParentNode as SafeXmlElement; parent != null; )
+            {
+                if (parent.HasClass(CellClass))
+                    return parent;
+                if (IsTable(parent))
+                    return null; // a table's own children are cells; we passed the boundary
+                parent = parent.ParentNode as SafeXmlElement;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// The first descendant of the cell with the given class that belongs to this cell
+        /// rather than to a table nested inside it, or null.
+        /// </summary>
+        public static SafeXmlElement FindDescendantWithClass(SafeXmlElement cell, string className)
+        {
+            return SafeXmlElement
+                .GetAllDivsWithClass(cell, className)
+                .FirstOrDefault(element =>
+                    !IsInsideTable(element) || ParentCellOf(element) == cell
+                );
+        }
+
+        /// <summary>
+        /// Every attribute of a table or cell element, as the JSON object that goes into
+        /// the [details] cell, with the edit-time artifacts removed: the whole-attribute
+        /// ones dropped, and the edit-only classes and style properties taken out of the
+        /// class and style attributes. An attribute left empty by that trimming is dropped
+        /// rather than written as "".
+        /// </summary>
+        public static JObject GetAttributesForExport(SafeXmlElement element)
+        {
+            var result = new JObject();
+            foreach (var pair in element.AttributePairs ?? new NameValue[0])
+            {
+                if (kEditOnlyAttributes.Contains(pair.Name))
+                    continue;
+                var value = pair.Value ?? "";
+                if (pair.Name == "class")
+                    value = StripEditOnlyClasses(value);
+                else if (pair.Name == "style")
+                    value = StripEditOnlyStyleProperties(value);
+                if (
+                    string.IsNullOrWhiteSpace(value)
+                    && (pair.Name == "class" || pair.Name == "style")
+                )
+                    continue;
+                result[pair.Name] = value;
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// The class attribute with the edit-time classes taken out.
+        /// </summary>
+        public static string StripEditOnlyClasses(string classes)
+        {
+            return string.Join(
+                " ",
+                classes
+                    .Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Where(name =>
+                        !kEditOnlyClasses.Contains(name)
+                        && !name.StartsWith(kEditOnlyClassPrefix, StringComparison.Ordinal)
+                    )
+            );
+        }
+
+        /// <summary>
+        /// The style attribute with the edit-time properties taken out. Declarations are
+        /// otherwise left exactly as they were written, since the renderer's inline
+        /// grid-template styles are what make an imported table lay out correctly.
+        /// </summary>
+        public static string StripEditOnlyStyleProperties(string style)
+        {
+            var kept = style
+                .Split(';')
+                .Where(declaration => !string.IsNullOrWhiteSpace(declaration))
+                .Select(declaration => declaration.Trim())
+                .Where(declaration =>
+                {
+                    var colon = declaration.IndexOf(':');
+                    if (colon < 0)
+                        return true; // not a declaration we understand; keep it
+                    var property = declaration.Substring(0, colon).Trim();
+                    return !kEditOnlyStyleProperties.Contains(property);
+                })
+                .ToList();
+            if (kept.Count == 0)
+                return "";
+            return string.Join("; ", kept) + ";";
+        }
+
+        /// <summary>
+        /// Puts the attributes from a [details] JSON object onto a freshly made table or
+        /// cell element, verbatim. The inverse of GetAttributesForExport.
+        /// </summary>
+        public static void ApplyAttributes(SafeXmlElement element, JObject attributes)
+        {
+            if (attributes == null)
+                return;
+            foreach (var property in attributes.Properties())
+            {
+                // Guard only against a name the XML parser would refuse; we deliberately do
+                // not filter or interpret the values.
+                var name = property.Name;
+                if (string.IsNullOrWhiteSpace(name))
+                    continue;
+                element.SetAttribute(name, property.Value.ToString());
+            }
+        }
+    }
+}

--- a/src/BloomTests/Spreadsheet/SpreadsheetTableTests.cs
+++ b/src/BloomTests/Spreadsheet/SpreadsheetTableTests.cs
@@ -1,0 +1,1115 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Bloom;
+using Bloom.Book;
+using Bloom.SafeXml;
+using Bloom.Spreadsheet;
+using Moq;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using OfficeOpenXml;
+using SIL.IO;
+using SIL.TestUtilities;
+
+namespace BloomTests.Spreadsheet
+{
+    /// <summary>
+    /// Tests that a bloom-table survives a spreadsheet export → import round trip. Export
+    /// gives each table on a page a [table] row followed by one [table cell] row per
+    /// visible cell: the table element and every one of its cells go into the hidden
+    /// [details] column as JSON, attributes and inline styles verbatim, while each cell's
+    /// own content rides in the ordinary columns (the language columns for text, [image
+    /// source] for a picture, [video source] for a video). Import rebuilds the table from
+    /// that JSON and puts it in place of the table the target page has, then fills the
+    /// cells through the same code that fills [page content] rows.
+    ///
+    /// Copying attributes rather than interpreting them is the point: Bloom never has to
+    /// understand a column width or a border matrix, and a book imported from a
+    /// spreadsheet renders correctly even if it is published without ever being opened in
+    /// the Edit tab, where the read-time CSS relies on the renderer's inline grid styles.
+    /// </summary>
+    public class SpreadsheetTableTests
+    {
+        static SpreadsheetTableTests()
+        {
+            // The package requires us to do this as a way of acknowledging that we
+            // accept the terms of the NonCommercial license.
+            ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
+        }
+
+        // A translation group as a text cell holds one, with the two languages the test
+        // book uses plus the lang="z" prototype.
+        private static string TextCell(string spanish, string english, string extraAttributes = "")
+        {
+            return $@"<div class=""bloom-cell"" data-content-type=""text"" {extraAttributes}>
+                <div class=""bloom-translationGroup bloom-trailingElement normal-style"">
+                    <div class=""bloom-editable normal-style bloom-content1 bloom-visibility-code-on"" lang=""es"" contenteditable=""true""><p>{spanish}</p></div>
+                    <div class=""bloom-editable normal-style"" lang=""z"" contenteditable=""true""><p></p></div>
+                    <div class=""bloom-editable normal-style bloom-contentNational1"" lang=""en"" contenteditable=""true""><p>{english}</p></div>
+                </div>
+            </div>";
+        }
+
+        // A picture cell: a bloom-canvas holding a background image canvas element, as
+        // tableEditing.ts builds one.
+        private const string imageCell =
+            @"<div class=""bloom-cell"" data-content-type=""image"" data-pad=""4px"" data-bg=""#ffeeaa"">
+                <div class=""bloom-canvas bloom-has-canvas-element bloom-leadingElement"">
+                    <div class=""bloom-canvas-element bloom-backgroundImage"" style=""width:100%;height:100%;"">
+                        <div class=""bloom-imageContainer""><img src=""flower.jpg""></img></div>
+                    </div>
+                </div>
+            </div>";
+
+        private const string videoCell =
+            @"<div class=""bloom-cell"" data-content-type=""video"">
+                <div class=""bloom-videoContainer bloom-leadingElement"">
+                    <video><source src=""video/fish.mp4""></source></video>
+                </div>
+            </div>";
+
+        // A cell holding a nested one-row, two-column table.
+        private static string NestedTableCell()
+        {
+            return $@"<div class=""bloom-cell"" data-content-type=""table"">
+                <div class=""bloom-table"" data-column-widths=""fill,fill"" data-row-heights=""fill"" style=""grid-template-columns: 1fr 1fr; --table-column-count: 2;"">
+                    {TextCell("Dentro", "Inside")}
+                    {TextCell("Tambien", "Also")}
+                </div>
+            </div>";
+        }
+
+        /// <summary>
+        /// The test book. `tableMarkup` is what goes in the lower half of the page, so we
+        /// can build the book with the table (the book that gets exported, and the
+        /// same-book import target), with an empty table of the same shape (proving the
+        /// spreadsheet itself carries the content), or with no table at all (proving import
+        /// reports and skips).
+        /// </summary>
+        private static string MakeBook(string tableMarkup)
+        {
+            return @"
+<!DOCTYPE html>
+
+<html>
+<head>
+</head>
+
+<body data-l1=""es"" data-l2=""en"" data-l3="""">
+	<div id=""bloomDataDiv"">
+		<div data-book=""bookTitle"" lang=""en"">
+			<p>Table round trip</p>
+		</div>
+	</div>
+    <div class=""bloom-page numberedPage customPage A5Portrait side-right bloom-bilingual"" data-page="""" id=""3a71a95a-4b62-4890-80b6-6b5b26f1b78a"" data-pagelineage=""adcd48df-e9ab-4a07-afd4-6a24d0398382"" data-page-number=""1"" lang="""">
+        <div class=""pageLabel"" data-i18n=""TemplateBooks.PageLabel.Just Text"" lang=""en"">
+            Just Text
+        </div>
+
+        <div class=""pageDescription"" lang=""en""></div>
+
+        <div class=""split-pane-component marginBox"" style="""">
+            <div class=""split-pane-component-inner"">
+                <div class=""bloom-translationGroup bloom-trailingElement"" data-default-languages=""auto"">
+                    <div class=""bloom-editable normal-style bloom-content1 bloom-visibility-code-on"" id=""heading-es"" lang=""es"" contenteditable=""true""><p>Mi mesa</p></div>
+                    <div class=""bloom-editable normal-style"" lang=""z"" contenteditable=""true""><p></p></div>
+                    <div class=""bloom-editable normal-style bloom-contentNational1"" id=""heading-en"" lang=""en"" contenteditable=""true""><p>My table</p></div>
+                </div>
+"
+                + tableMarkup
+                + @"
+            </div>
+        </div>
+    </div>
+</body>
+</html>
+";
+        }
+
+        // The table itself: three columns (one fixed at 120px), three rows, a merged cell
+        // with the bloom-skip cell it covers, a picture cell, a video cell and a nested
+        // table. The inline styles are what the renderer writes and what the read-time CSS
+        // needs; the data-* attributes are the durable model.
+        private static string MakeTable(bool withContent)
+        {
+            string Text(string spanish, string english, string extras = "") =>
+                withContent ? TextCell(spanish, english, extras) : TextCell("", "", extras);
+            var picture = withContent
+                ? imageCell
+                : imageCell.Replace("flower.jpg", "placeHolder.png");
+            var video = withContent
+                ? videoCell
+                : @"<div class=""bloom-cell"" data-content-type=""video""><div class=""bloom-videoContainer bloom-leadingElement bloom-noVideoSelected""></div></div>";
+            var nested = withContent
+                ? NestedTableCell()
+                : @"<div class=""bloom-cell"" data-content-type=""table""><div class=""bloom-table"" data-column-widths=""fill,fill"" data-row-heights=""fill"" style=""grid-template-columns: 1fr 1fr; --table-column-count: 2;""><div class=""bloom-cell"" data-content-type=""text""></div><div class=""bloom-cell"" data-content-type=""text""></div></div></div>";
+            return $@"<div class=""bloom-table bloom-leadingElement"" tabindex=""0""
+                     data-column-widths=""120px,fill,hug"" data-row-heights=""fill,fill,fill""
+                     data-gap-x=""6px"" data-gap-y=""8px"" data-border-default=""1px solid #333""
+                     style=""grid-template-columns: 120px 1fr min-content; grid-template-rows: 1fr 1fr 1fr; --table-column-count: 3; --bg: #eef;"">
+                {Text("Uno", "One", @"data-align=""center"" data-corners=""{&quot;radius&quot;:4}""")}
+                {picture}
+                {video}
+                {Text("Ancho", "Wide", @"data-span-x=""2"" style=""--span-x: 2;""")}
+                <div class=""bloom-cell bloom-skip"" data-content-type=""text""></div>
+                {nested}
+                {Text("Tres", "Three")}
+                {Text("Cuatro", "Four")}
+                {Text("Cinco", "Five")}
+            </div>";
+        }
+
+        private InternalSpreadsheet _sheetFromExport;
+        private HtmlDom _roundtrippedDom; // imported over a copy of the exported book
+        private HtmlDom _emptyTableDom; // imported into a book whose table has no content
+        private List<string> _warningsForBookWithoutTable;
+        private HtmlDom _domWithoutTable;
+
+        private static InternalSpreadsheet ExportBook(string bookHtml)
+        {
+            var mockLangDisplayNameResolver = new Mock<ILanguageDisplayNameResolver>();
+            mockLangDisplayNameResolver
+                .Setup(x => x.GetLanguageDisplayName("en"))
+                .Returns("English");
+            mockLangDisplayNameResolver
+                .Setup(x => x.GetLanguageDisplayName("es"))
+                .Returns("Spanish");
+            var exporter = new SpreadsheetExporter(mockLangDisplayNameResolver.Object);
+            exporter.Params = new SpreadsheetExportParams();
+            return exporter.Export(new HtmlDom(bookHtml, true), "fakeImagesFolderpath");
+        }
+
+        /// <summary>
+        /// Writes the sheet to a real .xlsx and reads it back before importing: only the
+        /// written file has the language cells flattened to text the way a real import
+        /// sees them.
+        /// </summary>
+        private static async Task<List<string>> RoundTripThroughFileAndImportAsync(
+            InternalSpreadsheet sheetFromExport,
+            params HtmlDom[] targets
+        )
+        {
+            using (var tempFile = TempFile.WithExtension("xlsx"))
+            {
+                sheetFromExport.WriteToFile(tempFile.Path);
+                var sheet = InternalSpreadsheet.ReadFromFile(tempFile.Path);
+                var warnings = new List<string>();
+                foreach (var target in targets)
+                    warnings.AddRange(
+                        await new TestSpreadsheetImporter(null, target).ImportAsync(sheet)
+                    );
+                return warnings;
+            }
+        }
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            var bookWithTable = MakeBook(MakeTable(true));
+            var origDom = new HtmlDom(bookWithTable, true);
+            _roundtrippedDom = new HtmlDom(bookWithTable, true);
+            _emptyTableDom = new HtmlDom(MakeBook(MakeTable(false)), true);
+            _domWithoutTable = new HtmlDom(MakeBook(""), true);
+
+            // Sanity: the test books are what we think they are before the round trip.
+            AssertThatXmlIn
+                .Dom(origDom.RawDom)
+                .HasSpecifiedNumberOfMatchesForXpath(
+                    "//div[contains(@class,'bloom-table')]",
+                    2 // the table and the one nested in it
+                );
+            AssertThatXmlIn
+                .Dom(origDom.RawDom)
+                .HasSpecifiedNumberOfMatchesForXpath("//div[contains(@class,'bloom-skip')]", 1);
+            Assert.That(
+                origDom.RawDom.InnerXml,
+                Does.Contain("Uno"),
+                "sanity: the exported book has the cell text"
+            );
+            Assert.That(
+                _emptyTableDom.RawDom.InnerXml,
+                Does.Not.Contain("Uno"),
+                "sanity: the empty-table target has no cell text of its own"
+            );
+            AssertThatXmlIn
+                .Dom(_domWithoutTable.RawDom)
+                .HasNoMatchForXpath("//div[contains(@class,'bloom-table')]");
+
+            _sheetFromExport = ExportBook(bookWithTable);
+            await RoundTripThroughFileAndImportAsync(
+                _sheetFromExport,
+                _roundtrippedDom,
+                _emptyTableDom
+            );
+            _warningsForBookWithoutTable = await RoundTripThroughFileAndImportAsync(
+                _sheetFromExport,
+                _domWithoutTable
+            );
+        }
+
+        private HtmlDom GetDom(string target)
+        {
+            switch (target)
+            {
+                case "roundtrip":
+                    return _roundtrippedDom;
+                case "emptytable":
+                    return _emptyTableDom;
+                default:
+                    throw new ArgumentException($"unknown test dom '{target}'");
+            }
+        }
+
+        private static SafeXmlElement GetTable(HtmlDom dom)
+        {
+            var table = dom.SafeSelectNodes("//div[contains(@class,'bloom-table')]")
+                .Cast<SafeXmlElement>()
+                .FirstOrDefault(t => SpreadsheetTables.ParentCellOf(t) == null);
+            Assert.That(table, Is.Not.Null, "the page should still have a top-level table");
+            return table;
+        }
+
+        private static SafeXmlElement GetCell(SafeXmlElement table, int row, int column)
+        {
+            var cells = SpreadsheetTables.CellsOf(table);
+            var columnCount = SpreadsheetTables.ColumnCount(table);
+            var index = row * columnCount + column;
+            Assert.That(
+                index,
+                Is.LessThan(cells.Count),
+                $"the table should have a cell at row {row}, column {column}"
+            );
+            return cells[index];
+        }
+
+        private static string TextOfCell(SafeXmlElement cell, string lang)
+        {
+            var editable = cell.SafeSelectNodes(
+                    $".//div[contains(@class,'bloom-editable') and @lang='{lang}']"
+                )
+                .Cast<SafeXmlElement>()
+                .FirstOrDefault();
+            Assert.That(
+                editable,
+                Is.Not.Null,
+                $"the cell should have a bloom-editable for '{lang}'"
+            );
+            return editable.InnerText.Trim();
+        }
+
+        private List<ContentRow> Rows => _sheetFromExport.ContentRows.ToList();
+
+        private static JObject Details(ContentRow row)
+        {
+            var content = row.GetCell(InternalSpreadsheet.DetailsColumnLabel).Content;
+            Assert.That(content, Is.Not.Null.And.Not.Empty, "the row should have details JSON");
+            return JObject.Parse(content);
+        }
+
+        [Test]
+        public void SheetHasTableRowThenCellRowsInOrder()
+        {
+            var rows = Rows;
+            var tableRowIndex = rows.FindIndex(r =>
+                r.MetadataKey == InternalSpreadsheet.TableRowLabel
+            );
+            Assert.That(tableRowIndex, Is.GreaterThan(0), "the table's row exists");
+            Assert.That(
+                rows[tableRowIndex - 1].MetadataKey,
+                Is.EqualTo(InternalSpreadsheet.PageContentRowLabel),
+                "the heading's row comes before the table, as it does on the page"
+            );
+
+            // The eight visible cells, row-major, with the nested table's own rows
+            // interrupting after the cell that holds it.
+            var expected = new[]
+            {
+                "table-cell:0,0,text",
+                "table-cell:0,1,image",
+                "table-cell:0,2,video",
+                "table-cell:1,0,text",
+                "table-cell:1,2,table",
+                "nested-table:1,2",
+                "table-cell:0,0,text",
+                "table-cell:0,1,text",
+                "table-cell:2,0,text",
+                "table-cell:2,1,text",
+                "table-cell:2,2,text",
+            };
+            var actual = new List<string>();
+            for (var i = tableRowIndex + 1; i < rows.Count; i++)
+            {
+                var details = Details(rows[i]);
+                var parent = details["parent"] as JObject;
+                if (rows[i].MetadataKey == InternalSpreadsheet.TableRowLabel)
+                {
+                    Assert.That(parent, Is.Not.Null, "only a nested table follows the first one");
+                    actual.Add($"nested-table:{parent["row"]},{parent["col"]}");
+                }
+                else
+                {
+                    Assert.That(
+                        rows[i].MetadataKey,
+                        Is.EqualTo(InternalSpreadsheet.TableCellRowLabel)
+                    );
+                    actual.Add($"table-cell:{details["row"]},{details["col"]},{details["type"]}");
+                }
+            }
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void SkippedCellHasNoRowButIsInTheTableDetails()
+        {
+            var tableRow = Rows.First(r => r.MetadataKey == InternalSpreadsheet.TableRowLabel);
+            var cells = (JArray)Details(tableRow)["cells"];
+            Assert.That(cells.Count, Is.EqualTo(9), "all nine grid positions are described");
+            var skipped = cells
+                .OfType<JObject>()
+                .Single(c =>
+                    ((string)c["attributes"]?["class"] ?? "").Contains(SpreadsheetTables.SkipClass)
+                );
+            Assert.That((int)skipped["row"], Is.EqualTo(1));
+            Assert.That((int)skipped["col"], Is.EqualTo(1));
+            Assert.That(
+                Rows.Where(r => r.MetadataKey == InternalSpreadsheet.TableCellRowLabel)
+                    .Select(Details)
+                    .Where(d => d["parent"] == null)
+                    .Count(d => (int)d["row"] == 1 && (int)d["col"] == 1),
+                Is.EqualTo(0),
+                "a covered cell gets no row of its own"
+            );
+        }
+
+        [Test]
+        public void TableDetailsCarryAttributesAndStylesVerbatim()
+        {
+            var tableRow = Rows.First(r => r.MetadataKey == InternalSpreadsheet.TableRowLabel);
+            var attributes = (JObject)Details(tableRow)["attributes"];
+            Assert.That((string)Details(tableRow)["kind"], Is.EqualTo("table"));
+            Assert.That((string)attributes["data-column-widths"], Is.EqualTo("120px,fill,hug"));
+            Assert.That((string)attributes["data-row-heights"], Is.EqualTo("fill,fill,fill"));
+            Assert.That((string)attributes["data-gap-x"], Is.EqualTo("6px"));
+            Assert.That((string)attributes["data-gap-y"], Is.EqualTo("8px"));
+            Assert.That((string)attributes["data-border-default"], Is.EqualTo("1px solid #333"));
+            Assert.That((string)attributes["tabindex"], Is.EqualTo("0"));
+            var style = (string)attributes["style"];
+            Assert.That(style, Does.Contain("grid-template-columns: 120px 1fr min-content"));
+            Assert.That(style, Does.Contain("grid-template-rows: 1fr 1fr 1fr"));
+            Assert.That(style, Does.Contain("--table-column-count: 3"));
+            Assert.That(style, Does.Contain("--bg: #eef"));
+        }
+
+        [Test]
+        public void CellDetailsCarryPerCellFormatting()
+        {
+            var tableRow = Rows.First(r => r.MetadataKey == InternalSpreadsheet.TableRowLabel);
+            var cells = ((JArray)Details(tableRow)["cells"]).OfType<JObject>().ToList();
+            var firstCell = (JObject)cells[0]["attributes"];
+            Assert.That((string)firstCell["data-align"], Is.EqualTo("center"));
+            Assert.That((string)firstCell["data-corners"], Is.EqualTo("{\"radius\":4}"));
+            var pictureCell = (JObject)cells[1]["attributes"];
+            Assert.That((string)pictureCell["data-pad"], Is.EqualTo("4px"));
+            Assert.That((string)pictureCell["data-bg"], Is.EqualTo("#ffeeaa"));
+            var mergedCell = (JObject)cells[3]["attributes"];
+            Assert.That((string)mergedCell["data-span-x"], Is.EqualTo("2"));
+            Assert.That((string)mergedCell["style"], Does.Contain("--span-x: 2"));
+        }
+
+        [Test]
+        public void DetailsColumnIsHidden()
+        {
+            // Like [image source], [details] is machinery, not something a translator
+            // should be invited to edit.
+            var detailsColumn = _sheetFromExport.GetColumnForTag(
+                InternalSpreadsheet.DetailsColumnLabel
+            );
+            Assert.That(detailsColumn, Is.GreaterThanOrEqualTo(0), "sanity: column exists");
+            Assert.That(_sheetFromExport.HiddenColumns, Does.Contain(detailsColumn));
+        }
+
+        [Test]
+        public void TableContentDoesNotAlsoAppearAsPageContent()
+        {
+            var pageContentRows = Rows.Where(r =>
+                    r.MetadataKey == InternalSpreadsheet.PageContentRowLabel
+                )
+                .ToList();
+            Assert.That(
+                pageContentRows.Count,
+                Is.EqualTo(1),
+                "only the heading, outside the table, makes a [page content] row"
+            );
+            Assert.That(pageContentRows[0].GetCell("[es]").Content, Does.Contain("Mi mesa"));
+            foreach (var row in pageContentRows)
+            {
+                Assert.That(row.GetCell("[es]").Content, Does.Not.Contain("Uno"));
+                Assert.That(
+                    row.GetCell(InternalSpreadsheet.ImageSourceColumnLabel).Content,
+                    Does.Not.Contain("flower")
+                );
+                Assert.That(
+                    row.GetCell(InternalSpreadsheet.VideoSourceColumnLabel).Content,
+                    Is.Empty
+                );
+            }
+        }
+
+        [Test]
+        public void CellTextGoesInTheLanguageColumns()
+        {
+            var cellRows = Rows.Where(r => r.MetadataKey == InternalSpreadsheet.TableCellRowLabel)
+                .ToList();
+            var firstTextRow = cellRows.First(r => (string)Details(r)["type"] == "text");
+            Assert.That(firstTextRow.GetCell("[es]").Content, Does.Contain("Uno"));
+            Assert.That(firstTextRow.GetCell("[en]").Content, Does.Contain("One"));
+
+            var imageRow = cellRows.First(r => (string)Details(r)["type"] == "image");
+            Assert.That(
+                imageRow
+                    .GetCell(InternalSpreadsheet.ImageSourceColumnLabel)
+                    .Content.Replace('\\', '/'),
+                Is.EqualTo("images/flower.jpg")
+            );
+
+            var videoRow = cellRows.First(r => (string)Details(r)["type"] == "video");
+            Assert.That(
+                videoRow.GetCell(InternalSpreadsheet.VideoSourceColumnLabel).Content,
+                Is.EqualTo("video/fish.mp4")
+            );
+        }
+
+        [TestCase("roundtrip")]
+        [TestCase("emptytable")]
+        public void TableStructureAndFormattingSurvive(string target)
+        {
+            var table = GetTable(GetDom(target));
+            Assert.That(table.GetAttribute("data-column-widths"), Is.EqualTo("120px,fill,hug"));
+            Assert.That(table.GetAttribute("data-row-heights"), Is.EqualTo("fill,fill,fill"));
+            Assert.That(table.GetAttribute("data-gap-x"), Is.EqualTo("6px"));
+            Assert.That(table.GetAttribute("data-gap-y"), Is.EqualTo("8px"));
+            Assert.That(table.GetAttribute("data-border-default"), Is.EqualTo("1px solid #333"));
+            Assert.That(table.GetAttribute("tabindex"), Is.EqualTo("0"));
+            var style = table.GetAttribute("style");
+            Assert.That(
+                style,
+                Does.Contain("grid-template-columns: 120px 1fr min-content"),
+                "the renderer's inline grid style is what read-time CSS lays out with"
+            );
+            Assert.That(style, Does.Contain("--bg: #eef"));
+            Assert.That(
+                SpreadsheetTables.CellsOf(table).Count,
+                Is.EqualTo(9),
+                "every grid position, covered ones included, comes back"
+            );
+        }
+
+        [TestCase("roundtrip")]
+        [TestCase("emptytable")]
+        public void MergedAndCoveredCellsSurvive(string target)
+        {
+            var table = GetTable(GetDom(target));
+            var merged = GetCell(table, 1, 0);
+            Assert.That(merged.GetAttribute("data-span-x"), Is.EqualTo("2"));
+            Assert.That(merged.GetAttribute("style"), Does.Contain("--span-x: 2"));
+            var covered = GetCell(table, 1, 1);
+            Assert.That(
+                covered.HasClass(SpreadsheetTables.SkipClass),
+                Is.True,
+                "the covered cell is still there, and still covered"
+            );
+            Assert.That(
+                covered.InnerXml.Trim(),
+                Is.Empty,
+                "a covered cell holds nothing, so it is rebuilt empty"
+            );
+        }
+
+        [TestCase("roundtrip")]
+        [TestCase("emptytable")]
+        public void TextCellsSurviveInBothLanguages(string target)
+        {
+            var table = GetTable(GetDom(target));
+            Assert.That(TextOfCell(GetCell(table, 0, 0), "es"), Is.EqualTo("Uno"));
+            Assert.That(TextOfCell(GetCell(table, 0, 0), "en"), Is.EqualTo("One"));
+            Assert.That(TextOfCell(GetCell(table, 1, 0), "es"), Is.EqualTo("Ancho"));
+            Assert.That(TextOfCell(GetCell(table, 1, 0), "en"), Is.EqualTo("Wide"));
+            Assert.That(TextOfCell(GetCell(table, 2, 0), "es"), Is.EqualTo("Tres"));
+            Assert.That(TextOfCell(GetCell(table, 2, 1), "en"), Is.EqualTo("Four"));
+            Assert.That(TextOfCell(GetCell(table, 2, 2), "es"), Is.EqualTo("Cinco"));
+            Assert.That(
+                GetCell(table, 0, 0).GetAttribute("data-align"),
+                Is.EqualTo("center"),
+                "per-cell formatting survives alongside the text"
+            );
+        }
+
+        [TestCase("roundtrip")]
+        [TestCase("emptytable")]
+        public void PictureCellSurvives(string target)
+        {
+            var cell = GetCell(GetTable(GetDom(target)), 0, 1);
+            Assert.That(cell.GetAttribute("data-content-type"), Is.EqualTo("image"));
+            var canvas = cell.SafeSelectNodes(".//div[contains(@class,'bloom-canvas')]")
+                .Cast<SafeXmlElement>()
+                .FirstOrDefault();
+            Assert.That(canvas, Is.Not.Null, "a picture cell holds a bloom-canvas");
+            var img = cell.SafeSelectNodes(".//img").Cast<SafeXmlElement>().FirstOrDefault();
+            Assert.That(img, Is.Not.Null);
+            Assert.That(img.GetAttribute("src"), Is.EqualTo("flower.jpg"));
+            Assert.That(cell.GetAttribute("data-bg"), Is.EqualTo("#ffeeaa"));
+        }
+
+        [TestCase("roundtrip")]
+        [TestCase("emptytable")]
+        public void VideoCellSurvives(string target)
+        {
+            var cell = GetCell(GetTable(GetDom(target)), 0, 2);
+            Assert.That(cell.GetAttribute("data-content-type"), Is.EqualTo("video"));
+            var container = cell.SafeSelectNodes(".//div[contains(@class,'bloom-videoContainer')]")
+                .Cast<SafeXmlElement>()
+                .FirstOrDefault();
+            Assert.That(container, Is.Not.Null, "a video cell holds a bloom-videoContainer");
+            Assert.That(
+                container.GetAttribute("class"),
+                Does.Not.Contain("bloom-noVideoSelected"),
+                "the cell has a video again, so it is not marked as having none"
+            );
+            var source = cell.SafeSelectNodes(".//source").Cast<SafeXmlElement>().FirstOrDefault();
+            Assert.That(source, Is.Not.Null, "a video cell's video element has a source");
+            // The src is url-encoded, as the importer writes it for a page's video too.
+            Assert.That(
+                UrlPathString.CreateFromUrlEncodedString(source.GetAttribute("src")).NotEncoded,
+                Is.EqualTo("video/fish.mp4")
+            );
+        }
+
+        [TestCase("roundtrip")]
+        [TestCase("emptytable")]
+        public void NestedTableSurvivesWithItsText(string target)
+        {
+            var cell = GetCell(GetTable(GetDom(target)), 1, 2);
+            Assert.That(cell.GetAttribute("data-content-type"), Is.EqualTo("table"));
+            var nested = SpreadsheetTables.FindNestedTable(cell);
+            Assert.That(nested, Is.Not.Null, "the cell still holds a table");
+            Assert.That(nested.GetAttribute("data-column-widths"), Is.EqualTo("fill,fill"));
+            Assert.That(
+                nested.GetAttribute("style"),
+                Does.Contain("grid-template-columns: 1fr 1fr")
+            );
+            var nestedCells = SpreadsheetTables.CellsOf(nested);
+            Assert.That(nestedCells.Count, Is.EqualTo(2));
+            Assert.That(TextOfCell(nestedCells[0], "es"), Is.EqualTo("Dentro"));
+            Assert.That(TextOfCell(nestedCells[0], "en"), Is.EqualTo("Inside"));
+            Assert.That(TextOfCell(nestedCells[1], "es"), Is.EqualTo("Tambien"));
+            Assert.That(TextOfCell(nestedCells[1], "en"), Is.EqualTo("Also"));
+        }
+
+        [Test]
+        public void TableStaysWhereItWasOnThePage()
+        {
+            // Import replaces the table element but keeps its parent, so the table is still
+            // the second thing in the page's content, after the heading.
+            var table = GetTable(_roundtrippedDom);
+            var siblings = table
+                .ParentNode.ChildNodes.OfType<SafeXmlElement>()
+                .Select(e => e.GetAttribute("class"))
+                .ToList();
+            Assert.That(siblings.Count, Is.EqualTo(2));
+            Assert.That(siblings[0], Does.Contain("bloom-translationGroup"));
+            Assert.That(siblings[1], Does.Contain("bloom-table"));
+            Assert.That(
+                _roundtrippedDom
+                    .SafeSelectNodes("//div[@id='heading-es']")
+                    .Cast<SafeXmlElement>()
+                    .First()
+                    .InnerText,
+                Does.Contain("Mi mesa"),
+                "the page's own content outside the table imported as usual"
+            );
+        }
+
+        [Test]
+        public async Task EditedTranslationLandsInTheRightCellAndLanguage()
+        {
+            // Change one language cell of one [table cell] row, the way a translator would,
+            // and check it lands in that cell and only there.
+            var sheet = ExportBook(MakeBook(MakeTable(true)));
+            var rowToEdit = sheet
+                .ContentRows.Where(r => r.MetadataKey == InternalSpreadsheet.TableCellRowLabel)
+                .First(r =>
+                    r.GetCell(InternalSpreadsheet.DetailsColumnLabel).Content.Contains("\"row\":2")
+                    && r.GetCell(InternalSpreadsheet.DetailsColumnLabel)
+                        .Content.Contains("\"col\":1")
+                );
+            Assert.That(
+                rowToEdit.GetCell("[en]").Content,
+                Does.Contain("Four"),
+                "sanity: this is the cell we think it is before we change it"
+            );
+            rowToEdit.SetCell(sheet.GetRequiredColumnForLang("en"), "<p>Quatre</p>");
+
+            var target = new HtmlDom(MakeBook(MakeTable(true)), true);
+            await RoundTripThroughFileAndImportAsync(sheet, target);
+
+            var table = GetTable(target);
+            Assert.That(TextOfCell(GetCell(table, 2, 1), "en"), Is.EqualTo("Quatre"));
+            Assert.That(
+                TextOfCell(GetCell(table, 2, 1), "es"),
+                Is.EqualTo("Cuatro"),
+                "the other language of that cell is untouched"
+            );
+            Assert.That(
+                TextOfCell(GetCell(table, 2, 0), "en"),
+                Is.EqualTo("Three"),
+                "the neighbouring cell is untouched"
+            );
+        }
+
+        [Test]
+        public void ImportIntoPageWithoutTableReportsAndSkips()
+        {
+            Assert.That(
+                _warningsForBookWithoutTable,
+                Has.Some.Contains("found no table on the page for it"),
+                "importing a table into a page that has none is reported"
+            );
+            AssertThatXmlIn
+                .Dom(_domWithoutTable.RawDom)
+                .HasNoMatchForXpath("//div[contains(@class,'bloom-table')]"); // none is invented
+            Assert.That(
+                _domWithoutTable
+                    .SafeSelectNodes("//div[@id='heading-es']")
+                    .Cast<SafeXmlElement>()
+                    .First()
+                    .InnerText,
+                Does.Contain("Mi mesa"),
+                "the rest of the page still imported"
+            );
+        }
+
+        [Test]
+        public async Task SheetWithoutDetailsColumnLeavesTheBooksTableAlone()
+        {
+            // A spreadsheet from a book with no table (like any spreadsheet from an older
+            // Bloom) has no [details] column, so it says nothing about tables: importing it
+            // over a book that has one must not damage it.
+            var targetDom = new HtmlDom(MakeBook(MakeTable(true)), true);
+            var sheet = ExportBook(MakeBook(""));
+            Assert.That(
+                sheet.GetColumnForTag(InternalSpreadsheet.DetailsColumnLabel),
+                Is.LessThan(0),
+                "sanity: this sheet should have no details column"
+            );
+            var warnings = await RoundTripThroughFileAndImportAsync(sheet, targetDom);
+            Assert.That(warnings, Is.Empty);
+
+            var table = GetTable(targetDom);
+            Assert.That(TextOfCell(GetCell(table, 0, 0), "es"), Is.EqualTo("Uno"));
+            Assert.That(TextOfCell(GetCell(table, 2, 2), "en"), Is.EqualTo("Five"));
+            Assert.That(table.GetAttribute("data-column-widths"), Is.EqualTo("120px,fill,hug"));
+            Assert.That(
+                targetDom
+                    .SafeSelectNodes("//div[@id='heading-es']")
+                    .Cast<SafeXmlElement>()
+                    .First()
+                    .InnerText,
+                Does.Contain("Mi mesa"),
+                "sanity: the rest of the page imported from the table-less sheet"
+            );
+        }
+
+        [TestCase("")]
+        [TestCase("not json {")]
+        public async Task TableRowWithUnreadableDetailsLeavesTheBooksTableAlone(string details)
+        {
+            // The [details] column is present, but someone has blanked or mangled the cell
+            // on the [table] row. Bloom must not rebuild the table from nothing (which would
+            // erase the book's table); it says so and leaves the table as it was.
+            var sheet = ExportBook(MakeBook(MakeTable(true)));
+            var tableRow = sheet.ContentRows.First(r =>
+                r.MetadataKey == InternalSpreadsheet.TableRowLabel
+            );
+            Assert.That(
+                tableRow.GetCell(InternalSpreadsheet.DetailsColumnLabel).Content,
+                Does.Contain("\"kind\""),
+                "sanity: the exported details cell describes the table before we spoil it"
+            );
+            tableRow.SetCell(InternalSpreadsheet.DetailsColumnLabel, details);
+
+            var targetDom = new HtmlDom(MakeBook(MakeTable(true)), true);
+            var warnings = await RoundTripThroughFileAndImportAsync(sheet, targetDom);
+            Assert.That(warnings, Has.Some.Contains("could not read its [details] cell"));
+
+            var table = GetTable(targetDom);
+            Assert.That(TextOfCell(GetCell(table, 0, 0), "es"), Is.EqualTo("Uno"));
+            Assert.That(TextOfCell(GetCell(table, 2, 2), "en"), Is.EqualTo("Five"));
+            Assert.That(table.GetAttribute("data-column-widths"), Is.EqualTo("120px,fill,hug"));
+        }
+
+        [Test]
+        public async Task ImportCopiesCellImageAndVideoFilesIntoTheBook()
+        {
+            using (var spreadsheetFolder = new TemporaryFolder("tableSheetFolder"))
+            using (var bookFolder = new TemporaryFolder("tableBookFolder"))
+            {
+                var imagesFolder = Path.Combine(spreadsheetFolder.Path, "images");
+                Directory.CreateDirectory(imagesFolder);
+                using (var bitmap = new Bitmap(100, 50))
+                    bitmap.Save(Path.Combine(imagesFolder, "flower.jpg"), ImageFormat.Jpeg);
+                var videoFolder = Path.Combine(spreadsheetFolder.Path, "video");
+                Directory.CreateDirectory(videoFolder);
+                RobustFile.WriteAllText(
+                    Path.Combine(videoFolder, "fish.mp4"),
+                    "not really a video"
+                );
+
+                var dom = new HtmlDom(MakeBook(MakeTable(false)), true);
+                InternalSpreadsheet sheet;
+                using (var tempFile = TempFile.WithExtension("xlsx"))
+                {
+                    _sheetFromExport.WriteToFile(tempFile.Path);
+                    sheet = InternalSpreadsheet.ReadFromFile(tempFile.Path);
+                }
+                await new TestSpreadsheetImporter(
+                    null,
+                    dom,
+                    spreadsheetFolder.Path,
+                    bookFolder.Path
+                ).ImportAsync(sheet);
+
+                Assert.That(
+                    RobustFile.Exists(Path.Combine(bookFolder.Path, "flower.jpg")),
+                    "a picture cell's file lands in the book folder"
+                );
+                Assert.That(
+                    RobustFile.Exists(Path.Combine(bookFolder.Path, "video", "fish.mp4")),
+                    "a video cell's file lands in the book's video folder"
+                );
+                var table = GetTable(dom);
+                var img = GetCell(table, 0, 1)
+                    .SafeSelectNodes(".//img")
+                    .Cast<SafeXmlElement>()
+                    .First();
+                Assert.That(img.GetAttribute("src"), Is.EqualTo("flower.jpg"));
+            }
+        }
+
+        [Test]
+        public void ExportStripsEditTimeArtifacts()
+        {
+            // prepare-for-save.ts takes these off before Bloom saves a page; we strip them
+            // again so a spreadsheet made from a page that somehow still has them cannot
+            // carry one session's selection or anchor names into another book.
+            var messyTable = MakeTable(true)
+                .Replace(
+                    "class=\"bloom-table bloom-leadingElement\"",
+                    "class=\"bloom-table bloom-leadingElement table--selected bloom-current-table bloom-pointer-near\" data-table-attached=\"true\""
+                )
+                .Replace(
+                    "class=\"bloom-cell\" data-content-type=\"image\"",
+                    "class=\"bloom-cell cell--selected bloom-pulse-fill\" data-content-type=\"image\" data-btable-anchor-name=\"--btable-3\""
+                );
+            var sheet = ExportBook(MakeBook(messyTable));
+            var tableRow = sheet.ContentRows.First(r =>
+                r.MetadataKey == InternalSpreadsheet.TableRowLabel
+            );
+            var details = tableRow.GetCell(InternalSpreadsheet.DetailsColumnLabel).Content;
+            Assert.That(
+                details,
+                Does.Contain("bloom-leadingElement"),
+                "sanity: the durable classes are still there"
+            );
+            foreach (
+                var artifact in new[]
+                {
+                    "table--selected",
+                    "bloom-current-table",
+                    "bloom-pointer-near",
+                    "data-table-attached",
+                    "cell--selected",
+                    "bloom-pulse-fill",
+                    "data-btable-anchor-name",
+                }
+            )
+                Assert.That(details, Does.Not.Contain(artifact));
+        }
+
+        /// <summary>
+        /// A book whose pages hold nothing but a table, one page per entry in `texts`. A
+        /// custom page with a single Table section, or a canvas page with nothing but a
+        /// table, is a realistic layout, and such a page has no [page content] row at all,
+        /// so its [table] row is the only thing that can bring the importer onto it.
+        /// </summary>
+        private static string MakeTableOnlyBook(params string[] texts)
+        {
+            var pages = texts.Select(
+                (text, index) =>
+                    $@"
+    <div class=""bloom-page numberedPage customPage A5Portrait side-right bloom-bilingual"" data-page="""" id=""table-only-page-{index}"" data-page-number=""{index + 1}"" lang="""">
+        <div class=""pageLabel"" data-i18n=""TemplateBooks.PageLabel.Custom"" lang=""en"">Custom</div>
+        <div class=""pageDescription"" lang=""en""></div>
+        <div class=""split-pane-component marginBox"" style="""">
+            <div class=""split-pane-component-inner"">
+                <div class=""bloom-table bloom-leadingElement"" data-column-widths=""{(index == 0 ? "fill,fill" : "80px,fill")}"" data-row-heights=""fill"" style=""grid-template-columns: {(index == 0 ? "1fr 1fr" : "80px 1fr")}; --table-column-count: 2;"">
+                    {TextCell(text + " uno", text + " one")}
+                    {TextCell(text + " dos", text + " two")}
+                </div>
+            </div>
+        </div>
+    </div>"
+            );
+            return @"
+<!DOCTYPE html>
+
+<html>
+<head>
+</head>
+
+<body data-l1=""es"" data-l2=""en"" data-l3="""">
+	<div id=""bloomDataDiv"">
+		<div data-book=""bookTitle"" lang=""en""><p>Table only</p></div>
+	</div>
+"
+                + string.Join("\n", pages)
+                + @"
+</body>
+</html>
+";
+        }
+
+        private static int CountNumberedPages(HtmlDom dom)
+        {
+            return dom.GetPageElements()
+                .Count(p => p.GetAttribute("class").Contains("numberedPage"));
+        }
+
+        private static List<SafeXmlElement> TopLevelTablesOfPage(SafeXmlElement page)
+        {
+            return SpreadsheetTables.TopLevelTables(page);
+        }
+
+        [Test]
+        public async Task TableOnlyPagesRoundTripIntoTheSameBook()
+        {
+            // Nothing on these pages makes a [page content] row, so the [table] rows have to
+            // advance the importer from page to page by themselves.
+            var bookHtml = MakeTableOnlyBook("Alpha", "Beta");
+            var sourceDom = new HtmlDom(bookHtml, true);
+            Assert.That(CountNumberedPages(sourceDom), Is.EqualTo(2), "sanity: two pages");
+            Assert.That(
+                sourceDom.GetPageElements().Sum(p => TopLevelTablesOfPage(p).Count),
+                Is.EqualTo(2),
+                "sanity: one table per page"
+            );
+
+            var sheet = ExportBook(bookHtml);
+            Assert.That(
+                sheet.ContentRows.Count(r =>
+                    r.MetadataKey == InternalSpreadsheet.PageContentRowLabel
+                ),
+                Is.EqualTo(0),
+                "sanity: these pages have no content outside their tables"
+            );
+            Assert.That(
+                sheet.ContentRows.Count(r => r.MetadataKey == InternalSpreadsheet.TableRowLabel),
+                Is.EqualTo(2)
+            );
+            // Export puts the page type on the first row it makes for a page, which here is
+            // the [table] row; that is what tells import to start a new page.
+            var pageTypeColumn = sheet.GetColumnForTag(InternalSpreadsheet.PageTypeColumnLabel);
+            Assert.That(pageTypeColumn, Is.GreaterThanOrEqualTo(0));
+            foreach (
+                var tableRow in sheet.ContentRows.Where(r =>
+                    r.MetadataKey == InternalSpreadsheet.TableRowLabel
+                )
+            )
+                Assert.That(tableRow.GetCell(pageTypeColumn).Content, Is.EqualTo("Custom"));
+
+            var target = new HtmlDom(bookHtml, true);
+            var warnings = await RoundTripThroughFileAndImportAsync(sheet, target);
+            Assert.That(warnings, Is.Empty);
+
+            Assert.That(CountNumberedPages(target), Is.EqualTo(2));
+            var pages = target
+                .GetPageElements()
+                .Where(p => p.GetAttribute("class").Contains("numberedPage"))
+                .ToList();
+            var firstTable = TopLevelTablesOfPage(pages[0]).Single();
+            var secondTable = TopLevelTablesOfPage(pages[1]).Single();
+            Assert.That(
+                TextOfCell(SpreadsheetTables.CellsOf(firstTable)[0], "es"),
+                Is.EqualTo("Alpha uno")
+            );
+            Assert.That(
+                TextOfCell(SpreadsheetTables.CellsOf(firstTable)[1], "en"),
+                Is.EqualTo("Alpha two")
+            );
+            Assert.That(
+                TextOfCell(SpreadsheetTables.CellsOf(secondTable)[0], "es"),
+                Is.EqualTo("Beta uno"),
+                "the second page's table got the second page's rows, not the first's"
+            );
+            Assert.That(
+                firstTable.GetAttribute("data-column-widths"),
+                Is.EqualTo("fill,fill"),
+                "each page's table keeps its own shape"
+            );
+            Assert.That(secondTable.GetAttribute("data-column-widths"), Is.EqualTo("80px,fill"));
+        }
+
+        [Test]
+        public async Task UnreadableDetailsUseUpTheBooksTableSoLaterTablesLandRight()
+        {
+            // Two pages, a table on each. The first [table] row's details are spoiled; the
+            // second's are fine and carry an edit. The first table must be left alone and
+            // the second must still receive its own edit, not be skipped or land on the
+            // first page's table.
+            var bookHtml = MakeTableOnlyBook("Alpha", "Beta");
+            var sheet = ExportBook(bookHtml);
+            var tableRows = sheet
+                .ContentRows.Where(r => r.MetadataKey == InternalSpreadsheet.TableRowLabel)
+                .ToList();
+            Assert.That(tableRows.Count, Is.EqualTo(2), "sanity: one [table] row per page");
+            tableRows[0].SetCell(InternalSpreadsheet.DetailsColumnLabel, "");
+            var betaCellRow = sheet.ContentRows.First(r =>
+                r.MetadataKey == InternalSpreadsheet.TableCellRowLabel
+                && r.GetCell("[es]").Content.Contains("Beta uno")
+            );
+            betaCellRow.SetCell(sheet.GetRequiredColumnForLang("es"), "<p>Beta edited</p>");
+
+            var target = new HtmlDom(bookHtml, true);
+            var warnings = await RoundTripThroughFileAndImportAsync(sheet, target);
+            Assert.That(warnings, Has.Some.Contains("could not read its [details] cell"));
+
+            var pages = target
+                .GetPageElements()
+                .Where(p => p.GetAttribute("class").Contains("numberedPage"))
+                .ToList();
+            Assert.That(pages.Count, Is.EqualTo(2), "no page was added");
+            var firstTable = TopLevelTablesOfPage(pages[0]).Single();
+            var secondTable = TopLevelTablesOfPage(pages[1]).Single();
+            Assert.That(
+                TextOfCell(SpreadsheetTables.CellsOf(firstTable)[0], "es"),
+                Is.EqualTo("Alpha uno"),
+                "the table with the spoiled row is untouched"
+            );
+            Assert.That(
+                TextOfCell(SpreadsheetTables.CellsOf(secondTable)[0], "es"),
+                Is.EqualTo("Beta edited"),
+                "the second table still got its own rows"
+            );
+            Assert.That(secondTable.GetAttribute("data-column-widths"), Is.EqualTo("80px,fill"));
+        }
+
+        [Test]
+        public async Task UnreadableDetailsBeyondTheBooksTablesAddNoPage()
+        {
+            // The sheet has two tables; the book has one. The second [table] row's details
+            // are spoiled. Import must not add a page for a row it cannot use.
+            var sheet = ExportBook(MakeTableOnlyBook("Alpha", "Beta"));
+            var tableRows = sheet
+                .ContentRows.Where(r => r.MetadataKey == InternalSpreadsheet.TableRowLabel)
+                .ToList();
+            Assert.That(tableRows.Count, Is.EqualTo(2), "sanity: one [table] row per page");
+            tableRows[1].SetCell(InternalSpreadsheet.DetailsColumnLabel, "");
+
+            var target = new HtmlDom(MakeTableOnlyBook("Gamma"), true);
+            Assert.That(CountNumberedPages(target), Is.EqualTo(1), "sanity: one page to start");
+            var warnings = await RoundTripThroughFileAndImportAsync(sheet, target);
+            Assert.That(warnings, Has.Some.Contains("found no table on the page for it"));
+
+            Assert.That(CountNumberedPages(target), Is.EqualTo(1), "no page was added");
+            var table = GetTable(target);
+            Assert.That(
+                TextOfCell(SpreadsheetTables.CellsOf(table)[0], "es"),
+                Is.EqualTo("Alpha uno"),
+                "the first table still imported"
+            );
+        }
+
+        [Test]
+        public async Task TableOnlyPageImportsOntoAnAddedPage()
+        {
+            // The target book runs out of pages part way through: the second table has no
+            // page to land on, so import must add one, as it does for any other row type.
+            var sheet = ExportBook(MakeTableOnlyBook("Alpha", "Beta"));
+            var target = new HtmlDom(MakeTableOnlyBook("Gamma"), true);
+            Assert.That(CountNumberedPages(target), Is.EqualTo(1), "sanity: one page to start");
+
+            var warnings = await RoundTripThroughFileAndImportAsync(sheet, target);
+            Assert.That(warnings, Is.Empty);
+
+            Assert.That(
+                CountNumberedPages(target),
+                Is.EqualTo(2),
+                "a page was added for the second table"
+            );
+            var pages = target
+                .GetPageElements()
+                .Where(p => p.GetAttribute("class").Contains("numberedPage"))
+                .ToList();
+            Assert.That(
+                TextOfCell(
+                    SpreadsheetTables.CellsOf(TopLevelTablesOfPage(pages[0]).Single())[0],
+                    "es"
+                ),
+                Is.EqualTo("Alpha uno")
+            );
+            var addedTable = TopLevelTablesOfPage(pages[1]).Single();
+            Assert.That(
+                TextOfCell(SpreadsheetTables.CellsOf(addedTable)[0], "es"),
+                Is.EqualTo("Beta uno")
+            );
+            Assert.That(
+                TextOfCell(SpreadsheetTables.CellsOf(addedTable)[1], "en"),
+                Is.EqualTo("Beta two")
+            );
+            Assert.That(
+                addedTable.GetAttribute("data-column-widths"),
+                Is.EqualTo("80px,fill"),
+                "the added page's table has the shape the spreadsheet described, not the shape of the page it was copied from"
+            );
+            Assert.That(
+                target.RawDom.InnerXml,
+                Does.Not.Contain("Gamma"),
+                "the target book's own table content was replaced"
+            );
+        }
+
+        [Test]
+        public async Task TableRowForAPageWithNoTableAnywhereReportsAndSkips()
+        {
+            // A book with no table at all cannot receive one: there is no default page that
+            // holds a table, and inventing one would be inventing a shape nothing asked for.
+            var sheet = ExportBook(MakeTableOnlyBook("Alpha"));
+            var target = new HtmlDom(MakeBook(""), true);
+            var warnings = await RoundTripThroughFileAndImportAsync(sheet, target);
+
+            Assert.That(warnings, Has.Some.Contains("found no table on the page for it"));
+            AssertThatXmlIn
+                .Dom(target.RawDom)
+                .HasNoMatchForXpath("//div[contains(@class,'bloom-table')]");
+        }
+
+        [Test]
+        public void StripEditOnlyStylePropertiesKeepsEverythingElse()
+        {
+            // A cell's anchor name is minted per session and must not be saved; the grid
+            // styles beside it must come through untouched.
+            var kept = SpreadsheetTables.StripEditOnlyStyleProperties(
+                "anchor-name: --btable-3; --span-x: 2; --hint-top-color: red; padding: 4px"
+            );
+            Assert.That(kept, Is.EqualTo("--span-x: 2; padding: 4px;"));
+            Assert.That(
+                SpreadsheetTables.StripEditOnlyStyleProperties("anchor-name: --btable-3"),
+                Is.Empty
+            );
+        }
+    }
+}


### PR DESCRIPTION
Last of six stacked PRs splitting #8315. **Base is `BL-16818-e2e-tests` (#8329).** Nothing here touches anything the earlier five changed, so it could equally be reviewed first.

A table survives the round trip out to a spreadsheet and back. `SpreadsheetTables.cs` holds the whole of the table-specific reading and writing, so the exporter and importer gain little more than the calls into it. A table becomes a `[table]` row carrying its shape and sizing, followed by one row per table row, and comes back as the same table: cells keep their content type, their pictures and their videos, and a nested table comes back nested.

The half worth reading closely is what happens when a spreadsheet is wrong. An unreadable `[details]` cell leaves the table it names alone rather than half-importing it, and an unreadable `[table]` row adds no page at all, so a hand-edited sheet cannot quietly cost a person a page of their book.

Half the diff is `SpreadsheetTableTests.cs`.

## Checks

`build/agent-dotnet.sh test --filter "FullyQualifiedName~Spreadsheet"`: 427 passed, 0 failed.

[Claude Opus 5 following a prompt from Hatton]


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8330)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8330)
<!-- Reviewable:end -->
