### PR TITLE
Stop cleanUpNbsps orphaning CKEditor's zero-width filling char in titles (BL-16808)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -1509,20 +1509,41 @@ function handlePageEditing(
                 if (!ckeditorSelection) {
                     return; // may be changing pages?
                 }
+                // If there's no tool active, we don't need to update the markup.
+                const activeTool =
+                    currentTool && toolbox.toolboxIsShowing()
+                        ? currentTool
+                        : undefined;
+
+                // Restoring a bookmark goes through ckeditor's selectRanges(), and in the
+                // Chromium-based WebView2 (ckeditor's "webkit" branch) that plants a zero-width
+                // "filling char" (U+200B) at the caret whenever the caret sits
+                // next to an inline element, such as the bloom-linebreak span Shift+Enter inserts.
+                // ckeditor removes it again by node reference, so anything that later rebuilds the
+                // box's HTML (Show Hidden Characters, a reader tool's markup) leaves the character
+                // behind to be saved into the book (BL-16808). Nothing below rewrites this box
+                // unless a tool is active, or there is actually a comment or an nbsp to clean up;
+                // if nothing rewrites the box there is no selection to preserve. So only take a
+                // bookmark when one of those is true, which for ordinary typing is never. (Same
+                // gate as master's BL-16717 change.)
+                const needsBookmarks =
+                    !!activeTool || editableMightBeRewritten(editableDiv);
+
                 // there is also createBookmarks2(), which avoids actually inserting anything. That has the
                 // advantage that changing a character in the middle of a word will allow the entire word to
                 // be evaluated by the markup routine. However, testing shows that the cursor then doesn't
                 // actually go back to where it was: it gets shifted to the right.
-                let bookmarks = ckeditorSelection.createBookmarks(true);
+                let bookmarks = needsBookmarks
+                    ? ckeditorSelection.createBookmarks(true)
+                    : undefined;
 
                 // For some reason, we have cases, mostly (always?) on paste, where
                 // ckeditor is inserting tons of comments which are messing with our parsing
                 // See http://issues.bloomlibrary.org/youtrack/issue/BL-4775
                 removeCommentsFromEditableHtml(editableDiv);
 
-                // If there's no tool active, we don't need to update the markup.
-                if (currentTool && toolbox.toolboxIsShowing()) {
-                    if (currentTool.isUpdateMarkupAsync()) {
+                if (activeTool) {
+                    if (activeTool.isUpdateMarkupAsync()) {
                         // It's possible that removeCommentsFromEditableHtml moved the selection, typically
                         // to the start of the editableDiv. This doesn't matter on the synchronous branch,
                         // because we restore it at the end of this method, after the other updates, and no
@@ -1534,14 +1555,16 @@ function handlePageEditing(
                         // it now, and then again after actually changing the markup, which might move the selection again.
                         // (This is why we don't allow updateMarkupAsync to modify the DOM, except by means of
                         // the function it returns, which is executed synchronously with fixing the selection.)
-                        ckeditorOfThisBox
-                            .getSelection()
-                            .selectBookmarks(bookmarks);
+                        if (bookmarks) {
+                            ckeditorOfThisBox
+                                .getSelection()
+                                .selectBookmarks(bookmarks);
+                        }
                         ckeditorSelection = ckeditorOfThisBox.getSelection();
                         bookmarks = ckeditorSelection.createBookmarks(true);
 
                         const actualUpdateFunc =
-                            await currentTool.updateMarkupAsync();
+                            await activeTool.updateMarkupAsync();
                         if (
                             keydownEventCounter ===
                             counterValueThatIdentifiesThisKeyDown
@@ -1559,7 +1582,7 @@ function handlePageEditing(
                         // Unfortunately, we can't easily do that in a top-level (general for all tools) way because of
                         // our current architecture. Namely, the reader tools have a lower-level
                         // doMarkup() which gets called more than just from here.
-                        currentTool.updateMarkup();
+                        activeTool.updateMarkup();
                     }
                 }
 
@@ -1571,7 +1594,9 @@ function handlePageEditing(
                 // in some way that is still not understood. This was fixed by changing all this to trigger on
                 // a different event (keydown instead of keypress).
                 // Note: causing the bookmarks to be selected actually removes the bookmark spans.
-                ckeditorOfThisBox.getSelection().selectBookmarks(bookmarks);
+                if (bookmarks) {
+                    ckeditorOfThisBox.getSelection().selectBookmarks(bookmarks);
+                }
             }
         }
         // clear this value to prevent unnecessary calls to clearTimeout() for timeouts that have already expired.
@@ -1628,6 +1653,16 @@ export function cleanUpNbsps(editableDiv: HTMLElement) {
     const preserveNbspAfter = [" ", "«", "—"];
     const preserveNbspBefore = [" ", "»", ":", ";", "!", "?"];
 
+    // Whether we actually converted anything. Assigning innerHTML rebuilds every node in the box
+    // even when the string is unchanged. Besides losing the selection, that detaches the text
+    // node holding ckeditor's "filling char" (the U+200B it puts at the caret in the
+    // Chromium-based WebView2 and remembers by node so it can take it out again). Once
+    // detached, nothing removes the
+    // character, and it gets saved into the book: a title typed with Enter at a word boundary
+    // came out as "One" U+200B "Two" (BL-16808). Almost every keystroke leaves nothing to convert,
+    // so only write when there is something to write.
+    let replacedAnNbsp = false;
+
     let i = -1;
     let j = -1;
     // Simultaneously loop through the text and the html, finding each corresponding nbsp.
@@ -1675,9 +1710,10 @@ export function cleanUpNbsps(editableDiv: HTMLElement) {
                 editableDivText.substring(0, j) +
                 " " +
                 editableDivText.substring(j + 1);
+            replacedAnNbsp = true;
         }
     }
-    editableDiv.innerHTML = editableDivHtml;
+    if (replacedAnNbsp) editableDiv.innerHTML = editableDivHtml;
 
     // Restore the bookmarks. See comment above.
     if (originalBookMarkContent)
@@ -1700,6 +1736,19 @@ function setCkeditorBookmarkContent(
     });
 
     return existingContent;
+}
+
+// Could the clean-up steps in handlePageEditing's mainTask (removeCommentsFromEditableHtml and
+// cleanUpNbsps) actually change this box? Both rewrite innerHTML only when they find something
+// to fix, so this looks for the two things they look for. It deliberately over-estimates - an
+// nbsp that cleanUpNbsps would decide to keep still counts - because the only cost of a false
+// yes is that we take a ckeditor bookmark we didn't need, which is what the code did
+// unconditionally before. A false NO would be a bug: we'd lose the user's insertion point when
+// one of them did rewrite the box.
+// (exported for testing)
+export function editableMightBeRewritten(editable: HTMLElement): boolean {
+    const html = editable.innerHTML;
+    return html.includes("<!--") || html.includes("&nbsp;");
 }
 
 // exported for testing

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolboxSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolboxSpec.ts
@@ -1,7 +1,37 @@
 import { describe, it, expect } from "vitest";
-import { cleanUpNbsps, removeCommentsFromEditableHtml } from "./toolbox";
+import {
+    cleanUpNbsps,
+    editableMightBeRewritten,
+    removeCommentsFromEditableHtml,
+} from "./toolbox";
 
 describe("toolbox tests", () => {
+    // This gate decides whether we take a ckeditor bookmark, which in the Chromium-based WebView2
+    // plants a zero-width filling char at the caret. Saying "no" when one of the clean-ups would
+    // in fact rewrite the
+    // box would lose the user's insertion point, so it must catch everything they act on.
+    it("editableMightBeRewritten says no for ordinary text", () => {
+        const div = document.createElement("div");
+        div.innerHTML = "<p>overflow</p><p>plain text, nothing to clean up</p>";
+
+        expect(editableMightBeRewritten(div)).toBe(false);
+    });
+
+    it("editableMightBeRewritten says yes for anything the clean-ups act on", () => {
+        const withComment = document.createElement("div");
+        withComment.innerHTML = "<p>text</p>";
+        withComment.firstChild!.appendChild(document.createComment("x"));
+        // sanity check: this is the case removeCommentsFromEditableHtml rewrites
+        expect(withComment.innerHTML).toContain("<!--");
+        expect(editableMightBeRewritten(withComment)).toBe(true);
+
+        const withNbsp = document.createElement("div");
+        withNbsp.innerHTML = "<p>a&nbsp;b</p>";
+        // sanity check: the nbsp really did survive into the html cleanUpNbsps scans
+        expect(withNbsp.innerHTML).toContain("&nbsp;");
+        expect(editableMightBeRewritten(withNbsp)).toBe(true);
+    });
+
     it("removeCommentsFromEditableHtml removes comments correctly including ones with new lines", () => {
         const p = document.createElement("p");
         const span1 = document.createElement("span");
@@ -123,5 +153,57 @@ describe("toolbox tests", () => {
         // Ideally, we would remove the nbsp here, but in this corner case, the most
         // important thing is to do no harm.
         runNbspTest('<span data-attr="&nbsp;yuck!">A&nbsp;B</span>');
+    });
+
+    // runNbspTest only compares serialized html, which cannot tell "we left the DOM alone" apart
+    // from "we rebuilt it into something that serializes the same". These two check the actual
+    // nodes, because rebuilding matters: it detaches the text node ckeditor is tracking for its
+    // filling char, which then never gets removed and ends up saved in the book (BL-16808).
+    it("cleanUpNbsps keeps the same text node when there is nothing to convert", () => {
+        const div = document.createElement("div");
+        div.innerHTML = "<p>A b&nbsp;</p>"; // trailing nbsp, so nothing to convert
+        const textNodeBefore = div.querySelector("p")!.firstChild;
+        // Sanity check the setup: we mean to be watching a text node.
+        expect(textNodeBefore?.nodeType).toBe(Node.TEXT_NODE);
+
+        cleanUpNbsps(div);
+
+        expect(div.innerHTML).toBe("<p>A b&nbsp;</p>");
+        expect(div.querySelector("p")!.firstChild).toBe(textNodeBefore);
+    });
+
+    it("cleanUpNbsps does rebuild the content when there is something to convert", () => {
+        const div = document.createElement("div");
+        div.innerHTML = "<p>A&nbsp;b c</p>";
+        const textNodeBefore = div.querySelector("p")!.firstChild;
+        // Sanity check the setup: this nbsp is one we expect to be converted.
+        expect(textNodeBefore?.textContent).toBe("A\u00A0b c");
+
+        cleanUpNbsps(div);
+
+        expect(div.innerHTML).toBe("<p>A b c</p>");
+        expect(div.querySelector("p")!.firstChild).not.toBe(textNodeBefore);
+    });
+
+    // cleanUpNbsps empties any ckeditor bookmark span while it works and refills it at the end.
+    // That refill has to happen whether or not the box was rewritten.
+    it("cleanUpNbsps restores bookmark content on both the rewritten and the untouched path", () => {
+        const bookmark =
+            '<span data-cke-bookmark="1" id="cke_bm_1A" style="display: none;">&nbsp;</span>';
+
+        // Nothing to convert: the nodes are left alone and the bookmark keeps its content.
+        const untouched = document.createElement("div");
+        untouched.innerHTML = `<p>A b&nbsp;${bookmark}</p>`;
+        const textNodeBefore = untouched.querySelector("p")!.firstChild;
+        expect(textNodeBefore?.nodeType).toBe(Node.TEXT_NODE);
+        cleanUpNbsps(untouched);
+        expect(untouched.innerHTML).toBe(`<p>A b&nbsp;${bookmark}</p>`);
+        expect(untouched.querySelector("p")!.firstChild).toBe(textNodeBefore);
+
+        // Something to convert: the box is rewritten and the bookmark still gets its content back.
+        const rewritten = document.createElement("div");
+        rewritten.innerHTML = `<p>A&nbsp;b ${bookmark}c</p>`;
+        cleanUpNbsps(rewritten);
+        expect(rewritten.innerHTML).toBe(`<p>A b ${bookmark}c</p>`);
     });
 });


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
**Problem.** Follow-up to #8305. A tester found that on 6.4 a title typed as "One Two" with Enter (or Shift+Enter) pressed at the start of "Two" still reaches the Publish tab and bloomlibrary.org as "OneTwo", even though #8305 now puts a line break between the two lines. Show Hidden Characters reveals a zero-width space at the start of the second line. 6.5 does not have the problem.

**Cause.** CKEditor plants a zero-width "filling char" (U+200B) at the caret whenever it re-selects a caret that sits next to an inline element, such as the line-break span Shift+Enter inserts, and removes it later by holding a reference to that text node. Bloom's half-second tidy-up after every keystroke took a CKEditor bookmark and restored it, which is such a re-select, and it also assigned the box's `innerHTML` whether or not anything had changed. Each rewrite detached the node CKEditor was tracking, so the character stayed as ordinary text, a fresh one was planted on the next pause, and the result was saved. Chromium renders a newline adjacent to U+200B as nothing at all, so the line break became invisible. Reproduced in a running 6.4 build over CDP, and master fixed both halves in BL-16558 and BL-16717, which is why 6.5 is clean.

**What the PR does.** Ports the two master changes: `cleanUpNbsps` assigns `innerHTML` only when it actually converted a non-breaking space, and the tidy-up takes a bookmark only when a tool is active or the box holds a comment or an nbsp, the only cases in which anything rewrites it. With both, the tester's Enter and Shift+Enter sequences are clean at every step in a running Bloom, Show Hidden Characters included, and the saved title is "One \nTwo". Five new tests check node identity and the gate. Not done: cleaning books that already carry a stray zero-width space, and stripping one that CKEditor itself plants after, say, a Backspace next to a line break and that Show Hidden Characters then orphans; master strips those at save (BL-16490), which was judged too risky for 6.4 because Khmer, Thai and Myanmar text uses U+200B legitimately.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16808


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8332)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8332)
<!-- Reviewable:end -->


