### PR TITLE
Fix Edit tab top bar growing taller with long translations (BL-16834)

### DIFF
--- a/src/BloomBrowserUI/react_components/BookSettingsButton.tsx
+++ b/src/BloomBrowserUI/react_components/BookSettingsButton.tsx
@@ -38,13 +38,22 @@ export const BookSettingsButton: React.FunctionComponent = (props) => {
             textColor={kTextOnPurple}
             disabledTextColor={kDisabledTextOnPurple}
             cssOverrides={css`
-                width: 88px;
+                // The label wraps, and the TopBar is only as tall as its tallest child, so a
+                // label that wraps to three lines makes the whole bar taller (BL-16834, with
+                // the French "Paramètres du Livre et de la Page"). Let the button widen enough
+                // for long translations to fit on two lines, and clamp the label to two lines
+                // regardless so no translation can ever change the bar's height.
+                min-width: 88px;
+                max-width: 124px;
                 white-space: normal;
                 line-height: 1.15;
 
                 span {
-                    display: inline-block;
-                    max-width: 72px;
+                    display: -webkit-box;
+                    -webkit-box-orient: vertical;
+                    -webkit-line-clamp: 2;
+                    overflow: hidden;
+                    max-width: 108px;
                 }
 
                 // Recolor the (solid black) icon to black at 80% opacity so it matches


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
**Problem.** With the UI language set to French, the Edit tab's top bar is noticeably taller than in English (a 6.5 regression; 6.4 did not show it). The "Book and Page Settings" button's French label, "Paramètres du Livre et de la Page", wraps onto three lines and pushes the whole bar down.

**Cause.** The button was fixed at 88px wide with a freely wrapping label. In 6.5 the top bar is a single React flex row whose height follows its tallest child, so a three-line label grows the bar. In 6.4 the same wrapping happened, but the bar lived in a fixed-height WinForms-hosted browser that simply hid it.

**What the PR does.** A CSS-only change to the Book and Page Settings button:
- The button may now widen, from 88px up to 124px, so long translations (French, Portuguese) fit on two lines.
- The label is clamped to two lines with an ellipsis as a backstop, so no translation can ever change the bar's height.
- English now reads "Book and Page / Settings" in a slightly wider button; the bar height is unchanged (71px in both English and French, measured in a running Bloom).
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16834

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8334)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8334)
<!-- Reviewable:end -->
