### PR TITLE
Fix BL-16833 [6.4] Publishing Android App doesn't pay attention to license

### DIFF
--- a/src/BloomExe/Publish/Rab/RabProjectService.cs
+++ b/src/BloomExe/Publish/Rab/RabProjectService.cs
@@ -1185,6 +1185,23 @@ namespace Bloom.Publish.Rab
             var booksToExport = bookInfos.ToList();
             var bloomPubPathsToKeep = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+            // Like the other publish paths, refuse to publish a book in a language its copyright holder
+            // has not licensed (BL-16833). Check every book, including ones whose BloomPUB we would
+            // merely reuse, before touching anything on disk.
+            EnsureBooksAreLicensedForPublishing(
+                booksToExport.Select(bookInfo =>
+                {
+                    var book = _collectionModel.GetBookFromBookInfo(bookInfo);
+                    return (
+                        book,
+                        GetBookTitleForRab(book, bookInfo),
+                        BloomPubPublishSettings
+                            .GetPublishSettingsForBook(_bookServer, bookInfo)
+                            .LanguagesToInclude.ToArray()
+                    );
+                })
+            );
+
             foreach (var bookInfo in booksToExport)
             {
                 var existing =
@@ -1266,6 +1283,35 @@ namespace Bloom.Publish.Rab
             }
 
             return exportedBooks;
+        }
+
+        /// <summary>
+        /// Stops Prepare/Build when any book headed into the app may not be published in the languages its
+        /// BloomPUB would include (see LicenseChecker), by throwing with the LicenseChecker message; the
+        /// caller's ReportFailure puts that in the Apps screen log. When several books have problems, each
+        /// line of the message names the book. This mirrors the check the BloomPUB, ePUB, and PDF publish
+        /// paths make before they publish.
+        /// </summary>
+        internal static void EnsureBooksAreLicensedForPublishing(
+            IEnumerable<(global::Bloom.Book.Book Book, string Title, string[] Languages)> books
+        )
+        {
+            var checker = new LicenseChecker();
+            var problems = books
+                .Select(book => (book.Title, Message: checker.CheckBook(book.Book, book.Languages)))
+                .Where(problem => problem.Message != null)
+                .ToList();
+            if (problems.Count == 0)
+                return;
+
+            throw new ApplicationException(
+                problems.Count == 1
+                    ? problems[0].Message
+                    : string.Join(
+                        Environment.NewLine,
+                        problems.Select(problem => $"{problem.Title}: {problem.Message}")
+                    )
+            );
         }
 
         internal static string ResolveBloomPubPath(

--- a/src/BloomTests/Book/LicenseCheckerTests.cs
+++ b/src/BloomTests/Book/LicenseCheckerTests.cs
@@ -63,9 +63,16 @@ namespace BloomTests.Book
             Assert.That(result, Does.Not.Contain("zh-CN"));
         }
 
-        private TemporaryFolder SetupDefaultOfflineLicenseInfo()
+        /// <summary>
+        /// Points LicenseChecker at an offline cache (no internet) in which the kingstone.superbible.* books
+        /// are licensed for a handful of languages, notably NOT English or French. Callers must dispose the
+        /// folder and reset LicenseChecker (SetOfflineFolder(null), SetAllowInternetAccess(true)) afterwards.
+        /// </summary>
+        internal static TemporaryFolder SetupDefaultOfflineLicenseInfo(
+            string folderName = "DefaultOfflineLicenseTest"
+        )
         {
-            var folder = new TemporaryFolder("DefaultOfflineLicenseTest");
+            var folder = new TemporaryFolder(folderName);
             LicenseChecker.SetOfflineFolder(folder.FolderPath);
             LicenseChecker.SetAllowInternetAccess(false);
             LicenseChecker.WriteObfuscatedFile(

--- a/src/BloomTests/Publish/Rab/RabLicenseCheckTests.cs
+++ b/src/BloomTests/Publish/Rab/RabLicenseCheckTests.cs
@@ -1,0 +1,130 @@
+using System;
+using Bloom.Book;
+using Bloom.Publish.Rab;
+using BloomTests.Book;
+using NUnit.Framework;
+
+namespace BloomTests.Publish.Rab
+{
+    /// <summary>
+    /// Publish > Apps must respect the same content-license restrictions as the other publish paths (BL-16833):
+    /// a book carrying a bloom-licensed-content-id may only go into the app in the languages its copyright
+    /// holder has permitted.
+    /// </summary>
+    [TestFixture]
+    public class RabLicenseCheckTests : BookTestsBase
+    {
+        private const string kLicensedBookHead =
+            "<meta name='bloom-licensed-content-id' content='kingstone.superbible.ruth'></meta>";
+        private const string kBookBody =
+            @"<div class='bloom-page numberedPage customPage A5Portrait'>
+				<div class='marginBox'>
+					<div class='bloom-translationGroup bloom-trailingElement normal-style'>
+						<div class='bloom-editable bloom-content1 bloom-visibility-code-on' contenteditable='true' lang='en'>some text</div>
+						<div class='bloom-editable bloom-content1 bloom-visibility-code-on' contenteditable='true' lang='ru'>Russian text</div>
+					</div>
+				</div>
+			</div>";
+
+        private BloomTemp.TemporaryFolder _licenseCacheFolder;
+
+        protected override string GetTestFolderName() => "RabLicenseCheckTests";
+
+        [SetUp]
+        public override void Setup()
+        {
+            base.Setup();
+            _licenseCacheFolder = LicenseCheckerTests.SetupDefaultOfflineLicenseInfo(
+                "RabLicenseCheckTests-licenses"
+            );
+        }
+
+        [TearDown]
+        public override void TearDown()
+        {
+            LicenseChecker.SetOfflineFolder(null);
+            LicenseChecker.SetAllowInternetAccess(true);
+            _licenseCacheFolder?.Dispose();
+            base.TearDown();
+        }
+
+        [Test]
+        public void EnsureBooksAreLicensedForPublishing_UnlicensedLanguage_ThrowsWithLicenseMessage()
+        {
+            var book = CreateBookWithPhysicalFile(kBookBody, kLicensedBookHead);
+            // Sanity check that the fixture really does forbid English for this book.
+            Assert.That(new LicenseChecker().CheckBook(book, new[] { "en" }), Is.Not.Null);
+
+            var exception = Assert.Throws<ApplicationException>(() =>
+                RabProjectService.EnsureBooksAreLicensedForPublishing(
+                    new[] { (book, "Ruth", new[] { "en" }) }
+                )
+            );
+
+            Assert.That(
+                exception.Message,
+                Is.EqualTo(
+                    string.Format(
+                        LicenseChecker.kUnlicenseLanguageMessage,
+                        book.PrettyPrintLanguage("en")
+                    )
+                )
+            );
+        }
+
+        [Test]
+        public void EnsureBooksAreLicensedForPublishing_LicensedLanguage_DoesNotThrow()
+        {
+            var book = CreateBookWithPhysicalFile(kBookBody, kLicensedBookHead);
+
+            Assert.DoesNotThrow(() =>
+                RabProjectService.EnsureBooksAreLicensedForPublishing(
+                    new[] { (book, "Ruth", new[] { "ru" }) }
+                )
+            );
+        }
+
+        [Test]
+        public void EnsureBooksAreLicensedForPublishing_BookWithoutLicenseId_DoesNotThrow()
+        {
+            var book = CreateBookWithPhysicalFile(kBookBody, headContent: null);
+            // Sanity check: this book has no license restriction at all.
+            Assert.That(
+                book.OurHtmlDom.SelectSingleNode("//meta[@name='bloom-licensed-content-id']"),
+                Is.Null
+            );
+
+            Assert.DoesNotThrow(() =>
+                RabProjectService.EnsureBooksAreLicensedForPublishing(
+                    new[] { (book, "Free Book", new[] { "en", "fr" }) }
+                )
+            );
+        }
+
+        [Test]
+        public void EnsureBooksAreLicensedForPublishing_SeveralProblemBooks_NamesEachBook()
+        {
+            var book = CreateBookWithPhysicalFile(kBookBody, kLicensedBookHead);
+
+            var exception = Assert.Throws<ApplicationException>(() =>
+                RabProjectService.EnsureBooksAreLicensedForPublishing(
+                    new[]
+                    {
+                        (book, "Ruth", new[] { "en" }),
+                        (book, "Licensed OK", new[] { "ru" }),
+                        (book, "Esther", new[] { "en" }),
+                    }
+                )
+            );
+
+            var lines = exception.Message.Split(
+                new[] { Environment.NewLine },
+                StringSplitOptions.None
+            );
+            Assert.That(lines.Length, Is.EqualTo(2));
+            Assert.That(lines[0], Does.StartWith("Ruth: "));
+            Assert.That(lines[1], Does.StartWith("Esther: "));
+            Assert.That(exception.Message, Does.Not.Contain("Licensed OK"));
+        }
+    }
+}


### PR DESCRIPTION
<!-- preflight-narrative:begin --> **Problem**  Publish > Apps (Reading App Builder) would happily build a content-licensed book, such as a Super Bible title, into an Android app in a language the copyright holder has not permitted (English, for Super Bible). Every other publish path (BloomPUB, ePUB, PDF, upload) stops with a licensing message; this one showed nothing.  **Cause**  The Reading App Builder workflow never consulted `LicenseChecker`. It exported BloomPUBs for the app straight from each book's publish settings.  **What the PR does**  - Before Prepare or Build exports any BloomPUB, every book headed into the app is checked with `LicenseChecker` against the languages its BloomPUB would include. Books whose BloomPUB would merely be reused are checked too, and the check runs before anything on disk is touched. - A restricted language makes the operation fail with the same licensing message the other paths show, in the Apps screen log. When several books have problems, each line names the book. - Unit tests cover a forbidden language, a permitted language, an unrestricted book, and several problem books, reusing the offline license fixture from the existing LicenseChecker tests. <!-- preflight-narrative:end -->  Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16833  🤖 Generated with [Claude Code](https://claude.com/claude-code)  [Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8335)  <!-- Reviewable:start --> - - - This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8335) <!-- Reviewable:end -->  

---
[Devin review](https://app.devin.ai/review/BloomBooks/BloomDesktop/pull/8335)
