### PR TITLE
Stop deleting U+200B word breaks (Khmer/Thai/Myanmar) on save (BL-16843)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
+++ b/src/BloomBrowserUI/bookEdit/js/editableDivUtils.ts
@@ -335,9 +335,12 @@ export class EditableDivUtils {
 
     // Get the cleaned up data (getData()) from ckeditor, rather than just the raw html.
     // Specifically, we want it to remove the zero-width space characters that ckeditor inserts.
-    // See BL-12391. Note that getData() only removes the filling char ckeditor is actively
-    // tracking; an orphaned one survives it, so we also strip stray filling chars explicitly
-    // (see removeCkEditorFillingChars and BL-16490).
+    // See BL-12391. Note that getData() only leaves out the filling char ckeditor is actively
+    // tracking. An orphaned one (see removeTrackedCkEditorFillingChar) survives it, and we
+    // deliberately do NOT strip such characters here: Thai, Khmer and Myanmar text uses U+200B
+    // as a real word break, and a blanket strip deleted those from every box on save (BL-16843).
+    // Instead, the code that rewrites a box's html takes the tracked char out first, so it is
+    // never orphaned to begin with.
     // Return the bookmarks for each editable div, so that we can restore the selection after
     // modifying the divs.
     // Changes to this logic may need to be reflected in audioRecording.ts' cleanUpCkEditorHtml.
@@ -366,13 +369,7 @@ export class EditableDivUtils {
                     }
                 }
 
-                // Strip stray filling chars before comparing: if the live DOM has an
-                // orphaned filling char that getData() didn't remove, the stripped data
-                // will differ from div.innerHTML and trigger the replacement that removes it.
-                const ckEditorData =
-                    EditableDivUtils.removeCkEditorFillingChars(
-                        ckeditorOfThisBox.getData(),
-                    );
+                const ckEditorData = ckeditorOfThisBox.getData();
                 if (ckEditorData !== div.innerHTML) {
                     this.safelyReplaceContentWithCkEditorData(
                         div,
@@ -393,12 +390,6 @@ export class EditableDivUtils {
         div: HTMLDivElement,
         ckEditorData: string,
     ) {
-        // Belt-and-suspenders for callers that pass getData() directly (e.g.
-        // audioRecording.cleanUpCkEditorHtml): make sure we never write an
-        // orphaned ckeditor filling char into the DOM. See BL-16490.
-        ckEditorData =
-            EditableDivUtils.removeCkEditorFillingChars(ckEditorData);
-
         let needToRemoveInitialParagraph = false;
         let divChildNodes = Array.from(div.childNodes);
         if (
@@ -451,17 +442,51 @@ export class EditableDivUtils {
     }
 
     // CKEditor 4 inserts a "filling char" (U+200B ZERO WIDTH SPACE) at the caret on
-    // WebKit/Blink to keep the cursor navigable near inline-element boundaries and
-    // before <br>. It removes the one it is tracking, but when the decodable/leveled
-    // reader rewrites a box's innerHTML out from under ckeditor, that filling char is
-    // orphaned: getData() no longer strips it, so it gets saved and corrupts reader
-    // word matching (the analyzer treats U+200B as a word split while the highlighter
-    // does not). Strip any such stray filling chars. See BL-16490.
-    // We deliberately remove only U+200B; U+200C (ZWNJ) and U+200D (ZWJ) are legitimate
-    // in some scripts and must be preserved.
-    public static removeCkEditorFillingChars(html: string): string {
-        const fillingChar = String.fromCharCode(0x200b); // U+200B ZERO WIDTH SPACE
-        return html.split(fillingChar).join("");
+    // WebKit/Blink to keep the cursor navigable near inline-element boundaries and before
+    // <br>. It remembers THE NODE it put the character in (custom data "cke-fillingChar" on
+    // the editable) and later takes the character out of that node again; getData() leaves
+    // it out too. So the character is only a problem when something rewrites the box's
+    // innerHTML from the live DOM: the string carries the U+200B as ordinary text, the node
+    // ckeditor remembers is detached, and the character is "orphaned" - nothing will ever
+    // remove it, it gets saved into the book, and it corrupts reader word matching (the
+    // analyzer treats U+200B as a word split while the highlighter does not). See BL-16490.
+    //
+    // Call this BEFORE any such rewrite, so the character never gets baked into the string.
+    // It takes out only the character ckeditor is tracking, exactly as ckeditor itself would
+    // (a U+200B followed by a plain space becomes an nbsp, so the space is not lost to
+    // whitespace collapsing), and forgets the reference so ckeditor does not write to a
+    // detached node later. An earlier fix for BL-16490 instead stripped every U+200B from
+    // a box's html on save, which also deleted the real word-break characters that Thai,
+    // Khmer and Myanmar text depends on (BL-16843). U+200B outside the tracked node is
+    // deliberately left alone here for the same reason.
+    // Rewrites fed from getData() (doCkEditorCleanup, audioRecording.cleanUpCkEditorHtml)
+    // don't need this, because getData() has already left the tracked character out.
+    public static removeTrackedCkEditorFillingChar(element: HTMLElement): void {
+        const editable = EditableDivUtils.ckEditorEditableOf(element);
+        const trackedNode = editable?.getCustomData("cke-fillingChar")?.$;
+        if (!trackedNode) {
+            return;
+        }
+        editable!.removeCustomData("cke-fillingChar");
+        if (!element.contains(trackedNode)) {
+            return; // already orphaned by some earlier rewrite; nothing left to take out
+        }
+        // The node can hold more than the filling char: text the user typed right after the
+        // caret was placed lands in the same node, and in Khmer, Thai or Myanmar that text can
+        // itself contain U+200B word breaks. ckeditor planted exactly one character, so take out
+        // only the first U+200B and leave any later ones alone. (ckeditor's own removal is less
+        // careful and strips every U+200B in the node; we don't copy that.)
+        // Edit in place with deleteData/replaceData rather than assigning the whole text, so
+        // live ranges (the caret, reader highlights) in the rest of the node keep their places.
+        const text = trackedNode as Text;
+        const i = text.data.indexOf("\u200B");
+        if (i < 0) {
+            return; // ckeditor already took it out (its own removal leaves the node behind)
+        }
+        text.deleteData(i, 1);
+        if (text.data[i] === " ") {
+            text.replaceData(i, 1, "\u00A0");
+        }
     }
 
     // I don't know why cdEditor's getData() converts paragraphs with only a <br>
@@ -689,37 +714,53 @@ export class EditableDivUtils {
     // word break, and searching for the character would have quietly turned the repair off
     // for a whole book in those languages.
     // Asking is not enough on its own, though: ckeditor keeps the reference as custom data on
-    // the editable DIV, so anything that rewrites the box's innerHTML (doCkEditorCleanup,
-    // cleanUpNbsps) detaches the text node while leaving the reference behind. That is the
-    // BL-16490 "orphaned filling char", and it must NOT block the repair - nothing is tracking
-    // it any more, so nothing will write to it. Hence the isConnected/contains check: what
-    // blocks us is a node ckeditor is tracking that is still in this box.
+    // the editable DIV, so a rewrite of the box's innerHTML (doCkEditorCleanup, or any rewrite
+    // that didn't call removeTrackedCkEditorFillingChar first) detaches the text node while
+    // leaving the reference behind. That is the BL-16490 "orphaned filling char", and it must
+    // NOT block the repair - nothing is tracking it any more, so nothing will write to it.
+    // Hence the isConnected/contains check: what blocks us is a node ckeditor is tracking that
+    // is still in this box.
     // If a ckeditor upgrade ever renamed this key, or changed the shape it stores, this would
     // stop guarding and we would be back to the behavior that shipped in the first fix for
     // BL-16717, which merged regardless.
-    // (Typed locally rather than through CKEDITOR.editor: our ckeditor.d.ts only declares the
-    // editable(element) setter overloads, not the no-argument getter that actually exists. The
-    // value is a CKEDITOR.dom.text, whose `$` is the DOM node it wraps.)
     private static ckEditorFillingCharNodeIn(
         element: HTMLElement,
     ): Node | undefined {
-        const ckEditorOfThisBox = (
-            element as HTMLElement & {
-                bloomCkEditor?: {
-                    editable: () => {
-                        getCustomData: (
-                            key: string,
-                        ) => { $?: Node } | undefined;
-                    };
-                };
-            }
-        ).bloomCkEditor;
-        const trackedNode = ckEditorOfThisBox
-            ?.editable()
-            ?.getCustomData("cke-fillingChar")?.$;
+        const trackedNode =
+            EditableDivUtils.ckEditorEditableOf(element)?.getCustomData(
+                "cke-fillingChar",
+            )?.$;
         return trackedNode && element.contains(trackedNode)
             ? trackedNode
             : undefined;
+    }
+
+    // The CKEDITOR.editable of the ckeditor instance on this box, if it has one: the object
+    // ckeditor keeps its filling-char reference on.
+    // (Typed locally rather than through CKEDITOR.editor: our ckeditor.d.ts only declares the
+    // editable(element) setter overloads, not the no-argument getter that actually exists. The
+    // custom-data value is a CKEDITOR.dom.text, whose `$` is the DOM node it wraps.)
+    private static ckEditorEditableOf(element: HTMLElement):
+        | {
+              getCustomData: (key: string) => { $?: Node } | undefined;
+              removeCustomData: (key: string) => unknown;
+          }
+        | undefined {
+        const ckEditorOfThisBox = (
+            element as HTMLElement & {
+                bloomCkEditor?: {
+                    editable: () =>
+                        | {
+                              getCustomData: (
+                                  key: string,
+                              ) => { $?: Node } | undefined;
+                              removeCustomData: (key: string) => unknown;
+                          }
+                        | undefined;
+                };
+            }
+        ).bloomCkEditor;
+        return ckEditorOfThisBox?.editable();
     }
 
     public static restoreSelectionFromCkEditorBookmarks(

--- a/src/BloomBrowserUI/bookEdit/js/editableDivUtilsSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/js/editableDivUtilsSpec.ts
@@ -195,26 +195,16 @@ describe("EditableDivUtils Tests", () => {
         }
     });
 
-    it("removeCkEditorFillingChars removes U+200B but preserves U+200C and U+200D", () => {
-        const zwsp = String.fromCharCode(0x200b); // filling char we want gone
-        const zwnj = String.fromCharCode(0x200c); // legitimate; must be kept
-        const zwj = String.fromCharCode(0x200d); // legitimate; must be kept
-
-        // sanity check the test data
-        expect(zwsp).not.toEqual(zwnj);
-        const input = `a${zwsp}b${zwnj}c${zwj}d${zwsp}`;
-        expect(input.indexOf(zwsp)).toBeGreaterThan(-1);
-
-        const result = EditableDivUtils.removeCkEditorFillingChars(input);
-
-        expect(result.indexOf(zwsp)).toEqual(-1);
-        expect(result).toEqual(`ab${zwnj}c${zwj}d`);
-    });
-
-    it("safelyReplaceContentWithCkEditorData strips orphaned filling chars", () => {
+    // Thai, Khmer and Myanmar text uses U+200B (the same character as ckeditor's filling char)
+    // as a real word break. An earlier fix for BL-16490 stripped every U+200B from a box on
+    // save, which deleted those word breaks from every page (BL-16843). These check that the
+    // save/markup path keeps them, and only the code that rewrites a box from the live DOM
+    // takes out the one character ckeditor is actually tracking.
+    it("safelyReplaceContentWithCkEditorData keeps U+200B word breaks in the text", () => {
         const zwsp = String.fromCharCode(0x200b);
-        const ckEditorData = `<p>ca${zwsp}t${zwsp}</p>`;
-        // sanity check: our input really does contain the filling char we expect to be stripped.
+        // Two Khmer words separated by a zero-width space, as a Khmer keyboard types them.
+        const ckEditorData = `<p>ខ្ញុំ${zwsp}ចូលចិត្ត</p>`;
+        // sanity check: our input really does contain the character that must survive.
         expect(ckEditorData.indexOf(zwsp)).toBeGreaterThan(-1);
 
         const div = document.createElement("div");
@@ -223,8 +213,109 @@ describe("EditableDivUtils Tests", () => {
             ckEditorData,
         );
 
-        expect(div.innerHTML.indexOf(zwsp)).toEqual(-1);
-        expect(div.innerHTML).toEqual("<p>cat</p>");
+        expect(div.innerHTML).toEqual(ckEditorData);
+    });
+
+    it("doCkEditorCleanup keeps U+200B word breaks that ckeditor's getData() reports", () => {
+        const zwsp = String.fromCharCode(0x200b);
+        const wordsWithBreak = `<p>a${zwsp}b</p>`;
+        const div = document.createElement("div");
+        // The live DOM differs from getData() (as it does whenever ckeditor is holding a filling
+        // char), so the cleanup rewrites the box from getData().
+        div.innerHTML = `<p>a${zwsp}b${zwsp}</p>`;
+        (div as HTMLElement & { bloomCkEditor?: object }).bloomCkEditor = {
+            getData: () => wordsWithBreak,
+        };
+        // sanity check the setup: the rewrite will happen
+        expect(div.innerHTML).not.toEqual(wordsWithBreak);
+
+        EditableDivUtils.doCkEditorCleanup([div], false);
+
+        expect(div.innerHTML).toEqual(wordsWithBreak);
+    });
+
+    it("removeTrackedCkEditorFillingChar takes out only the character ckeditor is tracking", () => {
+        const zwsp = String.fromCharCode(0x200b);
+        const div = document.createElement("div");
+        const p = document.createElement("p");
+        // a real word break, in a node ckeditor is not tracking
+        p.appendChild(document.createTextNode(`a${zwsp}b`));
+        const fillingCharNode = document.createTextNode(zwsp);
+        p.appendChild(fillingCharNode);
+        div.appendChild(p);
+        const tracking = stubCkEditorTracking(div, fillingCharNode);
+        // sanity check the setup
+        expect(p.textContent).toBe(`a${zwsp}b${zwsp}`);
+
+        EditableDivUtils.removeTrackedCkEditorFillingChar(div);
+
+        expect(p.textContent).toBe(`a${zwsp}b`);
+        expect(fillingCharNode.textContent).toBe("");
+        expect(tracking.removed).toBe(true);
+    });
+
+    it("removeTrackedCkEditorFillingChar keeps text typed into the filling char's node and turns a following space into nbsp, as ckeditor does", () => {
+        const zwsp = String.fromCharCode(0x200b);
+        const div = document.createElement("div");
+        const p = document.createElement("p");
+        p.appendChild(document.createElement("strong")).textContent = "bold";
+        // Typing right after the filling char puts the letters in the same node. ckeditor's own
+        // removal turns "U+200B space" into an nbsp so the space survives whitespace collapsing.
+        const fillingCharNode = document.createTextNode(`${zwsp} typed`);
+        p.appendChild(fillingCharNode);
+        div.appendChild(p);
+        stubCkEditorTracking(div, fillingCharNode);
+
+        EditableDivUtils.removeTrackedCkEditorFillingChar(div);
+
+        expect(fillingCharNode.textContent).toBe("\u00A0typed");
+        expect(p.childNodes[1]).toBe(fillingCharNode); // edited in place, not replaced
+    });
+
+    it("removeTrackedCkEditorFillingChar keeps U+200B word breaks typed into the filling char's node", () => {
+        const zwsp = String.fromCharCode(0x200b);
+        const div = document.createElement("div");
+        const p = document.createElement("p");
+        p.appendChild(document.createElement("strong")).textContent = "bold";
+        // ckeditor planted one U+200B; the user then typed two Khmer words with a real word
+        // break between them into the same node. Only the planted one may go.
+        const fillingCharNode = document.createTextNode(
+            `${zwsp}ខ្ញុំ${zwsp}ចូលចិត្ត`,
+        );
+        p.appendChild(fillingCharNode);
+        div.appendChild(p);
+        stubCkEditorTracking(div, fillingCharNode);
+
+        EditableDivUtils.removeTrackedCkEditorFillingChar(div);
+
+        expect(fillingCharNode.textContent).toBe(`ខ្ញុំ${zwsp}ចូលចិត្ត`);
+    });
+
+    it("removeTrackedCkEditorFillingChar forgets an orphaned filling char without touching the box", () => {
+        const zwsp = String.fromCharCode(0x200b);
+        const div = document.createElement("div");
+        div.innerHTML = `<p>a${zwsp}b</p>`;
+        const orphan = document.createTextNode(zwsp);
+        const tracking = stubCkEditorTracking(div, orphan);
+        // sanity check the setup: the tracked node is not in the box
+        expect(div.contains(orphan)).toBe(false);
+
+        EditableDivUtils.removeTrackedCkEditorFillingChar(div);
+
+        expect(div.innerHTML).toBe(`<p>a${zwsp}b</p>`);
+        expect(orphan.textContent).toBe(zwsp);
+        expect(tracking.removed).toBe(true);
+    });
+
+    it("removeTrackedCkEditorFillingChar does nothing when ckeditor holds no filling char", () => {
+        const zwsp = String.fromCharCode(0x200b);
+        const div = document.createElement("div");
+        div.innerHTML = `<p>a${zwsp}b</p>`;
+        stubCkEditorTracking(div, undefined);
+
+        EditableDivUtils.removeTrackedCkEditorFillingChar(div);
+
+        expect(div.innerHTML).toBe(`<p>a${zwsp}b</p>`);
     });
 
     // Build a div (attached, so it has a real selection) whose paragraph has been split into
@@ -476,18 +567,31 @@ describe("EditableDivUtils Tests", () => {
         div.remove();
     });
 
-    // Make div look like a box whose ckeditor is tracking fillingCharNode as its filling char.
-    // ckeditor keeps that reference as custom data on the editable div and hands it back as a
-    // CKEDITOR.dom.text, whose `$` is the DOM node.
-    function stubCkEditorTracking(div: HTMLElement, fillingCharNode: Node) {
+    // Make div look like a box whose ckeditor is tracking fillingCharNode as its filling char
+    // (or nothing, if undefined). ckeditor keeps that reference as custom data on the editable
+    // div and hands it back as a CKEDITOR.dom.text, whose `$` is the DOM node. Returns a record
+    // of whether the reference was removed, so tests can check we told ckeditor to forget it.
+    function stubCkEditorTracking(
+        div: HTMLElement,
+        fillingCharNode: Node | undefined,
+    ): { removed: boolean } {
+        const tracking = { removed: false };
+        let tracked = fillingCharNode;
         (div as HTMLElement & { bloomCkEditor?: object }).bloomCkEditor = {
             editable: () => ({
                 getCustomData: (key: string) =>
-                    key === "cke-fillingChar"
-                        ? { $: fillingCharNode }
+                    key === "cke-fillingChar" && tracked
+                        ? { $: tracked }
                         : undefined,
+                removeCustomData: (key: string) => {
+                    if (key === "cke-fillingChar" && tracked) {
+                        tracked = undefined;
+                        tracking.removed = true;
+                    }
+                },
             }),
         };
+        return tracking;
     }
 
     it("mergeAdjacentTextNodes leaves the box alone while ckeditor holds a filling char", () => {

--- a/src/BloomBrowserUI/bookEdit/js/showInvisibles.ts
+++ b/src/BloomBrowserUI/bookEdit/js/showInvisibles.ts
@@ -95,6 +95,11 @@ export function showInvisibles(e) {
         return;
     }
     inShowInvisiblesMode = true;
+    // Rewriting the editable's HTML below from the live DOM would turn ckeditor's zero-width
+    // "filling char" into ordinary text that nothing removes again (BL-16490), so take it out
+    // first. Before saving the caret position, since removing a character ahead of the caret
+    // shifts that offset.
+    EditableDivUtils.removeTrackedCkEditorFillingChar(editable.get(0));
     // Rewriting the editable's HTML below destroys the selection, which made the
     // cursor jump to the start of the box (BL-16616). Save the caret position as a
     // character offset and restore it afterwards; offsets stay valid because each
@@ -173,6 +178,8 @@ export function hideInvisibles(e) {
 
         // restore all the original characters
         const editable = $(e.target).closest(".bloom-editable");
+        // As in showInvisibles, don't bake ckeditor's filling char into the rewritten html.
+        EditableDivUtils.removeTrackedCkEditorFillingChar(editable.get(0));
         // As in showInvisibles, preserve the caret across the HTML rewrite.
         // On blur the selection has already left the editable, so this returns -1
         // and we correctly don't yank the selection back.

--- a/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/talkingBook/audioRecording.ts
@@ -4022,15 +4022,7 @@ export default class AudioRecording implements IAudioRecorder {
         const ckeditorOfThisBox = (<any>editableDiv).bloomCkEditor;
         if (!ckeditorOfThisBox) return;
 
-        // Strip stray ckeditor filling chars before comparing: an orphaned one that
-        // getData() didn't remove would otherwise make both sides equal, skip the
-        // cleanup below, and leave the zero-width space in the copy we analyze. See BL-16490.
-        if (
-            editableDiv.innerHTML !==
-            EditableDivUtils.removeCkEditorFillingChars(
-                ckeditorOfThisBox.getData(),
-            )
-        ) {
+        if (editableDiv.innerHTML !== ckeditorOfThisBox.getData()) {
             // Flag the element we are processing so we can find it in the version we make from ckeditor's getData().
             element.setAttribute("data-element-we-are-processing", "this-one");
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolbox.ts
@@ -1857,6 +1857,16 @@ export function cleanUpNbsps(editableDiv: HTMLElement) {
     // We'll put them back in at the end.
     const originalBookMarkContent = setCkeditorBookmarkContent(editableDiv, "");
 
+    // If we end up rewriting the box (below), the html we write back must not carry ckeditor's
+    // zero-width "filling char" as ordinary text, or it is orphaned and saved into the book
+    // (BL-16490; and see removeTrackedCkEditorFillingChar). So take it out of the DOM first,
+    // before we read the html. We don't yet know whether we will convert anything, so this
+    // over-estimates the same way editableMightBeRewritten does: any nbsp at all. The only cost
+    // of a false yes is removing a character ckeditor was about to remove itself.
+    if (editableDiv.innerHTML.includes("&nbsp;")) {
+        EditableDivUtils.removeTrackedCkEditorFillingChar(editableDiv);
+    }
+
     let editableDivHtml = editableDiv.innerHTML;
     // innerText does not include hidden text; innerHTML does.
     // So we use textContent -- which includes hidden text -- to ensure the html and text are in sync.
@@ -1972,11 +1982,16 @@ export function editableMightBeRewritten(editable: HTMLElement): boolean {
 // insertion point at the start.
 export function removeCommentsFromEditableHtml(editable: HTMLElement) {
     // [\s\S] is a hack representing every character (including newline)
-    const fixedHtml = editable.innerHTML.replace(/<!--[\s\S]*?-->/g, "");
+    const commentRegex = /<!--[\s\S]*?-->/g;
     // This test makes it less likely we will move the selection. But you should still allow for
     // the possibility.
-    if (fixedHtml !== editable.innerHTML) {
-        editable.innerHTML = fixedHtml;
+    if (editable.innerHTML.replace(commentRegex, "") !== editable.innerHTML) {
+        // Don't bake ckeditor's zero-width filling char into the html we write back, where it
+        // would be orphaned and saved into the book (BL-16490). See
+        // removeTrackedCkEditorFillingChar, and the same step in cleanUpNbsps. Taking it out
+        // changes the html, so read it again afterwards.
+        EditableDivUtils.removeTrackedCkEditorFillingChar(editable);
+        editable.innerHTML = editable.innerHTML.replace(commentRegex, "");
     }
 }
 

--- a/src/BloomBrowserUI/bookEdit/toolbox/toolboxSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/toolbox/toolboxSpec.ts
@@ -184,4 +184,101 @@ describe("toolbox tests", () => {
         expect(div.innerHTML).toBe("<p>A b c</p>");
         expect(div.querySelector("p")!.firstChild).not.toBe(textNodeBefore);
     });
+
+    // Make div look like a box whose ckeditor is tracking fillingCharNode as its zero-width
+    // "filling char" (see EditableDivUtils.removeTrackedCkEditorFillingChar).
+    function stubCkEditorTracking(div: HTMLElement, fillingCharNode: Node) {
+        let tracked: Node | undefined = fillingCharNode;
+        (div as HTMLElement & { bloomCkEditor?: object }).bloomCkEditor = {
+            editable: () => ({
+                getCustomData: (key: string) =>
+                    key === "cke-fillingChar" && tracked
+                        ? { $: tracked }
+                        : undefined,
+                removeCustomData: () => {
+                    tracked = undefined;
+                },
+            }),
+        };
+    }
+
+    // When the rebuild does happen, the html written back is read from the live DOM, so
+    // ckeditor's filling char would be baked in as ordinary text and orphaned - the
+    // BL-16490 hazard. It must be taken out first; but a U+200B that is real text (a Thai,
+    // Khmer or Myanmar word break) must survive (BL-16843).
+    it("cleanUpNbsps takes out ckeditor's filling char, and only that, before rebuilding the box", () => {
+        const zwsp = String.fromCharCode(0x200b);
+        const div = document.createElement("div");
+        const p = document.createElement("p");
+        p.appendChild(document.createTextNode(`a${zwsp}b\u00A0c d`));
+        const fillingCharNode = document.createTextNode(zwsp);
+        p.appendChild(fillingCharNode);
+        div.appendChild(p);
+        stubCkEditorTracking(div, fillingCharNode);
+        // Sanity check the setup: there is an nbsp to convert, so the box will be rebuilt,
+        // and both zero-width spaces are in it.
+        expect(div.innerHTML).toBe(`<p>a${zwsp}b&nbsp;c d${zwsp}</p>`);
+
+        cleanUpNbsps(div);
+
+        expect(div.innerHTML).toBe(`<p>a${zwsp}b c d</p>`);
+    });
+
+    it("cleanUpNbsps leaves ckeditor's filling char alone when there is no nbsp to consider", () => {
+        const zwsp = String.fromCharCode(0x200b);
+        const div = document.createElement("div");
+        const p = document.createElement("p");
+        p.appendChild(document.createTextNode("ab"));
+        const fillingCharNode = document.createTextNode(zwsp);
+        p.appendChild(fillingCharNode);
+        div.appendChild(p);
+        stubCkEditorTracking(div, fillingCharNode);
+
+        cleanUpNbsps(div);
+
+        // ckeditor still needs it to show the caret; it will remove it itself.
+        expect(fillingCharNode.textContent).toBe(zwsp);
+        expect(p.childNodes[1]).toBe(fillingCharNode);
+    });
+
+    it("removeCommentsFromEditableHtml takes out ckeditor's filling char before rebuilding the box", () => {
+        const zwsp = String.fromCharCode(0x200b);
+        const div = document.createElement("div");
+        const p = document.createElement("p");
+        p.appendChild(document.createTextNode(`a${zwsp}b`));
+        p.appendChild(document.createComment("x"));
+        const fillingCharNode = document.createTextNode(zwsp);
+        p.appendChild(fillingCharNode);
+        div.appendChild(p);
+        stubCkEditorTracking(div, fillingCharNode);
+        // sanity check the setup
+        expect(div.innerHTML).toBe(`<p>a${zwsp}b<!--x-->${zwsp}</p>`);
+
+        removeCommentsFromEditableHtml(div);
+
+        expect(div.innerHTML).toBe(`<p>a${zwsp}b</p>`);
+    });
+
+    it("removeCommentsFromEditableHtml leaves the box (and ckeditor's filling char) alone when there is no comment to remove", () => {
+        const zwsp = String.fromCharCode(0x200b);
+        const div = document.createElement("div");
+        const p = document.createElement("p");
+        // "<!--" can appear in serialized html without being a comment node: attribute
+        // values don't escape "<". That must not count as something to rewrite.
+        p.setAttribute("data-note", "<!-- not a comment");
+        const textNode = document.createTextNode("ab");
+        p.appendChild(textNode);
+        const fillingCharNode = document.createTextNode(zwsp);
+        p.appendChild(fillingCharNode);
+        div.appendChild(p);
+        stubCkEditorTracking(div, fillingCharNode);
+        // sanity check the setup
+        expect(div.innerHTML).toContain("<!--");
+
+        removeCommentsFromEditableHtml(div);
+
+        expect(p.childNodes[0]).toBe(textNode); // not rebuilt
+        expect(fillingCharNode.textContent).toBe(zwsp);
+        expect(p.childNodes[1]).toBe(fillingCharNode);
+    });
 });


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
**Problem.** On 6.5, saving a page deletes every zero-width space (U+200B) from the text. Khmer, Thai and Myanmar keyboards insert that character between words, so text is silently altered on every save, and the Leveled and Decodable Reader tools see a whole paragraph as one word (a 26-word Khmer paragraph counted as one 98-letter word), so no level limit can ever trip. Anything rendered without a dictionary for those scripts loses its line breaks. 6.4 keeps the characters.

**Cause.** CKEditor places a U+200B "filling char" at the caret and tracks it by node; its `getData()` already omits it. When Bloom rewrote a box's HTML from the live DOM, that node was detached and the character became orphaned text that got saved (BL-16490). The 6.5 fix for that stripped every U+200B from a box on save and reader markup, which also removed the real word breaks.

**Fix.**
- The blanket strip is gone: `getData()` output is used as-is on save, reader markup and talking-book cleanup, so real U+200B word breaks survive.
- A new helper, `EditableDivUtils.removeTrackedCkEditorFillingChar`, takes out only the one character CKEditor planted in the node it is tracking (a following plain space becomes an nbsp, as CKEditor does), leaves any word breaks the user typed into that node alone, and drops CKEditor's reference.
- It runs before every rewrite that copies live HTML back into a box, so a filling char can never be orphaned: the nbsp and comment clean-ups after each typing pause, and show/hide invisibles.
- Tests cover the helper, both clean-ups, and U+200B word breaks surviving save.

Books that already carry an orphaned U+200B from earlier 6.5 builds keep it, the same trade-off 6.4 made for BL-16808.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16843

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8336)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8336)
<!-- Reviewable:end -->
