### PR TITLE
Stop offering Bloom Games target images to the AI image editor (BL-16793)

### DIFF
--- a/src/BloomBrowserUI/bookEdit/aiImageEditor/aiImageEditorPageCommands.test.ts
+++ b/src/BloomBrowserUI/bookEdit/aiImageEditor/aiImageEditorPageCommands.test.ts
@@ -193,6 +193,35 @@ describe("aiImageEditorPageCommands: the menu command", () => {
             slotIndex: 2,
         });
     });
+
+    test("a game target's copy of a picture does not shift the index (BL-16793)", () => {
+        // A Bloom Games target holds a copy of its draggable's whole content, image container
+        // and all. C# declines to OFFER that copy to the AI image editor, but it still counts
+        // it when numbering, so this side has to count it too.
+        document.body.innerHTML = `
+            <div class="bloom-page" id="${kPageId}">
+                <div class="bloom-canvas-element" data-draggable-id="d1">
+                    <div class="bloom-imageContainer"><img src="dog.png" /></div>
+                </div>
+                <div data-target-of="d1">
+                    <div class="bloom-targetWrapper">
+                        <div class="bloom-imageContainer"><img src="dog.png" /></div>
+                    </div>
+                </div>
+                <div class="bloom-canvas-element" data-draggable-id="d2">
+                    <div class="bloom-imageContainer"><img src="cat.png" /></div>
+                </div>
+            </div>`;
+        const secondDraggablesImage = document.querySelector(
+            '[data-draggable-id="d2"] img',
+        ) as HTMLImageElement;
+
+        launchAiImageEditor(secondDraggablesImage, undefined);
+
+        expect(postJson).toHaveBeenCalledWith("aiImageEditor/saveThenLaunch", {
+            slotIndex: 2,
+        });
+    });
 });
 
 describe("aiImageEditorPageCommands: applying current-page replacements", () => {

--- a/src/BloomBrowserUI/bookEdit/aiImageEditor/aiImageEditorPageCommands.ts
+++ b/src/BloomBrowserUI/bookEdit/aiImageEditor/aiImageEditorPageCommands.ts
@@ -139,6 +139,15 @@ export function applyAiImageEditorReplacements(
             // offers the undo while an image container is active, and after the launch
             // saved and reloaded this page nothing is — so without this, Ctrl+Z right
             // after the editor closes would do nothing until the user clicked the image.
+            //
+            // It does a second job, which matters on a Bloom Games page: a draggable's
+            // target holds a copy of the draggable's content, and activating the draggable
+            // is what makes Bloom rebuild that copy. changeImageByElement above does NOT
+            // (verified against a running Bloom: without this line the target went on
+            // showing the replaced picture), so the target would otherwise keep a picture
+            // we no longer offer any way to edit (BL-16793). An off-page slot has no
+            // active element to rely on, so C# repoints those copies itself — see
+            // GetGameTargetImageCopiesOfSlot in AiImageEditorApi.cs.
             theOneCanvasElementManager.setActiveElementToClosest(target);
             applied++;
         });

--- a/src/BloomExe/web/controllers/AiImageEditorApi.cs
+++ b/src/BloomExe/web/controllers/AiImageEditorApi.cs
@@ -903,6 +903,11 @@ namespace Bloom.web.controllers
         /// page, so the index the page frame sends at launch means the same thing here. It has
         /// one exclusion this does not need: Bloom injects controls into the live page, and a
         /// save strips them, so they are never in the DOM we read.
+        ///
+        /// Deciding which slots to OFFER is a separate job, done in EnumerateBookImages: a slot
+        /// it declines still holds its index here. Keeping this list unfiltered is what lets the
+        /// page frame work out an index for itself without knowing which slots we kept, so
+        /// resist the temptation to move any of that filtering in here.
         /// </summary>
         internal static SafeXmlElement[] SelectImageSlotsOnPage(SafeXmlElement page) =>
             page.SafeSelectNodes(
@@ -924,6 +929,63 @@ namespace Bloom.web.controllers
             if (img != null)
                 return img;
             return (slot.GetAttribute("style") ?? "").Contains("background-image") ? slot : null;
+        }
+
+        /// <summary>
+        /// Marks a Bloom Games target: the place a draggable is meant to be dragged to, whose
+        /// value is the data-draggable-id of that draggable. The rest of Bloom's knowledge of
+        /// games lives in the front end (see GameTool.tsx and bloom-player's
+        /// dragActivityRuntime.ts); these two constants are all this file needs.
+        /// </summary>
+        internal const string kGameTargetOfAttribute = "data-target-of";
+
+        /// <summary>Marks a canvas element the reader can drag in a Bloom Game.</summary>
+        internal const string kDraggableIdAttribute = "data-draggable-id";
+
+        /// <summary>
+        /// True when this image slot is inside a Bloom Games target, which makes its picture a
+        /// COPY of a draggable's rather than an image of its own: Bloom fills a target by cloning
+        /// the whole content of its draggable, image container and all (copyContentToTarget in
+        /// bloom-player's dragActivityRuntime.ts). Such a slot is not worth offering to the AI
+        /// image editor — the draggable's own slot is the real one, and Bloom regenerates target
+        /// content from the draggable, so an edit made to the copy would just be overwritten
+        /// (BL-16793).
+        ///
+        /// Keyed on the attribute's PRESENCE, not its value: the Games templates ship
+        /// data-target-of="" and the id is filled in at runtime.
+        /// </summary>
+        internal static bool IsSlotInsideGameTarget(SafeXmlElement slot) =>
+            slot.ParentWithAttribute(kGameTargetOfAttribute) != null;
+
+        /// <summary>
+        /// The image elements of the Bloom Games target(s) that hold a copy of this slot's
+        /// picture — empty for the great majority of slots, which are not part of a game at all.
+        /// A slot has such copies only when it belongs to a draggable that has a target; a canvas
+        /// background, or a draggable whose target has no content, has none. Internal for testing.
+        /// </summary>
+        /// <param name="page">the page the slot lives on; targets are matched within it only</param>
+        /// <param name="slot">an image container from <see cref="SelectImageSlotsOnPage"/></param>
+        internal static SafeXmlElement[] GetGameTargetImageCopiesOfSlot(
+            SafeXmlElement page,
+            SafeXmlElement slot
+        )
+        {
+            var draggableId = slot.ParentWithAttribute(kDraggableIdAttribute)
+                ?.GetAttribute(kDraggableIdAttribute);
+            if (string.IsNullOrEmpty(draggableId))
+                return Array.Empty<SafeXmlElement>();
+
+            // Compare the attribute here rather than building an XPath around draggableId, which
+            // comes out of the book's own markup and would need quoting.
+            return page.SafeSelectNodes(".//*[@" + kGameTargetOfAttribute + "]")
+                .OfType<SafeXmlElement>()
+                .Where(target => target.GetAttribute(kGameTargetOfAttribute) == draggableId)
+                // A target's copy is a whole image container, so it is a slot in its own right;
+                // ask the same two helpers the real slots go through.
+                .SelectMany(target => SelectImageSlotsOnPage(target))
+                .Select(GetImageElementOfSlot)
+                .Where(element => element != null)
+                .ToArray();
         }
 
         /// <summary>
@@ -1185,6 +1247,13 @@ namespace Bloom.web.controllers
                 // worked out for itself, without knowing which slots we kept.
                 for (var ordinal = 0; ordinal < slots.Length; ordinal++)
                 {
+                    // A Bloom Games target shows a copy of its draggable's picture, so its image
+                    // container is a second slot showing the same image. Offering it made a game
+                    // page look like it had nearly twice as many pictures as it has, and editing
+                    // the copy would achieve nothing (BL-16793).
+                    if (IsSlotInsideGameTarget(slots[ordinal]))
+                        continue;
+
                     var element = GetImageElementOfSlot(slots[ordinal]);
                     if (element == null)
                         continue;
@@ -1623,7 +1692,10 @@ namespace Bloom.web.controllers
             {
                 // Leave the live (current) page to the front-end: it will call Bloom's
                 // changeImage() with newSrc and these attributes so the canvas + normal save
-                // flow handle it.
+                // flow handle it. A game target on that page needs nothing from us either:
+                // applyAiImageEditorReplacements makes the swapped slot the active canvas
+                // element, and that is what makes Bloom rebuild the copy the draggable's
+                // target holds (see the comment on that line).
                 creditAttributes = ReadCreditAttributes(book.FolderPath, newFileName);
                 return true;
             }
@@ -1639,6 +1711,33 @@ namespace Bloom.web.controllers
                 element,
                 new NullProgress()
             );
+
+            // If this slot belongs to a Bloom Games draggable, its target holds a copy of the
+            // picture, and nothing else will repoint that copy: we no longer offer it to the AI
+            // image editor, and the front end rebuilds a target's copy only when its draggable
+            // becomes the selected canvas element — which, this not being the page the user has
+            // open, it never does. Left alone, the target would go on showing the replaced
+            // picture, and its reference to the old file would also stop
+            // DeleteSupersededAiImageFiles reclaiming it (BL-16793).
+            //
+            // This repoints the copy and re-derives its credit attributes; it deliberately does
+            // not touch the sizing and cropping the copy inherited from the draggable. Those
+            // suit the old image's shape, so a replacement of a different shape looks right only
+            // once the user next selects that draggable and the front end rebuilds the copy
+            // properly. Guessing at them here would mean a second, poorer implementation of
+            // copyContentToTarget.
+            foreach (var copy in GetGameTargetImageCopiesOfSlot(page, slots[ordinal]))
+            {
+                HtmlDom.SetImageElementUrl(
+                    copy,
+                    UrlPathString.CreateFromUnencodedString(newFileName)
+                );
+                ImageUpdater.UpdateImgMetadataAttributesToMatchImage(
+                    book.FolderPath,
+                    copy,
+                    new NullProgress()
+                );
+            }
 
             if (element.HasAttribute("data-book"))
                 pageForDataDivSync = page;

--- a/src/BloomExe/web/controllers/AiImageEditorApi.cs
+++ b/src/BloomExe/web/controllers/AiImageEditorApi.cs
@@ -970,9 +970,20 @@ namespace Bloom.web.controllers
             SafeXmlElement slot
         )
         {
-            var draggableId = slot.ParentWithAttribute(kDraggableIdAttribute)
-                ?.GetAttribute(kDraggableIdAttribute);
+            var draggable = slot.ParentWithAttribute(kDraggableIdAttribute);
+            var draggableId = draggable?.GetAttribute(kDraggableIdAttribute);
             if (string.IsNullOrEmpty(draggableId))
+                return Array.Empty<SafeXmlElement>();
+
+            // Which of the draggable's own slots this is. A target holds a copy of the
+            // draggable's whole content, so the copy of THIS slot is the one in the same position
+            // inside the target, not every slot the target happens to hold: taking them all would
+            // repoint every one of a draggable's copies at whichever single picture the user had
+            // edited. Nothing Bloom ships puts two pictures in one draggable, but
+            // copyContentToTarget copies a whole bloom-canvas when it finds one, which is exactly
+            // that shape, so pair by position rather than trusting there to be only one.
+            var positionInDraggable = Array.IndexOf(SelectImageSlotsOnPage(draggable), slot);
+            if (positionInDraggable < 0)
                 return Array.Empty<SafeXmlElement>();
 
             // Compare the attribute here rather than building an XPath around draggableId, which
@@ -982,7 +993,12 @@ namespace Bloom.web.controllers
                 .Where(target => target.GetAttribute(kGameTargetOfAttribute) == draggableId)
                 // A target's copy is a whole image container, so it is a slot in its own right;
                 // ask the same two helpers the real slots go through.
-                .SelectMany(target => SelectImageSlotsOnPage(target))
+                .Select(target =>
+                {
+                    var copies = SelectImageSlotsOnPage(target);
+                    return positionInDraggable < copies.Length ? copies[positionInDraggable] : null;
+                })
+                .Where(copy => copy != null)
                 .Select(GetImageElementOfSlot)
                 .Where(element => element != null)
                 .ToArray();

--- a/src/BloomTests/web/controllers/AiImageEditorApiTests.cs
+++ b/src/BloomTests/web/controllers/AiImageEditorApiTests.cs
@@ -1336,6 +1336,169 @@ namespace BloomTests.web.controllers
         }
 
         // ------------------------------------------------------------------
+        // Bloom Games targets. A target holds a COPY of its draggable's content, image
+        // container and all, so the copy looks just like a slot of its own. It stays IN the
+        // slot list — the page frame counts it too, and the two numberings have to agree —
+        // but it is not offered to the AI image editor, and an off-page commit repoints it so
+        // it goes on showing its draggable's picture (BL-16793).
+        // ------------------------------------------------------------------
+
+        // A draggable holding one picture, plus the target that copies it. Mirrors what
+        // copyContentToTarget builds: the copy is an image container inside a
+        // bloom-targetWrapper. targetOf defaults to the draggable's id, as it is once a game
+        // has been set up; pass "" for a target straight out of a template, which has not been
+        // paired with a draggable yet.
+        private static string GameDraggableAndTargetHtml(
+            string draggableId,
+            string pictureFileName,
+            string targetOf = null
+        ) =>
+            $@"<div class='bloom-canvas-element' data-draggable-id='{draggableId}'>
+                   <div class='bloom-imageContainer'><img src='{pictureFileName}'/></div>
+               </div>
+               <div data-target-of='{targetOf ?? draggableId}'>
+                   <div class='bloom-targetWrapper'>
+                       <div class='bloom-imageContainer'><img src='{pictureFileName}'/></div>
+                   </div>
+               </div>";
+
+        [Test]
+        public void SelectImageSlotsOnPage_StillCountsAGameTargetsCopy()
+        {
+            // The copy must keep its place in this list even though we decline to offer it:
+            // an ordinal is an index into the UNFILTERED list, and slotIndexOnPage in
+            // aiImageEditorPageCommands.ts counts the copy on the live page as well. Filtering
+            // the copy out here instead would silently shift every later slot on the page.
+            var page = MakePageWithBody(GameDraggableAndTargetHtml("d1", "dog.png"));
+
+            var slots = AiImageEditorApi.SelectImageSlotsOnPage(page);
+
+            Assert.That(slots.Length, Is.EqualTo(2), "the target's copy must still hold an index");
+            Assert.That(
+                AiImageEditorApi.IsSlotInsideGameTarget(slots[0]),
+                Is.False,
+                "the draggable's own slot"
+            );
+            Assert.That(
+                AiImageEditorApi.IsSlotInsideGameTarget(slots[1]),
+                Is.True,
+                "the target's copy"
+            );
+        }
+
+        [Test]
+        public void IsSlotInsideGameTarget_TargetNotYetPairedWithADraggable_IsStillATarget()
+        {
+            // The Games templates ship data-target-of="", so presence of the attribute is what
+            // marks a target, not its value.
+            var page = MakePageWithBody(GameDraggableAndTargetHtml("d1", "dog.png", targetOf: ""));
+
+            var slots = AiImageEditorApi.SelectImageSlotsOnPage(page);
+
+            Assert.That(slots.Length, Is.EqualTo(2));
+            Assert.That(AiImageEditorApi.IsSlotInsideGameTarget(slots[1]), Is.True);
+        }
+
+        [Test]
+        public void IsSlotInsideGameTarget_OrdinarySlot_IsFalse()
+        {
+            var page = MakePageWithBody(
+                @"<div class='bloom-imageContainer'><img src='real.png'/></div>"
+            );
+
+            var slot = AiImageEditorApi.SelectImageSlotsOnPage(page)[0];
+
+            Assert.That(AiImageEditorApi.IsSlotInsideGameTarget(slot), Is.False);
+        }
+
+        [Test]
+        public void GetGameTargetImageCopiesOfSlot_DraggableWithATarget_ReturnsTheCopy()
+        {
+            var page = MakePageWithBody(GameDraggableAndTargetHtml("d1", "dog.png"));
+            var draggablesSlot = AiImageEditorApi.SelectImageSlotsOnPage(page)[0];
+            Assert.That(
+                AiImageEditorApi.IsSlotInsideGameTarget(draggablesSlot),
+                Is.False,
+                "sanity check: slot 0 should be the draggable's own, not the copy"
+            );
+
+            var copies = AiImageEditorApi.GetGameTargetImageCopiesOfSlot(page, draggablesSlot);
+
+            Assert.That(copies.Length, Is.EqualTo(1));
+            Assert.That(copies[0].GetAttribute("src"), Is.EqualTo("dog.png"));
+            Assert.That(
+                copies[0].ParentWithAttribute(AiImageEditorApi.kGameTargetOfAttribute),
+                Is.Not.Null,
+                "what came back must be the copy inside the target, not the draggable's own img"
+            );
+        }
+
+        [Test]
+        public void GetGameTargetImageCopiesOfSlot_AnotherDraggablesTarget_IsNotReturned()
+        {
+            var page = MakePageWithBody(
+                GameDraggableAndTargetHtml("d1", "dog.png")
+                    + GameDraggableAndTargetHtml("d2", "cat.png")
+            );
+            var slots = AiImageEditorApi.SelectImageSlotsOnPage(page);
+            Assert.That(slots.Length, Is.EqualTo(4), "two draggables and two copies");
+            var secondDraggablesSlot = slots[2];
+            Assert.That(
+                AiImageEditorApi.GetImageElementOfSlot(secondDraggablesSlot).GetAttribute("src"),
+                Is.EqualTo("cat.png"),
+                "sanity check: slot 2 should be the second draggable's own"
+            );
+
+            var copies = AiImageEditorApi.GetGameTargetImageCopiesOfSlot(
+                page,
+                secondDraggablesSlot
+            );
+
+            Assert.That(copies.Length, Is.EqualTo(1));
+            Assert.That(copies[0].GetAttribute("src"), Is.EqualTo("cat.png"));
+        }
+
+        [Test]
+        public void GetGameTargetImageCopiesOfSlot_SlotOutsideAnyDraggable_ReturnsNone()
+        {
+            // A canvas background is not a draggable, so it has no target and nothing to keep
+            // in step — even on a page that does have a game on it.
+            var page = MakePageWithBody(
+                @"<div class='bloom-imageContainer' style=""background-image:url('bg.png')""></div>"
+                    + GameDraggableAndTargetHtml("d1", "dog.png")
+            );
+            var backgroundSlot = AiImageEditorApi.SelectImageSlotsOnPage(page)[0];
+            Assert.That(
+                AiImageEditorApi.GetImageElementOfSlot(backgroundSlot),
+                Is.SameAs(backgroundSlot),
+                "sanity check: slot 0 should be the background"
+            );
+
+            Assert.That(
+                AiImageEditorApi.GetGameTargetImageCopiesOfSlot(page, backgroundSlot),
+                Is.Empty
+            );
+        }
+
+        [Test]
+        public void GetGameTargetImageCopiesOfSlot_DraggableWhoseTargetIsEmpty_ReturnsNone()
+        {
+            // A target's content is cleared in some game modes, and a target of a text or video
+            // draggable never holds a picture at all.
+            var page = MakePageWithBody(
+                @"<div class='bloom-canvas-element' data-draggable-id='d1'>
+                      <div class='bloom-imageContainer'><img src='dog.png'/></div>
+                  </div>
+                  <div data-target-of='d1'></div>"
+            );
+
+            var slots = AiImageEditorApi.SelectImageSlotsOnPage(page);
+
+            Assert.That(slots.Length, Is.EqualTo(1), "an empty target holds no slot");
+            Assert.That(AiImageEditorApi.GetGameTargetImageCopiesOfSlot(page, slots[0]), Is.Empty);
+        }
+
+        // ------------------------------------------------------------------
         // EmbedCreditsInNewImageFile: an AI-generated result file has no metadata of its own,
         // and Bloom rebuilds the data-copyright/creator/license attributes from the file's
         // metadata, so whatever credits the result should have must be written into the new

--- a/src/BloomTests/web/controllers/AiImageEditorApiTests.cs
+++ b/src/BloomTests/web/controllers/AiImageEditorApiTests.cs
@@ -1434,6 +1434,54 @@ namespace BloomTests.web.controllers
         }
 
         [Test]
+        public void GetGameTargetImageCopiesOfSlot_DraggableWithTwoPictures_ReturnsOnlyTheMatchingCopy()
+        {
+            // A target copies its draggable's whole content, so a draggable holding two pictures
+            // gives the target two copies. Each of the draggable's slots must map to the copy in
+            // the SAME position; returning both would let one AI edit overwrite the other
+            // picture's copy as well. Nothing Bloom ships builds a draggable like this, but
+            // copyContentToTarget copies a whole bloom-canvas when it finds one, which is this
+            // shape, so the pairing is pinned rather than left to luck.
+            var page = MakePageWithBody(
+                @"<div class='bloom-canvas-element' data-draggable-id='d1'>
+                      <div class='bloom-canvas'>
+                          <div class='bloom-imageContainer'><img src='dog.png'/></div>
+                          <div class='bloom-imageContainer'><img src='cat.png'/></div>
+                      </div>
+                  </div>
+                  <div data-target-of='d1'>
+                      <div class='bloom-targetWrapper'>
+                          <div class='bloom-canvas'>
+                              <div class='bloom-imageContainer'><img src='dog.png'/></div>
+                              <div class='bloom-imageContainer'><img src='cat.png'/></div>
+                          </div>
+                      </div>
+                  </div>"
+            );
+            var slots = AiImageEditorApi.SelectImageSlotsOnPage(page);
+            Assert.That(slots.Length, Is.EqualTo(4), "two pictures and two copies of them");
+            Assert.That(
+                AiImageEditorApi.GetImageElementOfSlot(slots[1]).GetAttribute("src"),
+                Is.EqualTo("cat.png"),
+                "sanity check: slot 1 should be the draggable's second picture"
+            );
+
+            var copiesOfFirst = AiImageEditorApi.GetGameTargetImageCopiesOfSlot(page, slots[0]);
+            var copiesOfSecond = AiImageEditorApi.GetGameTargetImageCopiesOfSlot(page, slots[1]);
+
+            Assert.That(copiesOfFirst.Length, Is.EqualTo(1), "one copy, not both");
+            Assert.That(copiesOfFirst[0].GetAttribute("src"), Is.EqualTo("dog.png"));
+            Assert.That(copiesOfSecond.Length, Is.EqualTo(1), "one copy, not both");
+            Assert.That(copiesOfSecond[0].GetAttribute("src"), Is.EqualTo("cat.png"));
+            // And they are different elements, so replacing one picture cannot touch the other.
+            Assert.That(
+                copiesOfFirst[0] == copiesOfSecond[0],
+                Is.False,
+                "each of the draggable's pictures must map to its own copy"
+            );
+        }
+
+        [Test]
         public void GetGameTargetImageCopiesOfSlot_AnotherDraggablesTarget_IsNotReturned()
         {
             var page = MakePageWithBody(


### PR DESCRIPTION
A Bloom Games target holds a clone of its draggable's content — image container and `<img>`
included — so every target looked to the AI image editor like another editable image slot. The
card's page, with a background plus three draggables, offered seven images instead of four. And
editing a clone achieved nothing: Bloom rebuilds a target's content from its draggable, so the
edit was overwritten.

`EnumerateBookImages` now declines any slot inside `[data-target-of]`.

The filtering deliberately does **not** go in `SelectImageSlotsOnPage`: a slot's identity is its
index in that unfiltered list, and both `slotIndexOnPage` (page frame) and
`applyAiImageEditorReplacements` re-derive that index, so a slot we decline still has to keep its
ordinal. Live check on the Games "Drag Images to Targets" page: the editor is now offered ordinals
`0, 3, 5, 7` — background plus three draggables — with `4, 6, 8` (the clones) held open but not
offered.

Because the clones are no longer editable, nothing else would repoint one when an AI edit replaces
a draggable's image on a page the user does not have open: the target would go on showing the
replaced picture, and its stale reference to the old file also stopped
`DeleteSupersededAiImageFiles` from reclaiming it. `TryApplyReplacement` now repoints those copies.
The currently-edited page needs no such work — making the swapped slot the active canvas element,
which `applyAiImageEditorReplacements` already does so Ctrl+Z can offer the undo, is what makes
Bloom rebuild the clone. That was verified by A/B against a running Bloom rather than assumed.

Verified against a running Bloom on a real game book, as well as by unit tests: the offered list,
the ordinal agreement between the two sides, the label renumbering, and an off-page commit
repointing both the draggable and its target's copy.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16793


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8337)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8337)
<!-- Reviewable:end -->
