### PR TITLE
Make resized images exactly the size we asked for (BL-16829)

### DIFF
--- a/src/BloomExe/ImageProcessing/ImageUtils.cs
+++ b/src/BloomExe/ImageProcessing/ImageUtils.cs
@@ -1159,7 +1159,10 @@ namespace Bloom.ImageProcessing
 
         /// <summary>
         /// Determine the largest image size that either matches the original width and height or
-        /// fits within the given maximums.  The aspect ratio of the original image is preserved.
+        /// fits within the given maximums.  The aspect ratio of the original image is preserved
+        /// as closely as whole pixels allow: the non-binding dimension is rounded, not truncated.
+        /// (Truncating made GraphicsMagick's fit-inside-the-box -scale treat the truncated dimension
+        /// as the tighter constraint and shave a pixel off the other one, BL-16829.)
         /// </summary>
         /// <param name="width">original width (unknown orientation)</param>
         /// <param name="height">original height (unknown orientation)</param>
@@ -1182,10 +1185,13 @@ namespace Bloom.ImageProcessing
                 {
                     if (aspect <= portraitAspect)
                         // closer to square than a standard page, the size is limited by the smaller dimension, the width of a portrait page
-                        return new Size(maxShortSide, (int)(aspect * (double)maxShortSide));
+                        return new Size(
+                            maxShortSide,
+                            (int)Math.Round(aspect * (double)maxShortSide)
+                        );
                     else
                         // Tall, skinny picture's size is limited by the larger dimension, the height of a portrait page
-                        return new Size((int)((double)maxLongSide / aspect), maxLongSide);
+                        return new Size((int)Math.Round((double)maxLongSide / aspect), maxLongSide);
                 }
             }
             else if (width > height)
@@ -1196,10 +1202,13 @@ namespace Bloom.ImageProcessing
                 {
                     if (aspect > landscapeAspect)
                         // Closer to square than the page, the size is limited by the smaller dimension of the page, which is the height in landscape
-                        return new Size((int)((double)maxShortSide / aspect), maxShortSide);
+                        return new Size(
+                            (int)Math.Round((double)maxShortSide / aspect),
+                            maxShortSide
+                        );
                     else
                         // Low, wide picture, the size is limited by the larger page dimension, which is the width in landscape.
-                        return new Size(maxLongSide, (int)(aspect * (double)maxLongSide));
+                        return new Size(maxLongSide, (int)Math.Round(aspect * (double)maxLongSide));
                 }
             }
             else
@@ -2297,8 +2306,13 @@ namespace Bloom.ImageProcessing
                             argsBldr.Append(" -density 96"); // GraphicsMagick defaults to 72 dpi, which is rather low
                             if (options.Size.Height > 0 && options.Size.Width > 0)
                                 // -resize would do a better job than -scale, but it can be much (~10x) slower on large images.
+                                // The trailing "!" makes GraphicsMagick produce exactly this size. Without it the
+                                // geometry is a box to fit inside while preserving the aspect ratio, and because our
+                                // size is already aspect-preserving to the nearest pixel, that "fit" could only lose
+                                // a pixel (3840x2156 came out 3839x2156, BL-16829). The distortion forced by "!" is
+                                // under half a pixel.
                                 argsBldr.AppendFormat(
-                                    " -scale {0}x{1}",
+                                    " -scale {0}x{1}!",
                                     options.Size.Width,
                                     options.Size.Height
                                 );

--- a/src/BloomTests/ImageProcessing/ImageFolderShrinkTests.cs
+++ b/src/BloomTests/ImageProcessing/ImageFolderShrinkTests.cs
@@ -455,16 +455,16 @@ namespace BloomTests.ImageProcessing
                 Is.LessThanOrEqualTo(ImageUtils.MaxBreadth),
                 $"{label}: short dimension should now fit within the maximum."
             );
-            // GraphicsMagick's -scale fits the image inside the box we ask for, so it can land a
-            // pixel short of the requested size; what matters is that it did not shrink further.
+            // Since BL-16829 the resize asks GraphicsMagick for exactly this size (the "!" flag on
+            // -scale), so the result must match to the pixel; it used to land a pixel short.
             Assert.That(
                 newSize.Width,
-                Is.EqualTo(expectedSize.Width).Within(2),
+                Is.EqualTo(expectedSize.Width),
                 $"{label}: unexpected width."
             );
             Assert.That(
                 newSize.Height,
-                Is.EqualTo(expectedSize.Height).Within(2),
+                Is.EqualTo(expectedSize.Height),
                 $"{label}: unexpected height."
             );
 

--- a/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
+++ b/src/BloomTests/ImageProcessing/ImageUtilsTests.cs
@@ -752,8 +752,9 @@ namespace BloomTests.ImageProcessing
         [TestCase(3000, 5000, 2304, 3840)] // portrait, both too large elongated
         [TestCase(2500, 5000, 1920, 3840)] // portrait, height too large
         [TestCase(5000, 2500, 3840, 1920)] // landscape, width too large
-        [TestCase(3800, 3000, 3546, 2800)] // landscape, height too large
-        [TestCase(3000, 3800, 2800, 3546)] // portrait, width too large
+        [TestCase(3800, 3000, 3547, 2800)] // landscape, height too large (3546.67 rounds up)
+        [TestCase(3000, 3800, 2800, 3547)] // portrait, width too large (3546.67 rounds up)
+        [TestCase(kDylanWidth, kDylanHeight, kDylanExpectedWidth, kDylanExpectedHeight)] // BL-16829: 2156.6 must round to 2157, not truncate to 2156
         public static void TestGetImageSizes(int width, int height, int newWidth, int newHeight)
         {
             var size = ImageUtils.GetDesiredImageSize(width, height);
@@ -768,6 +769,172 @@ namespace BloomTests.ImageProcessing
                 $"Computed height for {width},{height} is correct."
             );
         }
+
+        #region BL-16829: resized images must come out exactly the size we asked for
+
+        // The "Dylan" photo from the "4K Image BloomPUB Resolutions" manual test: 3992x2242, a little
+        // wider than 16:9. Scaling it to Bloom's 3840-pixel maximum width makes the height 2156.6.
+        // Before BL-16829, GetDesiredImageSize truncated that to 2156, and GraphicsMagick's -scale
+        // (with no "!" flag) then fitted the image *inside* 3840x2156, so the truncated height became
+        // the binding constraint and the width came out as 3839.
+        private const int kDylanWidth = 3992;
+        private const int kDylanHeight = 2242;
+        private const int kDylanExpectedWidth = 3840;
+        private const int kDylanExpectedHeight = 2157;
+
+        /// <summary>
+        /// The file-level resize used by the folder shrink (old-book migration, ProcessBook) and by
+        /// BookCompressor must produce a file of exactly the dimensions it was asked for.
+        /// </summary>
+        [Test]
+        public void ResizeImageFileWithOptionalTransparency_WideLandscapePhoto_IsExactlyTheDesiredSize()
+        {
+            using (var folder = new TemporaryFolder("ImageUtilsTests_ResizeFile_WidePhoto"))
+            {
+                var path = folder.Combine("dylan.jpg");
+                CreateLargeJpeg(path, kDylanWidth, kDylanHeight);
+                var desiredSize = ImageUtils.GetDesiredImageSize(kDylanWidth, kDylanHeight);
+                Assert.That(
+                    desiredSize.Width,
+                    Is.EqualTo(kDylanExpectedWidth),
+                    "setup: the desired width should be the maximum long side"
+                );
+
+                bool resized;
+                using (var tagFile = RobustFileIO.CreateTaglibFile(path))
+                {
+                    resized = ImageUtils.ResizeImageFileWithOptionalTransparency(
+                        path,
+                        desiredSize,
+                        false,
+                        false,
+                        tagFile
+                    );
+                }
+                Assert.That(
+                    resized,
+                    Is.True,
+                    "GraphicsMagick (the 'gm' folder beside the test assembly) is missing or failed to run."
+                );
+
+                Assert.That(
+                    GetImageDimensions(path),
+                    Is.EqualTo(new Size(kDylanExpectedWidth, kDylanExpectedHeight)),
+                    "the resized file should be exactly the size GetDesiredImageSize asked for"
+                );
+            }
+        }
+
+        /// <summary>
+        /// Importing an oversized photo into a book (the path the manual test exercised) must shrink it
+        /// to exactly the maximum size, not a pixel short of it.
+        /// </summary>
+        [Test]
+        public void ProcessAndSaveImageIntoFolder_WideLandscapePhoto_ShrinksToExactlyTheDesiredSize()
+        {
+            using (
+                var sourceFolder = new TemporaryFolder("ImageUtilsTests_Import_WidePhoto_Source")
+            )
+            using (var bookFolder = new TemporaryFolder("ImageUtilsTests_Import_WidePhoto_Book"))
+            {
+                var sourcePath = sourceFolder.Combine("dylan.jpg");
+                CreateLargeJpeg(sourcePath, kDylanWidth, kDylanHeight);
+                using (var image = PalasoImage.FromFileRobustly(sourcePath))
+                {
+                    Assert.That(
+                        image.Image.Width,
+                        Is.EqualTo(kDylanWidth),
+                        "setup: the source image should be oversized"
+                    );
+
+                    var fileName = ImageUtils.ProcessAndSaveImageIntoFolder(
+                        image,
+                        bookFolder.Path,
+                        false
+                    );
+
+                    Assert.That(
+                        GetImageDimensions(bookFolder.Combine(fileName)),
+                        Is.EqualTo(new Size(kDylanExpectedWidth, kDylanExpectedHeight)),
+                        "the imported image should be exactly the maximum size"
+                    );
+                }
+            }
+        }
+
+        /// <summary>
+        /// Publishing (BloomPUB, ePUB) resizes to the book's image settings. Every setting used to
+        /// lose pixels the same way (e.g. 1278x718 instead of 1280x719 at the default setting).
+        /// </summary>
+        [TestCase(2160, 3840, 3840, 2157)] // 4K
+        [TestCase(1080, 1920, 1920, 1078)] // Full HD: the size the manual test plan expects
+        [TestCase(720, 1280, 1280, 719)] // default BloomPUB setting
+        public void AdjustImageForDisplay_WideLandscapePhoto_ShrinksToExactlyTheDesiredSize(
+            int maxShortSide,
+            int maxLongSide,
+            int expectedWidth,
+            int expectedHeight
+        )
+        {
+            using (
+                var sourceFolder = new TemporaryFolder("ImageUtilsTests_Publish_WidePhoto_Source")
+            )
+            using (var destFolder = new TemporaryFolder("ImageUtilsTests_Publish_WidePhoto_Dest"))
+            {
+                var sourcePath = sourceFolder.Combine("dylan.jpg");
+                CreateLargeJpeg(sourcePath, kDylanWidth, kDylanHeight);
+
+                var result = ImageUtils.AdjustImageForDisplay(
+                    sourcePath,
+                    destFolder.Path,
+                    maxShortSide: maxShortSide,
+                    maxLongSide: maxLongSide
+                );
+
+                Assert.That(result, Is.Not.Null, "Expected a resized version to be created");
+                Assert.That(
+                    GetImageDimensions(result),
+                    Is.EqualTo(new Size(expectedWidth, expectedHeight)),
+                    $"the published image should be exactly the size that fits {maxLongSide}x{maxShortSide}"
+                );
+            }
+        }
+
+        /// <summary>
+        /// Generate a photo-like JPEG of the given size. Generated rather than committed, because a
+        /// multi-megapixel file is what makes the test meaningful and we don't want it in the repo.
+        /// </summary>
+        private static void CreateLargeJpeg(string path, int width, int height)
+        {
+            using (var bitmap = new Bitmap(width, height))
+            {
+                using (var graphics = Graphics.FromImage(bitmap))
+                {
+                    graphics.Clear(Color.SteelBlue);
+                    graphics.FillEllipse(
+                        Brushes.Orange,
+                        width / 4,
+                        height / 4,
+                        width / 2,
+                        height / 2
+                    );
+                }
+                bitmap.Save(path, ImageFormat.Jpeg);
+            }
+        }
+
+        /// <summary>
+        /// Read the pixel dimensions of an image file without holding a lock on the file
+        /// (Image.FromFile would keep the file open for the life of the Image).
+        /// </summary>
+        private static Size GetImageDimensions(string path)
+        {
+            using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read))
+            using (var image = Image.FromStream(stream, false, false))
+                return image.Size;
+        }
+
+        #endregion
 
         [Test]
         [TestCase(true)]


### PR DESCRIPTION
Fixes [BL-16829](https://issues.bloomlibrary.org/youtrack/issue/BL-16829).

## Problem

Every resize Bloom does through GraphicsMagick came out a pixel short of the maximum. `GetDesiredImageSize` truncated the non-binding dimension (2242 × 3840/3992 = 2156.6 → 2156), and `RunGraphicsMagick` passed that to `-scale` without the `!` flag, so GraphicsMagick treated the geometry as a box to fit inside. The truncated height became the tighter constraint and the width came out as 3839 instead of 3840. The same happened at every BloomPUB/ePUB image setting (1278×718 instead of 1280×719 at the default).

This has no visible effect for readers; images are scaled to their container by CSS and the aspect ratio was never actually wrong. It is a correctness tidy-up: the code now does what its comments, the docs, and the manual test plan say it does, and the folder-shrink tests no longer need a `Within(2)` tolerance to pass.

## Fix

- `GetDesiredImageSize` rounds the non-binding dimension instead of truncating.
- `RunGraphicsMagick` appends `!` to the `-scale` geometry so GraphicsMagick produces exactly the computed size. Every size handed to GraphicsMagick comes from `GetDesiredImageSize` on dimensions read from the same file, so the forced size never distorts by more than half a pixel.

## Tests

New tests pin the exact output size on all three resize paths (the file-level resize used by the folder shrink and `BookCompressor`, import into a book folder, and `AdjustImageForDisplay` at the 4K, Full HD, and default publish settings), using a generated 3992×2242 JPEG. Two existing `TestGetImageSizes` cases update for rounding (3546.67 → 3547). The folder-shrink tests now assert exact sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8340)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8340)
<!-- Reviewable:end -->
