### PR TITLE
Retry transient license-server failures and log why a check failed

### DIFF
--- a/src/BloomExe/Book/LicenseChecker.cs
+++ b/src/BloomExe/Book/LicenseChecker.cs
@@ -8,7 +8,9 @@ using System.Text;
 using System.Threading.Tasks;
 using Bloom.Api;
 using L10NSharp;
+using SIL.Code;
 using SIL.IO;
+using SIL.Reporting;
 using SIL.WritingSystems;
 using SIL.Xml;
 
@@ -33,6 +35,23 @@ namespace Bloom.Book
         {
             s_httpClient = client;
         }
+
+        // The license server occasionally rejects a request outright. Without a retry, one such blip
+        // shows the user the "trouble reaching the server" message (when there is no offline cache)
+        // and makes the nightly integration test flake.
+        // We deliberately do not retry a timeout (TaskCanceledException): the caller is blocked for the
+        // whole fetch, and tripling a 100-second timeout would be far worse than the blip we're guarding against.
+        private const int kFetchAttempts = 3;
+        internal const int kDefaultRetryDelayMs = 500;
+        internal static int RetryDelayMs = kDefaultRetryDelayMs; // tests set this to 0
+        private static readonly ISet<Type> kTransientFetchExceptions = new HashSet<Type>
+        {
+            typeof(HttpRequestException),
+        };
+
+        // The exception that made the last fetch fail (null if it succeeded). Lets tests report what the
+        // server actually said when a check fails, rather than just "didCheck was false".
+        internal static Exception LastFetchExceptionForTests { get; private set; }
 
         private static string _offlineFolderPath = ProjectContext.GetBloomAppDataFolder(); // normally stays here except in unit tests
         private static bool _allowInternetAccess = true;
@@ -70,14 +89,24 @@ namespace Bloom.Book
         )
         {
             string permissionsJson;
+            LastFetchExceptionForTests = null;
             if (_allowInternetAccess)
             {
                 try
                 {
                     // RunSync executes on the thread pool so we don't deadlock if called on a
                     // thread with a synchronization context (e.g. the WinForms UI thread).
-                    permissionsJson = Bloom.Utils.AsyncUtil.RunSync(() =>
-                        s_httpClient.GetStringAsync("https://content-licenses.bloomlibrary.org")
+                    permissionsJson = RetryUtility.Retry(
+                        () =>
+                            Bloom.Utils.AsyncUtil.RunSync(() =>
+                                s_httpClient.GetStringAsync(
+                                    "https://content-licenses.bloomlibrary.org"
+                                )
+                            ),
+                        kFetchAttempts,
+                        RetryDelayMs,
+                        kTransientFetchExceptions,
+                        memo: "license server"
                     );
                     if (!string.IsNullOrEmpty(_offlineFolderPath))
                     {
@@ -95,8 +124,10 @@ namespace Bloom.Book
                 }
                 catch (Exception w) when (w is HttpRequestException || w is TaskCanceledException)
                 {
-                    // A network failure (or timeout) reaching the license server: fall back to any cached copy.
-                    Bloom.Utils.MiscUtils.SuppressUnusedExceptionVarWarning(w);
+                    // A network failure (or timeout) reaching the license server, even after retrying:
+                    // fall back to any cached copy.
+                    LastFetchExceptionForTests = w;
+                    Logger.WriteError("Could not reach the license server", w);
                     if (!TryGetOfflineCache(out permissionsJson))
                     {
                         didCheck = false;

--- a/src/BloomTests/Book/LicenseCheckerTests.cs
+++ b/src/BloomTests/Book/LicenseCheckerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,17 +27,37 @@ namespace BloomTests.Book
             LicenseChecker.SetAllowInternetAccess(true);
             LicenseChecker.SetOfflineFolder(null);
             LicenseChecker.SetHttpClientForTests(new HttpClient());
+            LicenseChecker.RetryDelayMs = LicenseChecker.kDefaultRetryDelayMs;
         }
 
-        // An HttpClient handler that always fails, to simulate the license server being unreachable.
-        private sealed class FailingHttpMessageHandler : HttpMessageHandler
+        // An HttpClient handler that fails the first N requests and then succeeds with the default
+        // offline license JSON. Counts the attempts made, so tests can check the retry in LicenseChecker.
+        private sealed class FailThenSucceedHttpMessageHandler : HttpMessageHandler
         {
+            private readonly int _failuresBeforeSuccess;
+            public int Attempts { get; private set; }
+
+            public FailThenSucceedHttpMessageHandler(int failuresBeforeSuccess)
+            {
+                _failuresBeforeSuccess = failuresBeforeSuccess;
+            }
+
             protected override Task<HttpResponseMessage> SendAsync(
                 HttpRequestMessage request,
                 CancellationToken cancellationToken
             )
             {
-                throw new HttpRequestException("simulated network failure");
+                Attempts++;
+                if (Attempts <= _failuresBeforeSuccess)
+                    throw new HttpRequestException(
+                        $"simulated transient failure on attempt {Attempts}"
+                    );
+                return Task.FromResult(
+                    new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(kDefaultLicenseJson),
+                    }
+                );
             }
         }
 
@@ -68,7 +89,11 @@ namespace BloomTests.Book
             var key = "kingstone.superbible.ruth";
             bool didCheck;
             IEnumerable<string> result = checker.GetProblemLanguages(inputLangs, key, out didCheck);
-            Assert.That(didCheck, Is.EqualTo(expectCheck));
+            Assert.That(
+                didCheck,
+                Is.EqualTo(expectCheck),
+                "last fetch exception: " + LicenseChecker.LastFetchExceptionForTests
+            );
             if (didCheck)
             {
                 Assert.That(result, Does.Contain("en"));
@@ -87,7 +112,11 @@ namespace BloomTests.Book
             var key = "kingstone.superbible.ruth";
             bool didCheck;
             IEnumerable<string> result = checker.GetProblemLanguages(inputLangs, key, out didCheck);
-            Assert.That(didCheck, Is.True);
+            Assert.That(
+                didCheck,
+                Is.True,
+                "last fetch exception: " + LicenseChecker.LastFetchExceptionForTests
+            );
             Assert.That(result, Does.Contain("en"));
             Assert.That(result, Does.Contain("fr"));
             Assert.That(result, Does.Not.Contain("ru"));
@@ -99,7 +128,9 @@ namespace BloomTests.Book
         {
             LicenseChecker.SetAllowInternetAccess(true);
             LicenseChecker.SetOfflineFolder(null); // no offline cache available
-            LicenseChecker.SetHttpClientForTests(new HttpClient(new FailingHttpMessageHandler()));
+            LicenseChecker.RetryDelayMs = 0;
+            var handler = new FailThenSucceedHttpMessageHandler(failuresBeforeSuccess: 3);
+            LicenseChecker.SetHttpClientForTests(new HttpClient(handler));
             var checker = new LicenseChecker();
             var inputLangs = new[] { "en", "bjn" };
 
@@ -109,10 +140,16 @@ namespace BloomTests.Book
                 out bool didCheck
             );
 
+            Assert.That(handler.Attempts, Is.EqualTo(3), "we try three times, then give up");
             Assert.That(
                 didCheck,
                 Is.False,
                 "a network failure with no cache means we could not check the license"
+            );
+            Assert.That(
+                LicenseChecker.LastFetchExceptionForTests,
+                Is.InstanceOf<HttpRequestException>(),
+                "the failure that made us give up is recorded"
             );
             Assert.That(
                 result,
@@ -129,8 +166,9 @@ namespace BloomTests.Book
                 // SetupDefaultOfflineLicenseInfo disables internet access; re-enable it so we take the
                 // online path, hit the failing client, and fall back to the cache it wrote.
                 LicenseChecker.SetAllowInternetAccess(true);
+                LicenseChecker.RetryDelayMs = 0;
                 LicenseChecker.SetHttpClientForTests(
-                    new HttpClient(new FailingHttpMessageHandler())
+                    new HttpClient(new FailThenSucceedHttpMessageHandler(failuresBeforeSuccess: 3))
                 );
                 var checker = new LicenseChecker();
                 var inputLangs = new[] { "en", "bjn" };
@@ -173,7 +211,15 @@ namespace BloomTests.Book
             LicenseChecker.SetAllowInternetAccess(false);
             LicenseChecker.WriteObfuscatedFile(
                 folder.FolderPath + "/license.cache",
-                @"{
+                kDefaultLicenseJson
+            );
+            return folder;
+        }
+
+        // License data in the shape the server returns: kingstone.superbible.* books are licensed for a
+        // handful of languages, notably NOT English or French, and ruth additionally for bjn.
+        private const string kDefaultLicenseJson =
+            @"{
   ""range"": ""Sheet1!A1:B1001"",
   ""majorDimension"": ""ROWS"",
   ""values"": [
@@ -222,9 +268,38 @@ namespace BloomTests.Book
       ""bjn""
     ]
   ]
-}"
+}";
+
+        [Test]
+        public void GetProblemLanguages_TwoTransientFailuresThenSuccess_RetriesAndChecks()
+        {
+            LicenseChecker.SetAllowInternetAccess(true);
+            LicenseChecker.SetOfflineFolder(null); // no cache, so only a successful fetch can give didCheck
+            LicenseChecker.RetryDelayMs = 0;
+            var handler = new FailThenSucceedHttpMessageHandler(failuresBeforeSuccess: 2);
+            LicenseChecker.SetHttpClientForTests(new HttpClient(handler));
+            var checker = new LicenseChecker();
+            Assert.That(handler.Attempts, Is.EqualTo(0), "sanity check: no requests made yet");
+
+            var result = checker.GetProblemLanguages(
+                new[] { "en", "bjn" },
+                "kingstone.superbible.ruth",
+                out bool didCheck
             );
-            return folder;
+
+            Assert.That(
+                handler.Attempts,
+                Is.EqualTo(3),
+                "two failed attempts plus the successful third one"
+            );
+            Assert.That(didCheck, Is.True, "the third attempt succeeded, so the check was done");
+            Assert.That(
+                LicenseChecker.LastFetchExceptionForTests,
+                Is.Null,
+                "a successful fetch clears the recorded failure"
+            );
+            Assert.That(result, Does.Contain("en"), "en is not licensed per the fetched data");
+            Assert.That(result, Does.Not.Contain("bjn"), "bjn is licensed per the fetched data");
         }
 
         [Test]


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
**Problem.** The license server that tells Bloom which languages a restricted book may be published in occasionally rejects a single request. When that happened and the user had no offline copy of the license data, publishing showed "Bloom is having trouble reaching the server". The same blip made the nightly `ProblemLanguages_KeepsAsteriskMatch` integration test flake, and neither the Bloom log nor the test output said what the server had done.

**What the PR does.**
- The fetch now goes through `RetryUtility`: three attempts, half a second apart, before Bloom falls back to the offline cache or gives up. Only outright request failures are retried; a timeout is not, so a stalled server still costs one timeout rather than three.
- When every attempt fails, the exception is written to the Bloom log, so a user report of the "trouble reaching the server" message can be diagnosed.
- The last fetch exception is kept in an internal static for tests, and the two live integration tests append it to their assertion message, so a flake now says why it failed.
- A fake HTTP handler that fails N times and then succeeds lets unit tests cover retry-then-success and give-up with and without a cache, with the retry delay set to zero.
<!-- preflight-narrative:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8341)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8341)
<!-- Reviewable:end -->
