### PR TITLE
Remove upper case on collection chooser (BL-16856)

### DIFF
--- a/src/BloomBrowserUI/collection/CollectionChooserDialog.tsx
+++ b/src/BloomBrowserUI/collection/CollectionChooserDialog.tsx
@@ -56,10 +56,7 @@ const titleRightGroupStyle = css`
     display: flex;
     align-items: center;
     gap: 8px;
-    // The language button sets text-transform:none on itself; override it here
-    // (only in this dialog) so the label reads uppercase per the design.
     & button {
-        text-transform: uppercase !important;
         font-size: 14px;
     }
     // DialogTitle forces font-weight:bold on all its descendants; the design


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
**Problem.** In the Open / Create Collections dialog, the UI language button in the title bar showed the selected language in all capitals ("ENGLISH"), unlike the same menu elsewhere in Bloom. The language name should read in its normal casing.

**What the PR does.** The dialog's title-bar style had a rule that forced the language button's label to uppercase. That rule is removed, so the button now shows the language name as the shared UI language menu renders it ("English"). The button's 14px size and normal weight in this dialog are kept.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16856

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8345)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8345)
<!-- Reviewable:end -->
