### PR TITLE
Revive or remove the last non-manual skipped tests

### DIFF
--- a/src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.tsx
+++ b/src/BloomBrowserUI/bookEdit/toolbox/ToolboxRoot.tsx
@@ -958,6 +958,12 @@ export const ToolboxRoot: React.FunctionComponent = () => {
                                             : toolboxHeaderIconStyles
                                     }
                                     data-toolid={section.id}
+                                    data-testid="toolbox-header-icon"
+                                    // The icon path is also exposed as data so tests can
+                                    // check which icon a header shows without reading styles.
+                                    data-icon-src={
+                                        toolIconPathByToolId[section.id]
+                                    }
                                     style={{
                                         backgroundImage: `url(${toolIconPathByToolId[section.id] || ""})`,
                                     }}

--- a/src/BloomBrowserUI/react_components/ToolboxRootTestHarness/component-tests/toolbox-root-react.uitest.ts
+++ b/src/BloomBrowserUI/react_components/ToolboxRootTestHarness/component-tests/toolbox-root-react.uitest.ts
@@ -239,58 +239,58 @@ test.describe("ToolboxRoot React mode", () => {
         ).toHaveCount(0);
     });
 
-    // Split out of the test above and disabled rather than deleted, because it asserts on
-    // things the React header has never produced, and deciding what it *should* produce is a
-    // product question, not a test fix:
-    //  - ".subscription-badge" is emitted by the legacy jQuery toolbox
-    //    (toolbox.ts buildToolboxHeader), not by the React header, so the count is 0 here.
-    //  - ".toolbox-react-header-icon" does not exist anywhere in the app — no component or
-    //    stylesheet has ever defined that class.
-    // It also checks tool icons via computed background-image, which
-    // src/BloomBrowserUI/AGENTS.md tells us not to do ("Don't check for styles in tests as a
-    // way to know the status of something... have components add css classes"). So whoever
-    // re-enables this should first decide whether the React header renders subscription
-    // badges and icons at all, then give those elements stable classes/test ids to assert on.
-    test.fixme(
-        "header shows icons and subscription badges",
-        async ({ page }) => {
-            await routeToolboxApis(page);
+    // Canvas, Motion and Music are the tools that need a subscription, so each of their
+    // headers carries a badge; Talking Book does not. Every enabled tool's header carries
+    // an icon. Which image each icon shows is a static lookup table and is not asserted.
+    test("header shows icons and subscription badges", async ({ page }) => {
+        await routeToolboxApis(page);
 
-            await page.route(
-                "**/bloom/api/toolbox/enabledTools",
-                async (route) => {
-                    await route.fulfill({
-                        status: 200,
-                        contentType: "text/plain",
-                        body: "canvas,motion,music,settings",
-                    });
-                },
-            );
-
-            await page.goto("/?component=ToolboxRootTestHarness");
-
-            await expect(page.getByText("Loading component…")).toHaveCount(0, {
-                timeout: 15000,
+        await page.route("**/bloom/api/toolbox/enabledTools", async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: "text/plain",
+                body: "canvas,motion,music,talkingBook,settings",
             });
+        });
 
-            await expect(page.locator(".subscription-badge")).toHaveCount(3);
+        await page.goto("/?component=ToolboxRootTestHarness");
 
-            await expect(
-                page.locator(
-                    ".toolbox-react-header-icon[data-toolid='canvas']",
-                ),
-            ).toHaveCSS(
-                "background-image",
-                /Canvas%20Icon\.svg|Canvas Icon\.svg/,
+        // The harness's first mount waits on the Vite dev server transforming the
+        // toolbox module graph, which on a cold server takes well over the default
+        // expect timeout; every test in this file uses the same wait for the same reason.
+        await expect(page.getByText("Loading component…")).toHaveCount(0, {
+            timeout: 15000,
+        });
+
+        // Five headers: the four tools plus the "More..." (settings) header. The component
+        // exposes each header's icon path as data-icon-src; "More..." has no icon of its own.
+        const icons = page.getByTestId("toolbox-header-icon");
+        await expect(icons).toHaveCount(5);
+        const icon = (toolId: string) =>
+            icons.and(page.locator(`[data-toolid='${toolId}']`));
+        for (const toolId of ["canvas", "motion", "music", "talkingBook"]) {
+            await expect(icon(toolId)).toHaveCount(1);
+            await expect(icon(toolId)).toHaveAttribute(
+                "data-icon-src",
+                /svg|png/,
             );
-            await expect(
-                page.locator(
-                    ".toolbox-react-header-icon[data-toolid='motion']",
-                ),
-            ).toHaveCSS("background-image", /motion\.svg/);
-            await expect(
-                page.locator(".toolbox-react-header-icon[data-toolid='music']"),
-            ).toHaveCSS("background-image", /music-notes-white\.svg/);
-        },
-    );
+        }
+        await expect(icon("settings")).toHaveCount(1);
+        await expect(icon("settings")).not.toHaveAttribute("data-icon-src");
+
+        // Scoped to the headers: the "More..." panel lists the tools with their own
+        // badges, which are not what this test is about.
+        const headerBadges = (toolId: string) =>
+            page
+                .locator(".MuiAccordionSummary-root", {
+                    has: icon(toolId),
+                })
+                .getByTestId("subscription-badge");
+        for (const toolId of ["canvas", "motion", "music"]) {
+            await expect(headerBadges(toolId)).toHaveCount(1);
+        }
+        for (const toolId of ["talkingBook", "settings"]) {
+            await expect(headerBadges(toolId)).toHaveCount(0);
+        }
+    });
 });

--- a/src/BloomBrowserUI/react_components/requiresSubscription.tsx
+++ b/src/BloomBrowserUI/react_components/requiresSubscription.tsx
@@ -150,6 +150,7 @@ export const SubscriptionBadgeWithTooltipAndDialog: React.FunctionComponent<{
     return (
         <BloomTooltip tip={featureMessage} placement="bottom-end">
             <img
+                data-testid="subscription-badge"
                 css={css`
                     height: 1.5em;
                     margin-left: 1em;

--- a/src/BloomTests/Book/BookStarterTests.cs
+++ b/src/BloomTests/Book/BookStarterTests.cs
@@ -280,38 +280,6 @@ namespace BloomTests.Book
                 .HasSpecifiedNumberOfMatchesForXpath("//div[contains(@class,'titlePage')]", 1);
         }
 
-        [
-            Test,
-            Ignore(
-                "Current architecture gives responsibility for updating to Book, so can't be tested here."
-            )
-        ]
-        public void CreateBookOnDiskFromTemplate_FromFactoryVaccinations_HasCorrectImageOnCover()
-        {
-            AssertThatXmlIn
-                .HtmlFile(GetNewMoonAndCapBookPath())
-                .HasSpecifiedNumberOfMatchesForXpath(
-                    "//div[contains(@class,'cover')]//img[@src='HL0014-1.png']",
-                    1
-                );
-        }
-
-        [
-            Test,
-            Ignore(
-                "Current architecture spreads this responsibility for updating to Book, so can't be tested here."
-            )
-        ]
-        public void CreateBookOnDiskFromTemplate_FromFactoryVaccinations_HasCorrectTopicOnCover()
-        {
-            AssertThatXmlIn
-                .HtmlFile(GetNewMoonAndCapBookPath())
-                .HasSpecifiedNumberOfMatchesForXpath(
-                    "//div[contains(@class,'cover')]//*[@data-derived='topic' and text()='Health']",
-                    1
-                );
-        }
-
         private string GetNewMoonAndCapBookPath()
         {
             var source = Path.Combine(

--- a/src/BloomTests/Book/BookTests.cs
+++ b/src/BloomTests/Book/BookTests.cs
@@ -2155,13 +2155,6 @@ namespace BloomTests.Book
             Assert.IsTrue(book.CanDelete);
         }
 
-        [Test, Ignore("broken")]
-        public void CanDelete_TemplateBook_False()
-        {
-            var book = CreateBook();
-            Assert.IsFalse(book.CanDelete);
-        }
-
         [Test]
         public void GetBookletLayoutMethod_A5Portrait_NotCalendar_Fold()
         {

--- a/src/BloomTests/Book/HtmlDomTests.cs
+++ b/src/BloomTests/Book/HtmlDomTests.cs
@@ -555,7 +555,6 @@ namespace BloomTests.Book
         }
 
         [Test]
-        [Ignore("Does not currently work...not sure how to make it right.")]
         public void GetImageElementUrl_ElementIsImgWithPercent2B_ReturnsSrc()
         {
             var element = MakeElement("<img src='test%2bme'/>");
@@ -563,11 +562,10 @@ namespace BloomTests.Book
         }
 
         [Test]
-        [Ignore("Does not currently work...not sure how to make it right.")]
         public void GetImageElementUrl_ElementIsImgWithPlus_ReturnsSrc()
         {
             var element = MakeElement("<img src='test+me'/>");
-            Assert.AreEqual("test+me", HtmlDom.GetImageElementUrl(element).UrlEncoded);
+            Assert.AreEqual("test%2bme", HtmlDom.GetImageElementUrl(element).UrlEncoded);
         }
 
         [Test]

--- a/src/BloomTests/XmlHtmlConverterTests.cs
+++ b/src/BloomTests/XmlHtmlConverterTests.cs
@@ -130,10 +130,13 @@ namespace BloomTests
             }
         }
 
-        [Test, Ignore("Will fix in BL-2558")]
+        [Test]
         public void SaveAsHTML_HasEmUpAgainstStrong_DoesNotInsertSpace()
         {
             var dom = SafeXmlDocument.Create();
+            // Every real book DOM is loaded with PreserveWhitespace on (BookStorage, BL-2484),
+            // which also keeps the indenting writer from separating inline-only children.
+            dom.PreserveWhitespace = true;
             var original = "<p><em>one</em><strong>two</strong></p>";
             dom.LoadXml(XmlHtmlConverter.CreateHtmlString("<div data-book='test'/>" + original));
             using (var temp = new TempFile())


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
**Problem.** After #8311 the nightly still reported six skipped C# tests and one skipped React component test. All seven were long-ignored tests whose reasons had gone stale, so the count kept hiding whether anything real was skipped.

**Fix.** Each is either revived or removed, by what the ignore reason turned out to mean:
- **HtmlDomTests, two plus-sign image-URL tests**: the code was right and the tests' expectations were not. UrlPathString deliberately treats `+` as a literal plus and encodes it as `%2b` (BL-3259). One expectation changed; both run again.
- **XmlHtmlConverterTests, em next to strong**: the test built its DOM without `PreserveWhitespace`, a shape production never saves, so the indenting writer split the two inline elements. Every real book is loaded with `PreserveWhitespace` on (BookStorage, BL-2484). The test now does the same and passes. Confirmed in a live Bloom that the app never had the bug, which is why BL-2558 was unreproducible; BL-16858 records that.
- **Deleted**: BookTests CanDelete_TemplateBook_False (deletability has not depended on templateness since BL-2678) and two BookStarterTests Vaccinations cover tests (cover image and topic are filled in by Book, not BookStarter).
- **ToolboxRoot component test**: the fixme is a real test again. The React header does render a per-tool icon and a subscription badge for Canvas, Motion and Music. Both elements now carry test ids and the test asserts on those instead of computed styles.

Expected on the next nightly: C# and React component skips both go to 0.
<!-- preflight-narrative:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8347)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8347)
<!-- Reviewable:end -->

