### PR TITLE
Show the subscription overlay on Publish > Apps for a Playground book (BL-16855)

### DIFF
--- a/src/BloomExe/SubscriptionAndFeatures/FeatureRegistry.cs
+++ b/src/BloomExe/SubscriptionAndFeatures/FeatureRegistry.cs
@@ -183,6 +183,7 @@ namespace Bloom.SubscriptionAndFeatures
             {
                 Feature = FeatureName.TeamCollection,
                 SubscriptionTier = SubscriptionTier.LocalCommunity,
+                UnlockedByPlayground = false,
             },
             new FeatureInfo
             {
@@ -193,6 +194,10 @@ namespace Bloom.SubscriptionAndFeatures
             {
                 Feature = FeatureName.AppBuilder,
                 SubscriptionTier = SubscriptionTier.Pro,
+                // An app can include other books from the collection, so a selected Playground
+                // book must not unlock the Apps screen; it shows its "requires a subscription"
+                // overlay as for any other book. See UnlockedByPlayground (BL-16855).
+                UnlockedByPlayground = false,
             },
             new FeatureInfo
             {

--- a/src/BloomExe/SubscriptionAndFeatures/FeatureStatus.cs
+++ b/src/BloomExe/SubscriptionAndFeatures/FeatureStatus.cs
@@ -93,6 +93,15 @@ namespace Bloom.SubscriptionAndFeatures
 
         // When set, the feature is only visible if the corresponding experimental token is enabled.
         public string ExperimentalFeatureToken;
+
+        // A book made from the Playground template gets every feature as if the collection had an
+        // Enterprise subscription, so people can try things out. Set this to false for a feature
+        // that must stay governed by the real subscription even when a Playground book is selected.
+        // Team Collections is one, since it is about the collection, not the book. Publish > Apps
+        // is another: the other publish screens stay usable for a Playground book and just disable
+        // the button that actually publishes it, but an app can include other books from the
+        // collection, so there the whole screen falls back to the real subscription.
+        public bool UnlockedByPlayground = true;
     }
 
     /// <summary>
@@ -147,7 +156,7 @@ namespace Bloom.SubscriptionAndFeatures
         )
         {
             var tier = subscription.Tier;
-            if (book != null && book.IsPlayground && feature.Feature != FeatureName.TeamCollection)
+            if (book != null && book.IsPlayground && feature.UnlockedByPlayground)
                 tier = SubscriptionTier.Enterprise;
             var enabled = (int)tier >= (int)feature.SubscriptionTier;
             var visible =

--- a/src/BloomTests/Subscription/FeatureStatusPlaygroundTests.cs
+++ b/src/BloomTests/Subscription/FeatureStatusPlaygroundTests.cs
@@ -1,0 +1,70 @@
+using Bloom.SubscriptionAndFeatures;
+using BloomTests.Book;
+using NUnit.Framework;
+
+namespace BloomTests.FeatureStatusTests
+{
+    /// <summary>
+    /// A Playground book unlocks features as if the collection were Enterprise, except the few
+    /// features the registry marks as still governed by the real subscription (BL-16855).
+    /// </summary>
+    [TestFixture]
+    public class FeatureStatusPlaygroundTests : BookTestsBase
+    {
+        private const string kPlaygroundTemplateId = "aeb176bc-76fa-44e2-bb9d-6350698fce47";
+
+        protected override string GetTestFolderName() => "FeatureStatusPlaygroundTests";
+
+        private Bloom.Book.Book CreatePlaygroundBook()
+        {
+            var book = CreateBook();
+            book.BookInfo.BookLineage = kPlaygroundTemplateId;
+            // Sanity check that the lineage really makes this a Playground book.
+            Assert.That(book.IsPlayground, Is.True);
+            return book;
+        }
+
+        [Test]
+        public void GetFeatureStatus_PlaygroundBook_UnlocksOrdinaryProFeatureWithoutSubscription()
+        {
+            var subscription = Subscription.CreateTempSubscriptionForTier(SubscriptionTier.Basic);
+            var book = CreatePlaygroundBook();
+
+            var status = FeatureStatus.GetFeatureStatus(subscription, FeatureName.Canvas, book);
+
+            Assert.That(status.Enabled, Is.True);
+        }
+
+        [TestCase(FeatureName.AppBuilder)]
+        [TestCase(FeatureName.TeamCollection)]
+        public void GetFeatureStatus_PlaygroundBook_StillRequiresSubscriptionForExemptFeature(
+            FeatureName featureName
+        )
+        {
+            var subscription = Subscription.CreateTempSubscriptionForTier(SubscriptionTier.Basic);
+            // Sanity check: an ordinary book gets the same answer, so the Playground unlock is what we
+            // test. This must come first: CreateBook() reuses one BookInfo, which CreatePlaygroundBook()
+            // then marks as Playground.
+            Assert.That(
+                FeatureStatus.GetFeatureStatus(subscription, featureName, CreateBook()).Enabled,
+                Is.False
+            );
+            var book = CreatePlaygroundBook();
+
+            var status = FeatureStatus.GetFeatureStatus(subscription, featureName, book);
+
+            Assert.That(status.Enabled, Is.False);
+        }
+
+        [Test]
+        public void GetFeatureStatus_PlaygroundBook_AppBuilderEnabledWithProSubscription()
+        {
+            var subscription = Subscription.CreateTempSubscriptionForTier(SubscriptionTier.Pro);
+            var book = CreatePlaygroundBook();
+
+            var status = FeatureStatus.GetFeatureStatus(subscription, FeatureName.AppBuilder, book);
+
+            Assert.That(status.Enabled, Is.True);
+        }
+    }
+}


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
**Problem.** Open Publish > Apps with a book made from the Playground template selected, in a collection without a subscription that covers app building, and the screen is fully usable: no "requires a subscription" overlay appears, unlike for any other book. From there an app can be built that includes other books from the collection.

**Cause.** A Playground book is meant to let people try every feature, so feature status pretends the collection has an Enterprise subscription whenever a Playground book is selected. Only Team Collection was exempt. The Apps tab's overlay asks whether app building is enabled, is told yes, and stays hidden.

**What the PR does.**
- The feature registry gains a per-feature switch for whether a Playground book unlocks it. Team Collection and app building are the two features that stay governed by the real subscription: the other publish screens stay usable for a Playground book and just disable the button that publishes it, but an app can include other books, so there the whole screen falls back to the real subscription.
- With that, Publish > Apps shows the same subscription overlay for a Playground book as for any other, and a subscriber can still build an app from one.
- Unit tests cover the Playground unlock for an ordinary feature, the two exempt features, and app building with a real subscription.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16855


🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8348)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8348)
<!-- Reviewable:end -->

