### PR TITLE
Refuse to record audio/video from a Playground book (BL-16864)

### DIFF
--- a/src/BloomBrowserUI/publish/video/PublishAudioVideo.tsx
+++ b/src/BloomBrowserUI/publish/video/PublishAudioVideo.tsx
@@ -528,6 +528,7 @@ const PublishAudioVideoInternalInternal: React.FunctionComponent<{
                             enabled={
                                 !recording &&
                                 isLicenseOK &&
+                                !isPlaygroundBook &&
                                 !(isScalingActive && recordingVideo) &&
                                 havePreviewForOrientation
                             }


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
### Problem

A book made from the Playground template is a scratchpad: Bloom deliberately unlocks every
feature in it so people can try things out, and in exchange nothing made from it may be
published. Every publish screen enforces that — except **Publish > Audio or Video**, which only
disabled the final **Save...** button. **Record** and **Play Recording** stayed enabled, so you
could record a Playground book, click Play Recording, and Bloom would hand the finished file to
your video player — where it can be kept and used as a real publication. The block was on the
wrong button.

### Fix

Disable **Record** for a Playground book. `gotRecording` is only ever set by the websocket event
that a completed recording raises, so with Record off the rest of the stepper — Play Recording
and Save... — is unreachable, and the screen still previews the book normally.

This follows the pattern the other publish screens use, and that BL-16855 documented on
`FeatureInfo.UnlockedInPlayground`: "the other publish screens stay usable for a Playground book
and just disable the button that actually publishes it." On this screen the button that actually
produces the publishable artifact is Record, not Save.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16864


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8349)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8349)
<!-- Reviewable:end -->
