### PR TITLE
Localize hardcoded strings in Book Settings and the publish screens

### DIFF
--- a/DistFiles/localization/en/BloomLowPriority.xlf
+++ b/DistFiles/localization/en/BloomLowPriority.xlf
@@ -143,6 +143,46 @@
         <source xml:lang="en">Currently, Bloom does not support including audio from embedded videos in video output.</source>
         <note>ID: PublishTab.RecordVideo.NoAudioInVideo</note>
       </trans-unit>
+      <trans-unit id="PublishTab.Apps.UsbDebuggingDialog.Title">
+        <source xml:lang="en">How to set up your Android phone to receive apps via USB</source>
+        <note>ID: PublishTab.Apps.UsbDebuggingDialog.Title</note>
+        <note>Title bar of the dialog listing the steps for enabling USB debugging on an Android phone.</note>
+      </trans-unit>
+      <trans-unit id="PublishTab.Apps.UsbDebuggingDialog.OpenSettings">
+        <source xml:lang="en">Open the Settings on your phone.</source>
+        <note>ID: PublishTab.Apps.UsbDebuggingDialog.OpenSettings</note>
+        <note>Step 1 of 6 for enabling USB debugging. The quoted names in these steps are what Android itself shows, so translate them the way the phone does.</note>
+      </trans-unit>
+      <trans-unit id="PublishTab.Apps.UsbDebuggingDialog.OpenAboutPhone">
+        <source xml:lang="en">Open &apos;About phone&apos;. On some phones, you may need to then open &apos;Software information&apos; to find the &apos;Build number&apos;.</source>
+        <note>ID: PublishTab.Apps.UsbDebuggingDialog.OpenAboutPhone</note>
+        <note>Step 2 of 6 for enabling USB debugging.</note>
+      </trans-unit>
+      <trans-unit id="PublishTab.Apps.UsbDebuggingDialog.TapBuildNumber">
+        <source xml:lang="en">Find &apos;Build number&apos; and tap it 7 times until Developer options are enabled.</source>
+        <note>ID: PublishTab.Apps.UsbDebuggingDialog.TapBuildNumber</note>
+        <note>Step 3 of 6 for enabling USB debugging.</note>
+      </trans-unit>
+      <trans-unit id="PublishTab.Apps.UsbDebuggingDialog.OpenDeveloperOptions">
+        <source xml:lang="en">Go back to Settings and open &apos;Developer options&apos;.</source>
+        <note>ID: PublishTab.Apps.UsbDebuggingDialog.OpenDeveloperOptions</note>
+        <note>Step 4 of 6 for enabling USB debugging.</note>
+      </trans-unit>
+      <trans-unit id="PublishTab.Apps.UsbDebuggingDialog.TurnOnUsbDebugging">
+        <source xml:lang="en">Turn on &apos;USB debugging&apos;.</source>
+        <note>ID: PublishTab.Apps.UsbDebuggingDialog.TurnOnUsbDebugging</note>
+        <note>Step 5 of 6 for enabling USB debugging.</note>
+      </trans-unit>
+      <trans-unit id="PublishTab.Apps.UsbDebuggingDialog.ConnectCable">
+        <source xml:lang="en">Connect the phone to your computer with a USB cable and allow USB debugging if your phone asks.</source>
+        <note>ID: PublishTab.Apps.UsbDebuggingDialog.ConnectCable</note>
+        <note>Step 6 of 6 for enabling USB debugging.</note>
+      </trans-unit>
+      <trans-unit id="PublishTab.Apps.UsbDebuggingDialog.HowToVideo">
+        <source xml:lang="en">How to video</source>
+        <note>ID: PublishTab.Apps.UsbDebuggingDialog.HowToVideo</note>
+        <note>Text of a link at the bottom of the USB debugging instructions dialog; it opens a short YouTube video showing the same steps.</note>
+      </trans-unit>
       <trans-unit id="PublishTab.Upload.CheckEmailFailed">
         <source xml:lang="en">Bloom needs to verify your email, but our attempt to resend the request failed, possibly because you made too many requests too close together. Please check your email, and if you can't find the message, try again later.</source>
         <note>ID: PublishTab.Upload.CheckEmailFailed</note>

--- a/DistFiles/localization/en/BloomMediumPriority.xlf
+++ b/DistFiles/localization/en/BloomMediumPriority.xlf
@@ -709,6 +709,11 @@
         <source xml:lang="en">Do not show this book to the public yet. I will share its URL with reviewers for feedback.</source>
         <note>ID: PublishTab.Upload.Draft</note>
       </trans-unit>
+      <trans-unit id="Topic.Missing">
+        <source xml:lang="en">Missing</source>
+        <note>ID: Topic.Missing</note>
+        <note>Shown in red, with a warning icon, in place of the topic name on the publish screens when the book has no topic set yet.</note>
+      </trans-unit>
       <trans-unit id="PublishTab.Upload.Visibility">
         <source xml:lang="en">Visibility</source>
         <note>ID: PublishTab.Upload.Visibility</note>
@@ -984,6 +989,11 @@
       <trans-unit id="BookSettings.WhatToShowOnCover" sil:dynamic="true">
         <source xml:lang="en">Front Cover</source>
         <note>BookSettings.WhatToShowOnCover</note>
+      </trans-unit>
+      <trans-unit id="BookSettings.AllCoverPagesGroupLabel" sil:dynamic="true">
+        <source xml:lang="en">All Cover Pages</source>
+        <note>ID: BookSettings.AllCoverPagesGroupLabel</note>
+        <note>Section label in the Book Settings dialog, over the settings that apply to every cover page (front, inside front, inside back, back) rather than just the front cover.</note>
       </trans-unit>
       <trans-unit id="BookSettings.ShowContentLanguage" sil:dynamic="true">
         <source xml:lang="en">Show {0}</source>
@@ -1263,6 +1273,21 @@
         <source xml:lang="en">Launching app on phone</source>
         <note>ID: PublishTab.Apps.Progress.LaunchingOnPhone</note>
         <note>Progress message shown while Bloom launches the installed Android app on a connected phone.</note>
+      </trans-unit>
+      <trans-unit id="PublishTab.Apps.UsbDebuggingHelpLink">
+        <source xml:lang="en">How to set up your Android phone</source>
+        <note>ID: PublishTab.Apps.UsbDebuggingHelpLink</note>
+        <note>Text button on the Publish to Apps screen, under the step that installs the app on a phone. It opens a dialog of instructions for enabling USB debugging.</note>
+      </trans-unit>
+      <trans-unit id="PublishTab.Apps.WhatsNext">
+        <source xml:lang="en">What&apos;s Next?</source>
+        <note>ID: PublishTab.Apps.WhatsNext</note>
+        <note>Heading of the note box at the side of the Publish to Apps screen.</note>
+      </trans-unit>
+      <trans-unit id="PublishTab.Apps.WhatsNext.Explanation">
+        <source xml:lang="en">Actually publishing your app to the Android App Store requires several more steps. In the near future we hope to expand Bloom to help with that part of the process.</source>
+        <note>ID: PublishTab.Apps.WhatsNext.Explanation</note>
+        <note>Body of the "What's Next?" note box on the Publish to Apps screen. "Bloom" is a product name and must not be translated.</note>
       </trans-unit>
       <trans-unit id="PublishTab.Apps.SettingsDialog.Title">
         <source xml:lang="en">App Settings</source>

--- a/src/BloomBrowserUI/bookEdit/bookAndPageSettings/BookSettingsConfigrPages.tsx
+++ b/src/BloomBrowserUI/bookEdit/bookAndPageSettings/BookSettingsConfigrPages.tsx
@@ -114,6 +114,11 @@ export const useBookSettingsAreaDefinition = (
         "BookSettings.WhatToShowOnCover",
     );
 
+    const allCoverPagesLabel = useL10n(
+        "All Cover Pages",
+        "BookSettings.AllCoverPagesGroupLabel",
+    );
+
     const showLanguageNameLabel = useL10n(
         "Show Language Name",
         "BookSettings.ShowLanguageName",
@@ -460,7 +465,7 @@ export const useBookSettingsAreaDefinition = (
                         )}
                     />
                 </ConfigrGroup>
-                <ConfigrGroup label={"All Cover Pages"}>
+                <ConfigrGroup label={allCoverPagesLabel}>
                     <ConfigrCustomStringInput
                         label={coverBackgroundColorLabel}
                         control={coverColorPickerControl}

--- a/src/BloomBrowserUI/publish/Apps/AppPublisherScreen.tsx
+++ b/src/BloomBrowserUI/publish/Apps/AppPublisherScreen.tsx
@@ -159,6 +159,15 @@ const AppPublisherScreenContents: React.FunctionComponent<{
         "PublishTab.Apps.SettingsDialog.Copyright",
     );
     const aboutLabel = useL10n("About", "PublishTab.Apps.SettingsDialog.About");
+    const usbDebuggingHelpLabel = useL10n(
+        "How to set up your Android phone",
+        "PublishTab.Apps.UsbDebuggingHelpLink",
+    );
+    const whatsNextLabel = useL10n("What's Next?", "PublishTab.Apps.WhatsNext");
+    const whatsNextExplanation = useL10n(
+        "Actually publishing your app to the Android App Store requires several more steps. In the near future we hope to expand Bloom to help with that part of the process.",
+        "PublishTab.Apps.WhatsNext.Explanation",
+    );
     const preparingWorkspaceLabel = useL10n(
         "Preparing workspace",
         "PublishTab.Apps.Progress.PreparingWorkspace",
@@ -648,7 +657,7 @@ const AppPublisherScreenContents: React.FunctionComponent<{
                                             text-transform: none;
                                         `}
                                     >
-                                        How to set up your Android phone
+                                        {usbDebuggingHelpLabel}
                                     </Button>
                                 </div>
                                 <ActionLogAccordion
@@ -679,13 +688,9 @@ const AppPublisherScreenContents: React.FunctionComponent<{
                         margin-bottom: 4px;
                     `}
                 >
-                    What's Next?
+                    {whatsNextLabel}
                 </div>
-                <div>
-                    Actually publishing your app to the Android App Store
-                    requires several more steps. In the near future we hope to
-                    expand Bloom to help with that part of the process.
-                </div>
+                <div>{whatsNextExplanation}</div>
             </NoteBox>
             {showSettingsDialog && (
                 <AppBuilderSettingsDialog

--- a/src/BloomBrowserUI/publish/Apps/UsbDebuggingHelpDialog.tsx
+++ b/src/BloomBrowserUI/publish/Apps/UsbDebuggingHelpDialog.tsx
@@ -10,16 +10,37 @@ import {
     DialogTitle,
 } from "../../react_components/BloomDialog/BloomDialog";
 import { DialogCloseButton } from "../../react_components/BloomDialog/commonDialogComponents";
+import { useL10n } from "../../react_components/l10nHooks";
 
 const usbDebuggingHowToVideoUrl = "https://www.youtube.com/shorts/Vox832sN_D4";
 
-const usbDebuggingSteps = [
-    "Open the Settings on your phone.",
-    "Open 'About phone'. On some phones, you may need to then open 'Software information' to find the 'Build number'.",
-    "Find 'Build number' and tap it 7 times until Developer options are enabled.",
-    "Go back to Settings and open 'Developer options'.",
-    "Turn on 'USB debugging'.",
-    "Connect the phone to your computer with a USB cable and allow USB debugging if your phone asks.",
+// The steps a user follows on the phone itself. Each is its own localizable
+// string; the hooks are called unconditionally and in a fixed order.
+const useUsbDebuggingSteps = (): string[] => [
+    useL10n(
+        "Open the Settings on your phone.",
+        "PublishTab.Apps.UsbDebuggingDialog.OpenSettings",
+    ),
+    useL10n(
+        "Open 'About phone'. On some phones, you may need to then open 'Software information' to find the 'Build number'.",
+        "PublishTab.Apps.UsbDebuggingDialog.OpenAboutPhone",
+    ),
+    useL10n(
+        "Find 'Build number' and tap it 7 times until Developer options are enabled.",
+        "PublishTab.Apps.UsbDebuggingDialog.TapBuildNumber",
+    ),
+    useL10n(
+        "Go back to Settings and open 'Developer options'.",
+        "PublishTab.Apps.UsbDebuggingDialog.OpenDeveloperOptions",
+    ),
+    useL10n(
+        "Turn on 'USB debugging'.",
+        "PublishTab.Apps.UsbDebuggingDialog.TurnOnUsbDebugging",
+    ),
+    useL10n(
+        "Connect the phone to your computer with a USB cable and allow USB debugging if your phone asks.",
+        "PublishTab.Apps.UsbDebuggingDialog.ConnectCable",
+    ),
 ];
 
 const UsbDebuggingStepIcon: React.FunctionComponent<StepIconProps> = (
@@ -50,6 +71,15 @@ export const UsbDebuggingHelpDialog: React.FunctionComponent<{
     open: boolean;
     onClose: () => void;
 }> = (props) => {
+    const usbDebuggingSteps = useUsbDebuggingSteps();
+    const dialogTitle = useL10n(
+        "How to set up your Android phone to receive apps via USB",
+        "PublishTab.Apps.UsbDebuggingDialog.Title",
+    );
+    const howToVideoLabel = useL10n(
+        "How to video",
+        "PublishTab.Apps.UsbDebuggingDialog.HowToVideo",
+    );
     return (
         <BloomDialog
             open={props.open}
@@ -58,7 +88,7 @@ export const UsbDebuggingHelpDialog: React.FunctionComponent<{
             maxWidth={"sm"}
             fullWidth={true}
         >
-            <DialogTitle title="How to set up your Android phone to receive apps via USB" />
+            <DialogTitle title={dialogTitle} />
             <DialogMiddle
                 css={css`
                     width: 100%;
@@ -94,7 +124,7 @@ export const UsbDebuggingHelpDialog: React.FunctionComponent<{
                     `}
                 >
                     <MuiLink href={usbDebuggingHowToVideoUrl} underline="hover">
-                        How to video
+                        {howToVideoLabel}
                     </MuiLink>
                 </div>
             </DialogMiddle>

--- a/src/BloomBrowserUI/publish/commonPublish/PublishTopic.tsx
+++ b/src/BloomBrowserUI/publish/commonPublish/PublishTopic.tsx
@@ -17,6 +17,9 @@ import {
 
 export const PublishTopic: React.FunctionComponent = () => {
     const [topicName, setTopicName] = React.useState("");
+    // Note: the "Missing" we compare against below is a sentinel the api returns
+    // (LibraryPublishApi.HandleTopic), not display text, so it stays in English.
+    const missingLabel = useL10n("Missing", "Topic.Missing");
 
     function retrieveTopic() {
         get("libraryPublish/topic", (result) => {
@@ -52,7 +55,7 @@ export const PublishTopic: React.FunctionComponent = () => {
                                     margin-right: 5px;
                                 `}
                             />
-                            Missing
+                            {missingLabel}
                         </span>
                     ) : (
                         <span>{topicName}</span>


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
## Problem

Several pieces of Bloom's UI reach users as hardcoded English. A translator never sees them, so they stay English in every language, no matter how complete that language's translation is. This branch covers the ones found while sweeping the 6.5 UI ahead of the beta: the **All Cover Pages** section label in Book & Page Settings; on the **Publish to Apps** screen, the "How to set up your Android phone" button, the "What's Next?" note box and its paragraph; the entire **USB debugging help dialog** that button opens — its title, all six steps and the "How to video" link; and the red **"Missing"** shown in place of a topic on the publish screens.

## Fix

Each literal now goes through `useL10n(english, id)`, with a matching `<trans-unit>` in the English XLF files, carrying an ID note and a translator context note.

- 5 entries in `BloomMediumPriority.xlf` — the Book Settings label, the three Apps screen strings, and `Topic.Missing`.
- 8 entries in `BloomLowPriority.xlf` — the USB debugging dialog, which few users ever open.
- The dialog's step list was a module-level `const` array, so it became a small `useUsbDebuggingSteps()` hook: a fixed number of unconditional `useL10n` calls. The step ids say what each step does (`OpenSettings`, `TapBuildNumber`, …) rather than `Step1`–`Step6`; the ordering lives in each entry's note.
- In `PublishTopic.tsx` only the *displayed* "Missing" is localized. The `topicName === "Missing"` comparison is a sentinel returned by `LibraryPublishApi.HandleTopic` and deliberately stays English; a comment on the line says so.

No English wording changed — every `<source>` is the literal that was already shipping.
<!-- preflight-narrative:end -->


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8350)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8350)
<!-- Reviewable:end -->
