### PR TITLE
Retry the font information pane's close click in the e2e helper

### DIFF
--- a/src/BloomE2E/helpers/fontChooser.ts
+++ b/src/BloomE2E/helpers/fontChooser.ts
@@ -374,10 +374,24 @@ export async function readFontInformationPane(
     );
 }
 
-/** Close the information pane with its X button, and wait for it to go. */
+/**
+ * Close the information pane with its X button, and wait for it to go. A pane that has already
+ * closed itself is fine — see below — so this leaves the pane shut either way.
+ */
 export async function closeFontInformationPane(page: Page): Promise<void> {
     const pane = chooserFrame(page).locator(PANE);
-    await pane.locator(PANE_CLOSE_BUTTON).click({ timeout: 30000 });
+    // The pane is a MUI popover, which shuts on a click away — and dismissing the browser alert
+    // that showFontDetails raises counts as one. So on a slow machine the pane is often gone
+    // before we get here (seen on the nightly runner, and locally when the whole suite is
+    // running), and sometimes caught mid-unmount, where its close button is first "not stable",
+    // then detached. Waiting on a button in that state burns the whole timeout and fails a test
+    // whose subject is not the button at all. What this helper owes its caller is only that the
+    // pane ends up shut, so click the X while there is one, and treat an already-shut pane as
+    // done.
+    await expect(async () => {
+        if (!(await pane.isVisible())) return;
+        await pane.locator(PANE_CLOSE_BUTTON).click({ timeout: 3000 });
+    }).toPass({ timeout: 30000 });
     await expect(
         pane,
         "The font information pane stayed open after its close button was clicked.",


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
### Problem

The nightly BloomE2E suite has gone red on the same font-chooser test two runs running — "the information icon shows the font's raw metadata". It is the test, not Bloom, that is broken, and every nightly failure hides the real ones behind it.

### Cause

The font information pane is a MUI popover, so it shuts on a click away — and dismissing the browser alert that `showFontDetails` raises counts as one. On a slow machine the pane has therefore usually closed itself before `closeFontInformationPane` runs, or is caught mid-unmount, where its close button reads "not stable" and then "detached from the DOM". Either way the helper spends its whole 30-second budget waiting for a button that is on its way out, and fails a test whose subject is not that button at all.

The first attempt at a fix here retried the click, which did not help — the retry just spent the same 30 seconds. Running the full suite locally reproduced the failure and the page snapshot settled it: at the moment of failure the font dropdown is open and there is no information pane on screen.

### Fix

`closeFontInformationPane` now clicks the X only while there is one, and treats an already-shut pane as done. The pane ending up shut is the whole of what the helper owes its caller, and the `toBeHidden` assertion that checks it is unchanged.

Verified by running the whole e2e suite twice locally, where the failure reproduces under load: font-chooser fails on the old code and passes on this.
<!-- preflight-narrative:end -->

---
[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8351)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8351)
<!-- Reviewable:end -->
