### PR TITLE
Probe why a cover title typed on a new book can fail to reach the collection

### DIFF
--- a/PAPERCUTS.md
+++ b/PAPERCUTS.md
@@ -19,6 +19,19 @@ House rules:
 
 ---
 
+## 2026-09-11 — The Bloom log an e2e failure keeps is only reachable by unzipping the trace
+
+- **Cut:** #8343's `keepEvidenceOnFailure` attaches Bloom's `Log.txt` with `testInfo.attach({body})`.
+  The collection copy lands as real files under `test-results/<test>/collection/`, but the log does
+  not land anywhere you can open: it is not in `test-results/<test>/`, not in
+  `playwright-report/data/`, and the run's console prints only its truncated first line. Reading it
+  from the nightly's `e2e-report` artifact meant unzipping `trace.zip` and guessing which
+  `resources/<40-hex>` blob it was.
+- **Idea:** write it with `testInfo.outputPath("bloom-log.txt")` and attach by `path`, so it sits
+  beside `collection/` as a plain file in the artifact.
+- **Context:** hit while reading the 2026-09-11 nightly for the cover-title failure
+  (`src/BloomE2E/AUTOMATION-DEBT.md`); cost about ten minutes of hunting.
+
 ## 2026-09-11 — pnpm skips the install entirely after a rebase changes the lockfile
 
 - **Cut:** After rebasing onto a master that had refreshed `pnpm-lock.yaml`, `pnpm install` in

--- a/src/BloomE2E/AUTOMATION-DEBT.md
+++ b/src/BloomE2E/AUTOMATION-DEBT.md
@@ -295,6 +295,24 @@ shows a `.bloom-page`. Two page adds in a row therefore lost the second one.
 helpers no longer act early; the production endpoints still reply success to a request they
 dropped.
 
+seen again 2026-09-11 (Test Case ID 348, `copy-page.spec.ts`): the same drop hits
+`selectPage`, which the 2026-09-02 mitigation does not cover. `helpers/pageThumbnails.ts`
+waits only for the thumbnail to *exist* and then clicks it; its `waitForEditablePage` comes
+after the click, not before, so the click can land while the Edit tab is still settling. The
+kept Bloom log says the click went nowhere at all: the last line is `Entered Edit Tab` for
+the destination book, and for the next 60 seconds there is no `Select Page` and no `changing
+page via workspaceBundle.switchContentPage` — every selection that works logs both. The
+thumbnail therefore never gets `gridSelected` and the test fails on that assertion.
+
+What makes this one worth chasing rather than filing as flake: it fails **every** time on one
+developer machine (twice in full-suite runs and again running the spec alone) and **passed**
+on the 2026-09-11 nightly, so the runner and that machine differ in something that decides
+it. Nobody has found what. Until they do, the cheap fix is the same as the entry's: have
+`selectPage` wait for the Edit tab to be ready *before* it clicks, the way the other
+page-changing helpers now do.
+(Seen while preflighting #8351, which cannot reach any of this — its whole diff is one
+font-chooser helper.)
+
 ## Filling a text box directly leaves part of the old text behind
 
 A `.bloom-editable` is a CKEditor surface, and Playwright's `fill()` on one leaves a
@@ -534,8 +552,54 @@ branding and the machine is slow. Not reproduced locally.
 
 Worked around in the test, 2026-09-05: it no longer types a title, and keeps the folder
 `makeBookFromTemplate` returns, which is stable as long as the book has no title. A test
-whose subject is the title, or the folder rename, cannot take that route. Fix direction:
-find what reloads or re-saves the cover of a new book under a branding, or make
-`findBookFolder` able to find a book by its id (`collections/books` reports one) so a test
-does not depend on the rename at all.
+whose subject is the title, or the folder rename, cannot take that route.
+
+seen again: 2026-09-10 and 2026-09-11, in `bulk-upload-quick-test.spec.ts`, which cannot
+take that workaround because it needs four books findable by title. Both nightlies died on
+the first book, identically, so on the runner this is close to deterministic.
+
+What the 2026-09-11 evidence adds — the first failure since #8343 started keeping the
+collection and Bloom's log on a failed test, so for once we can see the wreckage:
+
+- **Only the cover title is lost.** In the kept collection every `data-book="bookTitle"`
+  div is empty, `<title>` is empty, and `meta.json` has `"title": ""` — while the page
+  added straight afterwards, the "Hello." typed on it, and the copyright set later through
+  the Publish dialog are all saved. One edit is being dropped, not a save failing.
+- **The signature in Bloom's log is an absence.** Locally `InsertTemplatePage` is followed
+  by `Renaming html … -> '<title>.htm'` and `Renaming folder …` before
+  `BookStorage.Saving…`. On the runner those two lines are missing: the `SaveThen` that
+  `OnInsertPage` wraps the insert in got page content back from the browser with no title
+  in it, so there was nothing to rename to. That absence is the cheapest way to spot this
+  failure in a nightly log.
+- **Not reproducible on a fast machine.** Twelve attempts on a developer box — six at full
+  speed, six with the WebView renderer throttled 6x over CDP — all renamed the folder and
+  saved the title. Renderer slowness alone is not the trigger.
+
+The open question, and the reason for the probe below: **is this Bloom, or is it how we
+type?** `typeInGroup` defaults to `page.keyboard.insertText`, which raises `input` but no
+`keydown`/`keypress`/`keyup` at all (see "Typing in a text box raises no key events"). If
+anything in the title's path hangs off a key event, or off the focus leaving the box, then
+a person is safe and only the suite is exposed. Against that: `insertText` saved the title
+12 times out of 12 locally, so it is not simply inert.
+
+**The probe: `cover-title-save.spec.ts`.** It makes the same book three times in one run,
+typing the title a different way each time — `insertText`, real key presses
+(`typeInGroup`'s new `"keyPresses"` method), and `insertText` followed by an explicit blur
+— and reports for each what the box held just before the save and whether the collection
+learned the title. Read it from a **nightly** run; locally all three pass. Alongside it,
+`EditingModel.UpdateBookDomFromBrowserPageContent` logs `Cover-title investigation: page
+content from the browser carries bookTitle …`, so the run's kept `Log.txt` says whether the
+text was already gone before Bloom saw it or was lost after. Between them the run tells us
+which of three segments loses it: the typing, the capture, or the save.
+
+Fix direction, once the probe has answered:
+
+- only `insertText` loses it → make `typeInGroup` type the way a person does, which also
+  unblocks `bulk-upload-quick-test`;
+- every variant loses it → it is Bloom, and the thing to find is what re-syncs the cover of
+  a brand-new book from its still-empty data-div.
+
+Either way, delete the probe and the `Cover-title investigation` log line when the question
+is settled. Independently of all this, `findBookFolder` could look a book up by its id
+(`collections/books` reports one) so that no test depends on the rename at all.
 (Found 2026-09-05 in the nightly run.)

--- a/src/BloomE2E/helpers/bookMaking.ts
+++ b/src/BloomE2E/helpers/bookMaking.ts
@@ -565,6 +565,16 @@ export async function clickInGroup(
 }
 
 /**
+ * How the characters get into the box.
+ *
+ * `insertText` is one insertion for the whole string: cheap, and enough for anything that works
+ * from the `input` event. `keyPresses` sends a real keydown/keypress/keyup per character, which
+ * is what a person's keyboard produces — use it where what is under test might listen for a key,
+ * or where the question is whether our typing is faithful enough (see cover-title-save.spec.ts).
+ */
+export type TypingMethod = "insertText" | "keyPresses";
+
+/**
  * Type text into one language's box of one translation group on the page being shown, the way a
  * person does. `groupSelector` picks the group, e.g. ".bookTitle" for the cover title.
  *
@@ -576,22 +586,28 @@ export async function typeInGroup(
     groupSelector: string,
     languageTag: string,
     text: string,
+    method: TypingMethod = "insertText",
 ): Promise<void> {
     // Click in, select what is there, and type over it. A box here is a CKEditor surface, and
     // filling it directly leaves part of the old text behind.
     const box = await clickInGroup(page, groupSelector, languageTag);
     await box.press("Control+a");
     await box.press("Delete");
-    // One insertion rather than a key press per character: the box has focus, and CKEditor and
-    // Bloom's own markup code both work from the input event this raises, so the result is the
-    // same and the cost does not grow with the length of the text.
+    // By default, one insertion rather than a key press per character: the box has focus, and
+    // CKEditor and Bloom's own markup code both work from the input event this raises, so the
+    // result is the same and the cost does not grow with the length of the text.
     //
-    // What this does NOT do is raise keydown, keypress or keyup. So a test that types here does
+    // What that does NOT do is raise keydown, keypress or keyup. So a test that types here does
     // not exercise anything in Bloom that listens for a key rather than for input, and the
-    // assertion below cannot tell the difference. A test whose subject IS a key press needs a
-    // helper of its own that presses that key. (AUTOMATION-DEBT.md: "Typing in a text box raises
-    // no key events".)
-    if (text) await page.keyboard.insertText(text);
+    // assertion below cannot tell the difference. Pass "keyPresses" when that matters.
+    // (AUTOMATION-DEBT.md: "Typing in a text box raises no key events".)
+    if (text) {
+        if (method === "keyPresses")
+            // A small delay per character, so the page gets to react between keys as it would
+            // under a person's hands; instant keystrokes are their own kind of unfaithful.
+            await box.pressSequentially(text, { delay: 30 });
+        else await page.keyboard.insertText(text);
+    }
     // Bloom's editor reacts to typing; confirm the box holds what we meant before moving on, so a
     // later failure cannot be blamed on text that never arrived.
     await expect(box).toHaveText(text, { timeout: 15000 });

--- a/src/BloomE2E/tests/cover-title-save.spec.ts
+++ b/src/BloomE2E/tests/cover-title-save.spec.ts
@@ -1,0 +1,141 @@
+// A probe, not a feature test. It exists to answer one open question in AUTOMATION-DEBT.md,
+// "A title typed on the cover of a new book can fail to reach the collection": on the nightly
+// runner a title typed on the cover of a brand-new book is sometimes dropped, and we do not yet
+// know whether that is Bloom losing an edit or our own typing not being enough like a person's.
+//
+// So it makes the same book three times in one run, typing the title a different way each time,
+// and reports which ways reached the collection:
+//
+//   1. insertText          — what helpers/bookMaking.ts typeInGroup does today. It raises `input`
+//                            but no keydown/keypress/keyup at all (see the debt entry "Typing in a
+//                            text box raises no key events").
+//   2. keyPresses          — a real key event per character, which is what a person produces.
+//   3. insertText + blur   — insertText, then focus explicitly leaves the box before Add Page, in
+//                            case what commits the edit is the box losing the focus rather than
+//                            the typing itself.
+//
+// Read it from a NIGHTLY run: on a developer machine all three pass (12 for 12 while this was
+// written), and only the runner reproduces the loss. The failure message names the variants that
+// lost the title, so one red row says which mechanism is at fault. Bloom logs what it actually
+// received from the browser for each of these saves ("Cover-title investigation:" in
+// EditingModel.UpdateBookDomFromBrowserPageContent), so the run's kept Log.txt then says whether
+// the text was already gone before Bloom saw it or was lost after.
+//
+// The collection carries a branding, because every failure so far has been under one.
+import { expect, test } from "../fixtures/bloomTest";
+import {
+    addPage,
+    editablePageFrame,
+    findBookFolder,
+    makeBookFromTemplate,
+    typeInGroup,
+} from "../helpers/bookMaking";
+import { switchTab } from "../helpers/workspace";
+import { kEnterpriseSubscriptionCode } from "../helpers/collectionSettings";
+
+test.use({
+    collectionSpec: {
+        name: "cover-title-save",
+        languages: ["en"],
+        subscriptionCode: kEnterpriseSubscriptionCode,
+    },
+});
+
+interface IVariant {
+    /** Used in the title, so a kept collection says which book came from which variant. */
+    name: string;
+    /** How the title gets into the box, and what happens to the focus afterwards. */
+    typeIt: (
+        page: import("@playwright/test").Page,
+        title: string,
+    ) => Promise<void>;
+}
+
+const VARIANTS: IVariant[] = [
+    {
+        name: "insertText",
+        typeIt: (page, title) => typeInGroup(page, ".bookTitle", "en", title),
+    },
+    {
+        name: "keyPresses",
+        typeIt: (page, title) =>
+            typeInGroup(page, ".bookTitle", "en", title, "keyPresses"),
+    },
+    {
+        name: "insertText then blur",
+        typeIt: async (page, title) => {
+            await typeInGroup(page, ".bookTitle", "en", title);
+            // Take the focus out of the box the way leaving it does, without clicking anything
+            // else on the page (a stray click could select a different element and change what
+            // Add Page then does).
+            await titleBox(page).blur();
+        },
+    },
+];
+
+/**
+ * The cover's English title box, WITHOUT touching it. Every read here has to leave the page as
+ * the variant left it: clicking the box back into focus right before the save would undo the
+ * blur variant, and would put a fresh click and focus into all three runs — the very kind of
+ * event that could mask, or cause, the loss being investigated.
+ */
+function titleBox(page: import("@playwright/test").Page) {
+    return editablePageFrame(page)
+        .locator('.bookTitle .bloom-editable[lang="en"]')
+        .first();
+}
+
+test("a title typed on a new book's cover reaches the collection, however it was typed", async ({
+    page,
+}) => {
+    test.setTimeout(600000);
+
+    const lost: string[] = [];
+    for (const variant of VARIANTS) {
+        const title = `Cover Title Probe ${variant.name}`;
+        await switchTab(page, "collection");
+        await makeBookFromTemplate(page, "Basic Book");
+        await variant.typeIt(page, title);
+
+        // What the browser holds right before the save. If this is already wrong, the text never
+        // survived in the page at all and Bloom was never given a chance to save it.
+        const inTheBoxBeforeSaving = await titleBox(page).innerText();
+
+        // Adding a page is what saves the cover: OnInsertPage wraps the insert in SaveThen, which
+        // asks the browser for the current page's content first.
+        await addPage(page, "Just Text");
+
+        let reachedTheCollection = true;
+        try {
+            await findBookFolder(page, title, 20000);
+        } catch (error) {
+            // findBookFolder throws both when the collection never learned the title and when it
+            // could not ask at all (Bloom gone, browser closed). Only the first is the result this
+            // probe is here to record; letting the second through as "the title was lost" would
+            // point the whole investigation at the wrong thing, so it fails the run instead.
+            if (!String(error).includes("has no book called")) throw error;
+            reachedTheCollection = false;
+        }
+
+        // One line per variant in the run's output, so a nightly log carries the whole result even
+        // when the assertion below stops at the first failure. Console.error, because that is what
+        // survives at the reporter's default verbosity.
+        console.error(
+            `[cover-title probe] ${variant.name}: in the box before saving = ` +
+                `"${inTheBoxBeforeSaving.trim()}", reached the collection = ${reachedTheCollection}`,
+        );
+        if (!reachedTheCollection)
+            lost.push(
+                `${variant.name} (the box held "${inTheBoxBeforeSaving.trim()}" when Add Page saved)`,
+            );
+    }
+
+    expect(
+        lost,
+        "A title typed on the cover of a new book did not reach the collection. Which variants " +
+            "lost it says where the fault is: only insertText means our typing is the problem and " +
+            "typeInGroup should type the way a person does; every variant means Bloom is losing " +
+            "the edit. See AUTOMATION-DEBT.md, 'A title typed on the cover of a new book can fail " +
+            "to reach the collection'.",
+    ).toEqual([]);
+});

--- a/src/BloomExe/Edit/EditingModel.cs
+++ b/src/BloomExe/Edit/EditingModel.cs
@@ -1854,12 +1854,54 @@ namespace Bloom.Edit
             }
             //OK, looks safe, time to save.
             var editedDom = new HtmlDom(docFromBrowser);
+            LogCoverTitleArrivingFromBrowser(editedDom);
             var newPageData = GetPageData(editedDom.RawDom);
             _nextSaveMustBeFull = CurrentBook.UpdateDomFromEditedPage(
                 editedDom,
                 out _modifiedPageElement,
                 _nextSaveMustBeFull || NeedToDoFullSave(newPageData)
             );
+        }
+
+        /// <summary>
+        /// Say, in the log, what book title (if any) arrived in the page content the browser just
+        /// sent us — but only when the page has a title box at all, so this is quiet for every
+        /// other page.
+        ///
+        /// This is here for the investigation written up in src/BloomE2E/AUTOMATION-DEBT.md, "A
+        /// title typed on the cover of a new book can fail to reach the collection": on a slow
+        /// machine a title typed on a brand-new book's cover is sometimes missing from the saved
+        /// book, and we cannot yet tell whether the text was already gone from the browser's page
+        /// or was lost after we had it. This line answers exactly that, in a nightly's kept
+        /// Log.txt. Delete it, and the note in AUTOMATION-DEBT.md, once the question is settled.
+        /// </summary>
+        private void LogCoverTitleArrivingFromBrowser(HtmlDom editedDom)
+        {
+            try
+            {
+                var titles = editedDom
+                    .RawDom.SafeSelectNodes("//div[@data-book='bookTitle']")
+                    .Cast<SafeXmlElement>()
+                    .ToList();
+                if (titles.Count == 0)
+                    return;
+                // Every language's box, so a title that landed under the wrong language is visible
+                // too rather than looking like no title at all.
+                var described = string.Join(
+                    ", ",
+                    titles.Select(t => $"{t.GetAttribute("lang")}=\"{t.InnerText?.Trim()}\"")
+                );
+                Logger.WriteEvent(
+                    $"Cover-title investigation: page content from the browser carries bookTitle {described}"
+                );
+            }
+            catch (Exception e)
+            {
+                // Never let a diagnostic break a save.
+                Logger.WriteEvent(
+                    $"Cover-title investigation: could not read bookTitle ({e.Message})"
+                );
+            }
         }
 
         // If we return 'true', we need to do a complete book save, otherwise we'll just save this page.


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
### Problem

Three nightlies have now lost a cover title. A title typed on the cover of a brand-new book is missing from the saved book, so the collection never learns it and Bloom never renames the folder to match — `import-recording` hit it on 5 September, and `bulk-upload-quick-test` has died on it on 10 and 11 September, which is why that test is red every night. On the runner it is close to deterministic; on a developer machine it has never once reproduced (twelve attempts, including with the WebView renderer throttled), so nobody can say whether Bloom is dropping an edit or our own typing is not enough like a person's.

### What this PR does

It adds no fix. It adds the two instruments that should settle the question from a single nightly run, and writes down what is known so far.

- **`cover-title-save.spec.ts`** makes the same book three times, typing the title a different way each time — today's `insertText`, real key presses, and `insertText` followed by an explicit blur — and reports for each what the box held just before the save and whether the collection learned the title.
- **`typeInGroup`** gains an optional typing-method argument for that. It defaults to today's behavior, so no existing test changes.
- **`EditingModel`** logs the `bookTitle` it finds in the page content the browser sends back for a save, and only for pages that have one. That splits the timeline again: it says whether the text was already gone before Bloom saw it, or was lost after.
- **`AUTOMATION-DEBT.md`** records what this investigation established — only the cover title is lost while everything typed after it saves; the log signature is a *missing* `Renaming folder` line after `InsertTemplatePage` — and what each probe outcome would mean. A separate entry notes that a dropped page-thumbnail click is the same already-listed gap.

Read the probe from a nightly; locally all three variants pass. Both instruments are meant to be deleted once the question is settled.
<!-- preflight-narrative:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8352)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8352)
<!-- Reviewable:end -->
