### PR TITLE
Fix BL-16811 Front cover and title page overwrite each other's title padding

### DIFF
--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowChecker.ts
@@ -417,6 +417,26 @@ export default class OverflowChecker {
         OverflowChecker.CheckPageAncestorOverflow(editable);
     } // end AdjustSizeOrMarkOverflow
 
+    // Whether a bloom-padForOverflow box should measure its descenders and store the resulting
+    // padding-bottom in its style attribute.
+    // The book title is one data-book field shown on several xmatter pages (the front cover, the
+    // title page, sometimes more), and Bloom keeps the style attribute of all its copies in sync.
+    // If every page measured and stored its own padding, the copies would overwrite each other's
+    // value on every visit, and the published book would carry whichever page was looked at last,
+    // clipping the cover title when that was the title page (BL-16811). The front cover is where
+    // descender clipping matters, so only the copy there measures; the other copies inherit the
+    // cover's padding through the normal sync, which is harmless there. Other padded fields are
+    // measured wherever they are.
+    public static shouldMeasurePaddingForOverflow(
+        editable: HTMLElement,
+    ): boolean {
+        if (editable.getAttribute("data-book") !== "bookTitle") {
+            return true;
+        }
+        const page = editable.closest(".bloom-page");
+        return !!page && page.classList.contains("outsideFrontCover");
+    }
+
     // Type 1 overflow handling: checks/resizes the element's containing canvas element and
     // marks whether the element overflows its own box. This is the per-element part of
     // overflow handling and can be called in a loop over multiple elements before calling
@@ -449,7 +469,10 @@ export default class OverflowChecker {
             "bloom-padForOverflow",
         );
 
-        if (preventOverflowY) {
+        if (
+            preventOverflowY &&
+            OverflowChecker.shouldMeasurePaddingForOverflow(editable)
+        ) {
             editable.style.paddingBottom = "0";
             const measurements =
                 MeasureText.getDescentMeasurementsOfBox(editable);

--- a/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowSpec.ts
+++ b/src/BloomBrowserUI/bookEdit/OverflowChecker/OverflowSpec.ts
@@ -1,5 +1,5 @@
 "use strict";
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import OverflowChecker from "../../bookEdit/OverflowChecker/OverflowChecker";
 import { removeTestRoot } from "../../utils/testHelper";
 import OverflowAncestorFixture from "./OverflowAncestorFixture.html?raw";
@@ -136,6 +136,75 @@ describe.skip("Overflow Tests", () => {
         }
         $(".myTest").each((index, element) =>
             RunAncestorMarginTest(index, element as HTMLElement),
+        );
+    });
+});
+
+// The padding-bottom that bloom-padForOverflow boxes measure is kept in the style attribute,
+// which Bloom syncs between all copies of a data-book field. So the title, which appears on
+// several xmatter pages, must only be measured on the front cover (BL-16811).
+describe("OverflowChecker.shouldMeasurePaddingForOverflow", () => {
+    const makeEditable = (
+        pageClasses: string | null,
+        dataBook: string,
+    ): HTMLElement => {
+        const editable = document.createElement("div");
+        editable.className = "bloom-editable bloom-padForOverflow";
+        editable.setAttribute("data-book", dataBook);
+        if (pageClasses !== null) {
+            const page = document.createElement("div");
+            page.className = pageClasses;
+            const group = document.createElement("div");
+            group.className = "bloom-translationGroup";
+            page.appendChild(group);
+            group.appendChild(editable);
+            document.body.appendChild(page);
+        } else {
+            document.body.appendChild(editable);
+        }
+        return editable;
+    };
+
+    beforeEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("measures the title on the front cover", () => {
+        const editable = makeEditable(
+            "bloom-page bloom-frontMatter frontCover outsideFrontCover",
+            "bookTitle",
+        );
+        expect(editable.closest(".bloom-page")).not.toBeNull(); // sanity check on the setup
+        expect(OverflowChecker.shouldMeasurePaddingForOverflow(editable)).toBe(
+            true,
+        );
+    });
+
+    it("does not measure the title on the title page", () => {
+        const editable = makeEditable(
+            "bloom-page bloom-frontMatter titlePage",
+            "bookTitle",
+        );
+        expect(OverflowChecker.shouldMeasurePaddingForOverflow(editable)).toBe(
+            false,
+        );
+    });
+
+    it("does not measure a title that is on no page at all", () => {
+        const editable = makeEditable(null, "bookTitle");
+        expect(editable.closest(".bloom-page")).toBeNull(); // sanity check on the setup
+        expect(OverflowChecker.shouldMeasurePaddingForOverflow(editable)).toBe(
+            false,
+        );
+    });
+
+    it("still measures other padded fields wherever they are", () => {
+        const editable = makeEditable(
+            "bloom-page bloom-frontMatter credits",
+            "author",
+        );
+        expect(OverflowChecker.shouldMeasurePaddingForOverflow(editable)).toBe(
+            true,
         );
     });
 });


### PR DESCRIPTION
<!-- preflight-narrative:begin -->
## Problem

The book title appears on both the front cover and the title page, and both copies carry
`bloom-padForOverflow`, so when either page opens in the editor Bloom measures the title's
descenders and stores the extra room they need as `padding-bottom` in the title's `style`
attribute. The two copies are set at different sizes and so need different amounts: about 3px on
the cover and none on the title page at the default sizes.

Bloom keeps the `style` attribute of every copy of a `data-book` field in sync. So the two pages
overwrote each other's padding on every visit, and whichever page was looked at last won. In the
editor you never noticed, because the padding is re-measured on every page load. But the *saved*
value is what gets published, and BloomPUB, ePUB, Bloom Reader and BloomLibrary render what is in
the file: a book published after visiting the title page last clipped the descenders (g, y, p, j)
of its cover title. As a side effect, the two pages genuinely changed every time they were looked
at, so a merely browsed book showed as modified, and a Team Collection saw spurious checkouts.

## Fix

The cover is the one place where this clipping matters, so `OverflowChecker` now measures the
title's padding **only on the outside front cover**. The title's other copies inherit the cover's
padding through the normal sync, which costs them a few pixels of extra room and nothing else, and
nothing overwrites the cover's value any more. Padded fields other than the title are still
measured wherever they appear.

This is a deliberate imperfection: the cover's measurement is not exactly right for the title page,
and we are choosing to live with that rather than store one value per page.

Four unit tests cover the new gate: the title on the cover, the title on the title page, a title
on no page, and another padded field on another page.
<!-- preflight-narrative:end -->

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16811

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[Devin review](https://devinreview.com/BloomBooks/BloomDesktop/pull/8353)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/BloomDesktop/8353)
<!-- Reviewable:end -->
